### PR TITLE
fix(rules): fix a problem where "all available episodes seen by" not returned correctly when episode 1 of season 1 is not present

### DIFF
--- a/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/server/src/modules/rules/getter/plex-getter.service.ts
@@ -107,47 +107,34 @@ export class PlexGetterService {
           const seasons = await this.plexApi.getChildrenMetadata(
             libItem.ratingKey,
           );
-          let allViewers: PlexSeenBy[] = [];
+          let allViewers = plexUsers.slice();
           for (const season of seasons) {
             const episodes = await this.plexApi.getChildrenMetadata(
               season.ratingKey,
             );
             for (const episode of episodes) {
-              if (season.index === 1 && episode.index === 1) {
-                const viewers: PlexSeenBy[] = await this.plexApi
-                  .getWatchHistory(episode.ratingKey)
-                  .catch((_err) => {
-                    return null;
-                  });
-                allViewers =
-                  viewers && viewers.length > 0
-                    ? allViewers.concat(viewers)
-                    : allViewers;
-              } else {
-                const viewers: PlexSeenBy[] = await this.plexApi
-                  .getWatchHistory(episode.ratingKey)
-                  .catch((_err) => {
-                    return null;
-                  });
+              const viewers: PlexSeenBy[] = await this.plexApi
+                .getWatchHistory(episode.ratingKey)
+                .catch((_err) => {
+                  return null;
+                });
 
-                if (allViewers) {
-                  allViewers.forEach((el, index) => {
-                    if (
-                      !viewers ||
-                      !viewers.find(
-                        (viewEl) => el.accountID === viewEl.accountID,
-                      )
-                    ) {
-                      allViewers.splice(index);
-                    }
-                  });
+              var i = allViewers.length;
+              while (i--) {
+                if (
+                  !viewers ||
+                  !viewers.find(
+                    (viewEl) => allViewers[i].plexId === viewEl.accountID,
+                  )
+                ) {
+                  allViewers.splice(i, 1);
                 }
               }
             }
           }
 
           if (allViewers && allViewers.length > 0) {
-            const viewerIds = allViewers.map((el) => +el.accountID);
+            const viewerIds = allViewers.map((el) => +el.plexId);
             return plexUsers
               .filter((el) => viewerIds.includes(el.plexId))
               .map((el) => el.username);


### PR DESCRIPTION
There was a problem where if you didn't have episode 1 of season 1 on your Plex server the expression would never be met.
If you had for example: S03E1-8 and all had been watched, you would suspect that "all available episodes seen by" would return the one that has seen those 8 episodes. but this was not the case.

I have changed it to not look for `season.index === 1 && episode.index === 1` to populate the `allViewers` array.
Instead I populated the array with all users on the server.
from there it does the same thing as before: removing everyone that doesn't exists in the `viewers` array.

With this change it doesn't matter which season you have and how many episode you have.
It will give those that have seen all episodes that are present on the server.