### PR TITLE
refactor: Added an extra check for manualCollectionName to the 'Plex-…

### DIFF
--- a/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/server/src/modules/rules/getter/plex-getter.service.ts
@@ -95,12 +95,27 @@ export class PlexGetterService {
           return item.Label ? item.Label.map((l) => l.tag) : [];
         }
         case 'collections': {
-          // fetch metadata because collections in plexLibrary object are wrong
           return metadata.Collection
             ? metadata.Collection.filter(
                 (el) =>
                   el.tag.toLowerCase().trim() !==
-                  (ruleGroup?.collection?.manualCollection
+                  (ruleGroup?.collection?.manualCollection &&
+                  ruleGroup?.collection?.manualCollectionName
+                    ? ruleGroup.collection.manualCollectionName
+                    : ruleGroup.name
+                  )
+                    .toLowerCase()
+                    .trim(),
+              ).length
+            : 0;
+        }
+        case 'collection_tags': {
+          return metadata.Collection
+            ? metadata.Collection.filter(
+                (el) =>
+                  el.tag.toLowerCase().trim() !==
+                  (ruleGroup?.collection?.manualCollection &&
+                  ruleGroup?.collection?.manualCollectionName
                     ? ruleGroup.collection.manualCollectionName
                     : ruleGroup.name
                   )


### PR DESCRIPTION
… Available in amount of other collections' rule. This fixes a potential nullpointer