### PR TITLE
fix: The server no longer crashes when community.plex.tv rate limits …

### DIFF
--- a/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/server/src/modules/api/plex-api/plex-api.service.ts
@@ -704,7 +704,7 @@ export class PlexApiService {
       let result: PlexCommunityWatchList[] = [];
       let next = true;
       let page = null;
-      const size = 50;
+      const size = 100;
 
       while (next) {
         const resp = await this.plexCommunityClient.query({


### PR DESCRIPTION
…have been hit. Also improved logging and increased API paging chunks to minimize the occurrence of this error.