### PR TITLE
fix: Ignore Plex smart collections due to library corruption

### DIFF
--- a/server/src/modules/api/plex-api/interfaces/collection.interface.ts
+++ b/server/src/modules/api/plex-api/interfaces/collection.interface.ts
@@ -16,6 +16,7 @@ export class PlexCollection {
   childCount: string;
   maxYear: string;
   minYear: string;
+  smart?: boolean;
 }
 
 export interface CreateUpdateCollection {

--- a/server/src/modules/collections/collections.controller.ts
+++ b/server/src/modules/collections/collections.controller.ts
@@ -183,7 +183,7 @@ export class CollectionsController {
   ) {
     const size = amount ? amount : 25;
     const offset = (page - 1) * size;
-    return this.collectionService.getCollectionLogsWithhPaging(
+    return this.collectionService.getCollectionLogsWithPaging(
       id,
       {
         offset: offset,

--- a/server/src/modules/collections/collections.service.ts
+++ b/server/src/modules/collections/collections.service.ts
@@ -1018,7 +1018,7 @@ export class CollectionsService {
       const resp = await this.plexApi.getCollections(libraryId.toString());
       if (resp) {
         const found = resp.find((coll) => {
-          return coll.title.trim() === name.trim();
+          return coll.title.trim() === name.trim() && !coll.smart;
         });
 
         return found?.ratingKey !== undefined ? found : undefined;
@@ -1035,7 +1035,16 @@ export class CollectionsService {
 
   public async findPlexCollectionByID(id: number): Promise<PlexCollection> {
     try {
-      return await this.plexApi.getCollection(id);
+      const result = await this.plexApi.getCollection(id);
+
+      if (result.smart) {
+        this.logger.warn(
+          `Plex collection ${id} is a smart collection which is not supported.`,
+        );
+        return undefined;
+      }
+
+      return result;
     } catch (err) {
       this.logger.warn(
         'An error occurred while searching for a specific Plex collection.',
@@ -1045,7 +1054,7 @@ export class CollectionsService {
     }
   }
 
-  async getCollectionLogsWithhPaging(
+  async getCollectionLogsWithPaging(
     id: number,
     { offset = 0, size = 25 }: { offset?: number; size?: number } = {},
     search: string = undefined,


### PR DESCRIPTION
Fixes #1353

I believe checking in the places I have done is fine as we have no reason to ever touch smart collections. If somebody already has a manual collection linked to a smart collection (highly unlikely), this will now log a warning and the collection will no longer be processed.