### PR TITLE
feat: Add "Show on library recommended" option

### DIFF
--- a/server/src/database/migrations/1733583643678-Collection_add_visibleOnRecommended_field.ts
+++ b/server/src/database/migrations/1733583643678-Collection_add_visibleOnRecommended_field.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CollectionAddVisibleOnRecommendedField1733583643678
+  implements MigrationInterface
+{
+  name = 'CollectionAddVisibleOnRecommendedField1733583643678';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE collection ADD COLUMN "visibleOnRecommended" boolean NOT NULL DEFAULT (0)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE collection DROP "visibleOnRecommended"`,
+    );
+  }
+}

--- a/server/src/modules/collections/collections.service.ts
+++ b/server/src/modules/collections/collections.service.ts
@@ -29,6 +29,7 @@ import { ECollectionLogType } from '../../modules/collections/entities/collectio
 interface addCollectionDbResponse {
   id: number;
   isActive: boolean;
+  visibleOnRecommended: boolean;
   visibleOnHome: boolean;
   deleteAfterDays: number;
   manualCollection: boolean;
@@ -252,7 +253,7 @@ export class CollectionsService {
         await this.plexApi.UpdateCollectionSettings({
           libraryId: collectionObj.libraryId,
           collectionId: plexCollection.ratingKey,
-          recommended: false,
+          recommended: collection.visibleOnRecommended,
           ownHome: collection.visibleOnHome,
           sharedHome: collection.visibleOnHome,
         });
@@ -267,7 +268,7 @@ export class CollectionsService {
           await this.plexApi.UpdateCollectionSettings({
             libraryId: collection.libraryId,
             collectionId: plexCollection.ratingKey,
-            recommended: false,
+            recommended: collection.visibleOnRecommended,
             ownHome: collection.visibleOnHome,
             sharedHome: collection.visibleOnHome,
           });
@@ -360,7 +361,7 @@ export class CollectionsService {
           await this.plexApi.UpdateCollectionSettings({
             libraryId: dbCollection.libraryId,
             collectionId: dbCollection.plexId,
-            recommended: false,
+            recommended: collection.visibleOnRecommended,
             ownHome: collection.visibleOnHome,
             sharedHome: collection.visibleOnHome,
           });
@@ -559,7 +560,7 @@ export class CollectionsService {
               await this.plexApi.UpdateCollectionSettings({
                 libraryId: collection.libraryId,
                 collectionId: collection.plexId,
-                recommended: false,
+                recommended: collection.visibleOnRecommended,
                 ownHome: collection.visibleOnHome,
                 sharedHome: collection.visibleOnHome,
               });
@@ -918,6 +919,7 @@ export class CollectionsService {
                 libraryId: collection.libraryId,
                 arrAction: collection.arrAction ? collection.arrAction : 0,
                 isActive: collection.isActive,
+                visibleOnRecommended: collection.visibleOnRecommended,
                 visibleOnHome: collection.visibleOnHome,
                 deleteAfterDays: collection.deleteAfterDays,
                 listExclusions: collection.listExclusions,

--- a/server/src/modules/collections/entities/collection.entities.ts
+++ b/server/src/modules/collections/entities/collection.entities.ts
@@ -39,6 +39,9 @@ export class Collection {
   arrAction: number;
 
   @Column({ default: false })
+  visibleOnRecommended: boolean;
+
+  @Column({ default: false })
   visibleOnHome: boolean;
 
   @Column({ nullable: true, default: null })

--- a/server/src/modules/collections/interfaces/collection.interface.ts
+++ b/server/src/modules/collections/interfaces/collection.interface.ts
@@ -10,6 +10,7 @@ export interface ICollection {
   description?: string;
   isActive: boolean;
   arrAction: number;
+  visibleOnRecommended?: boolean;
   visibleOnHome?: boolean;
   listExclusions?: boolean;
   forceOverseerr?: boolean;

--- a/server/src/modules/rules/rules.service.ts
+++ b/server/src/modules/rules/rules.service.ts
@@ -238,6 +238,7 @@ export class RulesService {
           forceOverseerr: params.forceOverseerr ? params.forceOverseerr : false,
           tautulliWatchedPercentOverride:
             params.tautulliWatchedPercentOverride ?? null,
+          visibleOnRecommended: params.collection?.visibleOnRecommended,
           visibleOnHome: params.collection?.visibleOnHome,
           deleteAfterDays: +params.collection?.deleteAfterDays,
           manualCollection: params.collection?.manualCollection,
@@ -365,6 +366,7 @@ export class RulesService {
               params.tautulliWatchedPercentOverride ?? null,
             radarrSettingsId: params.radarrSettingsId ?? null,
             sonarrSettingsId: params.sonarrSettingsId ?? null,
+            visibleOnRecommended: params.collection.visibleOnRecommended,
             visibleOnHome: params.collection.visibleOnHome,
             deleteAfterDays: +params.collection.deleteAfterDays,
             manualCollection: params.collection.manualCollection,

--- a/ui/src/components/AddModal/interfaces.tsx
+++ b/ui/src/components/AddModal/interfaces.tsx
@@ -18,6 +18,7 @@ export interface ICollectionMedia {
   description?: string
   isActive?: boolean
   arrAction?: number
+  visibleOnRecommended?: boolean
   visibleOnHome?: boolean
   deleteAfterDays?: number
   type?: EPlexDataType

--- a/ui/src/components/Collection/index.tsx
+++ b/ui/src/components/Collection/index.tsx
@@ -15,6 +15,7 @@ export interface ICollection {
   title: string
   description?: string
   isActive: boolean
+  visibleOnRecommended?: boolean
   visibleOnHome?: boolean
   deleteAfterDays?: number
   listExclusions?: boolean

--- a/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -51,6 +51,7 @@ interface ICreateApiObject {
   radarrSettingsId?: number
   sonarrSettingsId?: number
   collection: {
+    visibleOnRecommended: boolean
     visibleOnHome: boolean
     deleteAfterDays: number
     manualCollection?: boolean
@@ -85,6 +86,7 @@ const AddModal = (props: AddModal) => {
   const keepLogsForMonthsRef = useRef<any>()
   const tautulliWatchedPercentOverrideRef = useRef<any>()
   const manualCollectionNameRef = useRef<any>('My custom collection')
+  const [showRecommended, setShowRecommended] = useState<boolean>(true)
   const [showHome, setShowHome] = useState<boolean>(true)
   const [listExclusion, setListExclusion] = useState<boolean>(true)
   const [forceOverseerr, setForceOverseerr] = useState<boolean>(false)
@@ -288,6 +290,7 @@ const AddModal = (props: AddModal) => {
 
       if (collection) {
         setCollection(collection)
+        setShowRecommended(collection.visibleOnRecommended!)
         setShowHome(collection.visibleOnHome!)
         setListExclusion(collection.listExclusions!)
         setForceOverseerr(collection.forceOverseerr!)
@@ -347,6 +350,7 @@ const AddModal = (props: AddModal) => {
         radarrSettingsId: radarrSettingsId,
         sonarrSettingsId: sonarrSettingsId,
         collection: {
+          visibleOnRecommended: showRecommended,
           visibleOnHome: showHome,
           deleteAfterDays: +deleteAfterRef.current.value,
           manualCollection: manualCollection,
@@ -686,6 +690,29 @@ const AddModal = (props: AddModal) => {
                     defaultChecked={active}
                     onChange={() => {
                       setActive(!active)
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="form-row">
+              <label htmlFor="collection_visible" className="text-label">
+                Show on library recommended
+                <p className="text-xs font-normal">
+                  Show the collection on the Plex library recommended screen
+                </p>
+              </label>
+              <div className="form-input">
+                <div className="form-input-field">
+                  <input
+                    type="checkbox"
+                    name="collection_visible_library"
+                    id="collection_visible_library"
+                    className="border-zinc-600 hover:border-zinc-500 focus:border-zinc-500 focus:bg-opacity-100 focus:placeholder-zinc-400 focus:outline-none focus:ring-0"
+                    defaultChecked={showRecommended}
+                    onChange={() => {
+                      setShowRecommended(!showRecommended)
                     }}
                   />
                 </div>


### PR DESCRIPTION
I did not find an existing feature request for this. But since it is a rather straight forward addition, I thought lets just go for it.

This feature adds a new checkbox option to the "Rules" editor, to show the correlating collection on the plex library recommended page (similar to the existing "Show on home" option).

Notably, this involved a database change for the "collection" table. I was not entirely sure how the typeorm database migration generator works. I had to make manual changes to the generated migration file.