### PR TITLE
feat: Add "Last episode aired at (season)" for episodes

### DIFF
--- a/server/src/modules/collections/collections.service.ts
+++ b/server/src/modules/collections/collections.service.ts
@@ -1047,7 +1047,7 @@ export class CollectionsService {
     try {
       const result = await this.plexApi.getCollection(id);
 
-      if (result.smart) {
+      if (result?.smart) {
         this.logger.warn(
           `Plex collection ${id} is a smart collection which is not supported.`,
         );

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -337,6 +337,14 @@ export class RuleConstants {
           mediaType: MediaType.BOTH,
           type: RuleType.TEXT,
         },
+        {
+          id: 29,
+          name: 'sw_seasonLastEpisodeAiredAt',
+          humanName: 'Last episode aired at (season)',
+          mediaType: MediaType.SHOW,
+          type: RuleType.DATE,
+          showType: [EPlexDataType.EPISODES],
+        },
       ],
     },
     {

--- a/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/server/src/modules/rules/getter/plex-getter.service.ts
@@ -469,6 +469,17 @@ export class PlexGetterService {
           const result = plexUsers.filter((_, index) => filterResults[index]);
           return result.map((u) => u.username);
         }
+        case 'sw_seasonLastEpisodeAiredAt': {
+          const lastEpDate = await this.plexApi
+            .getChildrenMetadata(parent.ratingKey)
+            .then((eps) => {
+              eps.sort((a, b) => a.index - b.index);
+              return eps[eps.length - 1]?.originallyAvailableAt || null;
+            });
+
+          // originallyAvailableAt is usually an ISO 8601 date string, no need to convert from epoch time
+          return lastEpDate ? new Date(lastEpDate) : null;
+        }
         default: {
           return null;
         }


### PR DESCRIPTION
Similar to the filter **Last episode aired at** that targets shows & seasons, this one will return the last episode aired date for the season the episode belongs to.

This is to support this scenario: https://discord.com/channels/1152219249549512724/1324689589641941003