### PR TITLE
fix: stop returning music libraries

### DIFF
--- a/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
+++ b/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
@@ -72,7 +72,7 @@ export interface PlexRating {
 }
 
 export interface PlexLibrary {
-  type: 'show' | 'movie';
+  type: 'show' | 'movie' | 'artist';
   key: string;
   title: string;
   agent: string;

--- a/server/src/modules/api/plex-api/plex-api.controller.ts
+++ b/server/src/modules/api/plex-api/plex-api.controller.ts
@@ -30,10 +30,6 @@ export class PlexApiController {
   getLibraries() {
     return this.plexApiService.getLibraries();
   }
-  // @Get('libraries/sync')
-  // syncLibraries() {
-  //   return this.plexApiService.syncLibraries();
-  // }
   @Get('library/:id/content{/:page}')
   getLibraryContent(
     @Param('id') id: string,

--- a/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/server/src/modules/api/plex-api/plex-api.service.ts
@@ -189,7 +189,9 @@ export class PlexApiService {
         uri: '/library/sections',
       });
 
-      return response.MediaContainer.Directory;
+      return response.MediaContainer.Directory.filter(
+        (x) => x.type == 'movie' || x.type == 'show',
+      ) as PlexLibrary[];
     } catch (err) {
       this.logger.warn(
         'Plex api communication failure.. Is the application running?',


### PR DESCRIPTION
### Description

This PR filters out libraries that are not a movie or show type. This stops them showing up in the rule creator and library switcher.

### How to test

Please describe the steps to test your changes, including any setup required.

1. Create an audio Plex library. You don't need to add anything to it.
2. Validate the library does not show up and that your TV & Movie libraries still show.