### PR TITLE
Add Plex Default Library to Settings and Update Related Components

### DIFF
--- a/server/src/database/migrations/1748211262583-Add_plex_default_library.ts
+++ b/server/src/database/migrations/1748211262583-Add_plex_default_library.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPlexDefaultLibrary1748211262583 implements MigrationInterface {
+  name = 'AddPlexDefaultLibrary1748211262583';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "settings" ADD "plex_default_library" integer`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "settings" DROP COLUMN "plex_default_library"`,
+    );
+  }
+}

--- a/server/src/modules/settings/dto's/setting.dto.ts
+++ b/server/src/modules/settings/dto's/setting.dto.ts
@@ -23,6 +23,8 @@ export class SettingDto {
 
   plex_auth_token: string;
 
+  plex_default_library: number;
+
   overseerr_url: string;
 
   overseerr_api_key: string;

--- a/server/src/modules/settings/dto's/setting.dto.ts
+++ b/server/src/modules/settings/dto's/setting.dto.ts
@@ -23,7 +23,7 @@ export class SettingDto {
 
   plex_auth_token: string;
 
-  plex_default_library: number;
+  plex_default_library: number | null;
 
   overseerr_url: string;
 

--- a/server/src/modules/settings/entities/settings.entities.ts
+++ b/server/src/modules/settings/entities/settings.entities.ts
@@ -45,6 +45,9 @@ export class Settings implements SettingDto {
   plex_auth_token: string;
 
   @Column({ nullable: true })
+  plex_default_library: number;
+
+  @Column({ nullable: true })
   overseerr_api_key: string;
 
   @Column({ nullable: true })

--- a/server/src/modules/settings/settings.service.ts
+++ b/server/src/modules/settings/settings.service.ts
@@ -57,6 +57,8 @@ export class SettingsService implements SettingDto {
 
   plex_auth_token: string;
 
+  plex_default_library: number;
+
   overseerr_url: string;
 
   overseerr_api_key: string;
@@ -114,6 +116,7 @@ export class SettingsService implements SettingDto {
       this.plex_port = settingsDb?.plex_port;
       this.plex_ssl = settingsDb?.plex_ssl;
       this.plex_auth_token = settingsDb?.plex_auth_token;
+      this.plex_default_library = settingsDb?.plex_default_library;
       this.overseerr_url = settingsDb?.overseerr_url;
       this.overseerr_api_key = settingsDb?.overseerr_api_key;
       this.tautulli_url = settingsDb?.tautulli_url;

--- a/server/src/modules/settings/settings.service.ts
+++ b/server/src/modules/settings/settings.service.ts
@@ -57,7 +57,7 @@ export class SettingsService implements SettingDto {
 
   plex_auth_token: string;
 
-  plex_default_library: number;
+  plex_default_library: number | null;
 
   overseerr_url: string;
 

--- a/ui/src/components/Common/LibrarySwitcher/index.tsx
+++ b/ui/src/components/Common/LibrarySwitcher/index.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect } from 'react'
 import LibrariesContext from '../../../contexts/libraries-context'
+import SettingsContext from '../../../contexts/settings-context'
 import GetApiHandler from '../../../utils/ApiHandler'
 
 interface ILibrarySwitcher {
@@ -9,6 +10,7 @@ interface ILibrarySwitcher {
 
 const LibrarySwitcher = (props: ILibrarySwitcher) => {
   const LibrariesCtx = useContext(LibrariesContext)
+  const SettingsCtx = useContext(SettingsContext)
 
   const onSwitchLibrary = (event: { target: { value: string } }) => {
     props.onSwitch(+event.target.value)
@@ -20,7 +22,13 @@ const LibrarySwitcher = (props: ILibrarySwitcher) => {
         if (resp) {
           LibrariesCtx.addLibraries(resp)
           if (props.allPossible !== undefined && !props.allPossible) {
-            props.onSwitch(+resp[0].key)
+            // Use default library from settings if available, otherwise use first library
+            const defaultLibraryId = SettingsCtx.settings.plex_default_library
+            const libraryToUse = defaultLibraryId && resp.find(lib => +lib.key === defaultLibraryId)
+              ? defaultLibraryId
+              : +resp[0].key
+            
+            props.onSwitch(libraryToUse)
           }
         } else {
           LibrariesCtx.addLibraries([])

--- a/ui/src/components/Common/LibrarySwitcher/index.tsx
+++ b/ui/src/components/Common/LibrarySwitcher/index.tsx
@@ -24,10 +24,12 @@ const LibrarySwitcher = (props: ILibrarySwitcher) => {
           if (props.allPossible !== undefined && !props.allPossible) {
             // Use default library from settings if available, otherwise use first library
             const defaultLibraryId = SettingsCtx.settings.plex_default_library
-            const libraryToUse = defaultLibraryId && resp.find(lib => +lib.key === defaultLibraryId)
-              ? defaultLibraryId
-              : +resp[0].key
-            
+            const libraryToUse =
+              defaultLibraryId &&
+              resp.find((lib) => +lib.key === defaultLibraryId)
+                ? defaultLibraryId
+                : +resp[0].key
+
             props.onSwitch(libraryToUse)
           }
         } else {

--- a/ui/src/components/Overview/index.tsx
+++ b/ui/src/components/Overview/index.tsx
@@ -45,10 +45,12 @@ const Overview = () => {
       ) {
         // Use default library from settings if available, otherwise use first library
         const defaultLibraryId = SettingsCtx.settings.plex_default_library
-        const libraryToUse = defaultLibraryId && LibrariesCtx.libraries.find(lib => +lib.key === defaultLibraryId)
-          ? defaultLibraryId
-          : selectedLibrary || +LibrariesCtx.libraries[0].key
-        
+        const libraryToUse =
+          defaultLibraryId &&
+          LibrariesCtx.libraries.find((lib) => +lib.key === defaultLibraryId)
+            ? defaultLibraryId
+            : selectedLibrary || +LibrariesCtx.libraries[0].key
+
         switchLib(libraryToUse)
       }
     }, 300)

--- a/ui/src/components/Overview/index.tsx
+++ b/ui/src/components/Overview/index.tsx
@@ -2,6 +2,7 @@ import { clone } from 'lodash'
 import { useContext, useEffect, useRef, useState } from 'react'
 import LibrariesContext from '../../contexts/libraries-context'
 import SearchContext from '../../contexts/search-context'
+import SettingsContext from '../../contexts/settings-context'
 import GetApiHandler from '../../utils/ApiHandler'
 import LibrarySwitcher from '../Common/LibrarySwitcher'
 import OverviewContent, { IPlexMetadata } from './Content'
@@ -25,6 +26,7 @@ const Overview = () => {
   const pageData = useRef<number>(0)
   const SearchCtx = useContext(SearchContext)
   const LibrariesCtx = useContext(LibrariesContext)
+  const SettingsCtx = useContext(SettingsContext)
 
   const fetchAmount = 30
 
@@ -41,9 +43,13 @@ const Overview = () => {
         SearchCtx.search.text === '' &&
         LibrariesCtx.libraries.length > 0
       ) {
-        switchLib(
-          selectedLibrary ? selectedLibrary : +LibrariesCtx.libraries[0].key,
-        )
+        // Use default library from settings if available, otherwise use first library
+        const defaultLibraryId = SettingsCtx.settings.plex_default_library
+        const libraryToUse = defaultLibraryId && LibrariesCtx.libraries.find(lib => +lib.key === defaultLibraryId)
+          ? defaultLibraryId
+          : selectedLibrary || +LibrariesCtx.libraries[0].key
+        
+        switchLib(libraryToUse)
       }
     }, 300)
 

--- a/ui/src/components/Settings/Plex/index.tsx
+++ b/ui/src/components/Settings/Plex/index.tsx
@@ -135,7 +135,7 @@ const PlexSettings = () => {
         plex_ssl: +sslRef.current.checked, // not used, server derives this from https://
         plex_default_library: defaultLibraryRef.current?.value
           ? +defaultLibraryRef.current.value
-          : undefined,
+          : null,
       }
 
       if (plex_token) {

--- a/ui/src/components/Settings/Plex/index.tsx
+++ b/ui/src/components/Settings/Plex/index.tsx
@@ -6,14 +6,20 @@ import React, { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'react-toastify'
 import SettingsContext from '../../../contexts/settings-context'
 import GetApiHandler, {
-  DeleteApiHandler,
-  PostApiHandler,
+    DeleteApiHandler,
+    PostApiHandler,
 } from '../../../utils/ApiHandler'
 import Alert from '../../Common/Alert'
 import Button from '../../Common/Button'
 import DocsButton from '../../Common/DocsButton'
 import TestButton from '../../Common/TestButton'
 import PlexLoginButton from '../../Login/Plex'
+
+interface ILibrary {
+  key: string
+  type: 'movie' | 'show'
+  title: string
+}
 
 interface PresetServerDisplay {
   name: string
@@ -81,10 +87,22 @@ const PlexSettings = () => {
   }>({ status: false, version: '0' })
   const [availableServers, setAvailableServers] = useState<PlexDevice[]>()
   const [isRefreshingPresets, setIsRefreshingPresets] = useState(false)
+  const [libraries, setLibraries] = useState<ILibrary[]>([])
+  const defaultLibraryRef = useRef<HTMLSelectElement>(null)
 
   useEffect(() => {
     document.title = 'Maintainerr - Settings - Plex'
   }, [])
+
+  useEffect(() => {
+    if (tokenValid && libraries.length === 0) {
+      GetApiHandler('/plex/libraries').then((resp) => {
+        if (resp) {
+          setLibraries(resp)
+        }
+      })
+    }
+  }, [tokenValid])
 
   const submit = async (
     e: React.FormEvent<HTMLFormElement> | undefined,
@@ -102,6 +120,7 @@ const PlexSettings = () => {
         plex_port: number
         plex_name: string
         plex_ssl: number
+        plex_default_library?: number
         plex_auth_token?: string
       } = {
         plex_hostname: sslRef.current?.checked
@@ -114,6 +133,7 @@ const PlexSettings = () => {
         plex_port: +portRef.current.value,
         plex_name: nameRef.current.value,
         plex_ssl: +sslRef.current.checked, // not used, server derives this from https://
+        plex_default_library: defaultLibraryRef.current?.value ? +defaultLibraryRef.current.value : undefined,
       }
 
       if (plex_token) {
@@ -496,6 +516,33 @@ const PlexSettings = () => {
                     onError={authFailed}
                   ></PlexLoginButton>
                 )}
+              </div>
+            </div>
+          </div>
+
+          <div className="form-row">
+            <label htmlFor="defaultLibrary" className="text-label">
+              Default Library
+              <span className="label-tip">
+                {`Select the default library to display on the overview page`}
+              </span>
+            </label>
+            <div className="form-input">
+              <div className="form-input-field">
+                <select
+                  name="defaultLibrary"
+                  id="defaultLibrary"
+                  ref={defaultLibraryRef}
+                  defaultValue={settingsCtx.settings.plex_default_library?.toString() || ''}
+                  disabled={!tokenValid || libraries.length === 0}
+                >
+                  <option value="">No default library</option>
+                  {libraries.map((library) => (
+                    <option key={library.key} value={library.key}>
+                      {library.title} ({library.type})
+                    </option>
+                  ))}
+                </select>
               </div>
             </div>
           </div>

--- a/ui/src/components/Settings/Plex/index.tsx
+++ b/ui/src/components/Settings/Plex/index.tsx
@@ -6,8 +6,8 @@ import React, { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'react-toastify'
 import SettingsContext from '../../../contexts/settings-context'
 import GetApiHandler, {
-    DeleteApiHandler,
-    PostApiHandler,
+  DeleteApiHandler,
+  PostApiHandler,
 } from '../../../utils/ApiHandler'
 import Alert from '../../Common/Alert'
 import Button from '../../Common/Button'
@@ -133,7 +133,9 @@ const PlexSettings = () => {
         plex_port: +portRef.current.value,
         plex_name: nameRef.current.value,
         plex_ssl: +sslRef.current.checked, // not used, server derives this from https://
-        plex_default_library: defaultLibraryRef.current?.value ? +defaultLibraryRef.current.value : undefined,
+        plex_default_library: defaultLibraryRef.current?.value
+          ? +defaultLibraryRef.current.value
+          : undefined,
       }
 
       if (plex_token) {
@@ -533,7 +535,9 @@ const PlexSettings = () => {
                   name="defaultLibrary"
                   id="defaultLibrary"
                   ref={defaultLibraryRef}
-                  defaultValue={settingsCtx.settings.plex_default_library?.toString() || ''}
+                  defaultValue={
+                    settingsCtx.settings.plex_default_library?.toString() || ''
+                  }
                   disabled={!tokenValid || libraries.length === 0}
                 >
                   <option value="">No default library</option>

--- a/ui/src/contexts/settings-context.tsx
+++ b/ui/src/contexts/settings-context.tsx
@@ -1,9 +1,9 @@
 import {
-  createContext,
-  ReactElement,
-  ReactNode,
-  ReactPortal,
-  useState,
+    createContext,
+    ReactElement,
+    ReactNode,
+    ReactPortal,
+    useState,
 } from 'react'
 
 export interface ISettings {
@@ -20,6 +20,7 @@ export interface ISettings {
   plex_port: number
   plex_ssl: number
   plex_auth_token: string | null
+  plex_default_library: number
   overseerr_api_key: string
   tautulli_url: string
   tautulli_api_key: string

--- a/ui/src/contexts/settings-context.tsx
+++ b/ui/src/contexts/settings-context.tsx
@@ -20,7 +20,7 @@ export interface ISettings {
   plex_port: number
   plex_ssl: number
   plex_auth_token: string | null
-  plex_default_library: number
+  plex_default_library: number | null
   overseerr_api_key: string
   tautulli_url: string
   tautulli_api_key: string

--- a/ui/src/contexts/settings-context.tsx
+++ b/ui/src/contexts/settings-context.tsx
@@ -1,9 +1,9 @@
 import {
-    createContext,
-    ReactElement,
-    ReactNode,
-    ReactPortal,
-    useState,
+  createContext,
+  ReactElement,
+  ReactNode,
+  ReactPortal,
+  useState,
 } from 'react'
 
 export interface ISettings {


### PR DESCRIPTION
- Introduced `plex_default_library` property in SettingsService, SettingDto, and Settings entity.
- Updated LibrarySwitcher and Overview components to utilize the default library setting when switching libraries.
- Added a dropdown in PlexSettings for selecting the default library from available libraries.

### Description

Added a Plex default library setting that allows users to configure which library is automatically selected when visiting the overview page. This includes a new database column `plex_default_library` in the settings table, a UI setting in the Plex configuration to select the default library, and automatic library selection on the overview page using the configured default with fallback to the first available library if no default is set.

The approach prioritizes backward compatibility and follows established patterns by adding the setting to the existing `settings` table as a nullable field, ensuring existing installations continue to work without breaking changes. The UI integration places the setting in the Plex configuration page where users expect to find Plex-related settings, and only shows the library dropdown when Plex is authenticated and libraries are available. The implementation updates both the Overview component and LibrarySwitcher to respect the default setting, ensuring consistency across all pages while maintaining the existing "All" option behavior for pages that need it. A proper TypeORM migration ensures clean deployment to existing installations following the established migration naming convention.

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I have performed a self-review of my code.
- [x] I have linted and formatted my code.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

### How to test

Please describe the steps to test your changes, including any setup required.

1. Ensure Plex is properly confugured and authenticated in the application
2. Have at least 2 differentlibraries in your Plex server
3. Start the application and verify the migration runs successfully
4. Check that existing settings are preserved and the new column is added
5. Navigate to Settings → Plex
6. Verify the "Default Library" dropdown appears only when Plex is authenticated
7. Test selecting different libraries from the dropdown
8. Save changes and verify the setting persists after page refresh
9. Navigate to the Overview page
10. Verify it automatically loads the configured default library
11. Test with no default set - should fall back to first library
12. Test switching libraries manually - should remember the selection
13. Verify Collections and Rules pages still show "All" option (unchanged behavior)
14. Test that manual library selection works correctly
15. Test with invalid/default library ID (should fall back gracefully)
16. Test with deleted/removed library (should handle gracefully)
17. Test application restart preserves the setting
18. Set a default library, restart the application, and verify it's still selected
19. Test the complete flow: set default → visit overview → verify auto-selection
