### PR TITLE
Add Plex Rules that Include Mark As Watched Items

### DIFF
--- a/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
+++ b/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
@@ -49,6 +49,13 @@ export interface PlexLibraryResponse {
       | PlexCollection[]
       | PlexCollection
       | PlexPlaylist[];
+     Account?: Array<{
+      id: number;
+      globalViewCount: number;
+    }>;
+    identifier?: string;
+    mediaTagPrefix?: string;
+    mediaTagVersion?: number;
   };
 }
 export interface PlexGenre {
@@ -131,7 +138,7 @@ export interface PlexSeenBy extends PlexLibraryItem {
   originallyAvailableAt: string;
   viewedAt: number;
   accountID: number;
-  id: number;
   deviceID: number;
+  id: number;
   globalViewCount: number;
 }

--- a/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
+++ b/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
@@ -131,5 +131,7 @@ export interface PlexSeenBy extends PlexLibraryItem {
   originallyAvailableAt: string;
   viewedAt: number;
   accountID: number;
+  id: number;
   deviceID: number;
+  globalViewCount: number;
 }

--- a/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/server/src/modules/api/plex-api/plex-api.service.ts
@@ -428,6 +428,21 @@ export class PlexApiService {
     }
   }
 
+  public async getWatchHistoryIncludingMarked(itemId: string): Promise<PlexSeenBy[]> {
+    try {
+      const response = await this.plexClient.queryAll<PlexLibraryResponse>({
+        uri: `/library/metadata/${itemId}/users/top`,
+      });
+      return response.MediaContainer.Metadata as PlexSeenBy[];
+    } catch (err) {
+      this.logger.warn(
+        'Plex api communication failure.. Is the application running?',
+      );
+      this.logger.debug(err);
+      return undefined;
+    }
+  }
+
   public async getCollections(
     libraryId: string | number,
     subType?: 'movie' | 'show' | 'season' | 'episode',

--- a/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/server/src/modules/api/plex-api/plex-api.service.ts
@@ -433,7 +433,7 @@ export class PlexApiService {
       const response = await this.plexClient.queryAll<PlexLibraryResponse>({
         uri: `/library/metadata/${itemId}/users/top`,
       });
-      return response.MediaContainer.Metadata as PlexSeenBy[];
+      return response.MediaContainer.Account as PlexSeenBy[];
     } catch (err) {
       this.logger.warn(
         'Plex api communication failure.. Is the application running?',

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -475,6 +475,55 @@ export class RuleConstants {
           type: RuleType.TEXT_LIST,
           cacheReset: true,
         },
+        {
+          id: 43,
+          name: 'seenBy_includingMarked',
+          humanName: '[list] Viewed by (username) - including marked as watched',
+          mediaType: MediaType.MOVIE,
+          type: RuleType.TEXT_LIST,
+        },
+        {
+          id: 44,
+          name: 'sw_allEpisodesSeenBy_includingMarked',
+          humanName: '[list] Users that saw all available episodes - including marked as watched',
+          mediaType: MediaType.SHOW,
+          type: RuleType.TEXT_LIST, // return usernames []
+          showType: [EPlexDataType.SHOWS, EPlexDataType.SEASONS],
+        },
+        {
+          id: 45,
+          name: 'sw_watchers_includingMarked',
+          humanName: '[list] Users that watch the show/season/episode - including marked as watched',
+          mediaType: MediaType.SHOW,
+          type: RuleType.TEXT_LIST, // return usernames []
+          showType: [
+            EPlexDataType.SHOWS,
+            EPlexDataType.SEASONS,
+            EPlexDataType.EPISODES,
+          ],
+        },
+        {
+          id: 46,
+          name: 'sw_amountOfViews_includingMarked',
+          humanName: 'Total views - including marked as watched',
+          mediaType: MediaType.SHOW,
+          type: RuleType.NUMBER,
+        },
+        {
+          id: 47,
+          name: 'sw_viewedEpisodes_includingMarked',
+          humanName: 'Amount of watched episodes - including marked as watched',
+          mediaType: MediaType.SHOW,
+          type: RuleType.NUMBER,
+          showType: [EPlexDataType.SHOWS, EPlexDataType.SEASONS],
+        },
+        {
+          id: 48,
+          name: 'viewCount_includingMarked',
+          humanName: 'Times viewed - including marked as watched',
+          mediaType: MediaType.MOVIE,
+          type: RuleType.NUMBER,
+        },
       ],
     },
     {

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -478,14 +478,16 @@ export class RuleConstants {
         {
           id: 43,
           name: 'seenBy_includingMarked',
-          humanName: '[list] Viewed by (username) - including marked as watched',
+          humanName:
+            '[list] Viewed by (username) - including marked as watched',
           mediaType: MediaType.MOVIE,
           type: RuleType.TEXT_LIST,
         },
         {
           id: 44,
           name: 'sw_allEpisodesSeenBy_includingMarked',
-          humanName: '[list] Users that saw all available episodes - including marked as watched',
+          humanName:
+            '[list] Users that saw all available episodes - including marked as watched',
           mediaType: MediaType.SHOW,
           type: RuleType.TEXT_LIST, // return usernames []
           showType: [EPlexDataType.SHOWS, EPlexDataType.SEASONS],
@@ -493,7 +495,8 @@ export class RuleConstants {
         {
           id: 45,
           name: 'sw_watchers_includingMarked',
-          humanName: '[list] Users that watch the show/season/episode - including marked as watched',
+          humanName:
+            '[list] Users that watch the show/season/episode - including marked as watched',
           mediaType: MediaType.SHOW,
           type: RuleType.TEXT_LIST, // return usernames []
           showType: [

--- a/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/server/src/modules/rules/getter/plex-getter.service.ts
@@ -736,6 +736,150 @@ export class PlexGetterService {
 
           return Array.from(combinedCollections).map((el) => el.trim());
         }
+        case 'seenBy_includingMarked': {
+          const plexUsers = await this.plexApi.getCorrectedUsers(false);
+
+          const viewers: PlexSeenBy[] = await this.plexApi
+            .getWatchHistoryIncludingMarked(metadata.ratingKey)
+            .catch(() => {
+              return null;
+            });
+          if (viewers) {
+            const viewerIds = viewers.map((el) => +el.id);
+            return plexUsers
+              .filter((el) => viewerIds.includes(el.plexId))
+              .map((el) => el.username);
+          } else {
+            return [];
+          }
+        }
+        case 'sw_allEpisodesSeenBy_includingMarked': {
+          const plexUsers = await this.plexApi.getCorrectedUsers(false);
+
+          const seasons =
+            metadata.type !== 'season'
+              ? await this.plexApi.getChildrenMetadata(metadata.ratingKey)
+              : [metadata];
+          const allViewers = plexUsers.slice();
+          for (const season of seasons) {
+            const episodes = await this.plexApi.getChildrenMetadata(
+              season.ratingKey,
+            );
+            for (const episode of episodes) {
+              const viewers: PlexSeenBy[] = await this.plexApi
+                .getWatchHistoryIncludingMarked(episode.ratingKey)
+                .catch(() => {
+                  return null;
+                });
+
+              const arrLength = allViewers.length - 1;
+              allViewers
+                .slice()
+                .reverse()
+                .forEach((el, idx) => {
+                  if (
+                    !viewers ||
+                    !viewers.find((viewEl) => el.plexId === viewEl.id)
+                  ) {
+                    allViewers.splice(arrLength - idx, 1);
+                  }
+                });
+            }
+          }
+
+          if (allViewers && allViewers.length > 0) {
+            const viewerIds = allViewers.map((el) => +el.plexId);
+            return plexUsers
+              .filter((el) => viewerIds.includes(el.plexId))
+              .map((el) => el.username);
+          }
+
+          return [];
+        }
+        case 'sw_watchers_includingMarked': {
+          const plexUsers = await this.plexApi.getCorrectedUsers(false);
+
+          const watchHistory =
+            await this.plexApi.getWatchHistoryIncludingMarked(
+              metadata.ratingKey,
+            );
+
+          const viewers = watchHistory ? watchHistory.map((el) => +el.id) : [];
+          const uniqueViewers = [...new Set(viewers)];
+
+          if (uniqueViewers && uniqueViewers.length > 0) {
+            return plexUsers
+              .filter((el) => uniqueViewers.includes(+el.plexId))
+              .map((el) => el.username);
+          }
+          return [];
+        }
+        case 'sw_amountOfViews_includingMarked': {
+          let viewCount = 0;
+
+          // for episodes
+          if (metadata.type === 'episode') {
+            const views = await this.plexApi.getWatchHistoryIncludingMarked(
+              metadata.ratingKey,
+            );
+            viewCount = views
+              ? views.reduce((sum, viewer) => sum + viewer.globalViewCount, 0)
+              : 0;
+          } else {
+            // for seasons & shows
+            const seasons =
+              metadata.type !== 'season'
+                ? await this.plexApi.getChildrenMetadata(metadata.ratingKey)
+                : [metadata];
+
+            for (const season of seasons) {
+              const episodes = await this.plexApi.getChildrenMetadata(
+                season.ratingKey,
+              );
+              for (const episode of episodes) {
+                const views = await this.plexApi.getWatchHistoryIncludingMarked(
+                  episode.ratingKey,
+                );
+                if (views) {
+                  viewCount += views.reduce(
+                    (sum, viewer) => sum + viewer.globalViewCount,
+                    0,
+                  );
+                }
+              }
+            }
+          }
+          return viewCount;
+        }
+        case 'sw_viewedEpisodes_includingMarked': {
+          let viewCount = 0;
+          const seasons =
+            metadata.type !== 'season'
+              ? await this.plexApi.getChildrenMetadata(metadata.ratingKey)
+              : [metadata];
+          for (const season of seasons) {
+            const episodes = await this.plexApi.getChildrenMetadata(
+              season.ratingKey,
+            );
+            for (const episode of episodes) {
+              const views = await this.plexApi.getWatchHistoryIncludingMarked(
+                episode.ratingKey,
+              );
+              if (views?.length > 0) {
+                viewCount++;
+              }
+            }
+          }
+          return viewCount;
+        }
+        case 'viewCount_includingMarked': {
+          const viewers = await this.plexApi.getWatchHistoryIncludingMarked(
+            metadata.ratingKey,
+          );
+          return viewers
+            ? viewers.reduce((sum, viewer) => sum + viewer.globalViewCount, 0)
+            : 0;
+        }
         default: {
           return null;
         }


### PR DESCRIPTION
### Description

I have added 6 additional plex rules that use the below Plex API endpoint so that marking a movie/show as watched triggers it being added to a collection, even if it hasn't been actively streamed. 

https://developer.plex.tv/pms/#tag/Library/operation/libraryMetadataGetUsersTop

The new rules are as follows:

- [list] Viewed by (username) - including marked as watched
- [list] Users that saw all available episodes - including marked as watched
- [list] Users that watch the show/season/episode - including marked as watched
- Total views - including marked as watched
- Amount of watched episodes - including marked as watched
- Times viewed - including marked as watched

### Related issue

Feature request:
https://features.maintainerr.info/posts/24/recognize-watched-unwatched-state-of-items-in-plex

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I have performed a self-review of my code.
- [x] I have linted and formatted my code.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

### How to test

Add one of the new rules, mark an item as watched and see if it triggers the rule.
