### PR TITLE
fix: Handle zero Plex libraries in Overview

### DIFF
--- a/server/src/app/app.module.ts
+++ b/server/src/app/app.module.ts
@@ -90,7 +90,7 @@ export class AppModule implements OnModuleInit {
   async onModuleInit() {
     // Initialize modules requiring settings
     await this.settings.init();
-    await this.plexApi.initialize({});
+    await this.plexApi.initialize();
     this.overseerApi.init();
     this.tautulliApi.init();
     this.jellyseerrApi.init();

--- a/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
+++ b/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
@@ -81,7 +81,7 @@ export interface PlexLibrary {
 export interface PlexLibrariesResponse {
   MediaContainer: {
     totalSize: number;
-    Directory: PlexLibrary[];
+    Directory?: PlexLibrary[];
   };
 }
 

--- a/server/src/modules/settings/settings.service.ts
+++ b/server/src/modules/settings/settings.service.ts
@@ -559,7 +559,7 @@ export class SettingsService implements SettingDto {
 
       await this.init();
       this.logger.log('Settings updated');
-      await this.plexApi.initialize({});
+      await this.plexApi.initialize();
       this.overseerr.init();
       this.tautulli.init();
       this.internalApi.init();


### PR DESCRIPTION
Also clear the additional Plex clients & caches when uninitializing & reinitializing the Plex API client. Fixes stale data if you swap your Plex settings to a different server (for whatever reason).