### PR TITLE
fix: Stop "Plex API isn't fully initialized" log at startup

### DIFF
--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -58,7 +58,6 @@ export class PlexApiService {
     private readonly loggerFactory: MaintainerrLoggerFactory,
   ) {
     this.logger.setContext(PlexApiService.name);
-    void this.initialize();
   }
 
   private getDbSettings(): PlexSettings {


### PR DESCRIPTION
SettingsService is a forwardRef - the settings haven't loaded yet so initialize will fail. The settings service initializes the Plex API in its own initialize, which means removing it here to stop the log is fine.