### PR TITLE
fix(jellyfin): remove double normalization of CriticRating (#2375)

### DIFF
--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
@@ -175,7 +175,7 @@ describe('JellyfinGetterService', () => {
         id: 22,
         name: 'rating_critics',
         overrides: {
-          ratings: [{ source: 'critic', value: 75, type: 'critic' as const }],
+          ratings: [{ source: 'critic', value: 7.5, type: 'critic' as const }],
         },
         expected: 7.5,
       },

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
@@ -114,11 +114,10 @@ export class JellyfinGetterService {
         }
 
         case 'rating_critics': {
-          // Jellyfin CriticRating is on a 0-100 scale, normalize to 0-10
           const criticRating = metadata.ratings?.find(
             (r) => r.type === 'critic',
           )?.value;
-          return criticRating !== undefined ? criticRating / 10 : 0;
+          return criticRating ?? 0;
         }
 
         case 'rating_audience': {


### PR DESCRIPTION
CriticRating was divided by 10 in both the mapper (0-100 → 0-10) and the getter, resulting in a 0-1 scale instead of the documented 1-10 scale.

Fix https://github.com/Maintainerr/Maintainerr/issues/2375