### PR TITLE
refactor: use shared MediaItemType contracts and fix Jellyfin child s…

### DIFF
--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -492,6 +492,7 @@ export class JellyfinAdapterService implements IMediaServerService {
             ItemFields.ProviderIds,
             ItemFields.Path,
             ItemFields.DateCreated,
+            ItemFields.MediaSources,
           ],
           enableUserData: true,
         });
@@ -507,6 +508,7 @@ export class JellyfinAdapterService implements IMediaServerService {
           ItemFields.ProviderIds,
           ItemFields.Path,
           ItemFields.DateCreated,
+          ItemFields.MediaSources,
         ],
         enableUserData: true,
         // Filter by item type - defaults to all media types if not specified

--- a/apps/ui/src/components/Collection/CollectionItem/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionItem/index.tsx
@@ -1,6 +1,6 @@
 import { ICollection } from '..'
 import { useMediaServerLibraries } from '../../../api/media-server'
-import { type MediaItemType } from '@maintainerr/contracts'
+import { MediaItemTypeLabels } from '@maintainerr/contracts'
 
 interface ICollectionItem {
   collection: ICollection
@@ -18,21 +18,6 @@ function formatSize(bytes: number | null | undefined): string {
 
 const CollectionItem = (props: ICollectionItem) => {
   const { data: libraries } = useMediaServerLibraries()
-  const getMediaTypeLabel = (type: MediaItemType) => {
-    switch (type) {
-      case 'movie':
-        return 'Movies'
-      case 'show':
-        return 'Shows'
-      case 'season':
-        return 'Seasons'
-      case 'episode':
-        return 'Episodes'
-      default:
-        return 'Unknown'
-    }
-  }
-
   return (
     <>
       <a
@@ -95,7 +80,7 @@ const CollectionItem = (props: ICollectionItem) => {
                   Media Type
                 </p>
                 <p className="text-amber-500">
-                  {getMediaTypeLabel(props.collection.type)}
+                  {MediaItemTypeLabels[props.collection.type]}
                 </p>
               </div>
             ) : (

--- a/packages/contracts/src/media-server/enums.ts
+++ b/packages/contracts/src/media-server/enums.ts
@@ -16,12 +16,15 @@ export const MediaItemTypes: MediaItemType[] = [
 /** Display labels keyed by MediaItemType (derived). */
 export const MediaItemTypeLabels: Record<MediaItemType, string> =
   Object.fromEntries(
-    MediaItemTypes.map((t) => [t, t.charAt(0).toUpperCase() + t.slice(1) + 's']),
+    MediaItemTypes.map((t) => [
+      t,
+      t.charAt(0).toUpperCase() + t.slice(1) + 's',
+    ]),
   ) as Record<MediaItemType, string>
 
 /** Uppercase type strings for serialization, e.g. YAML export (derived). */
-export const MediaDataTypeStrings: string[] = MediaItemTypes.map(
-  (t) => MediaItemTypeLabels[t].toUpperCase(),
+export const MediaDataTypeStrings: string[] = MediaItemTypes.map((t) =>
+  MediaItemTypeLabels[t].toUpperCase(),
 )
 
 export function isMediaType(

--- a/packages/contracts/src/media-server/enums.ts
+++ b/packages/contracts/src/media-server/enums.ts
@@ -5,6 +5,7 @@ export enum MediaServerType {
 
 export type MediaItemType = 'movie' | 'show' | 'season' | 'episode'
 
+/** All MediaItemType values. Must match the MediaItemType union. */
 export const MediaItemTypes: MediaItemType[] = [
   'movie',
   'show',
@@ -12,12 +13,16 @@ export const MediaItemTypes: MediaItemType[] = [
   'episode',
 ]
 
-export const MediaDataTypeStrings: string[] = [
-  'MOVIES',
-  'SHOWS',
-  'SEASONS',
-  'EPISODES',
-]
+/** Display labels keyed by MediaItemType (derived). */
+export const MediaItemTypeLabels: Record<MediaItemType, string> =
+  Object.fromEntries(
+    MediaItemTypes.map((t) => [t, t.charAt(0).toUpperCase() + t.slice(1) + 's']),
+  ) as Record<MediaItemType, string>
+
+/** Uppercase type strings for serialization, e.g. YAML export (derived). */
+export const MediaDataTypeStrings: string[] = MediaItemTypes.map(
+  (t) => MediaItemTypeLabels[t].toUpperCase(),
+)
 
 export function isMediaType(
   itemType: MediaItemType | null | undefined,


### PR DESCRIPTION
…ize lookups

- Replace hardcoded getMediaTypeLabel switch in CollectionItem with MediaItemTypeLabels record from @maintainerr/contracts
- Add MediaItemTypeLabels (derived display labels) to contracts, make MediaDataTypeStrings derived from it — single source of truth
- Add ItemFields.MediaSources to Jellyfin getChildrenMetadata so episode sizes are returned when calculating show/season totals
