### PR TITLE
fix: prevent crash when removing media from null Jellyfin collection

### DIFF
--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -1156,46 +1156,48 @@ export class CollectionsService {
   }
 
   private async removeChildFromCollection(
-    collectionIds: { mediaServerId: string; dbId: number },
+    collectionIds: { mediaServerId: string | null; dbId: number },
     childId: string,
     logMeta?: CollectionLogMeta,
   ) {
     try {
-      const mediaServer = await this.getMediaServer();
       this.infoLogger(`Removing media with id ${childId} from collection..`);
 
-      try {
-        await mediaServer.removeFromCollection(
-          collectionIds.mediaServerId,
-          childId,
-        );
-
-        await this.connection
-          .createQueryBuilder()
-          .delete()
-          .from(CollectionMedia)
-          .where([
-            {
-              collectionId: collectionIds.dbId,
-              mediaServerId: childId,
-            },
-          ])
-          .execute();
-
-        await this.CollectionLogRecordForChild(
-          childId,
-          collectionIds.dbId,
-          'remove',
-          logMeta,
-        );
-      } catch (err) {
-        // 404 means media is not in collection, which is fine
-        if (!err.message?.includes('404')) {
-          this.infoLogger(
-            `Couldn't remove media from collection: ${err.message}`,
+      if (collectionIds.mediaServerId) {
+        try {
+          const mediaServer = await this.getMediaServer();
+          await mediaServer.removeFromCollection(
+            collectionIds.mediaServerId,
+            childId,
           );
+        } catch (err) {
+          // 404 means media is not in collection, which is fine
+          if (!err.message?.includes('404')) {
+            this.infoLogger(
+              `Couldn't remove media from collection: ${err.message}`,
+            );
+          }
         }
       }
+
+      await this.connection
+        .createQueryBuilder()
+        .delete()
+        .from(CollectionMedia)
+        .where([
+          {
+            collectionId: collectionIds.dbId,
+            mediaServerId: childId,
+          },
+        ])
+        .execute();
+
+      await this.CollectionLogRecordForChild(
+        childId,
+        collectionIds.dbId,
+        'remove',
+        logMeta,
+      );
     } catch (err) {
       this.logger.warn(
         'An error occurred while performing collection actions.',


### PR DESCRIPTION
## Summary
- Guard the Jellyfin `removeFromCollection` API call when `mediaServerId` is `null` (collection doesn't exist on the media server)
- Move DB cleanup (`CollectionMedia` deletion + log record) outside the inner try block so it always executes, even if the API call fails
- Update `removeChildFromCollection` parameter type to `string | null` for type accuracy

## Root cause
When a Jellyfin collection doesn't exist (auto-deleted when empty, or never created because "custom collection" is unchecked), `checkAutomaticMediaServerLink` correctly sets `mediaServerId = null`. But `removeChildFromCollection` passes this `null` straight to the Jellyfin SDK, which throws `RequiredError`. Since the DB cleanup was in the same `try` block as the API call, items became permanently stuck — every re-run hit the same error for the same items.

## Test plan
- [x] All 500 existing tests pass
- [x] Verify with Jellyfin: create a rule, run it, change conditions, re-run — items that no longer match should be removed from the Maintainerr collection without errors
- [x] Verify items are correctly removed from the Jellyfin media server collection when one exists

Closes #2509 