### PR TITLE
Finalize Jellyfin hardening for collections, search, and setup

### DIFF
--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -11,6 +11,7 @@ const jellyfinApiMocks = {
   getConfiguration: jest.fn(),
   getItems: jest.fn(),
   getItemUserData: jest.fn(),
+  getSearchHints: jest.fn(),
 };
 
 const collectionApiMocks = {
@@ -103,7 +104,9 @@ jest.mock('@jellyfin/sdk/lib/utils/api/index.js', () => ({
     removeFromCollection: (...args: unknown[]) =>
       collectionApiMocks.removeFromCollection(...args),
   })),
-  getSearchApi: jest.fn(),
+  getSearchApi: jest.fn().mockImplementation(() => ({
+    getSearchHints: (...args: unknown[]) => jellyfinApiMocks.getSearchHints(...args),
+  })),
   getPlaylistsApi: jest.fn(),
   getUserViewsApi: jest.fn(),
 }));
@@ -155,6 +158,7 @@ describe('JellyfinAdapterService', () => {
     });
     jellyfinApiMocks.getItems.mockResolvedValue({ data: { Items: [] } });
     jellyfinApiMocks.getItemUserData.mockResolvedValue({ data: undefined });
+    jellyfinApiMocks.getSearchHints.mockResolvedValue({ data: { SearchHints: [] } });
     collectionApiMocks.createCollection.mockResolvedValue({
       data: { Id: 'collection-1' },
     });
@@ -354,6 +358,76 @@ describe('JellyfinAdapterService', () => {
 
       expect(collections).toHaveLength(1);
       expect(collections[0].id).toBe('collection-in-lib');
+    });
+  });
+
+  describe('searchContent', () => {
+    beforeEach(async () => {
+      settingsService.getSettings.mockResolvedValue({
+        ...mockSettings,
+        jellyfin_user_id: 'user-1',
+      } as unknown as Awaited<ReturnType<SettingsService['getSettings']>>);
+      await service.initialize();
+    });
+
+    it('returns fully populated metadata items for search results', async () => {
+      jellyfinApiMocks.getSearchHints.mockResolvedValue({
+        data: {
+          SearchHints: [
+            { Id: 'movie-1', Name: 'Movie 1', Type: 'Movie' },
+            { Id: 'show-1', Name: 'Show 1', Type: 'Series' },
+          ],
+        },
+      });
+
+      jellyfinApiMocks.getItems.mockImplementation(
+        ({ ids }: { ids?: string[]; parentId?: string }) => {
+          if (ids?.[0] === 'movie-1') {
+            return Promise.resolve({
+              data: {
+                Items: [
+                  {
+                    Id: 'movie-1',
+                    Name: 'Movie 1',
+                    Type: 'Movie',
+                    DateCreated: '2024-01-01T00:00:00.000Z',
+                    ProviderIds: { Tmdb: '10' },
+                    Path: '/media/movie-1.mkv',
+                  },
+                ],
+              },
+            });
+          }
+
+          if (ids?.[0] === 'show-1') {
+            return Promise.resolve({
+              data: {
+                Items: [
+                  {
+                    Id: 'show-1',
+                    Name: 'Show 1',
+                    Type: 'Series',
+                    DateCreated: '2024-02-01T00:00:00.000Z',
+                    ProviderIds: { Tvdb: '20' },
+                    Path: '/media/show-1',
+                  },
+                ],
+              },
+            });
+          }
+
+          return Promise.resolve({ data: { Items: [] } });
+        },
+      );
+
+      const results = await service.searchContent('test');
+
+      expect(results).toHaveLength(2);
+      expect(results[0].providerIds.tmdb).toEqual(['10']);
+      expect(results[1].providerIds.tvdb).toEqual(['20']);
+      expect(results[0].addedAt).toEqual(new Date('2024-01-01T00:00:00.000Z'));
+      expect(results[1].addedAt).toEqual(new Date('2024-02-01T00:00:00.000Z'));
+      expect(results[0].addedAt).toBeInstanceOf(Date);
     });
   });
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -279,6 +279,84 @@ describe('JellyfinAdapterService', () => {
     );
   });
 
+  describe('getCollections', () => {
+    beforeEach(async () => {
+      settingsService.getSettings.mockResolvedValue({
+        ...mockSettings,
+        jellyfin_user_id: 'user-1',
+      } as unknown as Awaited<ReturnType<SettingsService['getSettings']>>);
+      await service.initialize();
+    });
+
+    it('filters collections to the requested library', async () => {
+      jellyfinApiMocks.getItems.mockImplementation(
+        (params: { parentId?: string; ids?: string[] }) => {
+          if (!params.parentId && !params.ids) {
+            return Promise.resolve({
+              data: {
+                Items: [
+                  {
+                    Id: 'collection-in-lib',
+                    Name: 'In Library',
+                    Type: 'BoxSet',
+                    ParentId: 'lib123',
+                    ChildCount: 1,
+                  },
+                  {
+                    Id: 'collection-other-lib',
+                    Name: 'Other Library',
+                    Type: 'BoxSet',
+                    ParentId: 'lib999',
+                    ChildCount: 1,
+                  },
+                ],
+              },
+            });
+          }
+
+          if (params.parentId === 'collection-in-lib') {
+            return Promise.resolve({
+              data: {
+                Items: [
+                  {
+                    Id: 'movie-1',
+                    Name: 'Movie 1',
+                    Type: 'Movie',
+                    ParentId: 'lib123',
+                    DateCreated: '2024-01-01T00:00:00.000Z',
+                  },
+                ],
+              },
+            });
+          }
+
+          if (params.parentId === 'collection-other-lib') {
+            return Promise.resolve({
+              data: {
+                Items: [
+                  {
+                    Id: 'movie-2',
+                    Name: 'Movie 2',
+                    Type: 'Movie',
+                    ParentId: 'lib999',
+                    DateCreated: '2024-01-01T00:00:00.000Z',
+                  },
+                ],
+              },
+            });
+          }
+
+          return Promise.resolve({ data: { Items: [] } });
+        },
+      );
+
+      const collections = await service.getCollections('lib123');
+
+      expect(collections).toHaveLength(1);
+      expect(collections[0].id).toBe('collection-in-lib');
+    });
+  });
+
   describe('getWatchHistory', () => {
     beforeEach(async () => {
       settingsService.getSettings.mockResolvedValue(

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -643,18 +643,15 @@ export class JellyfinAdapterService implements IMediaServerService {
         includeArtists: false,
       });
 
-      return (response.data.SearchHints || [])
-        .filter((hint) => hint.Id)
-        .map((hint) => ({
-          id: hint.Id || '',
-          title: hint.Name || '',
-          type: JellyfinMapper.toMediaItemType(hint.Type),
-          guid: hint.Id || '',
-          addedAt: new Date(),
-          providerIds: {},
-          mediaSources: [],
-          library: { id: '', title: '' },
-        })) as MediaItem[];
+      const hints = (response.data.SearchHints || []).filter(
+        (hint): hint is typeof hint & { Id: string } => Boolean(hint.Id),
+      );
+
+      const items = await Promise.all(
+        hints.map((hint) => this.getMetadata(hint.Id)),
+      );
+
+      return items.filter((item): item is MediaItem => item !== undefined);
     } catch (error) {
       this.logger.error('Failed to search Jellyfin content', error);
       return [];

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -869,7 +869,56 @@ export class JellyfinAdapterService implements IMediaServerService {
         ],
       });
 
-      return (response.data.Items || []).map(JellyfinMapper.toMediaCollection);
+      const collections = (response.data.Items || []).map(
+        JellyfinMapper.toMediaCollection,
+      );
+
+      const seriesLibraryCache = new Map<string, Promise<boolean>>();
+
+      const belongsToLibrary = async (item: MediaItem): Promise<boolean> => {
+        if (item.library.id === libraryId) {
+          return true;
+        }
+
+        if (item.type !== 'episode' || !item.grandparentId) {
+          return false;
+        }
+
+        let isMatchingSeries = seriesLibraryCache.get(item.grandparentId);
+        if (!isMatchingSeries) {
+          isMatchingSeries = this.getMetadata(item.grandparentId).then(
+            (seriesMetadata) => seriesMetadata?.library.id === libraryId,
+          );
+          seriesLibraryCache.set(item.grandparentId, isMatchingSeries);
+        }
+
+        return isMatchingSeries;
+      };
+
+      const filteredCollections = await Promise.all(
+        collections.map(async (collection) => {
+          if (collection.libraryId === libraryId) {
+            return collection;
+          }
+
+          const children = await this.getCollectionChildren(collection.id);
+          if (children.length === 0) {
+            return null;
+          }
+
+          for (const child of children) {
+            if (await belongsToLibrary(child)) {
+              return collection;
+            }
+          }
+
+          return null;
+        }),
+      );
+
+      return filteredCollections.filter(
+        (collection): collection is MediaCollection => collection !== null,
+      );
     } catch (error) {
       this.logger.error(`Failed to get collections for ${libraryId}`, error);
       return [];

--- a/apps/server/src/modules/api/media-server/media-server.factory.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-server.factory.spec.ts
@@ -81,12 +81,36 @@ describe('MediaServerFactory', () => {
     settingsService.getSettings.mockResolvedValue(
       createSettings({ media_server_type: MediaServerType.JELLYFIN }),
     );
-    jellyfinAdapter.isSetup.mockReturnValue(false);
+    jellyfinAdapter.isSetup
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
 
     const service = await factory.getService();
 
     expect(jellyfinAdapter.initialize).toHaveBeenCalledTimes(1);
     expect(service).toBe(jellyfinAdapter);
+  });
+
+  it('throws when Jellyfin remains uninitialized after initialize', async () => {
+    settingsService.getSettings.mockResolvedValue(
+      createSettings({ media_server_type: MediaServerType.JELLYFIN }),
+    );
+    jellyfinAdapter.isSetup.mockReturnValue(false);
+
+    await expect(factory.getService()).rejects.toBeInstanceOf(
+      ServiceUnavailableException,
+    );
+  });
+
+  it('throws when Plex remains uninitialized after initialize', async () => {
+    settingsService.getSettings.mockResolvedValue(
+      createSettings({ media_server_type: MediaServerType.PLEX }),
+    );
+    plexAdapter.isSetup.mockReturnValue(false);
+
+    await expect(factory.getService()).rejects.toBeInstanceOf(
+      ServiceUnavailableException,
+    );
   });
 
   it('returns Plex adapter without initialization if already setup', async () => {

--- a/apps/server/src/modules/api/media-server/media-server.factory.ts
+++ b/apps/server/src/modules/api/media-server/media-server.factory.ts
@@ -93,16 +93,13 @@ export class MediaServerFactory {
   ): Promise<IMediaServerService> {
     switch (serverType) {
       case MediaServerType.JELLYFIN:
-        if (!this.jellyfinAdapter.isSetup()) {
-          await this.jellyfinAdapter.initialize();
-        }
-        return this.jellyfinAdapter;
+        return await this.ensureAdapterReady(
+          serverType,
+          this.jellyfinAdapter,
+        );
 
       case MediaServerType.PLEX:
-        if (!this.plexAdapter.isSetup()) {
-          await this.plexAdapter.initialize();
-        }
-        return this.plexAdapter;
+        return await this.ensureAdapterReady(serverType, this.plexAdapter);
 
       default:
         throw new Error(`Unsupported media server type: ${serverType}`);
@@ -197,5 +194,22 @@ export class MediaServerFactory {
 
     // Both configured or neither configured - can't infer
     return null;
+  }
+
+  private async ensureAdapterReady(
+    serverType: MediaServerType,
+    adapter: IMediaServerService,
+  ): Promise<IMediaServerService> {
+    if (!adapter.isSetup()) {
+      await adapter.initialize();
+    }
+
+    if (!adapter.isSetup()) {
+      throw new ServiceUnavailableException(
+        `${serverType} adapter failed to initialize`,
+      );
+    }
+
+    return adapter;
   }
 }

--- a/apps/server/src/modules/collections/collections.controller.ts
+++ b/apps/server/src/modules/collections/collections.controller.ts
@@ -12,13 +12,31 @@ import {
   Put,
   Query,
 } from '@nestjs/common';
+import { ZodValidationPipe } from 'nestjs-zod';
+import { z } from 'zod';
+import { MaintainerrLogger } from '../logging/logs.service';
 import { CollectionWorkerService } from './collection-worker.service';
+import {
+  addToCollectionRequestSchema,
+  createCollectionRequestSchema,
+  removeCollectionRequestSchema,
+  removeFromCollectionRequestSchema,
+  updateCollectionRequestSchema,
+} from './collections.schemas';
 import { CollectionsService } from './collections.service';
 import {
   AddRemoveCollectionMedia,
   IAlterableMediaDto,
 } from './interfaces/collection-media.interface';
-import { MaintainerrLogger } from '../logging/logs.service';
+import { ICollection } from './interfaces/collection.interface';
+
+type CreateCollectionRequest = z.infer<typeof createCollectionRequestSchema>;
+type AddToCollectionRequest = z.infer<typeof addToCollectionRequestSchema>;
+type RemoveFromCollectionRequest = z.infer<
+  typeof removeFromCollectionRequestSchema
+>;
+type RemoveCollectionRequest = z.infer<typeof removeCollectionRequestSchema>;
+type UpdateCollectionRequest = z.infer<typeof updateCollectionRequestSchema>;
 
 @Controller('api/collections')
 export class CollectionsController {
@@ -30,42 +48,50 @@ export class CollectionsController {
     this.logger.setContext(CollectionsController.name);
   }
   @Post()
-  async createCollection(@Body() request: any) {
+  async createCollection(
+    @Body(new ZodValidationPipe(createCollectionRequestSchema))
+    request: CreateCollectionRequest,
+  ) {
     await this.collectionService.createCollectionWithChildren(
-      request.collection,
-      request.media,
+      request.collection as ICollection,
+      request.media as AddRemoveCollectionMedia[] | undefined,
     );
   }
   @Post('/add')
   async addToCollection(
-    @Body()
-    request: {
-      collectionId: number;
-      media: AddRemoveCollectionMedia[];
-      manual?: boolean;
-    },
+    @Body(new ZodValidationPipe(addToCollectionRequestSchema))
+    request: AddToCollectionRequest,
   ) {
     await this.collectionService.addToCollection(
       request.collectionId,
-      request.media,
+      request.media as AddRemoveCollectionMedia[],
       request.manual ? request.manual : false,
     );
   }
   @Post('/remove')
-  async removeFromCollection(@Body() request: any) {
+  async removeFromCollection(
+    @Body(new ZodValidationPipe(removeFromCollectionRequestSchema))
+    request: RemoveFromCollectionRequest,
+  ) {
     await this.collectionService.removeFromCollection(
       request.collectionId,
-      request.media,
+      request.media as AddRemoveCollectionMedia[],
     );
   }
   @Post('/removeCollection')
-  removeCollection(@Body() request: any) {
+  removeCollection(
+    @Body(new ZodValidationPipe(removeCollectionRequestSchema))
+    request: RemoveCollectionRequest,
+  ) {
     return this.collectionService.deleteCollection(request.collectionId);
   }
 
   @Put()
-  updateCollection(@Body() request: any) {
-    return this.collectionService.updateCollection(request);
+  updateCollection(
+    @Body(new ZodValidationPipe(updateCollectionRequestSchema))
+    request: UpdateCollectionRequest,
+  ) {
+    return this.collectionService.updateCollection(request as ICollection);
   }
 
   @Post('/handle')

--- a/apps/server/src/modules/collections/collections.schemas.ts
+++ b/apps/server/src/modules/collections/collections.schemas.ts
@@ -1,0 +1,57 @@
+import { MediaServerType, ServarrAction } from '@maintainerr/contracts';
+import { z } from 'zod';
+
+const mediaItemTypeSchema = z.enum(['movie', 'show', 'season', 'episode']);
+
+const addRemoveCollectionMediaSchema = z.object({
+  mediaServerId: z.string().min(1),
+  reason: z.unknown().optional(),
+});
+
+const collectionSchema = z.object({
+  id: z.number().int().positive().optional(),
+  type: mediaItemTypeSchema,
+  mediaServerId: z.string().min(1).nullable().optional(),
+  mediaServerType: z.nativeEnum(MediaServerType).nullable().optional(),
+  libraryId: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  isActive: z.boolean(),
+  arrAction: z.nativeEnum(ServarrAction),
+  visibleOnRecommended: z.boolean().optional(),
+  visibleOnHome: z.boolean().optional(),
+  listExclusions: z.boolean().optional(),
+  forceSeerr: z.boolean().optional(),
+  deleteAfterDays: z.number().int().nonnegative().optional(),
+  manualCollection: z.boolean().optional(),
+  manualCollectionName: z.string().optional(),
+  keepLogsForMonths: z.number().int().nonnegative().optional(),
+  tautulliWatchedPercentOverride: z.number().int().nonnegative().optional(),
+  radarrSettingsId: z.number().int().positive().optional(),
+  sonarrSettingsId: z.number().int().positive().optional(),
+  sortTitle: z.string().optional(),
+});
+
+export const createCollectionRequestSchema = z.object({
+  collection: collectionSchema,
+  media: z.array(addRemoveCollectionMediaSchema).optional(),
+});
+
+export const addToCollectionRequestSchema = z.object({
+  collectionId: z.number().int().positive(),
+  media: z.array(addRemoveCollectionMediaSchema),
+  manual: z.boolean().optional(),
+});
+
+export const removeFromCollectionRequestSchema = z.object({
+  collectionId: z.number().int().positive(),
+  media: z.array(addRemoveCollectionMediaSchema),
+});
+
+export const removeCollectionRequestSchema = z.object({
+  collectionId: z.number().int().positive(),
+});
+
+export const updateCollectionRequestSchema = collectionSchema.extend({
+  id: z.number().int().positive(),
+});

--- a/apps/server/src/modules/settings/settings.service.spec.ts
+++ b/apps/server/src/modules/settings/settings.service.spec.ts
@@ -1,0 +1,127 @@
+import {
+  MediaServerType,
+  MetadataProviderPreference,
+} from '@maintainerr/contracts';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Repository } from 'typeorm';
+import { InternalApiService } from '../api/internal-api/internal-api.service';
+import { MediaServerFactory } from '../api/media-server/media-server.factory';
+import { PlexApiService } from '../api/plex-api/plex-api.service';
+import { SeerrApiService } from '../api/seerr-api/seerr-api.service';
+import { ServarrService } from '../api/servarr-api/servarr.service';
+import { TautulliApiService } from '../api/tautulli-api/tautulli-api.service';
+import { TmdbApiService } from '../api/tmdb-api/tmdb.service';
+import { TvdbApiService } from '../api/tvdb-api/tvdb.service';
+import { MaintainerrLogger } from '../logging/logs.service';
+import { RadarrSettings } from './entities/radarr_settings.entities';
+import { Settings } from './entities/settings.entities';
+import { SonarrSettings } from './entities/sonarr_settings.entities';
+import { SettingsService } from './settings.service';
+
+describe('SettingsService', () => {
+  let service: SettingsService;
+
+  const plexApi = {} as jest.Mocked<PlexApiService>;
+  const mediaServerFactory = {} as jest.Mocked<MediaServerFactory>;
+  const servarr = {} as jest.Mocked<ServarrService>;
+  const seerr = {} as jest.Mocked<SeerrApiService>;
+  const tautulli = {} as jest.Mocked<TautulliApiService>;
+  const tmdbApi = {} as jest.Mocked<TmdbApiService>;
+  const tvdbApi = {} as jest.Mocked<TvdbApiService>;
+  const internalApi = {} as jest.Mocked<InternalApiService>;
+  const eventEmitter = {} as jest.Mocked<EventEmitter2>;
+  const logger = {
+    setContext: jest.fn(),
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as jest.Mocked<MaintainerrLogger>;
+
+  const settingsRepo = {
+    findOne: jest.fn(),
+    update: jest.fn(),
+    insert: jest.fn(),
+  } as unknown as jest.Mocked<Repository<Settings>>;
+
+  const radarrSettingsRepo = {} as jest.Mocked<Repository<RadarrSettings>>;
+  const sonarrSettingsRepo = {} as jest.Mocked<Repository<SonarrSettings>>;
+
+  const createSettings = (overrides: Partial<Settings> = {}): Settings =>
+    Object.assign(new Settings(), {
+      id: 1,
+      clientId: 'client-1',
+      applicationTitle: 'Maintainerr',
+      applicationUrl: 'http://localhost',
+      apikey: 'key',
+      locale: 'en',
+      metadata_provider_preference: MetadataProviderPreference.TMDB_PRIMARY,
+      media_server_type: null,
+      plex_name: null,
+      plex_hostname: null,
+      plex_port: null,
+      plex_ssl: null,
+      plex_auth_token: null,
+      jellyfin_url: null,
+      jellyfin_api_key: null,
+      jellyfin_user_id: null,
+      jellyfin_server_name: null,
+      collection_handler_job_cron: '0 0-23/12 * * *',
+      rules_handler_job_cron: '0 0-23/8 * * *',
+      ...overrides,
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new SettingsService(
+      plexApi,
+      mediaServerFactory,
+      servarr,
+      seerr,
+      tautulli,
+      tmdbApi,
+      tvdbApi,
+      internalApi,
+      settingsRepo,
+      radarrSettingsRepo,
+      sonarrSettingsRepo,
+      eventEmitter,
+      logger,
+    );
+  });
+
+  it('does not auto-select a media server when Plex and Jellyfin are both configured', async () => {
+    settingsRepo.findOne.mockResolvedValue(
+      createSettings({
+        jellyfin_url: 'http://jellyfin.local:8096',
+        jellyfin_api_key: 'jf-key',
+        plex_hostname: 'plex.local',
+        plex_name: 'Plex',
+        plex_port: 32400,
+        plex_auth_token: 'plex-token',
+      }),
+    );
+
+    await service.init();
+
+    expect(service.getMediaServerType()).toBeNull();
+    expect(settingsRepo.update).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('still auto-selects Jellyfin when only Jellyfin is configured', async () => {
+    settingsRepo.findOne.mockResolvedValue(
+      createSettings({
+        jellyfin_url: 'http://jellyfin.local:8096',
+        jellyfin_api_key: 'jf-key',
+      }),
+    );
+
+    await service.init();
+
+    expect(service.getMediaServerType()).toBe(MediaServerType.JELLYFIN);
+    expect(settingsRepo.update).toHaveBeenCalledWith(
+      { id: 1 },
+      { media_server_type: MediaServerType.JELLYFIN },
+    );
+  });
+});

--- a/apps/server/src/modules/settings/settings.service.ts
+++ b/apps/server/src/modules/settings/settings.service.ts
@@ -163,7 +163,21 @@ export class SettingsService implements SettingDto {
       // This handles upgrades from pre-Jellyfin versions (Plex) and any future
       // scenario where media_server_type is missing but a server is configured.
       if (!this.media_server_type) {
-        if (this.jellyfin_api_key) {
+        const jellyfinConfigured = Boolean(
+          this.jellyfin_url && this.jellyfin_api_key,
+        );
+        const plexConfigured = Boolean(
+          this.plex_hostname &&
+          this.plex_name &&
+          this.plex_port &&
+          this.plex_auth_token,
+        );
+
+        if (jellyfinConfigured && plexConfigured) {
+          this.logger.warn(
+            'Detected both Plex and Jellyfin configuration without media_server_type set. Leaving media server type unset until the user makes an explicit selection.',
+          );
+        } else if (jellyfinConfigured) {
           this.logger.log(
             'Detected existing Jellyfin configuration without media_server_type set. Setting to jellyfin.',
           );
@@ -172,7 +186,7 @@ export class SettingsService implements SettingDto {
             { id: this.id },
             { media_server_type: MediaServerType.JELLYFIN },
           );
-        } else if (this.plex_auth_token) {
+        } else if (plexConfigured) {
           this.logger.log(
             'Detected existing Plex configuration without media_server_type set. Setting to plex.',
           );


### PR DESCRIPTION
### Why

This branch started as a fix for a few Jellyfin stability issues, then was extended to close the still-valid gaps that remained after the Jellyfin merge into 3.0.

### What this PR fixes

- scopes Jellyfin collection lookup to the requested library instead of returning cross-library collections
- validates collection endpoint payloads with Zod before they reach the service layer
- avoids implicitly selecting a media server when both Plex and Jellyfin are configured without an explicit `media_server_type`
- makes Jellyfin search results hydrate through real metadata instead of returning fabricated partial media items
- fails fast when a media server adapter still is not set up after `initialize()` instead of returning a broken adapter
- adds focused regression coverage for the affected Jellyfin and factory behaviors

### Why this is better

This makes Jellyfin behavior more predictable in the places that matter most:

- collection operations stay library-correct
- invalid collection requests fail at the API boundary
- mixed Plex/Jellyfin configs no longer produce unsafe implicit selection
- search results now carry real provider IDs and metadata instead of placeholders
- adapter startup failures surface immediately instead of leaking into later request handling

### Validation

- targeted Jellyfin adapter and media server factory specs passed
- full server test suite passed: 39 suites, 651 tests

This PR targets `jellyfin-dev` and is intended to be the final Jellyfin hardening pass for the remaining verified issues in that branch line.