### PR TITLE
fix: preserve Plex IMDb rule evaluation behavior

### DIFF
--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -1,0 +1,60 @@
+import { Mocked, TestBed } from '@suites/unit';
+import { SettingsService } from '../../settings/settings.service';
+import { MaintainerrLoggerFactory } from '../../logging/logs.service';
+import { PlexApiService } from './plex-api.service';
+
+describe('PlexApiService.getMetadata', () => {
+  let service: PlexApiService;
+  let settingsService: Mocked<SettingsService>;
+  let loggerFactory: Mocked<MaintainerrLoggerFactory>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(PlexApiService).compile();
+
+    service = unit;
+    settingsService = unitRef.get(SettingsService);
+    loggerFactory = unitRef.get(MaintainerrLoggerFactory);
+
+    settingsService.plex_hostname = 'plex.local';
+    settingsService.plex_port = 32400;
+    settingsService.plex_ssl = 0;
+    settingsService.plex_auth_token = 'token';
+    loggerFactory.createLogger.mockReturnValue({
+      setContext: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as any);
+  });
+
+  it('requests external media enrichment when includeExternalMedia is enabled', async () => {
+    const query = jest.fn().mockResolvedValue({
+      MediaContainer: { Metadata: [{ ratingKey: '123' }] },
+    });
+
+    (service as any).plexClient = { query };
+
+    await service.getMetadata('123', { includeExternalMedia: true });
+
+    expect(query).toHaveBeenCalledWith(
+      '/library/metadata/123?includeExternalMedia=1&asyncAugmentMetadata=1',
+      true,
+    );
+  });
+
+  it('preserves includeChildren queries while requesting external media enrichment', async () => {
+    const query = jest.fn().mockResolvedValue({
+      MediaContainer: { Metadata: [{ ratingKey: '123' }] },
+    });
+
+    (service as any).plexClient = { query };
+
+    await service.getMetadata('123', { includeChildren: true });
+
+    expect(query).toHaveBeenCalledWith(
+      '/library/metadata/123?includeChildren=1&includeExternalMedia=1&asyncAugmentMetadata=1',
+      true,
+    );
+  });
+});

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -311,16 +311,22 @@ export class PlexApiService {
 
   public async getMetadata(
     key: string,
-    options: { includeChildren?: boolean } = {},
+    options: { includeChildren?: boolean; includeExternalMedia?: boolean } = {},
     useCache: boolean = true,
   ): Promise<PlexMetadata> {
     try {
+      const queryParams: string[] = [];
+
+      if (options.includeChildren) {
+        queryParams.push('includeChildren=1');
+      }
+
+      if (options.includeChildren || options.includeExternalMedia) {
+        queryParams.push('includeExternalMedia=1', 'asyncAugmentMetadata=1');
+      }
+
       const response = await this.plexClient.query<PlexMetadataResponse>(
-        `/library/metadata/${key}${
-          options.includeChildren
-            ? '?includeChildren=1&includeExternalMedia=1&asyncAugmentMetadata=1&asyncCheckFiles=1&asyncRefreshAnalysis=1'
-            : ''
-        }`,
+        `/library/metadata/${key}${queryParams.length > 0 ? `?${queryParams.join('&')}` : ''}`,
         useCache,
       );
       if (response) {

--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -1,0 +1,134 @@
+import { MediaItem, MediaItemType } from '@maintainerr/contracts';
+import { Mocked, TestBed } from '@suites/unit';
+import { createRulesDto } from '../../../../test/utils/data';
+import { PlexApiService } from '../../api/plex-api/plex-api.service';
+import { PlexGetterService } from './plex-getter.service';
+
+const createMediaItem = (overrides: Partial<MediaItem> = {}): MediaItem => ({
+  id: 'plex-item-123',
+  title: 'Test Movie',
+  type: 'movie' as MediaItemType,
+  guid: 'plex-guid-123',
+  addedAt: new Date('2024-01-15'),
+  providerIds: { tmdb: ['12345'], imdb: ['tt1234567'] },
+  mediaSources: [
+    {
+      id: 'source-1',
+      duration: 7200000,
+      bitrate: 8000000,
+      videoCodec: 'h264',
+      videoResolution: '1080p',
+      width: 1920,
+      height: 1080,
+    },
+  ],
+  library: { id: 'lib-1', title: 'Movies' },
+  genres: [{ name: 'Action' }],
+  actors: [{ name: 'Actor One' }],
+  labels: ['tag1'],
+  originallyAvailableAt: new Date('2024-01-01'),
+  ratings: [],
+  ...overrides,
+});
+
+describe('PlexGetterService', () => {
+  let plexGetterService: PlexGetterService;
+  let plexApi: Mocked<PlexApiService>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(PlexGetterService).compile();
+
+    plexGetterService = unit;
+    plexApi = unitRef.get(PlexApiService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requests external media metadata for IMDb ratings', async () => {
+    const mediaItem = createMediaItem();
+
+    plexApi.getMetadata.mockResolvedValue({
+      ratingKey: 'plex-item-123',
+      type: 'movie',
+      title: 'Test Movie',
+      Guid: [],
+      index: 1,
+      leafCount: 0,
+      viewedLeafCount: 0,
+      addedAt: 1,
+      updatedAt: 1,
+      guid: 'guid',
+      Media: [],
+      originallyAvailableAt: '2024-01-01',
+      Rating: [{ image: 'imdb://image.rating', type: 'audience', value: 7.8 }],
+    } as any);
+
+    const result = await plexGetterService.get(
+      31,
+      mediaItem,
+      'movie',
+      createRulesDto({ dataType: 'movie' }),
+    );
+
+    expect(result).toBe(7.8);
+    expect(plexApi.getMetadata).toHaveBeenCalledWith('plex-item-123', {
+      includeExternalMedia: true,
+    });
+  });
+
+  it('requests external media metadata for show IMDb ratings', async () => {
+    const mediaItem = createMediaItem({ type: 'episode' });
+
+    plexApi.getMetadata
+      .mockResolvedValueOnce({
+        ratingKey: 'plex-item-123',
+        type: 'episode',
+        title: 'Episode 1',
+        Guid: [],
+        index: 1,
+        leafCount: 0,
+        viewedLeafCount: 0,
+        addedAt: 1,
+        updatedAt: 1,
+        guid: 'guid',
+        Media: [],
+        originallyAvailableAt: '2024-01-01',
+        grandparentRatingKey: 'show-1',
+      } as any)
+      .mockResolvedValueOnce({
+        ratingKey: 'show-1',
+        type: 'show',
+        title: 'Test Show',
+        Guid: [],
+        index: 1,
+        leafCount: 0,
+        viewedLeafCount: 0,
+        addedAt: 1,
+        updatedAt: 1,
+        guid: 'guid-show',
+        Media: [],
+        originallyAvailableAt: '2024-01-01',
+        Rating: [
+          { image: 'imdb://image.rating', type: 'audience', value: 8.2 },
+        ],
+      } as any);
+
+    const result = await plexGetterService.get(
+      35,
+      mediaItem,
+      'episode',
+      createRulesDto({ dataType: 'show' }),
+    );
+
+    expect(result).toBe(8.2);
+    expect(plexApi.getMetadata).toHaveBeenNthCalledWith(1, 'plex-item-123', {
+      includeExternalMedia: true,
+    });
+    expect(plexApi.getMetadata).toHaveBeenNthCalledWith(2, 'show-1', {
+      includeExternalMedia: true,
+    });
+  });
+});

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -22,6 +22,7 @@ import { buildCollectionExcludeNames } from '../helpers/collection-exclude.helpe
 @Injectable()
 export class PlexGetterService {
   plexProperties: Property[];
+  private readonly metadataRequestOptions = { includeExternalMedia: true };
 
   constructor(
     private readonly plexApi: PlexApiService,
@@ -45,14 +46,20 @@ export class PlexGetterService {
 
       // fetch metadata, parent & grandparent from cache, this data is more complete
       // libItem.id maps to Plex's ratingKey
-      const metadata: PlexMetadata = await this.plexApi.getMetadata(libItem.id);
+      const metadata: PlexMetadata = await this.plexApi.getMetadata(
+        libItem.id,
+        this.metadataRequestOptions,
+      );
 
       // Parent/grandparent metadata is only needed for some properties.
       // Lazy-load and memoize so we don't fetch unless a case uses it.
       let parentPromise: Promise<PlexMetadata> | undefined;
       const getParent = async (): Promise<PlexMetadata | undefined> => {
         if (!metadata?.parentRatingKey) return undefined;
-        parentPromise ??= this.plexApi.getMetadata(metadata.parentRatingKey);
+        parentPromise ??= this.plexApi.getMetadata(
+          metadata.parentRatingKey,
+          this.metadataRequestOptions,
+        );
         return parentPromise;
       };
 
@@ -61,6 +68,7 @@ export class PlexGetterService {
         if (!metadata?.grandparentRatingKey) return undefined;
         grandparentPromise ??= this.plexApi.getMetadata(
           metadata.grandparentRatingKey,
+          this.metadataRequestOptions,
         );
         return grandparentPromise;
       };

--- a/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -210,7 +210,10 @@ export class RuleComparatorService {
       );
       this.abortSignal?.throwIfAborted();
 
-      if (firstVal != null && secondVal != null) {
+      const shouldCompare =
+        firstVal != null && (secondVal != null || rule.lastVal != null);
+
+      if (shouldCompare) {
         // do action
         const comparisonResult = this.doRuleAction(
           firstVal,
@@ -242,6 +245,14 @@ export class RuleComparatorService {
             this.workerData.splice(i, 1);
             this.workerIds.delete(mediaId);
           }
+        }
+      } else {
+        this.logMissingOperand(rule, mediaId, firstVal, secondVal);
+        this.addStatistictoParent(rule, firstVal, secondVal, mediaId, false);
+
+        if (+rule.operator === +RuleOperators.AND) {
+          this.workerData.splice(i, 1);
+          this.workerIds.delete(mediaId);
         }
       }
     }
@@ -358,6 +369,30 @@ export class RuleComparatorService {
       secondValue: secondVal,
       result: result,
     });
+  }
+
+  private logMissingOperand(
+    rule: RuleDto,
+    mediaId: string,
+    firstVal: RuleValueType,
+    secondVal: RuleValueType,
+  ): void {
+    const firstValueName = this.ruleConstanstService.getValueHumanName(
+      rule.firstVal,
+    );
+
+    this.logger.warn(
+      `Skipping rule comparison due to missing operand: ` +
+        `mediaId=${mediaId}, action=${RulePossibility[rule.action]}, ` +
+        `firstValueName=${firstValueName}, firstValue=${JSON.stringify(firstVal)}, ` +
+        `secondValueName=${this.getSecondValueName(rule)}, secondValue=${JSON.stringify(secondVal)}`,
+    );
+  }
+
+  private getSecondValueName(rule: RuleDto): string {
+    return rule.lastVal
+      ? this.ruleConstanstService.getValueHumanName(rule.lastVal)
+      : this.ruleConstanstService.getCustomValueIdentifier(rule.customVal).type;
   }
 
   private handleSectionAction(sectionActionAnd: boolean) {

--- a/apps/server/src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts
+++ b/apps/server/src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts
@@ -1,0 +1,155 @@
+import { Mocked, TestBed } from '@suites/unit';
+import { createMediaItem, createRulesDto } from '../../../../test/utils/data';
+import { MaintainerrLogger } from '../../logging/logs.service';
+import { RuleConstanstService } from '../constants/constants.service';
+import {
+  Application,
+  RulePossibility,
+  RuleType,
+} from '../constants/rules.constants';
+import { RuleDto } from '../dtos/rule.dto';
+import { RuleDbDto } from '../dtos/ruleDb.dto';
+import { ValueGetterService } from '../getter/getter.service';
+import { RuleComparatorService } from '../helpers/rule.comparator.service';
+
+const createStoredRule = (
+  id: number,
+  rule: RuleDto,
+  section = 0,
+): RuleDbDto => ({
+  id,
+  isActive: true,
+  ruleGroupId: 1,
+  ruleJson: JSON.stringify(rule),
+  section,
+});
+
+describe('RuleComparatorService.executeRulesWithData', () => {
+  let ruleComparatorService: RuleComparatorService;
+  let valueGetterService: Mocked<ValueGetterService>;
+  let ruleConstanstService: Mocked<RuleConstanstService>;
+  let logger: Mocked<MaintainerrLogger>;
+
+  const createSingleMedia = () =>
+    createMediaItem({ id: 'media-1', type: 'movie' as const });
+
+  const mockGetterSequence = (...values: unknown[]) => {
+    valueGetterService.get.mockReset();
+    values.forEach((value) => {
+      valueGetterService.get.mockResolvedValueOnce(value as never);
+    });
+  };
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(
+      RuleComparatorService,
+    ).compile();
+
+    ruleComparatorService = unit;
+    valueGetterService = unitRef.get(ValueGetterService);
+    ruleConstanstService = unitRef.get(RuleConstanstService);
+    logger = unitRef.get(MaintainerrLogger);
+
+    ruleConstanstService.getValueHumanName.mockReturnValue(
+      'Plex - IMDb rating (scale 1-10)',
+    );
+    ruleConstanstService.getCustomValueIdentifier.mockReturnValue({
+      type: 'number',
+      value: 6,
+    });
+  });
+
+  it('fails closed when the first value is missing for a custom comparison', async () => {
+    const mediaItem = createSingleMedia();
+    const rules = [
+      createStoredRule(1, {
+        operator: null,
+        action: RulePossibility.SMALLER,
+        firstVal: [Application.PLEX, 31],
+        customVal: { ruleTypeId: +RuleType.NUMBER, value: '6' },
+        section: 0,
+      }),
+    ];
+
+    mockGetterSequence(null);
+
+    const result = await ruleComparatorService.executeRulesWithData(
+      createRulesDto({ dataType: 'movie', rules }),
+      [mediaItem],
+    );
+
+    expect(result.data).toEqual([]);
+    expect(result.stats[0].result).toBe(false);
+    expect(result.stats[0].sectionResults[0].ruleResults[0]).toMatchObject({
+      action: 'smaller',
+      firstValue: null,
+      secondValue: 6,
+      result: false,
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Skipping rule comparison due to missing operand',
+      ),
+    );
+  });
+
+  it('preserves 3.1.0 numeric lastVal behavior when the second value is missing', async () => {
+    const mediaItem = createSingleMedia();
+    const rules = [
+      createStoredRule(1, {
+        operator: null,
+        action: RulePossibility.BIGGER,
+        firstVal: [Application.PLEX, 5],
+        lastVal: [Application.PLEX, 6],
+        section: 0,
+      }),
+    ];
+
+    mockGetterSequence(10, null);
+
+    const result = await ruleComparatorService.executeRulesWithData(
+      createRulesDto({ dataType: 'movie', rules }),
+      [mediaItem],
+    );
+
+    expect(result.data).toHaveLength(1);
+    expect(result.stats[0].result).toBe(true);
+    expect(result.stats[0].sectionResults[0].result).toBe(true);
+    expect(result.stats[0].sectionResults[0].ruleResults[0]).toMatchObject({
+      action: 'bigger',
+      firstValue: 10,
+      secondValue: null,
+      result: true,
+    });
+  });
+
+  it('preserves 3.1.0 text lastVal behavior when the second value is missing', async () => {
+    const mediaItem = createSingleMedia();
+    const rules = [
+      createStoredRule(1, {
+        operator: null,
+        action: RulePossibility.NOT_CONTAINS,
+        firstVal: [Application.PLEX, 8],
+        lastVal: [Application.PLEX, 10],
+        section: 0,
+      }),
+    ];
+
+    mockGetterSequence('HEVC 1080p', null);
+
+    const result = await ruleComparatorService.executeRulesWithData(
+      createRulesDto({ dataType: 'movie', rules }),
+      [mediaItem],
+    );
+
+    expect(result.data).toHaveLength(1);
+    expect(result.stats[0].result).toBe(true);
+    expect(result.stats[0].sectionResults[0].result).toBe(true);
+    expect(result.stats[0].sectionResults[0].ruleResults[0]).toMatchObject({
+      action: 'not_contains',
+      firstValue: 'HEVC 1080p',
+      secondValue: null,
+      result: true,
+    });
+  });
+});


### PR DESCRIPTION
## What this changes
This PR fixes Plex IMDb rules so they behave more reliably when you test or run rules.

In short:
- Maintainerr now asks Plex for the extra metadata needed to read IMDb ratings
- it does that for the item itself, and also for parent or grandparent items when needed
- rule comparisons are stricter when the main value is missing, so we do not get false matches from `null` values
- at the same time, it keeps the older behavior that avoided a separate set of regressions in `3.2.0`

## Why this was needed
There were really two problems mixed together:

1. Plex was sometimes not returning the IMDb rating in the metadata we were using for rule evaluation.
2. A null-handling fix stopped one bad result, but the broader version of that fix also changed other rule behavior compared with `3.1.0`.

This PR fixes both without adding extra load to the users Plex server.

## What changed in practice
- Plex metadata requests used during rule evaluation now ask for external metadata, which is where the IMDb rating comes from.
- Those requests were kept intentionally narrow so we do not trigger extra Plex refresh work during a normal rule check.
- If the main value for a comparison is missing, the rule now fails safely instead of comparing through `null`.
- If the secondary comparison value is missing, we keep the older behavior so existing rule results do not unexpectedly change.
- This also brings back useful Test Media results for the missing-value cases we were fixing, instead of leaving those checks confusing or misleading.

## Tests run
- `yarn workspace @maintainerr/server test --runTestsByPath src/modules/api/plex-api/plex-api.service.spec.ts src/modules/rules/getter/plex-getter.service.spec.ts src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts`