### PR TITLE
chore: address rule follow-up review comments

### DIFF
--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -315,18 +315,21 @@ export class PlexApiService {
     useCache: boolean = true,
   ): Promise<PlexMetadata> {
     try {
-      const queryParams: string[] = [];
+      const queryParams = new URLSearchParams();
 
       if (options.includeChildren) {
-        queryParams.push('includeChildren=1');
+        queryParams.set('includeChildren', '1');
       }
 
       if (options.includeChildren || options.includeExternalMedia) {
-        queryParams.push('includeExternalMedia=1', 'asyncAugmentMetadata=1');
+        queryParams.set('includeExternalMedia', '1');
+        queryParams.set('asyncAugmentMetadata', '1');
       }
 
+      const queryString = queryParams.toString();
+
       const response = await this.plexClient.query<PlexMetadataResponse>(
-        `/library/metadata/${key}${queryParams.length > 0 ? `?${queryParams.join('&')}` : ''}`,
+        `/library/metadata/${key}${queryString.length > 0 ? `?${queryString}` : ''}`,
         useCache,
       );
       if (response) {

--- a/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -250,7 +250,7 @@ export class RuleComparatorService {
         this.logMissingOperand(rule, mediaId, firstVal, secondVal);
         this.addStatistictoParent(rule, firstVal, secondVal, mediaId, false);
 
-        if (+rule.operator === +RuleOperators.AND) {
+        if (rule.operator != null && +rule.operator === +RuleOperators.AND) {
           this.workerData.splice(i, 1);
           this.workerIds.delete(mediaId);
         }
@@ -362,10 +362,7 @@ export class RuleComparatorService {
         rule.firstVal,
       ),
       firstValue: firstVal,
-      secondValueName: rule.lastVal
-        ? this.ruleConstanstService.getValueHumanName(rule.lastVal)
-        : this.ruleConstanstService.getCustomValueIdentifier(rule.customVal)
-            .type,
+      secondValueName: this.getSecondValueName(rule),
       secondValue: secondVal,
       result: result,
     });


### PR DESCRIPTION
## Summary
This follow-up addresses the review comments  were worth taking after the merged Plex IMDb rule evaluation fix in #2528.

## Changes
- switch Plex metadata query assembly to URLSearchParams without changing the query shape
- make the missing-operand AND branch explicitly ignore null operators
- reuse the existing second-value name helper to remove duplication in comparator statistics

## Validation
- yarn --cwd /workspaces/Maintainerr/apps/server test --runTestsByPath src/modules/api/plex-api/plex-api.service.spec.ts src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts --runInBand
- reran the manual rules matrix against v2.26.1 and v3.1.0 with 0 semantic differences

## Notes
- follow-up to the merged behavior fix in #2528
