### PR TITLE
refactor(contracts): share secret masking helpers

### DIFF
--- a/apps/server/src/utils/secretMasking.ts
+++ b/apps/server/src/utils/secretMasking.ts
@@ -1,5 +1,7 @@
-const FULL_MASK = '****';
-const VISIBLE_CHARS = 3;
+import {
+  maskSecret as sharedMaskSecret,
+  maskSecretString as sharedMaskSecretString,
+} from '@maintainerr/contracts';
 
 const SENSITIVE_PARAM_KEYS = [
   'api_key',
@@ -249,24 +251,9 @@ const sanitizePathSegmentValues = (value: string, segment: string): string => {
   return sanitized;
 };
 
-export const maskSecret = (value: string | null | undefined): string | null => {
-  if (value == null) {
-    return null;
-  }
+export const maskSecret = sharedMaskSecret;
 
-  if (value === '') {
-    return '';
-  }
-
-  if (value.length <= VISIBLE_CHARS * 2) {
-    return FULL_MASK;
-  }
-
-  return `${value.slice(0, VISIBLE_CHARS)}...${value.slice(-VISIBLE_CHARS)}`;
-};
-
-export const maskSecretString = (value: string): string =>
-  maskSecret(value) ?? FULL_MASK;
+export const maskSecretString = sharedMaskSecretString;
 
 export const sanitizeSecretString = (value: string): string => {
   let sanitized = sanitizeAuthorizationValues(value);

--- a/apps/ui/src/components/Settings/Jellyfin/index.tsx
+++ b/apps/ui/src/components/Settings/Jellyfin/index.tsx
@@ -8,6 +8,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import {
   type JellyfinSetting,
   jellyfinSettingSchema,
+  maskSecret,
 } from '@maintainerr/contracts'
 import { useEffect, useState } from 'react'
 import { Controller, useForm, useWatch } from 'react-hook-form'
@@ -276,8 +277,7 @@ const JellyfinSettings = () => {
                     <Select {...register('jellyfin_user_id')}>
                       {jellyfinUsers.map((user) => (
                         <option key={user.id} value={user.id}>
-                          {user.name} ({user.id.slice(0, 4)}...
-                          {user.id.slice(-4)})
+                          {user.name} ({maskSecret(user.id)})
                         </option>
                       ))}
                     </Select>
@@ -285,8 +285,7 @@ const JellyfinSettings = () => {
                     <Select disabled value={savedUserId}>
                       {savedUserId ? (
                         <option value={savedUserId}>
-                          Selected: {savedUserId.slice(0, 4)}...
-                          {savedUserId.slice(-4)}
+                          Selected: {maskSecret(savedUserId)}
                         </option>
                       ) : (
                         <option value="">

--- a/packages/contracts/src/app/index.ts
+++ b/packages/contracts/src/app/index.ts
@@ -1,2 +1,3 @@
 export * from './basicResponse.dto'
+export * from './maskSecret'
 export * from './versionResponse.dto'

--- a/packages/contracts/src/app/maskSecret.ts
+++ b/packages/contracts/src/app/maskSecret.ts
@@ -1,0 +1,21 @@
+export const FULL_MASK = '****'
+const VISIBLE_CHARS = 3
+
+export const maskSecret = (value: string | null | undefined): string | null => {
+  if (value == null) {
+    return null
+  }
+
+  if (value === '') {
+    return ''
+  }
+
+  if (value.length <= VISIBLE_CHARS * 2) {
+    return FULL_MASK
+  }
+
+  return `${value.slice(0, VISIBLE_CHARS)}...${value.slice(-VISIBLE_CHARS)}`
+}
+
+export const maskSecretString = (value: string): string =>
+  maskSecret(value) ?? FULL_MASK


### PR DESCRIPTION
## Summary
- centralize secret masking helpers in the contracts package
- reuse the shared masking helper in server log sanitization
- reuse the shared masking helper for Jellyfin user ID display in the UI
