### PR TITLE
fix(collections): remove batch collection creation causing crash on Jellyfin

### DIFF
--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -238,7 +238,6 @@ describe('JellyfinAdapterService', () => {
     it.each([
       [MediaServerFeature.LABELS, true],
       [MediaServerFeature.PLAYLISTS, true],
-      [MediaServerFeature.COLLECTION_CREATION_WITH_ITEMS, true],
       [MediaServerFeature.COLLECTION_VISIBILITY, false],
       [MediaServerFeature.WATCHLIST, false],
       [MediaServerFeature.CENTRAL_WATCH_HISTORY, false],
@@ -592,7 +591,7 @@ describe('JellyfinAdapterService', () => {
       await service.initialize();
     });
 
-    it('should pass initial item ids when creating a collection', async () => {
+    it('should create a collection without initial item ids', async () => {
       jellyfinApiMocks.getUsers.mockResolvedValue({
         data: [{ Id: 'user-1', Name: 'Alice' }],
       });
@@ -613,15 +612,19 @@ describe('JellyfinAdapterService', () => {
         libraryId: 'library-1',
         title: 'Test Collection',
         type: 'movie',
-        itemIds: ['item-1', 'item-2'],
       });
 
       expect(jest.mocked(getCollectionApi)).toHaveBeenCalled();
       expect(collectionApiMocks.createCollection).toHaveBeenCalledWith(
         expect.objectContaining({
-          ids: ['item-1', 'item-2'],
           name: 'Test Collection',
           parentId: 'library-1',
+          isLocked: true,
+        }),
+      );
+      expect(collectionApiMocks.createCollection).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          ids: expect.anything(),
         }),
       );
       expect(result.id).toBe('collection-1');

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -905,7 +905,6 @@ export class JellyfinAdapterService implements IMediaServerService {
         parentId: params.libraryId,
         // isLocked enables composite image generation from collection items
         isLocked: true,
-        ids: params.itemIds,
       });
 
       const collectionId = response.data.Id;

--- a/apps/server/src/modules/api/media-server/media-server.constants.ts
+++ b/apps/server/src/modules/api/media-server/media-server.constants.ts
@@ -18,7 +18,6 @@ export const MEDIA_SERVER_FEATURES: Record<
   [MediaServerType.JELLYFIN]: new Set([
     MediaServerFeature.LABELS, // Tags in Jellyfin
     MediaServerFeature.PLAYLISTS,
-    MediaServerFeature.COLLECTION_CREATION_WITH_ITEMS,
     // Note: COLLECTION_VISIBILITY not supported
     // Note: WATCHLIST not supported (no API)
     // Note: CENTRAL_WATCH_HISTORY not supported (requires user iteration)

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -33,6 +33,10 @@ describe('CollectionsService', () => {
     tmdbIdService = unitRef.get(TmdbIdService);
 
     mediaServer = {
+      supportsFeature: jest.fn().mockReturnValue(false),
+      createCollection: jest
+        .fn()
+        .mockResolvedValue({ id: 'remote-collection' }),
       addBatchToCollection: jest.fn().mockResolvedValue([]),
       removeFromCollection: jest.fn().mockResolvedValue(undefined),
       deleteCollection: jest.fn().mockResolvedValue(undefined),
@@ -96,6 +100,75 @@ describe('CollectionsService', () => {
     expect(mediaServer.removeFromCollection).toHaveBeenCalledWith(
       'remote-collection',
       'item-1',
+    );
+  });
+
+  it('recreates collections empty and resyncs existing items separately', async () => {
+    const collection = createCollection({
+      id: 3,
+      mediaServerId: null,
+      manualCollection: false,
+      libraryId: 'library-1',
+      title: 'Recreated Collection',
+    });
+    const collectionMedia = [
+      createCollectionMedia(collection, { mediaServerId: 'item-1' }),
+    ];
+
+    collectionRepo.findOne.mockResolvedValue(collection);
+    collectionMediaRepo.find.mockResolvedValue(collectionMedia);
+    collectionRepo.save.mockResolvedValue({
+      ...collection,
+      mediaServerId: 'remote-collection',
+    } as Collection);
+    jest
+      .spyOn(service as any, 'checkAutomaticMediaServerLink')
+      .mockResolvedValue(collection);
+    await service.addToCollection(collection.id, []);
+
+    expect(mediaServer.createCollection).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        itemIds: expect.anything(),
+      }),
+    );
+    expect(mediaServer.addBatchToCollection).toHaveBeenCalledWith(
+      'remote-collection',
+      ['item-1'],
+    );
+  });
+
+  it('creates collections with children by adding media after collection creation', async () => {
+    const collection = createCollection({
+      id: 4,
+      mediaServerId: null,
+      manualCollection: false,
+      libraryId: 'library-1',
+      title: 'Collection With Children',
+    });
+    const media = [{ mediaServerId: 'item-1' }];
+
+    jest.spyOn(service as any, 'addCollectionToDB').mockResolvedValue({
+      id: collection.id,
+      mediaServerId: 'remote-collection',
+    });
+    const addChildrenToCollectionSpy = jest
+      .spyOn(service as any, 'addChildrenToCollection')
+      .mockResolvedValue(undefined);
+
+    await service.createCollectionWithChildren(collection, media);
+
+    expect(mediaServer.createCollection).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        itemIds: expect.anything(),
+      }),
+    );
+    expect(addChildrenToCollectionSpy).toHaveBeenCalledWith(
+      {
+        mediaServerId: 'remote-collection',
+        dbId: collection.id,
+      },
+      media,
+      false,
     );
   });
 });

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -96,8 +96,9 @@ export class CollectionsService {
       }
     } catch (err) {
       this.logger.warn(
-        'An error occurred while performing collection actions.',
+        `An error occurred while performing collection actions: ${err.message}`,
       );
+      this.logger.debug(err);
       return undefined;
     }
   }
@@ -348,7 +349,6 @@ export class CollectionsService {
   async createCollection(
     collection: ICollection,
     empty = true,
-    media?: AddRemoveCollectionMedia[],
   ): Promise<{
     dbCollection: addCollectionDbResponse;
   }> {
@@ -361,10 +361,6 @@ export class CollectionsService {
         (collection.manualCollection == undefined ||
           !collection.manualCollection)
       ) {
-        const supportsCreationWithItems = mediaServer.supportsFeature(
-          MediaServerFeature.COLLECTION_CREATION_WITH_ITEMS,
-        );
-
         // Create collection via media server abstraction
         mediaCollection = await mediaServer.createCollection({
           libraryId: collection.libraryId,
@@ -372,11 +368,6 @@ export class CollectionsService {
           summary: collection?.description,
           sortTitle: collection?.sortTitle,
           type: collection.type,
-          ...(supportsCreationWithItems && media && media.length > 0
-            ? {
-                itemIds: media.map((childMedia) => childMedia.mediaServerId),
-              }
-            : {}),
         });
 
         // Store the media server ID from the created collection
@@ -448,17 +439,7 @@ export class CollectionsService {
     dbCollection: addCollectionDbResponse;
   }> {
     try {
-      const mediaServer = await this.getMediaServer();
-      const supportsCreationWithItems = mediaServer.supportsFeature(
-        MediaServerFeature.COLLECTION_CREATION_WITH_ITEMS,
-      );
-      const skipMediaServerAdd =
-        supportsCreationWithItems && !collection.manualCollection;
-      const createdCollection = await this.createCollection(
-        collection,
-        false,
-        media,
-      );
+      const createdCollection = await this.createCollection(collection, false);
 
       if (!createdCollection?.dbCollection) {
         return undefined;
@@ -474,7 +455,6 @@ export class CollectionsService {
           },
           media,
           false,
-          skipMediaServerAdd,
         );
       }
 
@@ -779,6 +759,7 @@ export class CollectionsService {
     media: AddRemoveCollectionMedia[],
     manual = false,
   ): Promise<Collection> {
+    if (!collection) return undefined;
     return this.addToCollectionInternal(collection.id, media, manual, true);
   }
 
@@ -823,22 +804,12 @@ export class CollectionsService {
               collection.libraryId,
             );
           } else {
-            const supportsCreationWithItems = mediaServer.supportsFeature(
-              MediaServerFeature.COLLECTION_CREATION_WITH_ITEMS,
-            );
             newColl = await mediaServer.createCollection({
               libraryId: collection.libraryId,
               title: collection.title,
               summary: collection.description,
               sortTitle: collection.sortTitle,
               type: collection.type,
-              ...(supportsCreationWithItems && collectionMedia.length > 0
-                ? {
-                    itemIds: collectionMedia.map(
-                      (existingMedia) => existingMedia.mediaServerId,
-                    ),
-                  }
-                : {}),
             });
           }
           if (newColl?.id) {
@@ -862,11 +833,7 @@ export class CollectionsService {
             }
 
             // Check if we need to sync existing items to a newly created collection
-            const needsResync =
-              collectionMedia.length > 0 &&
-              !mediaServer.supportsFeature(
-                MediaServerFeature.COLLECTION_CREATION_WITH_ITEMS,
-              );
+            const needsResync = collectionMedia.length > 0;
 
             // If we had existing collection_media items, sync them to the new media server collection
             if (needsResync) {
@@ -934,6 +901,7 @@ export class CollectionsService {
     collection: Collection,
     media: AddRemoveCollectionMedia[],
   ) {
+    if (!collection) return undefined;
     return this.removeFromCollectionInternal(collection.id, media, true);
   }
 

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -431,4 +431,42 @@ describe('RuleExecutorService', () => {
       collectionService.removeFromCollectionWithResolvedLink,
     ).not.toHaveBeenCalled();
   });
+
+  it('fails cleanly when collection sync returns undefined', async () => {
+    const { service, collectionService, eventEmitter } = createService(
+      MediaServerType.JELLYFIN,
+    );
+
+    collectionService.addToCollectionWithResolvedLink.mockResolvedValueOnce(
+      undefined,
+    );
+
+    (service as any).startTime = new Date();
+    (service as any).resultData = [{ id: 'm2' }];
+    (service as any).statisticsData = [];
+
+    await expect(
+      (
+        service as unknown as {
+          handleCollection: (ruleGroup: {
+            id: number;
+            collectionId: number;
+          }) => Promise<Set<string>>;
+        }
+      ).handleCollection({ id: 10, collectionId: 1 }),
+    ).resolves.toEqual(new Set());
+
+    expect(
+      collectionService.removeFromCollectionWithResolvedLink,
+    ).not.toHaveBeenCalled();
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      MaintainerrEvent.RuleHandler_Failed,
+      expect.objectContaining({
+        identifier: {
+          type: 'rulegroup',
+          value: 10,
+        },
+      }),
+    );
+  });
 });

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -513,7 +513,7 @@ export class RuleExecutorService {
         }
 
         abortSignal?.throwIfAborted();
-        if (dataToRemove.length > 0) {
+        if (collection && dataToRemove.length > 0) {
           collection =
             collMediaData.length > 0
               ? await this.collectionService.removeFromCollectionWithResolvedLink(
@@ -526,10 +526,16 @@ export class RuleExecutorService {
                 );
         }
 
+        if (!collection) {
+          throw new Error(
+            `Collection update failed for rule group ${rulegroup?.id} (collectionId: ${rulegroup?.collectionId})`,
+          );
+        }
+
         // Determine which items were actually added/removed by comparing DB state
         const updatedMediaServerIds = new Set(
           (
-            (await this.collectionService.getCollectionMedia(collection.id)) ??
+            (await this.collectionService.getCollectionMedia(collection?.id)) ??
             []
           ).map((e) => e.mediaServerId),
         );

--- a/packages/contracts/src/media-server/enums.ts
+++ b/packages/contracts/src/media-server/enums.ts
@@ -45,8 +45,6 @@ export function isValidMediaItemType(type: string): type is MediaItemType {
 export enum MediaServerFeature {
   /** Ability to set collection visibility (home/recommended) */
   COLLECTION_VISIBILITY = 'collection_visibility',
-  /** Ability to create collections with initial items */
-  COLLECTION_CREATION_WITH_ITEMS = 'collection_creation_with_items',
   /** Watchlist functionality via external API (Plex.tv) */
   WATCHLIST = 'watchlist',
   /** Central watch history endpoint (vs per-user iteration) */

--- a/packages/contracts/src/media-server/types.ts
+++ b/packages/contracts/src/media-server/types.ts
@@ -215,8 +215,6 @@ export interface CreateCollectionParams {
   summary?: string
   type: MediaItemType
   sortTitle?: string
-  /** Optional initial items to add on creation. Requires COLLECTION_CREATION_WITH_ITEMS feature. */
-  itemIds?: string[]
 }
 
 /** Plex-only visibility settings */


### PR DESCRIPTION
## Problem

Jellyfin users upgrading to v3.2.0 could hit:

```
Cannot read properties of undefined (reading 'id')
```

## Root cause

PR #2494 added a Jellyfin create-time optimization: pass initial item ids to `createCollection`.

If that create call failed, `addToCollectionInternal` returned `undefined`, and the rule executor later dereferenced `collection.id`.

## Fix

- Always create collections empty
- Keep batched add/remove/resync after creation
- Remove the now-unused create-with-items capability from contracts/adapter/tests
- Guard the failure path so a collection update failure does not cascade into `undefined.id`

## Regression note

This does **not** reintroduce #2489.
We still batch collection mutations; we only removed the create-time prepopulation shortcut.

## Trace

- Fragile path introduced by: PR #2494
- PR #2494 fixed: #2489
- Related follow-up: PR #2511 for #2493
- Fixes: #2546

## Test plan

- [x] Run targeted server specs:
  - `src/modules/collections/collections.service.spec.ts`
  - `src/modules/rules/tasks/rule-executor.service.spec.ts`
  - `src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts`
- [x] Verify Jellyfin recreate flow in app
- [ ] Verify Plex remains unaffected
