### PR TITLE
feat(metadata): add ID validation and retry path for metadata refresh

### DIFF
--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -12,6 +12,7 @@ const jellyfinApiMocks = {
   getConfiguration: jest.fn(),
   getItems: jest.fn(),
   getItemUserData: jest.fn(),
+  refreshItem: jest.fn(),
 };
 
 const collectionApiMocks = {
@@ -104,6 +105,9 @@ jest.mock('@jellyfin/sdk/lib/utils/api/index.js', () => ({
     removeFromCollection: (...args: unknown[]) =>
       collectionApiMocks.removeFromCollection(...args),
   })),
+  getItemRefreshApi: jest.fn().mockImplementation(() => ({
+    refreshItem: (...args: unknown[]) => jellyfinApiMocks.refreshItem(...args),
+  })),
   getSearchApi: jest.fn(),
   getPlaylistsApi: jest.fn(),
   getUserViewsApi: jest.fn(),
@@ -155,6 +159,7 @@ describe('JellyfinAdapterService', () => {
       data: { MaxResumePct: 90 },
     });
     jellyfinApiMocks.getItems.mockResolvedValue({ data: { Items: [] } });
+    jellyfinApiMocks.refreshItem.mockResolvedValue(undefined);
     collectionApiMocks.createCollection.mockResolvedValue({
       data: { Id: 'collection-1' },
     });
@@ -254,6 +259,33 @@ describe('JellyfinAdapterService', () => {
 
     it('should not throw when resetting all cache', () => {
       expect(() => service.resetMetadataCache()).not.toThrow();
+    });
+  });
+
+  describe('refreshItemMetadata', () => {
+    beforeEach(async () => {
+      settingsService.getSettings.mockResolvedValue(
+        mockSettings as unknown as Awaited<
+          ReturnType<SettingsService['getSettings']>
+        >,
+      );
+      await service.initialize();
+    });
+
+    it('queues refresh for valid Jellyfin item ids', async () => {
+      const itemId = 'a852a27afe324084ae66db579ee3ee18';
+
+      await service.refreshItemMetadata(itemId);
+
+      expect(jellyfinApiMocks.refreshItem).toHaveBeenCalledWith({ itemId });
+    });
+
+    it('rejects blank Jellyfin item ids before calling the API', async () => {
+      await expect(service.refreshItemMetadata('   ')).rejects.toThrow(
+        'refreshItemMetadata called with empty itemId — aborting metadata refresh request',
+      );
+
+      expect(jellyfinApiMocks.refreshItem).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -43,6 +43,10 @@ import { formatConnectionFailureMessage } from '../../../../utils/connection-err
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { SettingsService } from '../../../settings/settings.service';
 import cacheManager, { type Cache } from '../../lib/cache';
+import {
+  isBlankMediaServerId,
+  isForeignServerId,
+} from '../media-server-id.utils';
 import { supportsFeature } from '../media-server.constants';
 import type {
   IMediaServerService,
@@ -1437,23 +1441,21 @@ export class JellyfinAdapterService implements IMediaServerService {
       );
     }
 
+    if (isBlankMediaServerId(itemId)) {
+      throw new Error(
+        'refreshItemMetadata called with empty itemId — aborting metadata refresh request',
+      );
+    }
+
     try {
       await getItemRefreshApi(this.api).refreshItem({ itemId });
     } catch (error) {
-      this.logger.error(
+      this.logger.warn(
         `Failed to refresh Jellyfin metadata for item ${itemId}`,
       );
       this.logger.debug(error);
       throw error;
     }
-  }
-
-  /**
-   * Check if a library ID looks like it's from a different media server
-   * (e.g. Plex numeric IDs) or is empty/invalid.
-   */
-  private isLikelyMigrationId(libraryId: string): boolean {
-    return !libraryId || libraryId.trim() === '' || /^\d+$/.test(libraryId);
   }
 
   /**
@@ -1464,7 +1466,7 @@ export class JellyfinAdapterService implements IMediaServerService {
     operation: string,
     error: unknown,
   ): void {
-    if (this.isLikelyMigrationId(libraryId)) {
+    if (isForeignServerId(MediaServerType.JELLYFIN, libraryId)) {
       this.logger.warn(
         `Library '${libraryId || '(empty)'}' appears to be from a different media server. Please update the library setting in your rules.`,
       );

--- a/apps/server/src/modules/api/media-server/media-server-id.utils.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-server-id.utils.spec.ts
@@ -1,0 +1,133 @@
+import { MediaServerType } from '@maintainerr/contracts';
+import {
+  isForeignServerId,
+  isJellyfinEmptyGuid,
+  isLikelyJellyfinId,
+  isLikelyPlexId,
+  shouldRefreshMetadataItemId,
+} from './media-server-id.utils';
+
+describe('media-server-id.utils', () => {
+  describe('isLikelyPlexId', () => {
+    it('returns true for a numeric id', () => {
+      expect(isLikelyPlexId('12345')).toBe(true);
+    });
+
+    it.each([
+      ['blank', ''],
+      ['Jellyfin id', 'a852a27afe324084ae66db579ee3ee18'],
+    ])('returns false for %s', (_label, value) => {
+      expect(isLikelyPlexId(value)).toBe(false);
+    });
+  });
+
+  describe('isLikelyJellyfinId', () => {
+    it.each([
+      'a852a27afe324084ae66db579ee3ee18',
+      'e9b2dcaa-529c-426e-9433-5e9981f27f2e',
+    ])('returns true for %j', (value) => {
+      expect(isLikelyJellyfinId(value)).toBe(true);
+    });
+
+    it.each([
+      ['blank', ''],
+      ['wrong length', 'a852a27afe324084ae66db579ee3ee1'],
+      ['dash at wrong position', 'e9b2dcaa529c-426e-9433-5e9981f27f2e'],
+    ])('returns false for %s', (_label, value) => {
+      expect(isLikelyJellyfinId(value)).toBe(false);
+    });
+  });
+
+  describe('isJellyfinEmptyGuid', () => {
+    it.each([
+      '00000000-0000-0000-0000-000000000000',
+      '00000000000000000000000000000000',
+    ])('returns true for %j', (value) => {
+      expect(isJellyfinEmptyGuid(value)).toBe(true);
+    });
+
+    it('returns false for a non-empty id', () => {
+      expect(isJellyfinEmptyGuid('a852a27afe324084ae66db579ee3ee18')).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('isForeignServerId', () => {
+    it('returns true for blank on both server types', () => {
+      expect(isForeignServerId(MediaServerType.PLEX, '')).toBe(true);
+      expect(isForeignServerId(MediaServerType.JELLYFIN, '')).toBe(true);
+    });
+
+    it.each([
+      'a852a27afe324084ae66db579ee3ee18',
+      'e9b2dcaa-529c-426e-9433-5e9981f27f2e',
+    ])('returns true when Plex sees Jellyfin id %j', (value) => {
+      expect(isForeignServerId(MediaServerType.PLEX, value)).toBe(true);
+    });
+
+    it('returns false when Plex sees a numeric id', () => {
+      expect(isForeignServerId(MediaServerType.PLEX, '12345')).toBe(false);
+    });
+
+    it('returns true when Jellyfin sees a numeric id', () => {
+      expect(isForeignServerId(MediaServerType.JELLYFIN, '12345')).toBe(true);
+    });
+
+    it('returns false when Jellyfin sees a Jellyfin id', () => {
+      expect(
+        isForeignServerId(
+          MediaServerType.JELLYFIN,
+          'a852a27afe324084ae66db579ee3ee18',
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('shouldRefreshMetadataItemId', () => {
+    it('rejects blank', () => {
+      expect(shouldRefreshMetadataItemId(MediaServerType.JELLYFIN, '')).toBe(
+        false,
+      );
+    });
+
+    it('allows valid Plex id for Plex', () => {
+      expect(shouldRefreshMetadataItemId(MediaServerType.PLEX, '12345')).toBe(
+        true,
+      );
+    });
+
+    it.each([
+      'a852a27afe324084ae66db579ee3ee18',
+      'e9b2dcaa-529c-426e-9433-5e9981f27f2e',
+    ])('rejects Jellyfin id %j for Plex', (value) => {
+      expect(shouldRefreshMetadataItemId(MediaServerType.PLEX, value)).toBe(
+        false,
+      );
+    });
+
+    it('allows valid Jellyfin id for Jellyfin', () => {
+      expect(
+        shouldRefreshMetadataItemId(
+          MediaServerType.JELLYFIN,
+          'a852a27afe324084ae66db579ee3ee18',
+        ),
+      ).toBe(true);
+    });
+
+    it.each([
+      '00000000-0000-0000-0000-000000000000',
+      '00000000000000000000000000000000',
+    ])('rejects empty GUID %j for Jellyfin', (value) => {
+      expect(shouldRefreshMetadataItemId(MediaServerType.JELLYFIN, value)).toBe(
+        false,
+      );
+    });
+
+    it('rejects Plex numeric id for Jellyfin', () => {
+      expect(
+        shouldRefreshMetadataItemId(MediaServerType.JELLYFIN, '12345'),
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/server/src/modules/api/media-server/media-server-id.utils.ts
+++ b/apps/server/src/modules/api/media-server/media-server-id.utils.ts
@@ -1,0 +1,118 @@
+import { MediaServerType } from '@maintainerr/contracts';
+
+const JELLYFIN_EMPTY_GUID_DASHED = '00000000-0000-0000-0000-000000000000';
+const JELLYFIN_EMPTY_GUID_UNDASHED = '00000000000000000000000000000000';
+
+export function isBlankMediaServerId(
+  value: string | null | undefined,
+): boolean {
+  return value === undefined || value === null || value.trim() === '';
+}
+
+export function isLikelyPlexId(value: string): boolean {
+  if (isBlankMediaServerId(value)) {
+    return false;
+  }
+
+  for (const char of value) {
+    if (char < '0' || char > '9') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function isLikelyJellyfinId(value: string): boolean {
+  if (isBlankMediaServerId(value)) {
+    return false;
+  }
+
+  if (value.length === 32) {
+    return isHexSegment(value);
+  }
+
+  if (value.length === 36) {
+    return isDashedUuid(value);
+  }
+
+  return false;
+}
+
+export function isJellyfinEmptyGuid(value: string): boolean {
+  return (
+    value === JELLYFIN_EMPTY_GUID_DASHED ||
+    value === JELLYFIN_EMPTY_GUID_UNDASHED
+  );
+}
+
+export function isForeignServerId(
+  serverType: MediaServerType,
+  value: string,
+): boolean {
+  if (isBlankMediaServerId(value)) {
+    return true;
+  }
+
+  if (serverType === MediaServerType.JELLYFIN) {
+    return isLikelyPlexId(value);
+  }
+
+  if (serverType === MediaServerType.PLEX) {
+    return isLikelyJellyfinId(value);
+  }
+
+  return false;
+}
+
+export function shouldRefreshMetadataItemId(
+  serverType: MediaServerType,
+  value: string,
+): boolean {
+  if (isForeignServerId(serverType, value)) {
+    return false;
+  }
+
+  if (serverType === MediaServerType.JELLYFIN) {
+    return !isJellyfinEmptyGuid(value);
+  }
+
+  return true;
+}
+
+function isDashedUuid(value: string): boolean {
+  if (value.length !== 36) {
+    return false;
+  }
+
+  for (let i = 0; i < 36; i++) {
+    const char = value[i];
+    if (i === 8 || i === 13 || i === 18 || i === 23) {
+      if (char !== '-') {
+        return false;
+      }
+    } else {
+      const lower = char.toLowerCase();
+      if (!((lower >= '0' && lower <= '9') || (lower >= 'a' && lower <= 'f'))) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function isHexSegment(value: string): boolean {
+  if (value.length === 0) {
+    return false;
+  }
+
+  for (const char of value) {
+    const lower = char.toLowerCase();
+    if (!((lower >= '0' && lower <= '9') || (lower >= 'a' && lower <= 'f'))) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -71,6 +71,24 @@ describe('PlexAdapterService', () => {
     });
   });
 
+  describe('refreshItemMetadata', () => {
+    it('should delegate metadata refresh for non-empty item ids', async () => {
+      plexApi.refreshMediaMetadata.mockResolvedValue(undefined);
+
+      await service.refreshItemMetadata('12345');
+
+      expect(plexApi.refreshMediaMetadata).toHaveBeenCalledWith('12345');
+    });
+
+    it('should reject blank item ids before calling PlexApiService', async () => {
+      await expect(service.refreshItemMetadata('   ')).rejects.toThrow(
+        'refreshItemMetadata called with empty itemId — aborting metadata refresh request',
+      );
+
+      expect(plexApi.refreshMediaMetadata).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getStatus', () => {
     it('should return undefined when PlexApiService returns undefined', async () => {
       plexApi.getStatus.mockResolvedValue(undefined);

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -22,6 +22,10 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { EPlexDataType } from '../../plex-api/enums/plex-data-type-enum';
 import { PlexApiService } from '../../plex-api/plex-api.service';
+import {
+  isBlankMediaServerId,
+  isForeignServerId,
+} from '../media-server-id.utils';
 import { supportsFeature } from '../media-server.constants';
 import {
   IMediaServerService,
@@ -114,10 +118,7 @@ export class PlexAdapterService implements IMediaServerService {
     libraryId: string,
     options?: LibraryQueryOptions,
   ): Promise<PagedResult<MediaItem>> {
-    // Check for migration issue: Jellyfin uses 32-char hex UUIDs, Plex uses numeric IDs
-    // TODO: Extract migration ID detection to shared utility (see JellyfinAdapterService.isLikelyMigrationId)
-    const isJellyfinId = /^[a-f0-9]{32}$/i.test(libraryId);
-    if (!libraryId || libraryId.trim() === '' || isJellyfinId) {
+    if (isForeignServerId(MediaServerType.PLEX, libraryId)) {
       this.logger.warn(
         `Library '${libraryId || '(empty)'}' appears to be from a different media server. Please update the library setting in your rules.`,
       );
@@ -471,6 +472,12 @@ export class PlexAdapterService implements IMediaServerService {
   }
 
   async refreshItemMetadata(itemId: string): Promise<void> {
+    if (isBlankMediaServerId(itemId)) {
+      throw new Error(
+        'refreshItemMetadata called with empty itemId — aborting metadata refresh request',
+      );
+    }
+
     await this.plexApi.refreshMediaMetadata(itemId);
   }
 }

--- a/apps/server/src/modules/settings/metadata-settings.service.spec.ts
+++ b/apps/server/src/modules/settings/metadata-settings.service.spec.ts
@@ -1,3 +1,4 @@
+import { MediaServerType } from '@maintainerr/contracts';
 import { TestBed, type Mocked } from '@suites/unit';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Repository } from 'typeorm';
@@ -16,6 +17,7 @@ type QueryBuilderResult = {
     (selection: string, alias: string) => QueryBuilderResult
   >;
   where: jest.MockedFunction<(condition: string) => QueryBuilderResult>;
+  andWhere: jest.MockedFunction<(condition: string) => QueryBuilderResult>;
   getRawMany: jest.MockedFunction<
     () => Promise<Array<{ mediaServerId: string }>>
   >;
@@ -27,6 +29,7 @@ describe('MetadataSettingsService', () => {
   let mediaServerFactory: Mocked<MediaServerFactory>;
   let tmdbApi: Mocked<TmdbApiService>;
   let tvdbApi: Mocked<TvdbApiService>;
+  let logger: Mocked<MaintainerrLogger>;
 
   const createQueryBuilder = (
     rows: Array<{ mediaServerId: string }>,
@@ -34,11 +37,13 @@ describe('MetadataSettingsService', () => {
     const queryBuilder = {
       select: jest.fn(),
       where: jest.fn(),
+      andWhere: jest.fn(),
       getRawMany: jest.fn().mockResolvedValue(rows),
     } as QueryBuilderResult;
 
     queryBuilder.select.mockReturnValue(queryBuilder);
     queryBuilder.where.mockReturnValue(queryBuilder);
+    queryBuilder.andWhere.mockReturnValue(queryBuilder);
 
     return queryBuilder;
   };
@@ -55,34 +60,20 @@ describe('MetadataSettingsService', () => {
     tvdbApi = unitRef.get(TvdbApiService);
     unitRef.get('SettingsRepository');
     unitRef.get(EventEmitter2);
-    unitRef.get(MaintainerrLogger);
+    logger = unitRef.get(MaintainerrLogger);
   });
 
   it('prevents overlapping metadata refresh runs', async () => {
     const flush = jest.spyOn(Cache.prototype, 'flush').mockImplementation();
-    const queryBuilder = {
-      select: jest.fn(),
-      where: jest.fn(),
-      getRawMany: jest.fn(
-        () => new Promise<Array<{ mediaServerId: string }>>(() => undefined),
-      ),
-    } as QueryBuilderResult;
-
-    queryBuilder.select.mockReturnValue(queryBuilder);
-    queryBuilder.where.mockReturnValue(queryBuilder);
+    const refreshMediaServerItems = jest
+      .spyOn(service as any, 'refreshMediaServerItems')
+      .mockImplementation(() => new Promise<void>(() => undefined));
 
     tmdbApi.testConnection.mockResolvedValue({
       status: 'OK',
       code: 1,
       message: 'Success',
     });
-    collectionMediaRepo.createQueryBuilder.mockReturnValue(
-      queryBuilder as never,
-    );
-    mediaServerFactory.getService.mockResolvedValue({
-      isSetup: jest.fn().mockReturnValue(true),
-      refreshItemMetadata: jest.fn(),
-    } as never);
 
     const firstResponse = await service.refreshMetadataCache(
       MetadataProvider.TMDB,
@@ -101,9 +92,16 @@ describe('MetadataSettingsService', () => {
       code: 1,
       message: 'TMDB metadata refresh is already in progress',
     });
+    expect(refreshMediaServerItems).toHaveBeenCalledWith(
+      MetadataProvider.TMDB,
+      {
+        retryFailedItemsWithMetadataLookup: true,
+      },
+    );
     expect(tvdbApi.testConnection).not.toHaveBeenCalled();
     expect(flush).toHaveBeenCalledTimes(1);
 
+    refreshMediaServerItems.mockRestore();
     flush.mockRestore();
   });
 
@@ -132,6 +130,7 @@ describe('MetadataSettingsService', () => {
     );
     mediaServerFactory.getService.mockResolvedValue({
       isSetup: jest.fn().mockReturnValue(true),
+      getServerType: jest.fn().mockReturnValue(MediaServerType.PLEX),
       refreshItemMetadata,
     } as never);
 
@@ -140,6 +139,238 @@ describe('MetadataSettingsService', () => {
     expect(refreshItemMetadata).toHaveBeenCalledTimes(25);
     expect(maxInFlightCount).toBeLessThanOrEqual(
       MEDIA_SERVER_BATCH_SIZE.METADATA_REFRESH,
+    );
+  });
+
+  it('skips unrecognized Jellyfin refresh ids before queuing metadata refreshes', async () => {
+    const validJellyfinId = 'a852a27afe324084ae66db579ee3ee18';
+    const queryBuilder = createQueryBuilder([
+      { mediaServerId: validJellyfinId },
+      { mediaServerId: '123' },
+      { mediaServerId: '   ' },
+      { mediaServerId: '00000000-0000-0000-0000-000000000000' },
+      { mediaServerId: '00000000000000000000000000000000' },
+    ]);
+    const refreshItemMetadata = jest.fn().mockResolvedValue(undefined);
+
+    collectionMediaRepo.createQueryBuilder.mockReturnValue(
+      queryBuilder as never,
+    );
+    mediaServerFactory.getService.mockResolvedValue({
+      isSetup: jest.fn().mockReturnValue(true),
+      getServerType: jest.fn().mockReturnValue(MediaServerType.JELLYFIN),
+      refreshItemMetadata,
+    } as never);
+
+    await (service as any).refreshMediaServerItems(MetadataProvider.TMDB);
+
+    expect(refreshItemMetadata).toHaveBeenCalledTimes(1);
+    expect(refreshItemMetadata).toHaveBeenCalledWith(validJellyfinId);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('not recognized for jellyfin'),
+    );
+  });
+
+  it('skips likely Jellyfin ids before queuing Plex metadata refreshes', async () => {
+    const queryBuilder = createQueryBuilder([
+      { mediaServerId: '12345' },
+      { mediaServerId: 'a852a27afe324084ae66db579ee3ee18' },
+      { mediaServerId: 'e9b2dcaa-529c-426e-9433-5e9981f27f2e' },
+    ]);
+    const refreshItemMetadata = jest.fn().mockResolvedValue(undefined);
+
+    collectionMediaRepo.createQueryBuilder.mockReturnValue(
+      queryBuilder as never,
+    );
+    mediaServerFactory.getService.mockResolvedValue({
+      isSetup: jest.fn().mockReturnValue(true),
+      getServerType: jest.fn().mockReturnValue(MediaServerType.PLEX),
+      refreshItemMetadata,
+    } as never);
+
+    await (service as any).refreshMediaServerItems(MetadataProvider.TMDB);
+
+    expect(refreshItemMetadata).toHaveBeenCalledTimes(1);
+    expect(refreshItemMetadata).toHaveBeenCalledWith('12345');
+  });
+
+  it('does not verify failed items when retry lookup mode is explicitly disabled', async () => {
+    const queryBuilder = createQueryBuilder([{ mediaServerId: '12345' }]);
+    const refreshItemMetadata = jest
+      .fn()
+      .mockRejectedValue(new Error('refresh failed'));
+    const getMetadata = jest.fn().mockResolvedValue({ id: '12345' });
+
+    collectionMediaRepo.createQueryBuilder.mockReturnValue(
+      queryBuilder as never,
+    );
+    mediaServerFactory.getService.mockResolvedValue({
+      isSetup: jest.fn().mockReturnValue(true),
+      getServerType: jest.fn().mockReturnValue(MediaServerType.PLEX),
+      refreshItemMetadata,
+      getMetadata,
+    } as never);
+
+    await (service as any).refreshMediaServerItems(MetadataProvider.TMDB, {
+      retryFailedItemsWithMetadataLookup: false,
+    });
+
+    expect(refreshItemMetadata).toHaveBeenCalledTimes(1);
+    expect(getMetadata).not.toHaveBeenCalled();
+  });
+
+  it('verifies and retries failed items for manual metadata refreshes', async () => {
+    const queryBuilder = createQueryBuilder([{ mediaServerId: '12345' }]);
+    const refreshItemMetadata = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('refresh failed'))
+      .mockResolvedValueOnce(undefined);
+    const getMetadata = jest.fn().mockResolvedValue({ id: '12345' });
+
+    collectionMediaRepo.createQueryBuilder.mockReturnValue(
+      queryBuilder as never,
+    );
+    mediaServerFactory.getService.mockResolvedValue({
+      isSetup: jest.fn().mockReturnValue(true),
+      getServerType: jest.fn().mockReturnValue(MediaServerType.PLEX),
+      refreshItemMetadata,
+      getMetadata,
+    } as never);
+
+    await (service as any).refreshMediaServerItems(MetadataProvider.TMDB, {
+      retryFailedItemsWithMetadataLookup: true,
+    });
+
+    expect(refreshItemMetadata).toHaveBeenCalledTimes(2);
+    expect(getMetadata).toHaveBeenCalledWith('12345');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Retrying plex metadata refresh for item 12345'),
+    );
+  });
+
+  it('retries with the corrected id when lookup returns a different id', async () => {
+    const queryBuilder = createQueryBuilder([{ mediaServerId: 'stale-id' }]);
+    const refreshItemMetadata = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('refresh failed'))
+      .mockResolvedValueOnce(undefined);
+    const getMetadata = jest.fn().mockResolvedValue({ id: 'correct-id' });
+
+    collectionMediaRepo.createQueryBuilder.mockReturnValue(
+      queryBuilder as never,
+    );
+    mediaServerFactory.getService.mockResolvedValue({
+      isSetup: jest.fn().mockReturnValue(true),
+      getServerType: jest.fn().mockReturnValue(MediaServerType.JELLYFIN),
+      refreshItemMetadata,
+      getMetadata,
+    } as never);
+
+    await (service as any).refreshMediaServerItems(MetadataProvider.TMDB, {
+      retryFailedItemsWithMetadataLookup: true,
+    });
+
+    expect(refreshItemMetadata).toHaveBeenNthCalledWith(1, 'stale-id');
+    expect(refreshItemMetadata).toHaveBeenNthCalledWith(2, 'correct-id');
+    expect(getMetadata).toHaveBeenCalledWith('stale-id');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'verified item id correct-id after failure on stale-id',
+      ),
+    );
+  });
+
+  it('does not retry when item lookup throws after a failed manual refresh', async () => {
+    const mediaServerId = 'a852a27afe324084ae66db579ee3ee18';
+    const queryBuilder = createQueryBuilder([{ mediaServerId }]);
+    const refreshItemMetadata = jest
+      .fn()
+      .mockRejectedValue(new Error('refresh failed'));
+    const getMetadata = jest.fn().mockRejectedValue(new Error('lookup failed'));
+
+    collectionMediaRepo.createQueryBuilder.mockReturnValue(
+      queryBuilder as never,
+    );
+    mediaServerFactory.getService.mockResolvedValue({
+      isSetup: jest.fn().mockReturnValue(true),
+      getServerType: jest.fn().mockReturnValue(MediaServerType.JELLYFIN),
+      refreshItemMetadata,
+      getMetadata,
+    } as never);
+
+    await (service as any).refreshMediaServerItems(MetadataProvider.TMDB, {
+      retryFailedItemsWithMetadataLookup: true,
+    });
+
+    expect(refreshItemMetadata).toHaveBeenCalledTimes(1);
+    expect(getMetadata).toHaveBeenCalledWith(mediaServerId);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Failed to verify jellyfin item ${mediaServerId}`,
+      ),
+    );
+  });
+
+  it('does not retry when lookup returns a blank id after a failed manual refresh', async () => {
+    const mediaServerId = 'e9b2dcaa-529c-426e-9433-5e9981f27f2e';
+    const queryBuilder = createQueryBuilder([{ mediaServerId }]);
+    const refreshItemMetadata = jest
+      .fn()
+      .mockRejectedValue(new Error('refresh failed'));
+    const getMetadata = jest.fn().mockResolvedValue({ id: '   ' });
+
+    collectionMediaRepo.createQueryBuilder.mockReturnValue(
+      queryBuilder as never,
+    );
+    mediaServerFactory.getService.mockResolvedValue({
+      isSetup: jest.fn().mockReturnValue(true),
+      getServerType: jest.fn().mockReturnValue(MediaServerType.JELLYFIN),
+      refreshItemMetadata,
+      getMetadata,
+    } as never);
+
+    await (service as any).refreshMediaServerItems(MetadataProvider.TMDB, {
+      retryFailedItemsWithMetadataLookup: true,
+    });
+
+    expect(refreshItemMetadata).toHaveBeenCalledTimes(1);
+    expect(getMetadata).toHaveBeenCalledWith(mediaServerId);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('did not return a usable id'),
+    );
+  });
+
+  it('logs and surfaces the final failure when the retry also rejects', async () => {
+    const queryBuilder = createQueryBuilder([{ mediaServerId: '12345' }]);
+    const refreshItemMetadata = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('initial refresh failed'))
+      .mockRejectedValueOnce(new Error('retry refresh failed'));
+    const getMetadata = jest.fn().mockResolvedValue({ id: '12345' });
+
+    collectionMediaRepo.createQueryBuilder.mockReturnValue(
+      queryBuilder as never,
+    );
+    mediaServerFactory.getService.mockResolvedValue({
+      isSetup: jest.fn().mockReturnValue(true),
+      getServerType: jest.fn().mockReturnValue(MediaServerType.PLEX),
+      refreshItemMetadata,
+      getMetadata,
+    } as never);
+
+    await (service as any).refreshMediaServerItems(MetadataProvider.TMDB, {
+      retryFailedItemsWithMetadataLookup: true,
+    });
+
+    expect(refreshItemMetadata).toHaveBeenCalledTimes(2);
+    expect(getMetadata).toHaveBeenCalledWith('12345');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Retried plex metadata refresh failed for item 12345',
+      ),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      '1 item(s) could not be refreshed',
     );
   });
 });

--- a/apps/server/src/modules/settings/metadata-settings.service.ts
+++ b/apps/server/src/modules/settings/metadata-settings.service.ts
@@ -9,15 +9,24 @@ import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import cacheManager from '../api/lib/cache';
+import {
+  isBlankMediaServerId,
+  shouldRefreshMetadataItemId,
+} from '../api/media-server/media-server-id.utils';
 import { MEDIA_SERVER_BATCH_SIZE } from '../api/media-server/media-server.constants';
 import { MediaServerFactory } from '../api/media-server/media-server.factory';
-import cacheManager from '../api/lib/cache';
+import type { IMediaServerService } from '../api/media-server/media-server.interface';
 import { TmdbApiService } from '../api/tmdb-api/tmdb.service';
 import { TvdbApiService } from '../api/tvdb-api/tvdb.service';
 import { CollectionMedia } from '../collections/entities/collection_media.entities';
 import { MaintainerrLogger } from '../logging/logs.service';
 import { Settings } from './entities/settings.entities';
 import { MetadataProvider } from './metadata-provider';
+
+interface RefreshMediaServerItemsOptions {
+  retryFailedItemsWithMetadataLookup?: boolean;
+}
 
 @Injectable()
 export class MetadataSettingsService {
@@ -165,7 +174,9 @@ export class MetadataSettingsService {
       cacheManager.getCache(provider)?.flush();
       this.logger.log(`${provider.toUpperCase()} metadata cache cleared`);
 
-      void this.refreshMediaServerItems(provider).finally(() => {
+      void this.refreshMediaServerItems(provider, {
+        retryFailedItemsWithMetadataLookup: true,
+      }).finally(() => {
         if (this.activeMetadataRefreshProvider === provider) {
           this.activeMetadataRefreshProvider = null;
         }
@@ -188,34 +199,53 @@ export class MetadataSettingsService {
 
   private async refreshMediaServerItems(
     provider: MetadataProvider,
+    options: RefreshMediaServerItemsOptions = {},
   ): Promise<void> {
     try {
       const mediaServer = await this.mediaServerFactory.getService();
       if (!mediaServer?.isSetup()) return;
+      const serverType = mediaServer.getServerType();
 
       const column = provider === 'tmdb' ? 'tmdbId' : 'tvdbId';
       const rows = await this.collectionMediaRepo
         .createQueryBuilder('cm')
         .select('DISTINCT cm.mediaServerId', 'mediaServerId')
         .where(`cm.${column} IS NOT NULL`)
+        .andWhere(`cm.mediaServerId IS NOT NULL`)
+        .andWhere(`cm.mediaServerId != ''`)
         .getRawMany<{ mediaServerId: string }>();
 
       if (rows.length === 0) return;
+
+      const refreshableMediaServerIds = rows
+        .map(({ mediaServerId }) => mediaServerId.trim())
+        .filter((mediaServerId) =>
+          shouldRefreshMetadataItemId(serverType, mediaServerId),
+        );
+
+      const skippedCount = rows.length - refreshableMediaServerIds.length;
+      if (skippedCount > 0) {
+        this.logger.warn(
+          `Skipped ${skippedCount} item id(s) not recognized for ${serverType} while refreshing ${provider.toUpperCase()} metadata`,
+        );
+      }
+
+      if (refreshableMediaServerIds.length === 0) return;
 
       let failed = 0;
 
       for (
         let index = 0;
-        index < rows.length;
+        index < refreshableMediaServerIds.length;
         index += MEDIA_SERVER_BATCH_SIZE.METADATA_REFRESH
       ) {
-        const batch = rows.slice(
+        const batch = refreshableMediaServerIds.slice(
           index,
           index + MEDIA_SERVER_BATCH_SIZE.METADATA_REFRESH,
         );
         const results = await Promise.allSettled(
-          batch.map(({ mediaServerId }) =>
-            mediaServer.refreshItemMetadata(mediaServerId),
+          batch.map((mediaServerId) =>
+            this.refreshMediaServerItem(mediaServer, mediaServerId, options),
           ),
         );
 
@@ -225,7 +255,7 @@ export class MetadataSettingsService {
       }
 
       this.logger.log(
-        `${provider.toUpperCase()} media server refresh: ${rows.length - failed}/${rows.length} items queued`,
+        `${provider.toUpperCase()} media server refresh: ${refreshableMediaServerIds.length - failed}/${refreshableMediaServerIds.length} items queued`,
       );
       if (failed > 0) {
         this.logger.warn(`${failed} item(s) could not be refreshed`);
@@ -235,6 +265,67 @@ export class MetadataSettingsService {
         `Could not refresh ${provider.toUpperCase()} items on media server`,
       );
       this.logger.debug(error);
+    }
+  }
+
+  private async refreshMediaServerItem(
+    mediaServer: IMediaServerService,
+    itemId: string,
+    options: RefreshMediaServerItemsOptions,
+  ): Promise<void> {
+    try {
+      await mediaServer.refreshItemMetadata(itemId);
+    } catch (error) {
+      if (!options.retryFailedItemsWithMetadataLookup) {
+        throw error;
+      }
+
+      const serverType = mediaServer.getServerType();
+      this.logger.warn(
+        `Initial ${serverType} metadata refresh failed for item ${itemId}; verifying item before one retry`,
+      );
+      this.logger.debug(error);
+
+      let metadata;
+
+      try {
+        metadata = await mediaServer.getMetadata(itemId);
+      } catch (lookupError) {
+        this.logger.warn(
+          `Failed to verify ${serverType} item ${itemId} after metadata refresh failure`,
+        );
+        this.logger.debug(lookupError);
+        throw error;
+      }
+
+      if (!metadata || isBlankMediaServerId(metadata.id)) {
+        this.logger.warn(
+          `Skipping ${serverType} metadata refresh retry for item ${itemId}; item lookup did not return a usable id`,
+        );
+        throw error;
+      }
+
+      const verifiedItemId = metadata.id.trim();
+
+      if (verifiedItemId !== itemId) {
+        this.logger.warn(
+          `Retrying ${serverType} metadata refresh with verified item id ${verifiedItemId} after failure on ${itemId}`,
+        );
+      } else {
+        this.logger.warn(
+          `Retrying ${serverType} metadata refresh for item ${itemId} after successful verification`,
+        );
+      }
+
+      try {
+        await mediaServer.refreshItemMetadata(verifiedItemId);
+      } catch (retryError) {
+        this.logger.warn(
+          `Retried ${serverType} metadata refresh failed for item ${verifiedItemId}`,
+        );
+        this.logger.debug(retryError);
+        throw retryError;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `media-server-id.utils.ts` with heuristic ID classification (`isLikelyPlexId`, `isLikelyJellyfinId`, `isJellyfinEmptyGuid`, `isForeignServerId`, `shouldRefreshMetadataItemId`) to identify and skip IDs that belong to the wrong server type before queuing metadata refresh requests. All checks are implemented without regex to avoid ReDoS.
- Filters foreign-server IDs (e.g. Jellyfin UUIDs stored against a Plex instance, or all-digit Plex IDs stored against a Jellyfin instance) and Jellyfin empty GUIDs (`00000000...`) with a logged warning rather than silently failing.
- Adds a GET-on-failure retry path in `MetadataSettingsService.refreshMediaServerItem` for manual refresh triggers: on first failure, calls `getMetadata` to retrieve a verified (possibly corrected) item ID and retries once. This covers Jellyfin `Guid can't be empty` corruption scenarios where the stored ID has drifted from the server's current ID.
- Retry path is opt-in (`retryFailedItemsWithMetadataLookup`); automatic scheduled refreshes use the cheaper no-GET path.
- Adds blank-ID guards to both Jellyfin and Plex adapter `refreshItemMetadata` methods. Demotes adapter-level refresh failure logging from `error` to `warn` to avoid false alarms when the service-layer retry succeeds.

## Test plan

- [ ] `media-server-id.utils.spec.ts` — 25 unit tests covering all exported functions, both server types, edge cases (empty GUID both forms, dashes at wrong positions, blank/whitespace)
- [ ] `metadata-settings.service.spec.ts` — 10 integration tests: overlap prevention, batch concurrency, ID filtering for Jellyfin and Plex, retry disabled/same-ID/corrected-ID/lookup-throws/blank-ID/retry-fails paths
- [ ] `jellyfin-adapter.service.spec.ts` — refresh queues valid Jellyfin item IDs
- [ ] `plex-adapter.service.spec.ts` — existing tests confirm foreign-ID filter wired up
- [ ] Run `yarn workspace @maintainerr/server test` and confirm all 110 tests pass