### PR TITLE
fix: delete Tautulli config on media server switch to Jellyfin

### DIFF
--- a/apps/server/src/modules/settings/media-server-switch.service.ts
+++ b/apps/server/src/modules/settings/media-server-switch.service.ts
@@ -365,6 +365,8 @@ export class MediaServerSwitchService {
       updatedSettings.plex_port = null;
       updatedSettings.plex_ssl = null;
       updatedSettings.plex_auth_token = null;
+      updatedSettings.tautulli_url = null;
+      updatedSettings.tautulli_api_key = null;
     } else if (currentServerType === MediaServerType.JELLYFIN) {
       updatedSettings.jellyfin_url = null;
       updatedSettings.jellyfin_api_key = null;


### PR DESCRIPTION
### Description & Design

Please include:

This PR changes the logic when switching the media server from Plex to Jellyfin, erasing Tautulli's config as it's done with Plex's.
This way Maintainerr don't try to connect to the Tautulli service when checking connected services status.

### Related issue

Fixes #2596 

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I understand the code I am submitting and can explain how it works
- [x] I have performed a self-review of my code
- [x] I have linted and formatted my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

### How to test

Please describe the steps to test your changes, including any setup required.

1. Configure Plex as media server and Tautulli URL and token
2. Switch from Plex media server to Jellyfin
3. Trigger collection/rules handling
