### PR TITLE
fix: year-aware title matching to prevent false metadata rejections

### DIFF
--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -526,7 +526,11 @@ describe('JellyfinAdapterService', () => {
 
       await service.refreshItemMetadata(itemId);
 
-      expect(jellyfinApiMocks.refreshItem).toHaveBeenCalledWith({ itemId });
+      expect(jellyfinApiMocks.refreshItem).toHaveBeenCalledWith({
+        itemId,
+        metadataRefreshMode: 'Default',
+        imageRefreshMode: 'Default',
+      });
     });
 
     it('rejects blank Jellyfin item ids before calling the API', async () => {

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -1487,7 +1487,11 @@ export class JellyfinAdapterService implements IMediaServerService {
     }
 
     try {
-      await getItemRefreshApi(this.api).refreshItem({ itemId });
+      await getItemRefreshApi(this.api).refreshItem({
+        itemId,
+        metadataRefreshMode: 'Default',
+        imageRefreshMode: 'Default',
+      });
     } catch (error) {
       this.logger.warn(
         `Failed to refresh Jellyfin metadata for item ${itemId}`,

--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
@@ -231,7 +231,7 @@ export class PlexMapper {
       viewCount: undefined,
       skipCount: undefined,
       lastViewedAt: undefined,
-      year: undefined,
+      year: plex.year,
       durationMs: plex.media?.[0]?.duration,
       originallyAvailableAt: plex.originallyAvailableAt
         ? new Date(plex.originallyAvailableAt)

--- a/apps/server/src/modules/api/plex-api/interfaces/media.interface.ts
+++ b/apps/server/src/modules/api/plex-api/interfaces/media.interface.ts
@@ -6,6 +6,7 @@ export interface PlexMetadata {
   guid: string;
   type: 'movie' | 'show' | 'season' | 'episode' | 'collection';
   title: string;
+  year?: number;
   Guid: {
     id: string;
   }[];

--- a/apps/server/src/modules/metadata/interfaces/metadata.types.ts
+++ b/apps/server/src/modules/metadata/interfaces/metadata.types.ts
@@ -21,6 +21,7 @@ export interface PersonDetails {
 export interface MetadataDetails {
   id: number;
   title: string;
+  year?: number;
   overview?: string;
   posterUrl?: string;
   backdropUrl?: string;

--- a/apps/server/src/modules/metadata/metadata.service.spec.ts
+++ b/apps/server/src/modules/metadata/metadata.service.spec.ts
@@ -13,6 +13,9 @@ describe('MetadataService', () => {
     },
   }: {
     tmdbDetails?: {
+      title?: string;
+      year?: number;
+      type?: 'movie' | 'tv';
       externalIds?: {
         tmdb?: number;
         imdb?: string;
@@ -37,7 +40,7 @@ describe('MetadataService', () => {
         tmdbDetails
           ? {
               id: 101,
-              title: 'Home Alone',
+              title: 'Fixture Story',
               type: 'movie',
               ...tmdbDetails,
             }
@@ -93,6 +96,7 @@ describe('MetadataService', () => {
       service,
       tmdbProvider,
       tvdbProvider,
+      logger,
       mediaServer,
       mediaServerFactory,
     };
@@ -148,7 +152,7 @@ describe('MetadataService', () => {
     const showItem = createMediaItem({
       id: 'show-1',
       type: 'show',
-      title: 'Home Alone',
+      title: 'Fixture Story',
       providerIds: { tmdb: ['771'] },
     });
     const mediaServer = {
@@ -174,6 +178,217 @@ describe('MetadataService', () => {
     const result = await service.resolveIdsFromHierarchyMediaItem(episodeItem);
 
     expect(mediaServer.getMetadata).toHaveBeenCalledWith('show-1');
+    expect(result).toMatchObject({
+      tmdb: 771,
+      type: 'tv',
+    });
+  });
+
+  it('accepts direct provider ids without fetching details when the title suffix already provides the matching year', async () => {
+    const libraryItem = createMediaItem({
+      id: 'show-1',
+      type: 'show',
+      year: undefined,
+      title: 'Fixture Chronicle (2025)',
+      providerIds: {
+        tmdb: ['771'],
+        imdb: [],
+        tvdb: [],
+      },
+    });
+    const detailItem = createMediaItem({
+      id: 'show-1',
+      type: 'show',
+      year: 2025,
+      title: 'Fixture Chronicle (2025)',
+      providerIds: {
+        tmdb: ['771'],
+        imdb: [],
+        tvdb: [],
+      },
+    });
+    const mediaServer = {
+      getMetadata: jest.fn().mockResolvedValue(detailItem),
+    };
+    const { service, logger } = createService({
+      mediaServer,
+      tmdbDetails: {
+        title: 'Fixture Chronicle',
+        year: 2025,
+        type: 'tv',
+        externalIds: {
+          tmdb: 771,
+          type: 'tv',
+        },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(mediaServer.getMetadata).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      tmdb: 771,
+      type: 'tv',
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('still rejects direct provider ids after fetching details when the title suffix year disagrees', async () => {
+    const libraryItem = createMediaItem({
+      id: 'show-1',
+      type: 'show',
+      year: undefined,
+      title: 'Fixture Chronicle (2025)',
+      providerIds: {
+        tmdb: ['771'],
+        imdb: [],
+        tvdb: [],
+      },
+    });
+    const detailItem = createMediaItem({
+      id: 'show-1',
+      type: 'show',
+      year: 2025,
+      title: 'Fixture Chronicle (2025)',
+      providerIds: {
+        tmdb: ['771'],
+        imdb: [],
+        tvdb: [],
+      },
+    });
+    const mediaServer = {
+      getMetadata: jest.fn().mockResolvedValue(detailItem),
+    };
+    const { service, logger } = createService({
+      mediaServer,
+      tmdbDetails: {
+        title: 'Fixture Chronicle',
+        year: 2024,
+        type: 'tv',
+        externalIds: {
+          tmdb: 771,
+          type: 'tv',
+        },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(mediaServer.getMetadata).toHaveBeenCalledWith('show-1');
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Rejected direct provider IDs for media server item "Fixture Chronicle (2025)" because they resolved to "Fixture Chronicle" instead. The media server likely has incorrect metadata for this item, so no external IDs will be returned from this resolution attempt.',
+    );
+  });
+
+  it('fetches detail metadata when the initial item lacks a usable year signal', async () => {
+    const libraryItem = createMediaItem({
+      id: 'show-1',
+      type: 'show',
+      year: undefined,
+      title: 'Fixture Localized',
+      providerIds: {
+        tmdb: ['771'],
+        imdb: [],
+        tvdb: [],
+      },
+    });
+    const detailItem = createMediaItem({
+      id: 'show-1',
+      type: 'show',
+      year: 2025,
+      title: 'Fixture Chronicle (2025)',
+      providerIds: {
+        tmdb: ['771'],
+        imdb: [],
+        tvdb: [],
+      },
+    });
+    const mediaServer = {
+      getMetadata: jest.fn().mockResolvedValue(detailItem),
+    };
+    const { service, logger } = createService({
+      mediaServer,
+      tmdbDetails: {
+        title: 'Fixture Chronicle',
+        year: 2025,
+        type: 'tv',
+        externalIds: {
+          tmdb: 771,
+          type: 'tv',
+        },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(mediaServer.getMetadata).toHaveBeenCalledWith('show-1');
+    expect(result).toMatchObject({
+      tmdb: 771,
+      type: 'tv',
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('skips the detail lookup when the initial item already passes the year-aware title check', async () => {
+    const libraryItem = createMediaItem({
+      id: 'show-1',
+      type: 'show',
+      year: 2025,
+      title: 'Fixture Chronicle (2025)',
+      providerIds: {
+        tmdb: ['771'],
+        imdb: [],
+        tvdb: [],
+      },
+    });
+    const { service, logger, mediaServer } = createService({
+      tmdbDetails: {
+        title: 'Fixture Chronicle',
+        year: 2025,
+        type: 'tv',
+        externalIds: {
+          tmdb: 771,
+          type: 'tv',
+        },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(mediaServer.getMetadata).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      tmdb: 771,
+      type: 'tv',
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('skips the detail lookup when the title already matches', async () => {
+    const libraryItem = createMediaItem({
+      id: 'show-1',
+      type: 'show',
+      title: 'Fixture Chronicle',
+      providerIds: {
+        tmdb: ['771'],
+        imdb: [],
+        tvdb: [],
+      },
+    });
+    const { service, mediaServer } = createService({
+      tmdbDetails: {
+        title: 'Fixture Chronicle',
+        type: 'tv',
+        externalIds: {
+          tmdb: 771,
+          type: 'tv',
+        },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(mediaServer.getMetadata).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       tmdb: 771,
       type: 'tv',

--- a/apps/server/src/modules/metadata/metadata.service.spec.ts
+++ b/apps/server/src/modules/metadata/metadata.service.spec.ts
@@ -231,6 +231,9 @@ describe('MetadataService', () => {
       type: 'tv',
     });
     expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Title mismatch resolved by year-aware match for media server item "Fixture Chronicle (2025)" against "Fixture Chronicle".',
+    );
   });
 
   it('still rejects direct provider ids after fetching details when the title suffix year disagrees', async () => {
@@ -328,6 +331,9 @@ describe('MetadataService', () => {
       type: 'tv',
     });
     expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Title mismatch resolved by year-aware match for media server item "Fixture Localized" against "Fixture Chronicle".',
+    );
   });
 
   it('skips the detail lookup when the initial item already passes the year-aware title check', async () => {

--- a/apps/server/src/modules/metadata/metadata.service.ts
+++ b/apps/server/src/modules/metadata/metadata.service.ts
@@ -569,6 +569,12 @@ export class MetadataService {
     }
   }
 
+  private logYearMatch(itemTitle: string, providerTitle: string): void {
+    this.logger.debug(
+      `Title mismatch resolved by year-aware match for media server item "${itemTitle}" against "${providerTitle}".`,
+    );
+  }
+
   private async matchesProviderDetails(
     item: MediaItem,
     metadataDetails: MetadataDetails,
@@ -578,6 +584,7 @@ export class MetadataService {
     }
 
     if (this.matchesTitleWithYear(item, metadataDetails)) {
+      this.logYearMatch(item.title, metadataDetails.title);
       return true;
     }
 
@@ -590,7 +597,12 @@ export class MetadataService {
       return true;
     }
 
-    return this.matchesTitleWithYear(detailItem, metadataDetails);
+    if (this.matchesTitleWithYear(detailItem, metadataDetails)) {
+      this.logYearMatch(item.title, metadataDetails.title);
+      return true;
+    }
+
+    return false;
   }
 
   private async resolveAllIds(

--- a/apps/server/src/modules/metadata/metadata.service.ts
+++ b/apps/server/src/modules/metadata/metadata.service.ts
@@ -243,7 +243,7 @@ export class MetadataService {
         if (
           item.title &&
           metadataDetails?.title &&
-          !this.titlesMatch(item.title, metadataDetails.title)
+          !(await this.matchesProviderDetails(item, metadataDetails))
         ) {
           this.logger.warn(
             `Rejected direct provider IDs for media server item "${item.title}" because they resolved to "${metadataDetails.title}" instead. The media server likely has incorrect metadata for this item, so no external IDs will be returned from this resolution attempt.`,
@@ -431,28 +431,166 @@ export class MetadataService {
   }
 
   private titlesMatch(left: string, right: string): boolean {
-    const normalize = (value: string) => {
-      let normalized = '';
-
-      for (const character of value.toLowerCase()) {
-        const isDigit = character >= '0' && character <= '9';
-        const isLetter = character >= 'a' && character <= 'z';
-        if (isDigit || isLetter) {
-          normalized += character;
-        }
-      }
-
-      return normalized;
-    };
-
-    const normalizedLeft = normalize(left);
-    const normalizedRight = normalize(right);
+    const normalizedLeft = this.normalizeTitle(left);
+    const normalizedRight = this.normalizeTitle(right);
 
     if (normalizedLeft.length === 0 || normalizedRight.length === 0) {
       return left.trim().toLowerCase() === right.trim().toLowerCase();
     }
 
     return normalizedLeft === normalizedRight;
+  }
+
+  private normalizeTitle(value: string): string {
+    let normalized = '';
+
+    for (const character of value.toLowerCase()) {
+      const isDigit = character >= '0' && character <= '9';
+      const isLetter = character >= 'a' && character <= 'z';
+      if (isDigit || isLetter) {
+        normalized += character;
+      }
+    }
+
+    return normalized;
+  }
+
+  private readTitleYear(title: string): number | undefined {
+    const trimmedTitle = title.trim();
+    const parenthesizedSuffixStart = trimmedTitle.length - 6;
+    const parenthesizedYear = trimmedTitle.slice(
+      parenthesizedSuffixStart + 1,
+      trimmedTitle.length - 1,
+    );
+
+    if (
+      parenthesizedSuffixStart >= 0 &&
+      trimmedTitle.endsWith(')') &&
+      trimmedTitle.charAt(parenthesizedSuffixStart) === '(' &&
+      this.isYear(parenthesizedYear)
+    ) {
+      return Number.parseInt(parenthesizedYear, 10);
+    }
+
+    const spaceSeparatedSuffixStart = trimmedTitle.length - 5;
+    const spacedYear = trimmedTitle.slice(spaceSeparatedSuffixStart + 1);
+    if (
+      spaceSeparatedSuffixStart >= 0 &&
+      trimmedTitle.charAt(spaceSeparatedSuffixStart) === ' ' &&
+      this.isYear(spacedYear)
+    ) {
+      return Number.parseInt(spacedYear, 10);
+    }
+
+    return undefined;
+  }
+
+  private isYear(value: string): boolean {
+    return (
+      value.length === 4 &&
+      value.charCodeAt(0) >= 48 &&
+      value.charCodeAt(0) <= 57 &&
+      value.charCodeAt(1) >= 48 &&
+      value.charCodeAt(1) <= 57 &&
+      value.charCodeAt(2) >= 48 &&
+      value.charCodeAt(2) <= 57 &&
+      value.charCodeAt(3) >= 48 &&
+      value.charCodeAt(3) <= 57
+    );
+  }
+
+  private readItemYear(
+    item: Pick<MediaItem, 'year' | 'originallyAvailableAt' | 'title'>,
+  ): number | undefined {
+    if (item.year !== undefined) {
+      return item.year;
+    }
+
+    if (item.originallyAvailableAt) {
+      return item.originallyAvailableAt.getUTCFullYear();
+    }
+
+    return this.readTitleYear(item.title);
+  }
+
+  private stripTitleYear(title: string, year: number): string {
+    const trimmedTitle = title.trim();
+    const parenthesizedSuffix = `(${year})`;
+
+    if (trimmedTitle.endsWith(parenthesizedSuffix)) {
+      return trimmedTitle
+        .slice(0, trimmedTitle.length - parenthesizedSuffix.length)
+        .trimEnd();
+    }
+
+    const spaceSeparatedSuffix = ` ${year}`;
+    if (trimmedTitle.endsWith(spaceSeparatedSuffix)) {
+      return trimmedTitle
+        .slice(0, trimmedTitle.length - spaceSeparatedSuffix.length)
+        .trimEnd();
+    }
+
+    return trimmedTitle;
+  }
+
+  private matchesTitleWithYear(
+    item: Pick<MediaItem, 'title' | 'year' | 'originallyAvailableAt'>,
+    metadataDetails: MetadataDetails,
+  ): boolean {
+    const itemYear = this.readItemYear(item);
+    if (
+      itemYear === undefined ||
+      metadataDetails.year === undefined ||
+      itemYear !== metadataDetails.year
+    ) {
+      return false;
+    }
+
+    const metadataTitle = this.stripTitleYear(
+      metadataDetails.title,
+      metadataDetails.year,
+    );
+
+    return this.titlesMatch(
+      this.stripTitleYear(item.title, itemYear),
+      metadataTitle,
+    );
+  }
+
+  private async loadItemDetails(
+    itemId: string,
+  ): Promise<MediaItem | undefined> {
+    try {
+      const mediaServer = await this.mediaServerFactory.getService();
+      return await mediaServer.getMetadata(itemId);
+    } catch (error) {
+      this.logger.debug(error);
+      return undefined;
+    }
+  }
+
+  private async matchesProviderDetails(
+    item: MediaItem,
+    metadataDetails: MetadataDetails,
+  ): Promise<boolean> {
+    if (this.titlesMatch(item.title, metadataDetails.title)) {
+      return true;
+    }
+
+    if (this.matchesTitleWithYear(item, metadataDetails)) {
+      return true;
+    }
+
+    const detailItem = await this.loadItemDetails(item.id);
+    if (!detailItem) {
+      return false;
+    }
+
+    if (this.titlesMatch(detailItem.title, metadataDetails.title)) {
+      return true;
+    }
+
+    return this.matchesTitleWithYear(detailItem, metadataDetails);
   }
 
   private async resolveAllIds(

--- a/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.ts
+++ b/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.ts
@@ -43,6 +43,15 @@ export class TmdbMetadataProvider implements IMetadataProvider {
       : this.tmdbApi.getTvShow({ tvId: tmdbId });
   }
 
+  private parseYear(value?: string): number | undefined {
+    if (!value || value.length < 4) {
+      return undefined;
+    }
+
+    const year = Number.parseInt(value.slice(0, 4), 10);
+    return Number.isFinite(year) ? year : undefined;
+  }
+
   async getDetails(
     tmdbId: number,
     type: 'movie' | 'tv',
@@ -55,6 +64,9 @@ export class TmdbMetadataProvider implements IMetadataProvider {
     return {
       id: record.id,
       title: 'title' in record ? record.title : record.name,
+      year: this.parseYear(
+        'release_date' in record ? record.release_date : record.first_air_date,
+      ),
       overview: record.overview,
       posterUrl: this.buildImageUrl(record.poster_path, 'w500'),
       backdropUrl: this.buildImageUrl(record.backdrop_path, 'w1280'),

--- a/apps/server/src/modules/metadata/providers/tvdb-metadata.provider.ts
+++ b/apps/server/src/modules/metadata/providers/tvdb-metadata.provider.ts
@@ -34,6 +34,15 @@ export class TvdbMetadataProvider implements IMetadataProvider {
       : this.tvdbApi.getSeries(tvdbId);
   }
 
+  private parseYear(value?: string): number | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    const year = Number.parseInt(value, 10);
+    return Number.isFinite(year) ? year : undefined;
+  }
+
   async getDetails(
     tvdbId: number,
     type: 'movie' | 'tv',
@@ -46,6 +55,7 @@ export class TvdbMetadataProvider implements IMetadataProvider {
     return {
       id: record.id,
       title: record.name,
+      year: this.parseYear(record.year),
       overview: record.overview ?? undefined,
       posterUrl: this.tvdbApi.getPosterUrl(record, type),
       backdropUrl: this.tvdbApi.getBackdropUrl(record, type),


### PR DESCRIPTION
## Summary

- Media server titles with a year suffix (e.g. `"Title (2025)"`) were falsely rejected during provider ID validation because the normalized title included the year digits, mismatching the provider's bare title `"Title"`
- Adds year-aware title comparison that strips matching year suffixes before comparing base titles, with a cascading match strategy that avoids unnecessary media server API calls
- Plumbs `year` through Plex mapper (`metadataToMediaItem`) and both TMDB/TVDB providers into `MetadataDetails`

## Before

```
resolveIdsFromMediaItem(item)
│
├── getDetails(ids, type) → metadataDetails from TMDB/TVDB
│
└── titlesMatch(item.title, metadataDetails.title)
    │
    │  normalize("Title (2025)") → "title2025"
    │  normalize("Title")        → "title"
    │
    └── "title2025" ≠ "title" → ❌ REJECT (false positive)
        └── warns: "Rejected direct provider IDs..."
```

## After

```
resolveIdsFromMediaItem(item)
│
├── getDetails(ids, type) → metadataDetails from TMDB/TVDB
│
└── matchesProviderDetails(item, metadataDetails)
    │
    ├─ 1. titlesMatch(item.title, provider.title)
    │     "title2025" ≠ "title" → no match, continue
    │
    ├─ 2. matchesTitleWithYear(item, provider)     ← no API call
    │     ├─ readItemYear: year / originallyAvailableAt / title parse
    │     ├─ years both present and equal?
    │     ├─ stripTitleYear("Title (2025)", 2025) → "Title"
    │     ├─ stripTitleYear("Title", 2025)        → "Title"
    │     └─ titlesMatch("Title", "Title") → ✅ ACCEPT
    │
    ├─ 3. loadItemDetails(item.id)                 ← API call (only if 1+2 fail)
    │
    ├─ 4. titlesMatch(detailItem.title, provider.title)
    │
    └─ 5. matchesTitleWithYear(detailItem, provider)
```

Steps 3–5 are only reached when the library item has no usable year signal (no `year` field, no `originallyAvailableAt`, no year suffix in title) — e.g. a localized title that differs from the provider title entirely.

## Test plan

- [x] Accepts IDs when title has year suffix matching provider year (no detail fetch)
- [x] Accepts IDs when item already carries `year` field (no detail fetch)
- [x] Rejects IDs when year suffix disagrees with provider year (detail fetch, still rejected)
- [x] Falls back to detail fetch when library item has no year signal
- [x] Skips all year logic when titles match directly
- [x] All 7 existing + new tests pass