### PR TITLE
feat: Plex connection resilience — auto re-discovery + manual override

### DIFF
--- a/apps/server/src/database/migrations/1775929945733-AddPlexConnectionResilience.ts
+++ b/apps/server/src/database/migrations/1775929945733-AddPlexConnectionResilience.ts
@@ -1,10 +1,10 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddPlexConnectionResilience1775929945733 implements MigrationInterface {
-    name = 'AddPlexConnectionResilience1775929945733'
+  name = 'AddPlexConnectionResilience1775929945733';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
             CREATE TABLE "temporary_settings" (
                 "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
                 "clientId" varchar,
@@ -35,7 +35,7 @@ export class AddPlexConnectionResilience1775929945733 implements MigrationInterf
                 "plex_manual_mode" integer DEFAULT (0)
             )
         `);
-        await queryRunner.query(`
+    await queryRunner.query(`
             INSERT INTO "temporary_settings"(
                     "id",
                     "clientId",
@@ -90,21 +90,21 @@ export class AddPlexConnectionResilience1775929945733 implements MigrationInterf
                 "metadata_provider_preference"
             FROM "settings"
         `);
-        await queryRunner.query(`
+    await queryRunner.query(`
             DROP TABLE "settings"
         `);
-        await queryRunner.query(`
+    await queryRunner.query(`
             ALTER TABLE "temporary_settings"
                 RENAME TO "settings"
         `);
-    }
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
             ALTER TABLE "settings"
                 RENAME TO "temporary_settings"
         `);
-        await queryRunner.query(`
+    await queryRunner.query(`
             CREATE TABLE "settings" (
                 "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
                 "clientId" varchar,
@@ -133,7 +133,7 @@ export class AddPlexConnectionResilience1775929945733 implements MigrationInterf
                 "metadata_provider_preference" varchar NOT NULL DEFAULT ('tmdb_primary')
             )
         `);
-        await queryRunner.query(`
+    await queryRunner.query(`
             INSERT INTO "settings"(
                     "id",
                     "clientId",
@@ -188,9 +188,8 @@ export class AddPlexConnectionResilience1775929945733 implements MigrationInterf
                 "metadata_provider_preference"
             FROM "temporary_settings"
         `);
-        await queryRunner.query(`
+    await queryRunner.query(`
             DROP TABLE "temporary_settings"
         `);
-    }
-
+  }
 }

--- a/apps/server/src/database/migrations/1775929945733-AddPlexConnectionResilience.ts
+++ b/apps/server/src/database/migrations/1775929945733-AddPlexConnectionResilience.ts
@@ -1,0 +1,196 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPlexConnectionResilience1775929945733 implements MigrationInterface {
+    name = 'AddPlexConnectionResilience1775929945733'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE "temporary_settings" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "clientId" varchar,
+                "applicationTitle" varchar NOT NULL DEFAULT ('Maintainerr'),
+                "applicationUrl" varchar NOT NULL DEFAULT ('localhost'),
+                "apikey" varchar,
+                "locale" varchar NOT NULL DEFAULT ('en'),
+                "plex_name" varchar,
+                "plex_hostname" varchar,
+                "plex_port" integer DEFAULT (32400),
+                "plex_ssl" integer,
+                "plex_auth_token" varchar,
+                "collection_handler_job_cron" varchar NOT NULL DEFAULT ('0 0-23/12 * * *'),
+                "rules_handler_job_cron" varchar NOT NULL DEFAULT ('0 0-23/8 * * *'),
+                "tautulli_url" varchar,
+                "tautulli_api_key" varchar,
+                "media_server_type" varchar,
+                "jellyfin_url" varchar,
+                "jellyfin_api_key" varchar,
+                "jellyfin_user_id" varchar,
+                "jellyfin_server_name" varchar,
+                "seerr_url" varchar,
+                "seerr_api_key" varchar,
+                "tmdb_api_key" varchar,
+                "tvdb_api_key" varchar,
+                "metadata_provider_preference" varchar NOT NULL DEFAULT ('tmdb_primary'),
+                "plex_machine_id" varchar,
+                "plex_manual_mode" integer DEFAULT (0)
+            )
+        `);
+        await queryRunner.query(`
+            INSERT INTO "temporary_settings"(
+                    "id",
+                    "clientId",
+                    "applicationTitle",
+                    "applicationUrl",
+                    "apikey",
+                    "locale",
+                    "plex_name",
+                    "plex_hostname",
+                    "plex_port",
+                    "plex_ssl",
+                    "plex_auth_token",
+                    "collection_handler_job_cron",
+                    "rules_handler_job_cron",
+                    "tautulli_url",
+                    "tautulli_api_key",
+                    "media_server_type",
+                    "jellyfin_url",
+                    "jellyfin_api_key",
+                    "jellyfin_user_id",
+                    "jellyfin_server_name",
+                    "seerr_url",
+                    "seerr_api_key",
+                    "tmdb_api_key",
+                    "tvdb_api_key",
+                    "metadata_provider_preference"
+                )
+            SELECT "id",
+                "clientId",
+                "applicationTitle",
+                "applicationUrl",
+                "apikey",
+                "locale",
+                "plex_name",
+                "plex_hostname",
+                "plex_port",
+                "plex_ssl",
+                "plex_auth_token",
+                "collection_handler_job_cron",
+                "rules_handler_job_cron",
+                "tautulli_url",
+                "tautulli_api_key",
+                "media_server_type",
+                "jellyfin_url",
+                "jellyfin_api_key",
+                "jellyfin_user_id",
+                "jellyfin_server_name",
+                "seerr_url",
+                "seerr_api_key",
+                "tmdb_api_key",
+                "tvdb_api_key",
+                "metadata_provider_preference"
+            FROM "settings"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "settings"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "temporary_settings"
+                RENAME TO "settings"
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "settings"
+                RENAME TO "temporary_settings"
+        `);
+        await queryRunner.query(`
+            CREATE TABLE "settings" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "clientId" varchar,
+                "applicationTitle" varchar NOT NULL DEFAULT ('Maintainerr'),
+                "applicationUrl" varchar NOT NULL DEFAULT ('localhost'),
+                "apikey" varchar,
+                "locale" varchar NOT NULL DEFAULT ('en'),
+                "plex_name" varchar,
+                "plex_hostname" varchar,
+                "plex_port" integer DEFAULT (32400),
+                "plex_ssl" integer,
+                "plex_auth_token" varchar,
+                "collection_handler_job_cron" varchar NOT NULL DEFAULT ('0 0-23/12 * * *'),
+                "rules_handler_job_cron" varchar NOT NULL DEFAULT ('0 0-23/8 * * *'),
+                "tautulli_url" varchar,
+                "tautulli_api_key" varchar,
+                "media_server_type" varchar,
+                "jellyfin_url" varchar,
+                "jellyfin_api_key" varchar,
+                "jellyfin_user_id" varchar,
+                "jellyfin_server_name" varchar,
+                "seerr_url" varchar,
+                "seerr_api_key" varchar,
+                "tmdb_api_key" varchar,
+                "tvdb_api_key" varchar,
+                "metadata_provider_preference" varchar NOT NULL DEFAULT ('tmdb_primary')
+            )
+        `);
+        await queryRunner.query(`
+            INSERT INTO "settings"(
+                    "id",
+                    "clientId",
+                    "applicationTitle",
+                    "applicationUrl",
+                    "apikey",
+                    "locale",
+                    "plex_name",
+                    "plex_hostname",
+                    "plex_port",
+                    "plex_ssl",
+                    "plex_auth_token",
+                    "collection_handler_job_cron",
+                    "rules_handler_job_cron",
+                    "tautulli_url",
+                    "tautulli_api_key",
+                    "media_server_type",
+                    "jellyfin_url",
+                    "jellyfin_api_key",
+                    "jellyfin_user_id",
+                    "jellyfin_server_name",
+                    "seerr_url",
+                    "seerr_api_key",
+                    "tmdb_api_key",
+                    "tvdb_api_key",
+                    "metadata_provider_preference"
+                )
+            SELECT "id",
+                "clientId",
+                "applicationTitle",
+                "applicationUrl",
+                "apikey",
+                "locale",
+                "plex_name",
+                "plex_hostname",
+                "plex_port",
+                "plex_ssl",
+                "plex_auth_token",
+                "collection_handler_job_cron",
+                "rules_handler_job_cron",
+                "tautulli_url",
+                "tautulli_api_key",
+                "media_server_type",
+                "jellyfin_url",
+                "jellyfin_api_key",
+                "jellyfin_user_id",
+                "jellyfin_server_name",
+                "seerr_url",
+                "seerr_api_key",
+                "tmdb_api_key",
+                "tvdb_api_key",
+                "metadata_provider_preference"
+            FROM "temporary_settings"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "temporary_settings"
+        `);
+    }
+
+}

--- a/apps/server/src/modules/api/media-server/media-server.factory.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-server.factory.spec.ts
@@ -203,9 +203,7 @@ describe('MediaServerFactory', () => {
     });
 
     it('returns the adapter when status check succeeds', async () => {
-      jest
-        .spyOn(factory, 'getService')
-        .mockResolvedValue(plexAdapter as any);
+      jest.spyOn(factory, 'getService').mockResolvedValue(plexAdapter as any);
       (plexAdapter as any).getStatus.mockResolvedValue({
         machineIdentifier: 'abc',
       });
@@ -235,9 +233,7 @@ describe('MediaServerFactory', () => {
     });
 
     it('throws when re-initialization also fails to produce a live connection', async () => {
-      jest
-        .spyOn(factory, 'getService')
-        .mockResolvedValue(plexAdapter as any);
+      jest.spyOn(factory, 'getService').mockResolvedValue(plexAdapter as any);
       jest
         .spyOn(factory, 'getConfiguredServerType')
         .mockResolvedValue(MediaServerType.PLEX);

--- a/apps/server/src/modules/api/media-server/media-server.factory.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-server.factory.spec.ts
@@ -191,4 +191,62 @@ describe('MediaServerFactory', () => {
 
     await expect(factory.initialize()).resolves.toBeUndefined();
   });
+
+  describe('verifyConnection', () => {
+    beforeEach(() => {
+      settingsService.getSettings.mockResolvedValue(
+        createSettings({ media_server_type: MediaServerType.PLEX }),
+      );
+      plexAdapter.isSetup.mockReturnValue(true);
+      (plexAdapter as any).getStatus = jest.fn();
+      (logger as any).debug = jest.fn();
+    });
+
+    it('returns the adapter when status check succeeds', async () => {
+      jest
+        .spyOn(factory, 'getService')
+        .mockResolvedValue(plexAdapter as any);
+      (plexAdapter as any).getStatus.mockResolvedValue({
+        machineIdentifier: 'abc',
+      });
+
+      const result = await factory.verifyConnection();
+      expect(result).toBe(plexAdapter);
+    });
+
+    it('re-initializes and verifies again when first status check fails', async () => {
+      const getServiceSpy = jest
+        .spyOn(factory, 'getService')
+        .mockResolvedValue(plexAdapter as any);
+      jest
+        .spyOn(factory, 'getConfiguredServerType')
+        .mockResolvedValue(MediaServerType.PLEX);
+
+      // First status: fails. After re-init: succeeds.
+      (plexAdapter as any).getStatus
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ machineIdentifier: 'abc' });
+
+      const result = await factory.verifyConnection();
+
+      expect(plexAdapter.uninitialize).toHaveBeenCalled();
+      expect(getServiceSpy).toHaveBeenCalledTimes(2);
+      expect(result).toBe(plexAdapter);
+    });
+
+    it('throws when re-initialization also fails to produce a live connection', async () => {
+      jest
+        .spyOn(factory, 'getService')
+        .mockResolvedValue(plexAdapter as any);
+      jest
+        .spyOn(factory, 'getConfiguredServerType')
+        .mockResolvedValue(MediaServerType.PLEX);
+
+      (plexAdapter as any).getStatus.mockResolvedValue(undefined);
+
+      await expect(factory.verifyConnection()).rejects.toThrow(
+        'Media server still unreachable after re-initialization',
+      );
+    });
+  });
 });

--- a/apps/server/src/modules/api/media-server/media-server.factory.ts
+++ b/apps/server/src/modules/api/media-server/media-server.factory.ts
@@ -194,6 +194,42 @@ export class MediaServerFactory {
     return null;
   }
 
+  /**
+   * Verify that the configured media server is reachable. If the connection
+   * is dead, forces a re-initialization (which for Plex triggers re-discovery
+   * from plex.tv). Returns the ready adapter on success.
+   *
+   * Intended for use as a pre-flight check before jobs that depend on the
+   * media server (rule execution, collection handling).
+   */
+  async verifyConnection(): Promise<IMediaServerService> {
+    const adapter = await this.getService();
+    const status = await adapter.getStatus();
+
+    if (status) {
+      return adapter;
+    }
+
+    // Connection is dead — force re-initialization
+    this.logger.debug(
+      'Media server unreachable during pre-job check, attempting re-initialization',
+    );
+
+    const serverType = await this.getConfiguredServerType();
+    this.uninitializeServer(serverType);
+    const reinitAdapter = await this.getService(); // calls ensureAdapterReady → initialize()
+
+    // Verify the re-initialized adapter is actually reachable
+    const retryStatus = await reinitAdapter.getStatus();
+    if (!retryStatus) {
+      throw new Error(
+        'Media server still unreachable after re-initialization',
+      );
+    }
+
+    return reinitAdapter;
+  }
+
   private async ensureAdapterReady(
     serverType: MediaServerType,
     adapter: IMediaServerService,

--- a/apps/server/src/modules/api/media-server/media-server.factory.ts
+++ b/apps/server/src/modules/api/media-server/media-server.factory.ts
@@ -222,9 +222,7 @@ export class MediaServerFactory {
     // Verify the re-initialized adapter is actually reachable
     const retryStatus = await reinitAdapter.getStatus();
     if (!retryStatus) {
-      throw new Error(
-        'Media server still unreachable after re-initialization',
-      );
+      throw new Error('Media server still unreachable after re-initialization');
     }
 
     return reinitAdapter;

--- a/apps/server/src/modules/api/media-server/plex/plex.constants.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.constants.ts
@@ -4,7 +4,7 @@ import {
 } from '@maintainerr/contracts';
 
 export const PLEX_BATCH_SIZE = {
-  COLLECTION_MUTATION: 8,
+  COLLECTION_MUTATION: 4,
 } as const;
 
 const PLEX_SORT_FIELDS: Partial<Record<MediaLibrarySortField, string>> = {

--- a/apps/server/src/modules/api/plex-api/interfaces/server.interface.ts
+++ b/apps/server/src/modules/api/plex-api/interfaces/server.interface.ts
@@ -46,4 +46,5 @@ export interface PlexConnection {
   local: boolean;
   status?: number;
   message?: string;
+  latency?: number;
 }

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -2,6 +2,61 @@ import { Mocked, TestBed } from '@suites/unit';
 import { SettingsService } from '../../settings/settings.service';
 import { MaintainerrLoggerFactory } from '../../logging/logs.service';
 import { PlexApiService } from './plex-api.service';
+import { PlexConnection } from './interfaces/server.interface';
+
+describe('PlexApiService.rankConnections', () => {
+  const conn = (overrides: Partial<PlexConnection> = {}): PlexConnection => ({
+    protocol: 'http',
+    address: '192.168.1.50',
+    port: 32400,
+    uri: 'http://192.168.1.50:32400',
+    local: true,
+    status: 200,
+    ...overrides,
+  });
+
+  it('prefers reachable connections over unreachable ones', () => {
+    const ranked = PlexApiService.rankConnections([
+      conn({ address: '10.0.0.1', status: undefined }),
+      conn({ address: '10.0.0.2', status: 200 }),
+    ]);
+    expect(ranked[0].address).toBe('10.0.0.2');
+  });
+
+  it('prefers local connections over remote ones', () => {
+    const ranked = PlexApiService.rankConnections([
+      conn({ address: '1.2.3.4', local: false }),
+      conn({ address: '192.168.1.50', local: true }),
+    ]);
+    expect(ranked[0].address).toBe('192.168.1.50');
+  });
+
+  it('prefers direct IP over plex.direct hostnames', () => {
+    const ranked = PlexApiService.rankConnections([
+      conn({ address: 'abc123.plex.direct' }),
+      conn({ address: '192.168.1.50' }),
+    ]);
+    expect(ranked[0].address).toBe('192.168.1.50');
+  });
+
+  it('sorts by latency when all else is equal', () => {
+    const ranked = PlexApiService.rankConnections([
+      conn({ address: '192.168.1.2', latency: 100 }),
+      conn({ address: '192.168.1.1', latency: 10 }),
+    ]);
+    expect(ranked[0].address).toBe('192.168.1.1');
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      conn({ address: '10.0.0.1', local: false }),
+      conn({ address: '10.0.0.2', local: true }),
+    ];
+    const ranked = PlexApiService.rankConnections(input);
+    expect(ranked).not.toBe(input);
+    expect(input[0].address).toBe('10.0.0.1');
+  });
+});
 
 describe('PlexApiService.getMetadata', () => {
   let service: PlexApiService;
@@ -168,5 +223,70 @@ describe('PlexApiService.getMetadata', () => {
     await expect(service.validateAuthToken()).rejects.toThrow(
       'Plex auth token is required for validation',
     );
+  });
+});
+
+describe('PlexApiService.initialize', () => {
+  let service: PlexApiService;
+  let settingsService: Mocked<SettingsService>;
+  let loggerFactory: Mocked<MaintainerrLoggerFactory>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(PlexApiService).compile();
+
+    service = unit;
+    settingsService = unitRef.get(SettingsService);
+    loggerFactory = unitRef.get(MaintainerrLoggerFactory);
+
+    settingsService.plex_hostname = 'plex.local';
+    settingsService.plex_port = 32400;
+    settingsService.plex_ssl = 0;
+    settingsService.plex_auth_token = 'token';
+    settingsService.plex_manual_mode = 0;
+    settingsService.plex_machine_id = 'machine123';
+    settingsService.updatePlexConnectionDetails = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    loggerFactory.createLogger.mockReturnValue({
+      setContext: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as any);
+  });
+
+  it('clears plexClient when primary connection and rediscovery both fail', async () => {
+    // Mock getStatus to fail on the primary connection
+    jest.spyOn(service, 'getAvailableServers').mockResolvedValue([]);
+
+    await service.initialize();
+
+    expect(service.isPlexSetup()).toBe(false);
+  });
+
+  it('skips rediscovery in manual mode when primary connection fails', async () => {
+    settingsService.plex_manual_mode = 1;
+    const getServersSpy = jest
+      .spyOn(service, 'getAvailableServers')
+      .mockResolvedValue([]);
+
+    await service.initialize();
+
+    expect(getServersSpy).not.toHaveBeenCalled();
+    expect(service.isPlexSetup()).toBe(false);
+  });
+
+  it('attempts rediscovery when primary connection fails', async () => {
+    const getServersSpy = jest
+      .spyOn(service, 'getAvailableServers')
+      .mockResolvedValue([]);
+
+    await service.initialize();
+
+    // Verify rediscovery was attempted (getAvailableServers called)
+    expect(getServersSpy).toHaveBeenCalled();
+    // No working connection found, so client should be cleared
+    expect(service.isPlexSetup()).toBe(false);
   });
 });

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -44,6 +44,7 @@ import {
 } from './interfaces/media.interface';
 import {
   PlexAccountsResponse,
+  PlexConnection,
   PlexDevice,
   PlexStatusResponse,
 } from './interfaces/server.interface';
@@ -73,11 +74,55 @@ export class PlexApiService {
       auth_token: this.settings.plex_auth_token,
       useSsl: this.settings.plex_ssl === 1 ? true : false,
       webAppUrl: this.settings.plex_hostname,
+      manualMode: this.settings.plex_manual_mode === 1,
     };
   }
 
   public isPlexSetup(): boolean {
     return this.plexClient != null;
+  }
+
+  /**
+   * Rank discovered Plex connections by preference.
+   * Prefers local direct-IP connections (no DNS needed) over plex.direct
+   * hostnames, which avoids DNS resolution issues common in Docker.
+   *
+   * Priority: reachable > local + direct IP > local + plex.direct > remote
+   */
+  public static rankConnections(
+    connections: PlexConnection[],
+  ): PlexConnection[] {
+    const isDirectIp = (address: string) => {
+      // IPv6
+      if (address.includes(':')) return true;
+
+      // IPv4: four dot-separated groups of digits (e.g. 192.168.1.50)
+      const parts = address.split('.');
+      if (parts.length !== 4) return false;
+      return parts.every(
+        (p) => p.length > 0 && p.length <= 3 && !Number.isNaN(Number(p)),
+      );
+    };
+
+    return [...connections].sort((a, b) => {
+      // 1. Reachable first (status 200)
+      const aReachable = a.status === 200 ? 1 : 0;
+      const bReachable = b.status === 200 ? 1 : 0;
+      if (bReachable !== aReachable) return bReachable - aReachable;
+
+      // 2. Local over remote
+      const aLocal = a.local ? 1 : 0;
+      const bLocal = b.local ? 1 : 0;
+      if (bLocal !== aLocal) return bLocal - aLocal;
+
+      // 3. Direct IP over DNS-dependent hostnames (e.g., *.plex.direct)
+      const aDirectIp = isDirectIp(a.address) ? 1 : 0;
+      const bDirectIp = isDirectIp(b.address) ? 1 : 0;
+      if (bDirectIp !== aDirectIp) return bDirectIp - aDirectIp;
+
+      // 4. Lower latency preferred
+      return (a.latency ?? Infinity) - (b.latency ?? Infinity);
+    });
   }
 
   private buildCollectionItemsUri(itemIds: string[]): string {
@@ -151,34 +196,135 @@ export class PlexApiService {
       this.uninitialize();
       const settingsPlex = this.getDbSettings();
       const plexToken = settingsPlex.auth_token;
-      if (settingsPlex.ip && plexToken) {
-        this.plexClient = new PlexApi({
-          hostname: settingsPlex.ip,
-          port: settingsPlex.port,
-          https: settingsPlex.useSsl,
-          token: plexToken,
-        });
 
-        this.plexTvClient = new PlexTvApi(
-          plexToken,
-          this.loggerFactory.createLogger(),
-        );
-        this.plexCommunityClient = new PlexCommunityApi(
-          plexToken,
-          this.loggerFactory.createLogger(),
-        );
-
-        await this.setMachineId();
-      } else {
+      if (!settingsPlex.ip || !plexToken) {
         this.logger.warn(
           "Plex API isn't fully initialized, required settings aren't set",
         );
+        return;
+      }
+
+      this.plexTvClient = new PlexTvApi(
+        plexToken,
+        this.loggerFactory.createLogger(),
+      );
+      this.plexCommunityClient = new PlexCommunityApi(
+        plexToken,
+        this.loggerFactory.createLogger(),
+      );
+
+      // Try stored primary connection
+      this.plexClient = new PlexApi({
+        hostname: settingsPlex.ip,
+        port: settingsPlex.port,
+        https: settingsPlex.useSsl,
+        token: plexToken,
+      });
+
+      const machineId = await this.setMachineId();
+
+      if (machineId) {
+        return; // Primary connection works
+      }
+
+      // Manual mode: don't attempt re-discovery, user owns the connection
+      if (settingsPlex.manualMode) {
+        this.plexClient = undefined;
+        this.logger.warn(
+          'Plex connection failed (manual mode active — skipping re-discovery)',
+        );
+        return;
+      }
+
+      // Re-discover from plex.tv
+      const recovered = await this.rediscoverConnection(plexToken);
+      if (!recovered) {
+        // Clear the dead client so isSetup() reflects reality
+        this.plexClient = undefined;
       }
     } catch (error) {
+      this.plexClient = undefined;
       this.logger.error(
         `Couldn't connect to Plex.. Please check your settings`,
       );
       this.logger.debug(error);
+    }
+  }
+
+  /**
+   * Attempt to re-discover a working Plex connection from plex.tv.
+   * Matches the stored machineId to find the right server, ranks connections
+   * to prefer local direct-IP, and promotes the first working one to primary.
+   */
+  private async rediscoverConnection(plexToken: string): Promise<boolean> {
+    const storedMachineId = this.settings.plex_machine_id;
+
+    if (!storedMachineId) {
+      this.logger.debug(
+        'No stored machine ID — cannot identify server for re-discovery',
+      );
+      return false;
+    }
+
+    this.logger.log(
+      'Primary Plex connection failed, attempting re-discovery from plex.tv...',
+    );
+
+    try {
+      const devices = await this.getAvailableServers();
+      const matchingDevice = devices?.find(
+        (d) => d.clientIdentifier === storedMachineId,
+      );
+
+      if (!matchingDevice?.connection?.length) {
+        this.logger.debug(
+          'Re-discovery: server not found or no reachable connections',
+        );
+        return false;
+      }
+
+      const ranked = PlexApiService.rankConnections(matchingDevice.connection);
+
+      for (const conn of ranked) {
+        const testClient = new PlexApi({
+          hostname: conn.address,
+          port: conn.port,
+          https: conn.protocol === 'https',
+          timeout: CONNECTION_TEST_TIMEOUT_MS,
+          token: plexToken,
+        });
+
+        const ok = await testClient.getStatus();
+        if (!ok) continue;
+
+        // Found a working connection — promote it
+        this.plexClient = new PlexApi({
+          hostname: conn.address,
+          port: conn.port,
+          https: conn.protocol === 'https',
+          token: plexToken,
+        });
+
+        await this.settings.updatePlexConnectionDetails({
+          plex_hostname: conn.address,
+          plex_port: conn.port,
+          plex_ssl: conn.protocol === 'https' ? 1 : 0,
+        });
+
+        await this.setMachineId();
+
+        this.logger.log(
+          `Re-discovery: switched to ${conn.protocol}://${conn.address}:${conn.port} (local=${conn.local})`,
+        );
+        return true;
+      }
+
+      this.logger.debug('Re-discovery: all discovered connections failed');
+      return false;
+    } catch (error) {
+      this.logger.debug('Re-discovery from plex.tv failed');
+      this.logger.debug(error);
+      return false;
     }
   }
 
@@ -991,9 +1137,9 @@ export class PlexApiService {
               },
             );
 
-            device.connection = (
-              await Promise.all(filteredConnectionPromises)
-            ).filter(Boolean);
+            device.connection = PlexApiService.rankConnections(
+              (await Promise.all(filteredConnectionPromises)).filter(Boolean),
+            );
           }),
         );
       }
@@ -1257,11 +1403,20 @@ export class PlexApiService {
     });
   }
 
-  private async setMachineId() {
+  private async setMachineId(): Promise<string | null> {
     try {
       const response = await this.getStatus();
       if (response?.machineIdentifier) {
         this.machineId = response.machineIdentifier;
+
+        // Persist to DB so re-discovery can match the server when the
+        // primary connection is dead and we can't query the server directly.
+        if (this.settings.plex_machine_id !== response.machineIdentifier) {
+          await this.settings.updatePlexConnectionDetails({
+            plex_machine_id: response.machineIdentifier,
+          });
+        }
+
         return response.machineIdentifier;
       } else {
         this.logger.warn("Couldn't reach Plex");
@@ -1272,7 +1427,7 @@ export class PlexApiService {
         'Plex api communication failure.. Is the application running?',
       );
       this.logger.debug(error);
-      return undefined;
+      return null;
     }
   }
 

--- a/apps/server/src/modules/collections/collection-worker.service.ts
+++ b/apps/server/src/modules/collections/collection-worker.service.ts
@@ -9,6 +9,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import { LessThanOrEqual, Repository } from 'typeorm';
 import { delay } from '../../utils/delay';
+import { MediaServerFactory } from '../api/media-server/media-server.factory';
 import { SeerrApiService } from '../api/seerr-api/seerr-api.service';
 import { CollectionMediaHandledDto } from '../events/events.dto';
 import { MaintainerrLogger } from '../logging/logs.service';
@@ -38,6 +39,7 @@ export class CollectionWorkerService extends TaskBase {
     private readonly eventEmitter: EventEmitter2,
     private readonly collectionHandler: CollectionHandler,
     private readonly collectionsService: CollectionsService,
+    private readonly mediaServerFactory: MediaServerFactory,
     protected readonly logger: MaintainerrLogger,
     private readonly executionLock: ExecutionLockService,
   ) {
@@ -50,6 +52,17 @@ export class CollectionWorkerService extends TaskBase {
   }
 
   protected async executeTask() {
+    // Pre-flight: verify media server is reachable (triggers re-discovery for Plex)
+    try {
+      await this.mediaServerFactory.verifyConnection();
+    } catch (error) {
+      this.logger.warn(
+        'Media server unreachable, skipping collection handler run',
+      );
+      this.logger.debug(error);
+      return;
+    }
+
     this.eventEmitter.emit(
       MaintainerrEvent.CollectionHandler_Started,
       new CollectionHandlerStartedEventDto(

--- a/apps/server/src/modules/rules/tasks/rule-executor-job-manager.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor-job-manager.service.spec.ts
@@ -34,15 +34,21 @@ describe('RuleExecutorJobManagerService', () => {
       acquire: jest.fn().mockResolvedValue(jest.fn()),
     } as unknown as ExecutionLockService;
 
+    const mediaServerFactory = {
+      verifyConnection: jest.fn().mockResolvedValue({}),
+    };
+
     return {
       service: new RuleExecutorJobManagerService(
         ruleExecutorService as any,
         executionLock,
+        mediaServerFactory as any,
         eventEmitter as any,
         logger as any,
       ),
       ruleExecutorService,
       executionLock,
+      mediaServerFactory,
       eventEmitter,
     };
   };

--- a/apps/server/src/modules/rules/tasks/rule-executor-job-manager.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor-job-manager.service.ts
@@ -4,6 +4,7 @@ import {
 } from '@maintainerr/contracts';
 import { Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { MediaServerFactory } from '../../api/media-server/media-server.factory';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { ExecutionLockService } from '../../tasks/execution-lock.service';
 import { RuleExecutorService } from './rule-executor.service';
@@ -30,6 +31,7 @@ export class RuleExecutorJobManagerService implements OnApplicationShutdown {
   constructor(
     private readonly ruleExecutorService: RuleExecutorService,
     private readonly executionLock: ExecutionLockService,
+    private readonly mediaServerFactory: MediaServerFactory,
     private readonly eventEmitter: EventEmitter2,
     private readonly logger: MaintainerrLogger,
   ) {
@@ -161,6 +163,19 @@ export class RuleExecutorJobManagerService implements OnApplicationShutdown {
     this.processingQueue = true;
     this.processQueuePromise = (async () => {
       try {
+        // Pre-flight: verify media server is reachable (triggers re-discovery for Plex)
+        try {
+          await this.mediaServerFactory.verifyConnection();
+        } catch (error) {
+          this.logger.warn(
+            'Media server unreachable, skipping rule execution queue',
+          );
+          this.logger.debug(error);
+          this.queue.length = 0;
+          this.emitStatusUpdate();
+          return;
+        }
+
         while (this.queue.length > 0) {
           const next = this.queue.shift();
           this.emitStatusUpdate();

--- a/apps/server/src/modules/settings/dto's/setting.dto.ts
+++ b/apps/server/src/modules/settings/dto's/setting.dto.ts
@@ -30,6 +30,10 @@ export class SettingDto {
 
   plex_auth_token: string;
 
+  plex_machine_id?: string;
+
+  plex_manual_mode?: number;
+
   // Jellyfin settings
   jellyfin_url?: string;
 

--- a/apps/server/src/modules/settings/entities/settings.entities.ts
+++ b/apps/server/src/modules/settings/entities/settings.entities.ts
@@ -51,6 +51,12 @@ export class Settings implements SettingDto {
   @Column({ nullable: true })
   plex_auth_token: string;
 
+  @Column({ nullable: true })
+  plex_machine_id?: string;
+
+  @Column({ nullable: true, default: 0 })
+  plex_manual_mode?: number;
+
   // Jellyfin settings
   @Column({ nullable: true })
   jellyfin_url?: string;

--- a/apps/server/src/modules/settings/settings.service.ts
+++ b/apps/server/src/modules/settings/settings.service.ts
@@ -67,6 +67,10 @@ export class SettingsService implements SettingDto {
 
   plex_auth_token: string;
 
+  plex_machine_id?: string;
+
+  plex_manual_mode?: number;
+
   jellyfin_url?: string;
 
   jellyfin_api_key?: string;
@@ -136,6 +140,8 @@ export class SettingsService implements SettingDto {
       this.plex_port = settingsDb?.plex_port;
       this.plex_ssl = settingsDb?.plex_ssl;
       this.plex_auth_token = settingsDb?.plex_auth_token;
+      this.plex_machine_id = settingsDb?.plex_machine_id;
+      this.plex_manual_mode = settingsDb?.plex_manual_mode ?? 0;
       this.jellyfin_url = settingsDb?.jellyfin_url;
       this.jellyfin_api_key = settingsDb?.jellyfin_api_key;
       this.jellyfin_user_id = settingsDb?.jellyfin_user_id;
@@ -906,6 +912,39 @@ export class SettingsService implements SettingDto {
       normalizedCurrent.port !== normalizedNext.port ||
       normalizedCurrent.ssl !== normalizedNext.ssl
     );
+  }
+
+  /**
+   * Update specific Plex connection fields without triggering a full settings
+   * reload or re-initialization cycle. Used by PlexApiService during failover
+   * to persist the new connection details and machineId.
+   */
+  public async updatePlexConnectionDetails(
+    details: Partial<
+      Pick<
+        Settings,
+        | 'plex_hostname'
+        | 'plex_port'
+        | 'plex_ssl'
+        | 'plex_machine_id'
+        | 'plex_manual_mode'
+      >
+    >,
+  ): Promise<void> {
+    const settingsDb = await this.settingsRepo.findOne({ where: {} });
+    if (!settingsDb) return;
+
+    await this.settingsRepo.save({ ...settingsDb, ...details });
+
+    // Sync in-memory state so subsequent reads are consistent
+    if (details.plex_hostname !== undefined)
+      this.plex_hostname = details.plex_hostname;
+    if (details.plex_port !== undefined) this.plex_port = details.plex_port;
+    if (details.plex_ssl !== undefined) this.plex_ssl = details.plex_ssl;
+    if (details.plex_machine_id !== undefined)
+      this.plex_machine_id = details.plex_machine_id;
+    if (details.plex_manual_mode !== undefined)
+      this.plex_manual_mode = details.plex_manual_mode;
   }
 
   private async saveSettings(settings: Settings): Promise<Settings> {

--- a/apps/ui/src/api/settings.ts
+++ b/apps/ui/src/api/settings.ts
@@ -39,6 +39,8 @@ export interface ISettings {
   plex_port: number
   plex_ssl: number
   plex_auth_token: string | null
+  plex_machine_id?: string | null
+  plex_manual_mode?: number
   // Jellyfin settings
   jellyfin_url?: string
   jellyfin_api_key?: string

--- a/apps/ui/src/components/Settings/Plex/index.spec.tsx
+++ b/apps/ui/src/components/Settings/Plex/index.spec.tsx
@@ -34,6 +34,7 @@ let currentSettings: {
   plex_name?: string
   plex_ssl?: number
   plex_auth_token?: string
+  plex_manual_mode?: number
 } = {}
 
 vi.mock('../../../api/settings', () => ({
@@ -415,5 +416,57 @@ describe('PlexSettings', () => {
         screen.getByText('Authentication timed out. Please try again.'),
       ).toBeTruthy()
     })
+  })
+
+  it('requires a hostname before saving manual mode', async () => {
+    render(<PlexSettings />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Authenticated' })).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Advanced Settings' }))
+    fireEvent.click(screen.getByLabelText(/Enable manual mode/i))
+
+    const hostnameInput = await screen.findByLabelText(/Hostname \/ IP/i)
+
+    fireEvent.change(hostnameInput, {
+      target: { value: '   ' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Please enter a hostname or IP address.'),
+      ).toBeTruthy()
+    })
+
+    expect(updateSettings).not.toHaveBeenCalled()
+  })
+
+  it('requires a valid port before saving manual mode', async () => {
+    render(<PlexSettings />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Authenticated' })).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Advanced Settings' }))
+    fireEvent.click(screen.getByLabelText(/Enable manual mode/i))
+
+    const portInput = await screen.findByLabelText(/^Port$/i)
+
+    fireEvent.change(portInput, {
+      target: { value: '70000' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Please enter a valid port.')).toBeTruthy()
+    })
+
+    expect(updateSettings).not.toHaveBeenCalled()
   })
 })

--- a/apps/ui/src/components/Settings/Plex/index.tsx
+++ b/apps/ui/src/components/Settings/Plex/index.tsx
@@ -566,9 +566,8 @@ const PlexSettings = () => {
                 <label className="text-label">
                   Server
                   <span className="label-tip">
-                    Docker users: if connections fail, ensure your container can
-                    resolve the hostname or use Advanced Settings below with a
-                    direct IP
+                    Ensure DNS is properly configured since Plex depends on
+                    working DNS resolution
                   </span>
                 </label>
                 <div className="form-input">
@@ -705,8 +704,10 @@ const PlexSettings = () => {
                       >
                         Manual connection override
                         <span className="label-tip">
-                          Override the connection discovered by Plex. Disables
-                          automatic reconnection.
+                          Override the connection discovered by Plex.
+                          <br />
+                          Disables automatic reconnection — you manage the
+                          connection.
                         </span>
                       </label>
                       <div className="form-input">
@@ -733,6 +734,10 @@ const PlexSettings = () => {
                             />
                             <span className="text-sm text-zinc-300">
                               Enable manual mode
+                              <br />
+                              <span className="text-xs text-zinc-500">
+                                Plex authentication (above) is still required
+                              </span>
                             </span>
                           </label>
                         </div>
@@ -741,11 +746,6 @@ const PlexSettings = () => {
 
                     {manualMode && (
                       <>
-                        <p className="mb-4 text-sm text-zinc-500">
-                          Tip: If Plex shows *.plex.direct hostnames that
-                          don&apos;t resolve in your network, use a direct IP or
-                          Docker service name instead.
-                        </p>
 
                         <div className="form-row">
                           <label
@@ -801,7 +801,7 @@ const PlexSettings = () => {
 
                         <div className="form-row">
                           <label htmlFor="advanced-ssl" className="text-label">
-                            SSL
+                            TLS
                           </label>
                           <div className="form-input">
                             <div className="form-input-field">

--- a/apps/ui/src/components/Settings/Plex/index.tsx
+++ b/apps/ui/src/components/Settings/Plex/index.tsx
@@ -604,6 +604,8 @@ const PlexSettings = () => {
                           buttonType="default"
                           onClick={() => {
                             setSelectedServer(null)
+                            setManualMode(false)
+                            setAdvancedOpen(false)
                             clearError()
                             clearTestBanner()
                           }}
@@ -630,6 +632,8 @@ const PlexSettings = () => {
                               local: preset.local,
                               latency: preset.latency,
                             })
+                            setManualMode(false)
+                            setAdvancedOpen(false)
                             clearError()
                             clearTestBanner()
                           }

--- a/apps/ui/src/components/Settings/Plex/index.tsx
+++ b/apps/ui/src/components/Settings/Plex/index.tsx
@@ -204,21 +204,9 @@ const PlexSettings = () => {
       return
     }
 
-    if (
-      !selectedServer ||
-      selectedServer.hostname === '' ||
-      selectedServer.port === '' ||
-      selectedServer.name === ''
-    ) {
-      showInfo(
-        'Please complete server setup by selecting a server from the dropdown.',
-      )
-      return
-    }
-
     try {
       if (manualMode) {
-        // Advanced settings: save manual override
+        // Advanced settings: save manual override (no server selection required)
         const normalizedHostname =
           normalizePlexHostname(advancedHostname).trim()
         const port = Number(advancedPort.trim())
@@ -238,11 +226,23 @@ const PlexSettings = () => {
             ? `https://${normalizedHostname}`
             : normalizedHostname,
           plex_port: port,
-          plex_name: selectedServer.name,
+          plex_name: selectedServer?.name || normalizedHostname,
           plex_ssl: Number(advancedSsl),
           plex_manual_mode: 1,
         })
       } else {
+        if (
+          !selectedServer ||
+          selectedServer.hostname === '' ||
+          selectedServer.port === '' ||
+          selectedServer.name === ''
+        ) {
+          showInfo(
+            'Please complete server setup by selecting a server from the dropdown.',
+          )
+          return
+        }
+
         await updateSettings({
           ...buildPlexServerPayload(selectedServer),
           plex_manual_mode: 0,
@@ -676,7 +676,7 @@ const PlexSettings = () => {
             )}
 
             {/* Advanced Settings — hidden collapsible section */}
-            {isAuthenticated && selectedServer && (
+            {isAuthenticated && (
               <div className="mt-6">
                 <button
                   type="button"
@@ -844,7 +844,7 @@ const PlexSettings = () => {
                     disabled={
                       testing ||
                       !isAuthenticated ||
-                      !hasSelectedServer ||
+                      (!hasSelectedServer && !manualMode) ||
                       updatePlexAuthPending ||
                       testWouldTestWrongServer ||
                       hasUnsavedAdvancedChanges
@@ -858,7 +858,7 @@ const PlexSettings = () => {
                         ? 'Wait for Plex authentication to finish before testing.'
                         : !isAuthenticated
                           ? 'Authenticate with Plex before testing the connection.'
-                          : !hasSelectedServer
+                          : !hasSelectedServer && !manualMode
                             ? 'Select a Plex server before testing.'
                             : testWouldTestWrongServer ||
                                 hasUnsavedAdvancedChanges

--- a/apps/ui/src/components/Settings/Plex/index.tsx
+++ b/apps/ui/src/components/Settings/Plex/index.tsx
@@ -746,7 +746,6 @@ const PlexSettings = () => {
 
                     {manualMode && (
                       <>
-
                         <div className="form-row">
                           <label
                             htmlFor="advanced-hostname"

--- a/apps/ui/src/components/Settings/Plex/index.tsx
+++ b/apps/ui/src/components/Settings/Plex/index.tsx
@@ -1,4 +1,5 @@
 import { RefreshIcon } from '@heroicons/react/outline'
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/solid'
 import axios from 'axios'
 import { orderBy } from 'lodash-es'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -30,6 +31,7 @@ interface PresetServerDisplay {
   address: string
   port: number
   local: boolean
+  directIp: boolean
   status?: boolean
   latency?: number
 }
@@ -52,6 +54,18 @@ interface SelectedServer {
 
 const normalizePlexHostname = (hostname?: string) =>
   hostname?.replace('http://', '').replace('https://', '') ?? ''
+
+const isDirectIpAddress = (address: string) => {
+  if (address.includes(':')) return true
+
+  const parts = address.split('.')
+  if (parts.length !== 4) return false
+
+  return parts.every(
+    (part) =>
+      part.length > 0 && part.length <= 3 && !Number.isNaN(Number(part)),
+  )
+}
 
 const buildPlexServerPayload = (state: PlexServerFormState) => {
   const normalizedHostname = normalizePlexHostname(state.hostname)
@@ -79,6 +93,7 @@ export const hasUnsavedPlexServerChanges = (
 }
 
 const PlexSettings = () => {
+  const { settings } = useSettingsOutletContext()
   const [tokenValid, setTokenValid] = useState<boolean>(false)
   const [tokenValidationPending, setTokenValidationPending] =
     useState<boolean>(false)
@@ -91,6 +106,15 @@ const PlexSettings = () => {
     version: string
   }>({ status: false, version: '' })
   const [testing, setTesting] = useState(false)
+  const [manualMode, setManualMode] = useState(
+    () => settings?.plex_manual_mode === 1,
+  )
+  const [advancedOpen, setAdvancedOpen] = useState(
+    () => settings?.plex_manual_mode === 1,
+  )
+  const [advancedHostname, setAdvancedHostname] = useState('')
+  const [advancedPort, setAdvancedPort] = useState('')
+  const [advancedSsl, setAdvancedSsl] = useState(false)
   const {
     feedback,
     showInfo,
@@ -106,7 +130,6 @@ const PlexSettings = () => {
     useDeletePlexAuth()
   const { mutateAsync: updatePlexAuth, isPending: updatePlexAuthPending } =
     useUpdatePlexAuth()
-  const { settings } = useSettingsOutletContext()
   const hasStoredPlexToken = Boolean(settings?.plex_auth_token)
   const isAuthenticated = tokenValid
 
@@ -150,6 +173,25 @@ const PlexSettings = () => {
     settings?.plex_ssl,
   ])
 
+  // Pre-fill advanced fields from current settings when manual mode is enabled
+  useEffect(() => {
+    if (manualMode && settings) {
+      setAdvancedHostname(normalizePlexHostname(settings.plex_hostname) || '')
+      setAdvancedPort(
+        settings.plex_port != null ? String(settings.plex_port) : '32400',
+      )
+      setAdvancedSsl(Boolean(settings.plex_ssl))
+    }
+  }, [manualMode, settings])
+
+  // Track whether the user has edited the advanced fields since last save
+  const hasUnsavedAdvancedChanges =
+    manualMode &&
+    (advancedHostname !== normalizePlexHostname(settings?.plex_hostname) ||
+      advancedPort !==
+        (settings?.plex_port != null ? String(settings.plex_port) : '32400') ||
+      advancedSsl !== Boolean(settings?.plex_ssl))
+
   const clearTestBanner = useCallback(() => {
     setTestbanner({ status: false, version: '' })
   }, [])
@@ -175,7 +217,37 @@ const PlexSettings = () => {
     }
 
     try {
-      await updateSettings(buildPlexServerPayload(selectedServer))
+      if (manualMode) {
+        // Advanced settings: save manual override
+        const normalizedHostname =
+          normalizePlexHostname(advancedHostname).trim()
+        const port = Number(advancedPort.trim())
+
+        if (!normalizedHostname) {
+          showInfo('Please enter a hostname or IP address.')
+          return
+        }
+
+        if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+          showInfo('Please enter a valid port.')
+          return
+        }
+
+        await updateSettings({
+          plex_hostname: advancedSsl
+            ? `https://${normalizedHostname}`
+            : normalizedHostname,
+          plex_port: port,
+          plex_name: selectedServer.name,
+          plex_ssl: Number(advancedSsl),
+          plex_manual_mode: 1,
+        })
+      } else {
+        await updateSettings({
+          ...buildPlexServerPayload(selectedServer),
+          plex_manual_mode: 0,
+        })
+      }
       clearTestBanner()
       showUpdated()
     } catch {
@@ -209,6 +281,7 @@ const PlexSettings = () => {
           address: conn.address,
           port: conn.port,
           local: conn.local,
+          directIp: isDirectIpAddress(conn.address),
           status: conn.status == null ? true : conn.status === 200,
           latency: conn.latency,
         }),
@@ -216,8 +289,8 @@ const PlexSettings = () => {
     })
     return orderBy(
       finalPresets,
-      ['status', 'local', 'latency', 'ssl'],
-      ['desc', 'desc', 'asc', 'desc'],
+      ['status', 'local', 'directIp', 'latency', 'ssl'],
+      ['desc', 'desc', 'desc', 'asc', 'desc'],
     )
   }, [availableServers])
 
@@ -490,7 +563,14 @@ const PlexSettings = () => {
             {/* Server — only shown when authenticated */}
             {isAuthenticated && (
               <div className="form-row">
-                <label className="text-label">Server</label>
+                <label className="text-label">
+                  Server
+                  <span className="label-tip">
+                    Docker users: if connections fail, ensure your container can
+                    resolve the hostname or use Advanced Settings below with a
+                    direct IP
+                  </span>
+                </label>
                 <div className="form-input">
                   {selectedServer ? (
                     <div className="max-w-xl rounded-xl bg-zinc-800 p-4 ring-1 ring-zinc-700">
@@ -595,6 +675,161 @@ const PlexSettings = () => {
               </div>
             )}
 
+            {/* Advanced Settings — hidden collapsible section */}
+            {isAuthenticated && selectedServer && (
+              <div className="mt-6">
+                <button
+                  type="button"
+                  className="flex items-center gap-1 text-sm text-zinc-400 transition-colors hover:text-white"
+                  onClick={() => setAdvancedOpen((prev) => !prev)}
+                >
+                  {advancedOpen ? (
+                    <ChevronUpIcon className="h-4 w-4" />
+                  ) : (
+                    <ChevronDownIcon className="h-4 w-4" />
+                  )}
+                  Advanced Settings
+                  {manualMode && (
+                    <span className="ml-1.5 inline-flex items-center rounded bg-amber-700 px-1.5 py-0.5 text-xs text-amber-200">
+                      Manual
+                    </span>
+                  )}
+                </button>
+
+                {advancedOpen && (
+                  <div className="mt-3 rounded-xl bg-zinc-800/50 p-4 ring-1 ring-zinc-700">
+                    <div className="form-row">
+                      <label
+                        htmlFor="advanced-manual-mode"
+                        className="text-label"
+                      >
+                        Manual connection override
+                        <span className="label-tip">
+                          Override the connection discovered by Plex. Disables
+                          automatic reconnection.
+                        </span>
+                      </label>
+                      <div className="form-input">
+                        <div className="form-input-field">
+                          <label className="inline-flex items-center gap-2">
+                            <input
+                              id="advanced-manual-mode"
+                              name="advanced-manual-mode"
+                              type="checkbox"
+                              checked={manualMode}
+                              onChange={(e) => {
+                                setManualMode(e.target.checked)
+                                // When disabling manual mode while it's the saved state,
+                                // clear server selection to force re-discovery from plex.tv
+                                if (
+                                  !e.target.checked &&
+                                  settings?.plex_manual_mode === 1
+                                ) {
+                                  setSelectedServer(null)
+                                  clearTestBanner()
+                                }
+                              }}
+                              className="rounded border-zinc-500 bg-zinc-700 text-amber-600 focus:ring-amber-500"
+                            />
+                            <span className="text-sm text-zinc-300">
+                              Enable manual mode
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+
+                    {manualMode && (
+                      <>
+                        <p className="mb-4 text-sm text-zinc-500">
+                          Tip: If Plex shows *.plex.direct hostnames that
+                          don&apos;t resolve in your network, use a direct IP or
+                          Docker service name instead.
+                        </p>
+
+                        <div className="form-row">
+                          <label
+                            htmlFor="advanced-hostname"
+                            className="text-label"
+                          >
+                            Hostname / IP
+                            <span className="label-tip">
+                              e.g. plex, 192.168.1.50, or localhost
+                            </span>
+                          </label>
+                          <div className="form-input">
+                            <div className="form-input-field">
+                              <input
+                                id="advanced-hostname"
+                                name="advanced-hostname"
+                                type="text"
+                                value={advancedHostname}
+                                onChange={(e) =>
+                                  setAdvancedHostname(e.target.value)
+                                }
+                                placeholder={
+                                  normalizePlexHostname(
+                                    settings?.plex_hostname,
+                                  ) || 'plex'
+                                }
+                                className="block w-full min-w-0 flex-1 rounded-md border border-zinc-500 bg-zinc-700 text-white shadow-sm sm:text-sm sm:leading-5"
+                              />
+                            </div>
+                          </div>
+                        </div>
+
+                        <div className="form-row">
+                          <label htmlFor="advanced-port" className="text-label">
+                            Port
+                          </label>
+                          <div className="form-input">
+                            <div className="form-input-field">
+                              <input
+                                id="advanced-port"
+                                name="advanced-port"
+                                type="number"
+                                value={advancedPort}
+                                onChange={(e) =>
+                                  setAdvancedPort(e.target.value)
+                                }
+                                placeholder="32400"
+                                className="block w-full min-w-0 flex-1 rounded-md border border-zinc-500 bg-zinc-700 text-white shadow-sm sm:text-sm sm:leading-5"
+                              />
+                            </div>
+                          </div>
+                        </div>
+
+                        <div className="form-row">
+                          <label htmlFor="advanced-ssl" className="text-label">
+                            SSL
+                          </label>
+                          <div className="form-input">
+                            <div className="form-input-field">
+                              <label className="inline-flex items-center gap-2">
+                                <input
+                                  id="advanced-ssl"
+                                  name="advanced-ssl"
+                                  type="checkbox"
+                                  checked={advancedSsl}
+                                  onChange={(e) =>
+                                    setAdvancedSsl(e.target.checked)
+                                  }
+                                  className="rounded border-zinc-500 bg-zinc-700 text-amber-600 focus:ring-amber-500"
+                                />
+                                <span className="text-sm text-zinc-300">
+                                  Use HTTPS
+                                </span>
+                              </label>
+                            </div>
+                          </div>
+                        </div>
+                      </>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+
             <div className="actions mt-5 w-full">
               <div className="flex w-full flex-wrap sm:flex-nowrap">
                 <span className="m-auto rounded-md shadow-sm sm:ml-3 sm:mr-auto">
@@ -611,7 +846,8 @@ const PlexSettings = () => {
                       !isAuthenticated ||
                       !hasSelectedServer ||
                       updatePlexAuthPending ||
-                      testWouldTestWrongServer
+                      testWouldTestWrongServer ||
+                      hasUnsavedAdvancedChanges
                     }
                     isPending={testing}
                     feedbackStatus={
@@ -624,8 +860,9 @@ const PlexSettings = () => {
                           ? 'Authenticate with Plex before testing the connection.'
                           : !hasSelectedServer
                             ? 'Select a Plex server before testing.'
-                            : testWouldTestWrongServer
-                              ? 'Save your server selection before testing.'
+                            : testWouldTestWrongServer ||
+                                hasUnsavedAdvancedChanges
+                              ? 'Save your settings before testing.'
                               : undefined
                     }
                   />

--- a/packages/contracts/src/media-server/plex/plexSetting.ts
+++ b/packages/contracts/src/media-server/plex/plexSetting.ts
@@ -12,6 +12,7 @@ export const plexSettingSchema = z.object({
   useSsl: z.boolean().optional().default(false),
   // Plex stores hostname/port/SSL separately; this value may be a bare hostname.
   webAppUrl: z.string().trim().optional(),
+  manualMode: z.boolean().optional().default(false),
 })
 
 export type PlexSetting = z.infer<typeof plexSettingSchema>


### PR DESCRIPTION
## Summary

Since v3.5.0, manual hostname/port entry was removed in favor of OAuth-only server discovery. Users in Docker environments lose Plex connectivity when container IPs change because we store a single connection and have no recovery path. plex.tv also returns `*.plex.direct` hostnames that require external DNS — something Docker containers often can't resolve without proper DNS setup.

This PR adds three layers of resilience:

- **Auto re-discovery from plex.tv** — when the stored Plex connection fails during `initialize()`, query plex.tv for updated connection details, match by persisted `machineId`, rank connections (preferring local direct-IP over DNS-dependent `plex.direct` hostnames), and promote the first working one to primary. Only triggers on failure, not every startup.
- **Pre-job connectivity checks** — verify media server is reachable before rule execution and collection handling. If dead, force re-initialization (which triggers re-discovery for Plex). Works at the `IMediaServerService` abstraction level — covers both Plex and Jellyfin without leaking Plex-specific logic.
- **Manual override (Advanced Settings)** — collapsible UI section where users can specify hostname/port/SSL directly (Docker service names, static IPs). Completely static — disables all automatic reconnection. Pre-filled from current OAuth-discovered values.

### Key design decisions

- No `withReconnect` wrapper — `PlexApi` already has `axios-retry` with 3 retries + exponential backoff for transient blips. Re-discovery handles dead connections via pre-job checks. Mid-job IP changes are an accepted edge case (job fails, next pre-flight recovers).
- `rankConnections()` is a pure static method with no regex (uses string split for IP detection).
- `verifyConnection()` on `MediaServerFactory` uses only `IMediaServerService` interface methods — no Plex imports or types.
- Manual mode is explicit state (`plex_manual_mode` DB column), not derived from UI accordion state.

### New DB columns (migration included)

- `plex_machine_id` (varchar, nullable) — persisted so re-discovery can match the server when the primary connection is dead
- `plex_manual_mode` (integer, default 0) — flag to disable all re-discovery logic

Closes #2648

## Test plan

- [x] `rankConnections`: 5 unit tests (reachable preference, local preference, direct IP preference, latency sort, immutability)
- [x] `initialize`: 3 unit tests (clear on failed rediscovery, skip rediscovery in manual mode, attempt rediscovery on failure)
- [x] `verifyConnection`: 3 unit tests (success, re-init on failure, throw when re-init also fails)
- [x] UI: 2 unit tests (hostname validation, port validation for manual mode)
- [x] All 812 server tests and 130 UI tests passing
- [ ] Manual Docker test: Maintainerr + Plex in Compose, restart Plex (gets new IP), verify auto-reconnect in logs
- [ ] Manual test: set advanced settings with Docker service name, verify connection works without re-discovery
- [ ] Manual test: OAuth first → open Advanced Settings → verify fields pre-filled → save → verify manual mode active → disable → verify re-discovery dropdown returns
