### PR TITLE
fix(rules): rule creator drag-and-drop follow-ups

### DIFF
--- a/apps/ui/src/components/Common/AddButton/index.tsx
+++ b/apps/ui/src/components/Common/AddButton/index.tsx
@@ -1,19 +1,35 @@
 import { PlusCircleIcon } from '@heroicons/react/solid'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import Button, { type ButtonType } from '../Button'
 
 interface IAddButton {
   text: string
   onClick: () => void
+  icon?: ReactNode
+  buttonType?: ButtonType
+  buttonSize?: 'default' | 'lg' | 'md' | 'sm'
+  className?: string
+  title?: string
+  disabled?: boolean
+  type?: ButtonHTMLAttributes<HTMLButtonElement>['type']
 }
 
 const AddButton = (props: IAddButton) => {
   return (
-    <button
-      className="add-button m-auto flex h-9 rounded bg-maintainerr-600 text-zinc-200 shadow-md hover:bg-maintainerr"
+    <Button
+      buttonType={props.buttonType ?? 'primary'}
+      buttonSize={props.buttonSize ?? 'md'}
+      className={`add-button m-auto ${props.className ?? ''}`.trim()}
       onClick={props.onClick}
+      title={props.title}
+      disabled={props.disabled}
+      type={props.type ?? 'button'}
     >
-      {<PlusCircleIcon className="m-auto ml-4 h-5" />}
-      <p className="rules-button-text m-auto ml-1 mr-4">{props.text}</p>
-    </button>
+      <span className="rules-button-text flex items-center gap-1">
+        {props.icon ?? <PlusCircleIcon className="h-5 w-5" />}
+        <span>{props.text}</span>
+      </span>
+    </Button>
   )
 }
 

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
@@ -54,7 +54,6 @@ interface IRuleInput {
   mediaType?: MediaType
   dataType?: MediaItemType
   section?: number
-  newlyAdded?: number[]
   editData?: { rule: IRule }
   onCommit: (id: number, rule: IRule) => void
   onIncomplete: (id: number) => void
@@ -200,8 +199,7 @@ interface InitialRuleState {
 }
 
 const getInitialRuleState = (props: IRuleInput): InitialRuleState => {
-  const isNewlyAdded = props.id && props.newlyAdded?.includes(props.id)
-  const rule = isNewlyAdded ? undefined : props.editData?.rule
+  const rule = props.editData?.rule
 
   if (!rule) {
     return {

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/index.spec.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/index.spec.tsx
@@ -1,0 +1,203 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import RuleCreator, { type IRule } from './index'
+
+vi.mock('react-movable', () => {
+  const arrayMove = <T,>(array: T[], from: number, to: number) => {
+    const next = [...array]
+    const [moved] = next.splice(from, 1)
+    next.splice(to, 0, moved)
+    return next
+  }
+
+  const List = ({ values, onChange, renderList, renderItem }: any) => {
+    const scope = values[0] && 'rules' in values[0] ? 'section' : 'rule'
+    const children = values.map((value: unknown, index: number) => {
+      const item = renderItem({
+        value,
+        index,
+        isDragged: false,
+        isSelected: false,
+        isDisabled: false,
+        isOutOfBounds: false,
+        props: {
+          key: index,
+          style: {},
+          tabIndex: 0,
+          ref: null,
+          onKeyDown: undefined,
+        },
+      })
+
+      return (
+        <div key={`${scope}-${index}`}>
+          {item}
+          {index > 0 ? (
+            <button
+              type="button"
+              onClick={() =>
+                onChange({
+                  oldIndex: index,
+                  newIndex: index - 1,
+                  targetRect: {} as DOMRect,
+                })
+              }
+            >
+              {`Move ${scope} ${index + 1} up`}
+            </button>
+          ) : null}
+        </div>
+      )
+    })
+
+    return renderList({ children, props: { ref: null }, isDragged: false })
+  }
+
+  return { List, arrayMove }
+})
+
+vi.mock('./RuleInput', () => ({
+  default: ({
+    tagId,
+    section,
+    editData,
+    onCommit,
+    onIncomplete,
+    onDelete,
+  }: any) => (
+    <div>
+      <span>
+        {editData?.rule ? `Rule ${tagId} ready` : `Rule ${tagId} empty`}
+      </span>
+      <button
+        type="button"
+        onClick={() =>
+          onCommit(0, {
+            operator: null,
+            firstVal: ['1', String(tagId)],
+            action: 1,
+            section: (section ?? 1) - 1,
+          })
+        }
+      >
+        {`Commit rule ${tagId}`}
+      </button>
+      <button type="button" onClick={() => onIncomplete(0)}>
+        {`Mark rule ${tagId} incomplete`}
+      </button>
+      <button type="button" onClick={() => onDelete(0, 0)}>
+        {`Delete rule ${tagId}`}
+      </button>
+    </div>
+  ),
+}))
+
+const createRule = (
+  id: string,
+  section: number,
+  operator: string | null,
+): IRule => ({
+  operator,
+  firstVal: ['1', id],
+  action: 1,
+  section,
+})
+
+describe('RuleCreator', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('hides add actions while the only rule slot is incomplete', () => {
+    render(
+      <RuleCreator
+        onUpdate={vi.fn()}
+        onCancel={vi.fn()}
+        editData={{ rules: [] }}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: 'Add Rule' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'New Section' })).toBeNull()
+    expect(
+      screen.getByText("Some incomplete rules won't be saved"),
+    ).toBeTruthy()
+  })
+
+  it('rehides add actions when a committed rule becomes incomplete', async () => {
+    render(
+      <RuleCreator
+        onUpdate={vi.fn()}
+        onCancel={vi.fn()}
+        editData={{ rules: [createRule('100', 0, null)] }}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Add Rule' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'New Section' })).toBeTruthy()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Mark rule 1 incomplete' }),
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Add Rule' })).toBeNull()
+      expect(screen.queryByRole('button', { name: 'New Section' })).toBeNull()
+    })
+  })
+
+  it('emits reordered rules within a section', async () => {
+    const onUpdate = vi.fn()
+
+    render(
+      <RuleCreator
+        onUpdate={onUpdate}
+        onCancel={vi.fn()}
+        editData={{
+          rules: [createRule('101', 0, null), createRule('102', 0, '1')],
+        }}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move rule 2 up' }))
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalled()
+      expect(onUpdate.mock.lastCall?.[0]).toMatchObject([
+        { firstVal: ['1', '102'], section: 0, operator: null },
+        { firstVal: ['1', '101'], section: 0 },
+      ])
+    })
+  })
+
+  it('emits reordered sections with renumbered section indexes', async () => {
+    const onUpdate = vi.fn()
+
+    render(
+      <RuleCreator
+        onUpdate={onUpdate}
+        onCancel={vi.fn()}
+        editData={{
+          rules: [createRule('201', 0, null), createRule('202', 1, '0')],
+        }}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move section 2 up' }))
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalled()
+      expect(onUpdate.mock.lastCall?.[0]).toMatchObject([
+        { firstVal: ['1', '202'], section: 0, operator: null },
+        { firstVal: ['1', '201'], section: 1 },
+      ])
+    })
+  })
+})

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
@@ -337,9 +337,10 @@ const RuleCreator = (props: iRuleCreator) => {
       />
 
       {!hasIncompleteRule ? (
-        <div className="mb-3 mt-3 flex w-full">
-          <div className="m-auto xl:m-0">
+        <div className="mb-3 mt-3 flex w-full justify-start pl-6">
+          <div>
             <AddButton
+              className="mx-0"
               onClick={addSection}
               title="Add a new section"
               text="New Section"

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
@@ -220,7 +220,9 @@ const RuleCreator = (props: iRuleCreator) => {
           reorderSections(oldIndex, newIndex)
         }
         renderList={({ children, props: listProps }) => (
-          <div ref={listProps.ref}>{children}</div>
+          <div ref={listProps.ref} className="flex flex-col space-y-4">
+            {children}
+          </div>
         )}
         renderItem={({ value: section, props: itemProps, index }) => {
           const sectionNumber = (index ?? 0) + 1
@@ -230,7 +232,6 @@ const RuleCreator = (props: iRuleCreator) => {
               key={section.uid}
               {...itemRest}
               style={{ ...itemStyle, listStyle: 'none' }}
-              className="mb-4"
             >
               <div className="rounded-lg bg-zinc-700 px-6 py-0.5 shadow-md">
                 <div className="flex items-center">

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
@@ -13,6 +13,7 @@ import {
   useState,
 } from 'react'
 import { arrayMove, List } from 'react-movable'
+import AddButton from '../../../Common/AddButton'
 import Alert from '../../../Common/Alert'
 import SectionHeading from '../../../Common/SectionHeading'
 import RuleInput from './RuleInput'
@@ -49,12 +50,11 @@ let uidCounter = 0
 const newUid = (prefix: string) => `${prefix}-${++uidCounter}`
 
 const DRAG_KEYS = new Set([' ', 'ArrowUp', 'ArrowDown', 'j', 'k', 'Escape'])
-const stopDragKeyPropagation = (
-  inner: ((e: KeyboardEvent) => void) | undefined,
-) => (e: KeyboardEvent) => {
-  inner?.(e)
-  if (DRAG_KEYS.has(e.key)) e.stopPropagation()
-}
+const stopDragKeyPropagation =
+  (inner: ((e: KeyboardEvent) => void) | undefined) => (e: KeyboardEvent) => {
+    inner?.(e)
+    if (DRAG_KEYS.has(e.key)) e.stopPropagation()
+  }
 
 const buildInitialSections = (
   editData: { rules: IRule[] } | undefined,
@@ -98,7 +98,6 @@ const RuleCreator = (props: iRuleCreator) => {
   const [sections, setSections] = useState<SectionSlot[]>(() =>
     buildInitialSections(props.editData),
   )
-  const [newRuleUids, setNewRuleUids] = useState<Set<string>>(new Set())
   const didMountRef = useRef(false)
 
   const emitUpdate = useEffectEvent(() => {
@@ -112,15 +111,6 @@ const RuleCreator = (props: iRuleCreator) => {
     }
     emitUpdate()
   }, [sections])
-
-  const clearNewRuleUid = (uid: string) => {
-    setNewRuleUids((prev) => {
-      if (!prev.has(uid)) return prev
-      const next = new Set(prev)
-      next.delete(uid)
-      return next
-    })
-  }
 
   const handleCommit = (uid: string) => (_id: number, rule: IRule) => {
     setSections((prev) => {
@@ -136,7 +126,6 @@ const RuleCreator = (props: iRuleCreator) => {
       }))
       return changed ? next : prev
     })
-    clearNewRuleUid(uid)
   }
 
   const handleIncomplete = (uid: string) => () => {
@@ -170,12 +159,10 @@ const RuleCreator = (props: iRuleCreator) => {
         ? next
         : [{ uid: newUid('s'), rules: [{ uid: newUid('r'), rule: null }] }]
     })
-    clearNewRuleUid(ruleUid)
   }
 
   const addRule = (sectionUid: string) => {
     const uid = newUid('r')
-    setNewRuleUids((prev) => new Set(prev).add(uid))
     setSections((prev) =>
       prev.map((section) =>
         section.uid !== sectionUid
@@ -187,7 +174,6 @@ const RuleCreator = (props: iRuleCreator) => {
 
   const addSection = () => {
     const ruleUid = newUid('r')
-    setNewRuleUids((prev) => new Set(prev).add(ruleUid))
     setSections((prev) => [
       ...prev,
       { uid: newUid('s'), rules: [{ uid: ruleUid, rule: null }] },
@@ -221,7 +207,9 @@ const RuleCreator = (props: iRuleCreator) => {
     0,
   )
   const allowDelete = totalRules > 1
-  const hasPendingAdd = newRuleUids.size > 0
+  const hasIncompleteRule = sections.some((section) =>
+    section.rules.some((slot) => slot.rule === null),
+  )
 
   return (
     <div className="text-zinc-100">
@@ -282,7 +270,6 @@ const RuleCreator = (props: iRuleCreator) => {
                   }) => {
                     const tagId = (ruleIndex ?? 0) + 1
                     const absoluteId = ++absoluteCounter
-                    const isNew = newRuleUids.has(slot.uid)
                     const {
                       key: _ruleKey,
                       style: ruleStyle,
@@ -313,9 +300,7 @@ const RuleCreator = (props: iRuleCreator) => {
                               tagId={tagId}
                               section={sectionNumber}
                               editData={
-                                !isNew && slot.rule
-                                  ? { rule: slot.rule }
-                                  : undefined
+                                slot.rule ? { rule: slot.rule } : undefined
                               }
                               mediaType={props.mediaType}
                               dataType={props.dataType}
@@ -333,19 +318,15 @@ const RuleCreator = (props: iRuleCreator) => {
                   }}
                 />
 
-                {!hasPendingAdd ? (
+                {!hasIncompleteRule ? (
                   <div className="mb-2 flex w-full justify-end">
-                    <button
-                      type="button"
-                      className="flex h-8 rounded bg-maintainerr-600 text-zinc-200 shadow-md hover:bg-maintainerr"
+                    <AddButton
                       onClick={() => addRule(section.uid)}
                       title={`Add a new rule to Section ${sectionNumber}`}
-                    >
-                      <DocumentAddIcon className="m-auto ml-5 h-5" />
-                      <p className="button-text m-auto ml-1 mr-5 text-zinc-200">
-                        Add Rule
-                      </p>
-                    </button>
+                      text="Add Rule"
+                      icon={<DocumentAddIcon className="h-5 w-5" />}
+                      buttonSize="sm"
+                    />
                   </div>
                 ) : null}
               </div>
@@ -354,20 +335,16 @@ const RuleCreator = (props: iRuleCreator) => {
         }}
       />
 
-      {!hasPendingAdd ? (
+      {!hasIncompleteRule ? (
         <div className="mb-3 mt-3 flex w-full">
           <div className="m-auto xl:m-0">
-            <button
-              type="button"
-              className="flex h-8 rounded bg-maintainerr-600 text-zinc-200 shadow-md hover:bg-maintainerr"
+            <AddButton
               onClick={addSection}
               title="Add a new section"
-            >
-              <ClipboardListIcon className="m-auto ml-5 h-5" />
-              <p className="button-text m-auto ml-1 mr-5 text-zinc-200">
-                New Section
-              </p>
-            </button>
+              text="New Section"
+              icon={<ClipboardListIcon className="h-5 w-5" />}
+              buttonSize="sm"
+            />
           </div>
         </div>
       ) : null}

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
@@ -4,7 +4,14 @@ import {
   MenuIcon,
 } from '@heroicons/react/solid'
 import { type MediaItemType, MediaType } from '@maintainerr/contracts'
-import { useEffect, useEffectEvent, useState } from 'react'
+import { isEqual } from 'lodash-es'
+import {
+  type KeyboardEvent,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from 'react'
 import { arrayMove, List } from 'react-movable'
 import Alert from '../../../Common/Alert'
 import SectionHeading from '../../../Common/SectionHeading'
@@ -40,6 +47,14 @@ type SectionSlot = { uid: string; rules: RuleSlot[] }
 
 let uidCounter = 0
 const newUid = (prefix: string) => `${prefix}-${++uidCounter}`
+
+const DRAG_KEYS = new Set([' ', 'ArrowUp', 'ArrowDown', 'j', 'k', 'Escape'])
+const stopDragKeyPropagation = (
+  inner: ((e: KeyboardEvent) => void) | undefined,
+) => (e: KeyboardEvent) => {
+  inner?.(e)
+  if (DRAG_KEYS.has(e.key)) e.stopPropagation()
+}
 
 const buildInitialSections = (
   editData: { rules: IRule[] } | undefined,
@@ -84,12 +99,17 @@ const RuleCreator = (props: iRuleCreator) => {
     buildInitialSections(props.editData),
   )
   const [newRuleUids, setNewRuleUids] = useState<Set<string>>(new Set())
+  const didMountRef = useRef(false)
 
   const emitUpdate = useEffectEvent(() => {
     props.onUpdate(flattenSections(sections))
   })
 
   useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return
+    }
     emitUpdate()
   }, [sections])
 
@@ -103,14 +123,19 @@ const RuleCreator = (props: iRuleCreator) => {
   }
 
   const handleCommit = (uid: string) => (_id: number, rule: IRule) => {
-    setSections((prev) =>
-      prev.map((section) => ({
+    setSections((prev) => {
+      let changed = false
+      const next = prev.map((section) => ({
         ...section,
-        rules: section.rules.map((slot) =>
-          slot.uid === uid ? { ...slot, rule } : slot,
-        ),
-      })),
-    )
+        rules: section.rules.map((slot) => {
+          if (slot.uid !== uid) return slot
+          if (slot.rule && isEqual(slot.rule, rule)) return slot
+          changed = true
+          return { ...slot, rule }
+        }),
+      }))
+      return changed ? next : prev
+    })
     clearNewRuleUid(uid)
   }
 
@@ -261,12 +286,14 @@ const RuleCreator = (props: iRuleCreator) => {
                     const {
                       key: _ruleKey,
                       style: ruleStyle,
+                      onKeyDown: ruleOnKeyDown,
                       ...ruleRest
                     } = ruleProps
                     return (
                       <div
                         key={slot.uid}
                         {...ruleRest}
+                        onKeyDown={stopDragKeyPropagation(ruleOnKeyDown)}
                         style={{ ...ruleStyle, listStyle: 'none' }}
                       >
                         <div className="flex w-full items-start">

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
@@ -319,8 +319,9 @@ const RuleCreator = (props: iRuleCreator) => {
                 />
 
                 {!hasIncompleteRule ? (
-                  <div className="mb-2 flex w-full justify-end">
+                  <div className="mb-2 flex w-full justify-start">
                     <AddButton
+                      className="mx-0"
                       onClick={() => addRule(section.uid)}
                       title={`Add a new rule to Section ${sectionNumber}`}
                       text="Add Rule"

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
@@ -319,7 +319,7 @@ const RuleCreator = (props: iRuleCreator) => {
                 />
 
                 {!hasIncompleteRule ? (
-                  <div className="mb-2 flex w-full justify-start">
+                  <div className="flex w-full justify-start py-2">
                     <AddButton
                       className="mx-0"
                       onClick={() => addRule(section.uid)}
@@ -337,7 +337,7 @@ const RuleCreator = (props: iRuleCreator) => {
       />
 
       {!hasIncompleteRule ? (
-        <div className="mb-3 mt-3 flex w-full justify-start pl-6">
+        <div className="flex w-full justify-start py-2 pl-6">
           <div>
             <AddButton
               className="mx-0"

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -6,7 +6,6 @@ import {
   DocumentDuplicateIcon,
   DownloadIcon,
   QuestionMarkCircleIcon,
-  SaveIcon,
   UploadIcon,
 } from '@heroicons/react/solid'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -40,6 +39,7 @@ import Button from '../../../Common/Button'
 import CommunityRuleModal from '../../../Common/CommunityRuleModal'
 import LazyModalBoundary from '../../../Common/LazyModalBoundary'
 import LoadingSpinner from '../../../Common/LoadingSpinner'
+import SaveButton from '../../../Common/SaveButton'
 import { Input } from '../../../Forms/Input'
 import { Select } from '../../../Forms/Select'
 import type { AgentConfiguration } from '../../../Settings/Notifications/CreateNotificationModal'
@@ -1663,16 +1663,14 @@ const AddModal = (props: AddModal) => {
           </div>
           <div className="mt-5 hidden h-full w-full md:flex">
             <div className="m-auto flex xl:m-0">
-              <button
-                className="ml-auto mr-3 flex h-10 rounded bg-maintainerr-600 text-zinc-900 shadow-md hover:bg-maintainerr"
-                type="submit"
+              <SaveButton
+                label="Save"
+                pendingLabel="Save"
+                className="ml-auto mr-3"
+                isPending={isCreatePending || isUpdatePending}
                 disabled={isCreatePending || isUpdatePending}
-              >
-                {<SaveIcon className="m-auto ml-5 h-6 w-6 text-zinc-200" />}
-                <p className="button-text m-auto ml-1 mr-5 text-zinc-100">
-                  Save
-                </p>
-              </button>
+                type="submit"
+              />
               <button
                 className="ml-auto flex h-10 rounded bg-maintainerrdark text-zinc-900 shadow-md hover:bg-maintainerrdark-800"
                 onClick={cancel}
@@ -1688,14 +1686,15 @@ const AddModal = (props: AddModal) => {
           </div>
           <div className="fixed bottom-0 left-0 right-0 z-40 bg-zinc-800 px-4 py-3 shadow-[0_-2px_6px_rgba(0,0,0,0.4)] md:hidden">
             <div className="flex justify-center gap-3">
-              <button
-                className="flex h-10 w-full max-w-[160px] items-center justify-center rounded bg-maintainerr-600 text-zinc-900 shadow-md hover:bg-maintainerr disabled:opacity-60"
-                type="submit"
+              <SaveButton
+                label="Save"
+                pendingLabel="Save"
+                contentSize="compact"
+                className="w-full max-w-[160px]"
+                isPending={isCreatePending || isUpdatePending}
                 disabled={isCreatePending || isUpdatePending}
-              >
-                <SaveIcon className="h-5 w-5 text-zinc-200" />
-                <span className="ml-2 text-zinc-100">Save</span>
-              </button>
+                type="submit"
+              />
 
               <button
                 className="flex h-10 w-full max-w-[160px] items-center justify-center rounded bg-maintainerrdark text-zinc-900 shadow-md hover:bg-maintainerrdark-800 disabled:opacity-60"

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -1,6 +1,5 @@
 import { CloudDownloadIcon } from '@heroicons/react/outline'
 import {
-  BanIcon,
   ChevronDownIcon,
   ChevronUpIcon,
   DocumentDuplicateIcon,
@@ -1671,17 +1670,15 @@ const AddModal = (props: AddModal) => {
                 disabled={isCreatePending || isUpdatePending}
                 type="submit"
               />
-              <button
-                className="ml-auto flex h-10 rounded bg-maintainerrdark text-zinc-900 shadow-md hover:bg-maintainerrdark-800"
+              <Button
+                buttonType="default"
+                className="ml-auto"
                 onClick={cancel}
                 type="button"
                 disabled={isCreatePending || isUpdatePending}
               >
-                {<BanIcon className="m-auto ml-5 h-6 w-6 text-zinc-200" />}
-                <p className="button-text m-auto ml-1 mr-5 text-zinc-100">
-                  Cancel
-                </p>
-              </button>
+                Cancel
+              </Button>
             </div>
           </div>
           <div className="fixed bottom-0 left-0 right-0 z-40 bg-zinc-800 px-4 py-3 shadow-[0_-2px_6px_rgba(0,0,0,0.4)] md:hidden">
@@ -1696,15 +1693,15 @@ const AddModal = (props: AddModal) => {
                 type="submit"
               />
 
-              <button
-                className="flex h-10 w-full max-w-[160px] items-center justify-center rounded bg-maintainerrdark text-zinc-900 shadow-md hover:bg-maintainerrdark-800 disabled:opacity-60"
+              <Button
+                buttonType="default"
+                className="w-full max-w-[160px] justify-center"
                 type="button"
                 onClick={cancel}
                 disabled={isCreatePending || isUpdatePending}
               >
-                <BanIcon className="h-5 w-5 text-zinc-200" />
-                <span className="ml-2 text-zinc-100">Cancel</span>
-              </button>
+                Cancel
+              </Button>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
Follow-ups to #2715. Four focused fixes to the rule creator drag-and-drop refactor.

- **Keyboard reorder no longer double-triggers across nested lists.** `react-movable` attaches `onKeyDown` to each list item and does not stop propagation. With lists nested (rules inside sections), a Space/Arrow/j/k/Escape on a focused rule wrapper also reached the outer section's handler, putting the enclosing section into keyboard-drag mode. Rule wrappers now stop those specific keys from bubbling.
- **No render churn at drag start.** `react-movable` renders the dragged item in a `ReactDOM.createPortal`, which mounts a fresh `RuleInput`. Its commit effect fires with values identical to the stored rule and triggered a `setSections` update mid-drag. `handleCommit` now short-circuits when the incoming rule is deep-equal to the stored one.
- **No initial `onUpdate` on mount.** A `didMount` ref gates the emit effect so the parent's rule state is only updated on actual section changes, matching pre-#2715 behavior.
- **Removed dead code.** `RuleInput`'s `newlyAdded` prop and `isNewlyAdded` branch in `getInitialRuleState` were unreachable after #2715 — the UID-based state model encodes "new rule" by withholding `editData`. Dropped the prop and the branch.

## Test plan
- [x] `yarn build` — green
- [x] `yarn lint` — green
- [x] `yarn workspace @maintainerr/ui test` — 156/156 passing
- [ ] Reorder rules within a section via mouse
- [ ] Reorder sections via mouse
- [ ] Tab to a rule wrapper, press Space to lift, Arrow keys to move, Space to drop — only the rule moves, section stays put
- [ ] Open the rule group editor on an existing group — rules persist, no extra re-render flash
- [ ] Drag a rule with partially-filled fields — values survive the drop