### PR TITLE
Fix storage totals for shared Arr filesystems

### DIFF
--- a/apps/server/src/modules/api/servarr-api/common/servarr-api.service.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/common/servarr-api.service.spec.ts
@@ -1,0 +1,45 @@
+import type { ArrDiskspaceResource } from '@maintainerr/contracts';
+import type { MaintainerrLogger } from '../../../logging/logs.service';
+import { ServarrApi } from './servarr-api.service';
+
+class TestServarrApi extends ServarrApi<Record<string, never>> {}
+
+describe('ServarrApi', () => {
+  let api: TestServarrApi;
+  let logger: jest.Mocked<MaintainerrLogger>;
+
+  beforeEach(() => {
+    logger = {
+      setContext: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    } as unknown as jest.Mocked<MaintainerrLogger>;
+
+    api = new TestServarrApi(
+      { url: 'http://localhost:7878', apiKey: 'test' },
+      logger,
+    );
+  });
+
+  it('returns diskspace mounts unchanged when root folders are unavailable', async () => {
+    const diskspace: ArrDiskspaceResource[] = [
+      {
+        id: 1,
+        path: '/movies',
+        label: null,
+        freeSpace: 100,
+        totalSpace: 200,
+        hasAccurateTotalSpace: true,
+      },
+    ];
+
+    jest.spyOn(api as any, 'getDiskspace').mockResolvedValue(diskspace);
+    jest.spyOn(api as any, 'getRootFolders').mockResolvedValue(undefined);
+
+    await expect(api.getDiskspaceAndRootFolders()).resolves.toEqual({
+      mounts: diskspace,
+      rootFolderPaths: new Set(),
+    });
+  });
+});

--- a/apps/server/src/modules/api/servarr-api/common/servarr-api.service.ts
+++ b/apps/server/src/modules/api/servarr-api/common/servarr-api.service.ts
@@ -114,26 +114,29 @@ export abstract class ServarrApi<QueueItemAppendT> extends ExternalApiService {
    * These merged entries are safe for remaining-space calculations and for the
    * UI path picker. Total-space rule evaluation must use raw /diskspace data.
    */
-  public getDiskspaceWithRootFolders = async (): Promise<
-    DiskSpaceResource[]
-  > => {
+  public getDiskspaceAndRootFolders = async (): Promise<{
+    mounts: DiskSpaceResource[];
+    rootFolderPaths: Set<string>;
+  }> => {
     const [diskspace, rootFolders] = await Promise.all([
       this.getDiskspace(),
       this.getRootFolders(),
     ]);
 
-    const results: DiskSpaceResource[] = [...(diskspace ?? [])];
+    const mounts: DiskSpaceResource[] = [...(diskspace ?? [])];
     const existingPaths = new Set(
-      results.filter((d) => d.path).map((d) => normalizeDiskPath(d.path!)),
+      mounts.filter((d) => d.path).map((d) => normalizeDiskPath(d.path!)),
     );
+    const rootFolderPaths = new Set<string>();
 
     for (const folder of rootFolders ?? []) {
       if (!folder.path) continue;
 
       const normalized = normalizeDiskPath(folder.path);
+      rootFolderPaths.add(normalized);
       if (!existingPaths.has(normalized)) {
         existingPaths.add(normalized);
-        results.push({
+        mounts.push({
           id: folder.id,
           path: folder.path,
           label: null,
@@ -144,7 +147,14 @@ export abstract class ServarrApi<QueueItemAppendT> extends ExternalApiService {
       }
     }
 
-    return results;
+    return { mounts, rootFolderPaths };
+  };
+
+  public getDiskspaceWithRootFolders = async (): Promise<
+    DiskSpaceResource[]
+  > => {
+    const { mounts } = await this.getDiskspaceAndRootFolders();
+    return mounts;
   };
 
   public getQueue = async (): Promise<(QueueItem & QueueItemAppendT)[]> => {

--- a/apps/server/src/modules/storage-metrics/storage-metrics.constants.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.constants.ts
@@ -1,0 +1,2 @@
+export const LIBRARY_SIZES_CACHE_TTL_MS = 15 * 60 * 1000;
+export const FREE_SPACE_BUCKET_BYTES = 1024 * 1024;

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
@@ -120,4 +120,110 @@ describe('StorageMetricsService', () => {
       expect(mediaServer.computeLibraryStorageSizes).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('computeTotals', () => {
+    it('prefers root folder mounts and avoids double-counting the same filesystem', () => {
+      const mounts = [
+        {
+          instanceId: 1,
+          instanceType: 'radarr',
+          instanceName: 'Radarr',
+          path: '/',
+          label: '',
+          freeSpace: 50,
+          totalSpace: 100,
+          hasAccurateTotalSpace: true,
+        },
+        {
+          instanceId: 1,
+          instanceType: 'radarr',
+          instanceName: 'Radarr',
+          path: '/movies',
+          label: '',
+          freeSpace: 180,
+          totalSpace: 200,
+          hasAccurateTotalSpace: true,
+        },
+        {
+          instanceId: 1,
+          instanceType: 'radarr',
+          instanceName: 'Radarr',
+          path: '/downloads',
+          label: '',
+          freeSpace: 180,
+          totalSpace: 200,
+          hasAccurateTotalSpace: true,
+        },
+        {
+          instanceId: 1,
+          instanceType: 'sonarr',
+          instanceName: 'Sonarr',
+          path: '/tv',
+          label: '',
+          freeSpace: 180,
+          totalSpace: 200,
+          hasAccurateTotalSpace: true,
+        },
+      ];
+
+      const totals = (service as any).computeTotals(
+        mounts,
+        new Map([
+          ['radarr||1', new Set(['/movies'])],
+          ['sonarr||1', new Set(['/tv'])],
+        ]),
+      );
+
+      expect(totals).toEqual({
+        freeSpace: 180,
+        totalSpace: 200,
+        usedSpace: 20,
+        mountCount: 1,
+        accurateMountCount: 1,
+        accurateTotalSpace: true,
+      });
+    });
+
+    it('uses instance type when mapping root folders for overlapping instance ids', () => {
+      const mounts = [
+        {
+          instanceId: 1,
+          instanceType: 'radarr',
+          instanceName: 'Radarr',
+          path: '/movies',
+          label: '',
+          freeSpace: 180,
+          totalSpace: 200,
+          hasAccurateTotalSpace: true,
+        },
+        {
+          instanceId: 1,
+          instanceType: 'sonarr',
+          instanceName: 'Sonarr',
+          path: '/tv',
+          label: '',
+          freeSpace: 80,
+          totalSpace: 100,
+          hasAccurateTotalSpace: true,
+        },
+      ];
+
+      const totals = (service as any).computeTotals(
+        mounts,
+        new Map([
+          ['radarr||1', new Set(['/movies'])],
+          ['sonarr||1', new Set(['/tv'])],
+        ]),
+      );
+
+      expect(totals).toEqual({
+        freeSpace: 260,
+        totalSpace: 300,
+        usedSpace: 40,
+        mountCount: 2,
+        accurateMountCount: 2,
+        accurateTotalSpace: true,
+      });
+    });
+  });
 });

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
@@ -1,3 +1,4 @@
+import { StorageDiskspaceEntry } from '@maintainerr/contracts';
 import {
   InternalServerErrorException,
   ServiceUnavailableException,
@@ -6,6 +7,10 @@ import { Mocked, TestBed } from '@suites/unit';
 import { MediaServerFactory } from '../api/media-server/media-server.factory';
 import { IMediaServerService } from '../api/media-server/media-server.interface';
 import { MaintainerrLogger } from '../logging/logs.service';
+import {
+  FREE_SPACE_BUCKET_BYTES,
+  LIBRARY_SIZES_CACHE_TTL_MS,
+} from './storage-metrics.constants';
 import { StorageMetricsService } from './storage-metrics.service';
 
 const createDeferred = <T>() => {
@@ -89,6 +94,23 @@ describe('StorageMetricsService', () => {
       expect(second).toEqual(first);
     });
 
+    it('stores cache expiry using the shared cache TTL', async () => {
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1234);
+      mediaServer.computeLibraryStorageSizes.mockResolvedValue(
+        new Map([['library-1', 456]]),
+      );
+
+      await service.computeMediaServerLibrarySizes();
+
+      expect((service as any).librarySizesCache).toEqual(
+        expect.objectContaining({
+          expiresAt: 1234 + LIBRARY_SIZES_CACHE_TTL_MS,
+        }),
+      );
+
+      nowSpy.mockRestore();
+    });
+
     it('reuses the in-flight computation for concurrent requests', async () => {
       const serviceDeferred = createDeferred<IMediaServerService>();
       mediaServerFactory.getService.mockImplementation(
@@ -122,60 +144,66 @@ describe('StorageMetricsService', () => {
   });
 
   describe('computeTotals', () => {
-    it('prefers root folder mounts and avoids double-counting the same filesystem', () => {
-      const mounts = [
-        {
-          instanceId: 1,
-          instanceType: 'radarr',
-          instanceName: 'Radarr',
-          path: '/',
-          label: '',
-          freeSpace: 50,
-          totalSpace: 100,
-          hasAccurateTotalSpace: true,
-        },
-        {
-          instanceId: 1,
-          instanceType: 'radarr',
-          instanceName: 'Radarr',
-          path: '/movies',
-          label: '',
-          freeSpace: 180,
-          totalSpace: 200,
-          hasAccurateTotalSpace: true,
-        },
-        {
-          instanceId: 1,
-          instanceType: 'radarr',
-          instanceName: 'Radarr',
-          path: '/downloads',
-          label: '',
-          freeSpace: 180,
-          totalSpace: 200,
-          hasAccurateTotalSpace: true,
-        },
-        {
-          instanceId: 1,
-          instanceType: 'sonarr',
-          instanceName: 'Sonarr',
-          path: '/tv',
-          label: '',
-          freeSpace: 180,
-          totalSpace: 200,
-          hasAccurateTotalSpace: true,
-        },
-      ];
+    type MountInput = Partial<StorageDiskspaceEntry> & {
+      instanceType: 'radarr' | 'sonarr';
+      instanceId: number;
+      path: string;
+      totalSpace: number;
+      freeSpace: number;
+    };
 
-      const totals = (service as any).computeTotals(
+    const mount = (m: MountInput): StorageDiskspaceEntry => ({
+      instanceName: `${m.instanceType}-${m.instanceId}`,
+      label: '',
+      hasAccurateTotalSpace: true,
+      ...m,
+    });
+
+    const compute = (
+      mounts: StorageDiskspaceEntry[],
+      rootFolders: Record<string, string[]> = {},
+      hosts: Record<string, string> = {},
+    ) =>
+      (service as any).computeTotals(
         mounts,
-        new Map([
-          ['radarr||1', new Set(['/movies'])],
-          ['sonarr||1', new Set(['/tv'])],
-        ]),
-        new Map([
-          ['radarr||1', 'arr.local'],
-          ['sonarr||1', 'arr.local'],
-        ]),
+        new Map(Object.entries(rootFolders).map(([k, v]) => [k, new Set(v)])),
+        new Map(Object.entries(hosts)),
+      );
+
+    it('counts only root-folder-backed mounts and merges shared filesystems on the same host', () => {
+      const totals = compute(
+        [
+          mount({
+            instanceType: 'radarr',
+            instanceId: 1,
+            path: '/',
+            freeSpace: 50,
+            totalSpace: 100,
+          }),
+          mount({
+            instanceType: 'radarr',
+            instanceId: 1,
+            path: '/movies',
+            freeSpace: 180,
+            totalSpace: 200,
+          }),
+          mount({
+            instanceType: 'radarr',
+            instanceId: 1,
+            path: '/downloads',
+            freeSpace: 180,
+            totalSpace: 200,
+          }),
+          mount({
+            instanceType: 'sonarr',
+            instanceId: 1,
+            path: '/tv',
+            freeSpace: 180,
+            totalSpace: 200,
+          }),
+        ],
+        { 'radarr||1': ['/movies'], 'sonarr||1': ['/tv'] },
+        { 'radarr||1': 'arr.local', 'sonarr||1': 'arr.local' },
       );
 
       expect(totals).toEqual({
@@ -188,96 +216,163 @@ describe('StorageMetricsService', () => {
       });
     });
 
-    it('uses instance type when mapping root folders for overlapping instance ids', () => {
-      const mounts = [
-        {
-          instanceId: 1,
-          instanceType: 'radarr',
-          instanceName: 'Radarr',
-          path: '/movies',
-          label: '',
-          freeSpace: 180,
-          totalSpace: 200,
-          hasAccurateTotalSpace: true,
-        },
-        {
-          instanceId: 1,
-          instanceType: 'sonarr',
-          instanceName: 'Sonarr',
-          path: '/tv',
-          label: '',
-          freeSpace: 80,
-          totalSpace: 100,
-          hasAccurateTotalSpace: true,
-        },
-      ];
-
-      const totals = (service as any).computeTotals(
-        mounts,
-        new Map([
-          ['radarr||1', new Set(['/movies'])],
-          ['sonarr||1', new Set(['/tv'])],
-        ]),
-        new Map([
-          ['radarr||1', 'radarr.local'],
-          ['sonarr||1', 'sonarr.local'],
-        ]),
+    it('keys root folders by instance type so overlapping ids do not collide', () => {
+      const totals = compute(
+        [
+          mount({
+            instanceType: 'radarr',
+            instanceId: 1,
+            path: '/movies',
+            freeSpace: 180,
+            totalSpace: 200,
+          }),
+          mount({
+            instanceType: 'sonarr',
+            instanceId: 1,
+            path: '/tv',
+            freeSpace: 80,
+            totalSpace: 100,
+          }),
+        ],
+        { 'radarr||1': ['/movies'], 'sonarr||1': ['/tv'] },
+        { 'radarr||1': 'radarr.local', 'sonarr||1': 'sonarr.local' },
       );
 
-      expect(totals).toEqual({
-        freeSpace: 260,
-        totalSpace: 300,
-        usedSpace: 40,
-        mountCount: 2,
-        accurateMountCount: 2,
-        accurateTotalSpace: true,
-      });
+      expect(totals.totalSpace).toBe(300);
+      expect(totals.mountCount).toBe(2);
     });
 
-    it('does not merge identical signatures across different hosts', () => {
-      const mounts = [
-        {
-          instanceId: 1,
-          instanceType: 'radarr',
-          instanceName: 'Radarr',
-          path: '/movies',
-          label: '',
-          freeSpace: 180,
-          totalSpace: 200,
-          hasAccurateTotalSpace: true,
-        },
-        {
-          instanceId: 1,
-          instanceType: 'sonarr',
-          instanceName: 'Sonarr',
-          path: '/tv',
-          label: '',
-          freeSpace: 180,
-          totalSpace: 200,
-          hasAccurateTotalSpace: true,
-        },
-      ];
-
-      const totals = (service as any).computeTotals(
-        mounts,
-        new Map([
-          ['radarr||1', new Set(['/movies'])],
-          ['sonarr||1', new Set(['/tv'])],
-        ]),
-        new Map([
-          ['radarr||1', 'radarr-a.local'],
-          ['sonarr||1', 'sonarr-b.local'],
-        ]),
+    it('does not merge identical capacities across different hosts', () => {
+      const totals = compute(
+        [
+          mount({
+            instanceType: 'radarr',
+            instanceId: 1,
+            path: '/movies',
+            freeSpace: 180,
+            totalSpace: 200,
+          }),
+          mount({
+            instanceType: 'sonarr',
+            instanceId: 1,
+            path: '/tv',
+            freeSpace: 180,
+            totalSpace: 200,
+          }),
+        ],
+        { 'radarr||1': ['/movies'], 'sonarr||1': ['/tv'] },
+        { 'radarr||1': 'radarr-a.local', 'sonarr||1': 'sonarr-b.local' },
       );
 
-      expect(totals).toEqual({
-        freeSpace: 360,
-        totalSpace: 400,
-        usedSpace: 40,
-        mountCount: 2,
-        accurateMountCount: 2,
-        accurateTotalSpace: true,
-      });
+      expect(totals.totalSpace).toBe(400);
+      expect(totals.mountCount).toBe(2);
+    });
+
+    it('merges shared filesystems even when freeSpace drifts between back-to-back queries', () => {
+      const totals = compute(
+        [
+          mount({
+            instanceType: 'radarr',
+            instanceId: 1,
+            path: '/movies',
+            freeSpace: 30 * FREE_SPACE_BUCKET_BYTES,
+            totalSpace: 200,
+          }),
+          mount({
+            instanceType: 'sonarr',
+            instanceId: 1,
+            path: '/tv',
+            freeSpace: 30 * FREE_SPACE_BUCKET_BYTES + 512,
+            totalSpace: 200,
+          }),
+        ],
+        { 'radarr||1': ['/movies'], 'sonarr||1': ['/tv'] },
+        { 'radarr||1': 'arr.local', 'sonarr||1': 'arr.local' },
+      );
+
+      expect(totals.mountCount).toBe(1);
+      expect(totals.totalSpace).toBe(200);
+    });
+
+    it('keeps distinct same-capacity filesystems separate when usage differs materially', () => {
+      const totals = compute(
+        [
+          mount({
+            instanceType: 'radarr',
+            instanceId: 1,
+            path: '/movies',
+            freeSpace: 30 * FREE_SPACE_BUCKET_BYTES,
+            totalSpace: 200,
+          }),
+          mount({
+            instanceType: 'radarr',
+            instanceId: 1,
+            path: '/archive',
+            freeSpace: 28 * FREE_SPACE_BUCKET_BYTES,
+            totalSpace: 200,
+          }),
+        ],
+        { 'radarr||1': ['/movies', '/archive'] },
+        { 'radarr||1': 'arr.local' },
+      );
+
+      expect(totals.mountCount).toBe(2);
+      expect(totals.totalSpace).toBe(400);
+    });
+
+    it('falls back to path-based dedupe for mounts without accurate totals', () => {
+      const totals = compute(
+        [
+          mount({
+            instanceType: 'sonarr',
+            instanceId: 1,
+            path: '/tv',
+            freeSpace: 180,
+            totalSpace: 0,
+            hasAccurateTotalSpace: false,
+          }),
+          mount({
+            instanceType: 'sonarr',
+            instanceId: 1,
+            path: '/tv/',
+            freeSpace: 180,
+            totalSpace: 0,
+            hasAccurateTotalSpace: false,
+          }),
+        ],
+        { 'sonarr||1': ['/tv'] },
+        { 'sonarr||1': 'arr.local' },
+      );
+
+      expect(totals.mountCount).toBe(1);
+      expect(totals.accurateMountCount).toBe(0);
+      expect(totals.accurateTotalSpace).toBe(false);
+    });
+
+    it('counts every mount when no root folders are reported for the instance', () => {
+      const totals = compute(
+        [
+          mount({
+            instanceType: 'radarr',
+            instanceId: 1,
+            path: '/movies',
+            freeSpace: 180,
+            totalSpace: 200,
+          }),
+          mount({
+            instanceType: 'radarr',
+            instanceId: 1,
+            path: '/extras',
+            freeSpace: 80,
+            totalSpace: 100,
+          }),
+        ],
+        {},
+        { 'radarr||1': 'arr.local' },
+      );
+
+      expect(totals.mountCount).toBe(2);
+      expect(totals.totalSpace).toBe(300);
     });
   });
 });

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
@@ -172,6 +172,10 @@ describe('StorageMetricsService', () => {
           ['radarr||1', new Set(['/movies'])],
           ['sonarr||1', new Set(['/tv'])],
         ]),
+        new Map([
+          ['radarr||1', 'arr.local'],
+          ['sonarr||1', 'arr.local'],
+        ]),
       );
 
       expect(totals).toEqual({
@@ -214,11 +218,61 @@ describe('StorageMetricsService', () => {
           ['radarr||1', new Set(['/movies'])],
           ['sonarr||1', new Set(['/tv'])],
         ]),
+        new Map([
+          ['radarr||1', 'radarr.local'],
+          ['sonarr||1', 'sonarr.local'],
+        ]),
       );
 
       expect(totals).toEqual({
         freeSpace: 260,
         totalSpace: 300,
+        usedSpace: 40,
+        mountCount: 2,
+        accurateMountCount: 2,
+        accurateTotalSpace: true,
+      });
+    });
+
+    it('does not merge identical signatures across different hosts', () => {
+      const mounts = [
+        {
+          instanceId: 1,
+          instanceType: 'radarr',
+          instanceName: 'Radarr',
+          path: '/movies',
+          label: '',
+          freeSpace: 180,
+          totalSpace: 200,
+          hasAccurateTotalSpace: true,
+        },
+        {
+          instanceId: 1,
+          instanceType: 'sonarr',
+          instanceName: 'Sonarr',
+          path: '/tv',
+          label: '',
+          freeSpace: 180,
+          totalSpace: 200,
+          hasAccurateTotalSpace: true,
+        },
+      ];
+
+      const totals = (service as any).computeTotals(
+        mounts,
+        new Map([
+          ['radarr||1', new Set(['/movies'])],
+          ['sonarr||1', new Set(['/tv'])],
+        ]),
+        new Map([
+          ['radarr||1', 'radarr-a.local'],
+          ['sonarr||1', 'sonarr-b.local'],
+        ]),
+      );
+
+      expect(totals).toEqual({
+        freeSpace: 360,
+        totalSpace: 400,
         usedSpace: 40,
         mountCount: 2,
         accurateMountCount: 2,

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
@@ -84,6 +84,21 @@ export class StorageMetricsService {
     const mounts: StorageDiskspaceEntry[] = [];
     const instances: StorageInstanceStatus[] = [];
     const rootFolderPathsByInstance = new Map<string, Set<string>>();
+    const hostByInstance = new Map<string, string>();
+
+    for (const setting of radarrSettings) {
+      hostByInstance.set(
+        this.buildInstanceKey('radarr', setting.id),
+        this.extractHost(setting.url),
+      );
+    }
+
+    for (const setting of sonarrSettings) {
+      hostByInstance.set(
+        this.buildInstanceKey('sonarr', setting.id),
+        this.extractHost(setting.url),
+      );
+    }
 
     for (const result of mountResults) {
       instances.push(result.status);
@@ -97,7 +112,11 @@ export class StorageMetricsService {
       }
     }
 
-    const totals = this.computeTotals(mounts, rootFolderPathsByInstance);
+    const totals = this.computeTotals(
+      mounts,
+      rootFolderPathsByInstance,
+      hostByInstance,
+    );
 
     const [collectionSummary, topCollections, mediaServer] = await Promise.all([
       this.buildCollectionSummary(),
@@ -238,6 +257,7 @@ export class StorageMetricsService {
   private computeTotals(
     mounts: StorageDiskspaceEntry[],
     rootFolderPathsByInstance: Map<string, Set<string>>,
+    hostByInstance: Map<string, string>,
   ): StorageTotals {
     const seen = new Map<string, StorageDiskspaceEntry>();
 
@@ -247,7 +267,11 @@ export class StorageMetricsService {
     )) {
       if (!mount.path) continue;
 
-      const key = this.buildDedupKey(mount);
+      const instanceKey = this.buildInstanceKey(
+        mount.instanceType,
+        mount.instanceId,
+      );
+      const key = this.buildDedupKey(mount, hostByInstance.get(instanceKey));
 
       const existing = seen.get(key);
       if (!existing) {
@@ -325,21 +349,34 @@ export class StorageMetricsService {
     return `${type}||${id}`;
   }
 
-  private buildDedupKey(mount: StorageDiskspaceEntry): string {
+  private buildDedupKey(
+    mount: StorageDiskspaceEntry,
+    host: string | undefined,
+  ): string {
     if (mount.hasAccurateTotalSpace) {
       const label = mount.label?.trim().toLowerCase();
 
       if (label) {
-        return `accurate-label||${label}||${mount.totalSpace}||${mount.freeSpace}`;
+        return `${host ?? ''}||accurate-label||${label}||${mount.totalSpace}||${mount.freeSpace}`;
       }
 
       // Arr APIs do not expose a stable filesystem identifier, so for
       // accurate totals we fall back to a capacity signature to avoid
       // double-counting the same filesystem mounted at multiple paths.
-      return `accurate-capacity||${mount.totalSpace}||${mount.freeSpace}`;
+      return `${host ?? ''}||accurate-capacity||${mount.totalSpace}||${mount.freeSpace}`;
     }
 
-    return `path||${normalizeDiskPath(mount.path ?? '')}`;
+    return `${host ?? ''}||path||${normalizeDiskPath(mount.path ?? '')}`;
+  }
+
+  private extractHost(url: string | undefined): string {
+    if (!url) return '';
+
+    try {
+      return new URL(url).hostname.toLowerCase();
+    } catch {
+      return url.toLowerCase();
+    }
   }
 
   private async getConfiguredMediaServer(): Promise<IMediaServerService> {

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
@@ -30,17 +30,18 @@ import { MaintainerrLogger } from '../logging/logs.service';
 import { RadarrSettings } from '../settings/entities/radarr_settings.entities';
 import { SonarrSettings } from '../settings/entities/sonarr_settings.entities';
 
-interface DedupKey {
-  host: string;
-  path: string;
-}
-
 const LIBRARY_SIZES_CACHE_TTL_MS = 15 * 60 * 1000;
 
 interface LibrarySizesCacheEntry {
   generatedAt: string;
   sizeBytesByLibrary: Record<string, number>;
   expiresAt: number;
+}
+
+interface InstanceMountResult {
+  status: StorageInstanceStatus;
+  mounts: StorageDiskspaceEntry[];
+  rootFolderPaths: Set<string>;
 }
 
 @Injectable()
@@ -82,16 +83,21 @@ export class StorageMetricsService {
 
     const mounts: StorageDiskspaceEntry[] = [];
     const instances: StorageInstanceStatus[] = [];
+    const rootFolderPathsByInstance = new Map<string, Set<string>>();
 
     for (const result of mountResults) {
       instances.push(result.status);
       mounts.push(...result.mounts);
+
+      if (result.rootFolderPaths.size > 0) {
+        rootFolderPathsByInstance.set(
+          this.buildInstanceKey(result.status.type, result.status.id),
+          result.rootFolderPaths,
+        );
+      }
     }
 
-    const totals = this.computeTotals(mounts, [
-      ...radarrSettings,
-      ...sonarrSettings,
-    ]);
+    const totals = this.computeTotals(mounts, rootFolderPathsByInstance);
 
     const [collectionSummary, topCollections, mediaServer] = await Promise.all([
       this.buildCollectionSummary(),
@@ -165,10 +171,7 @@ export class StorageMetricsService {
   private async fetchInstanceMounts(
     setting: RadarrSettings | SonarrSettings,
     type: 'radarr' | 'sonarr',
-  ): Promise<{
-    status: StorageInstanceStatus;
-    mounts: StorageDiskspaceEntry[];
-  }> {
+  ): Promise<InstanceMountResult> {
     const baseStatus: StorageInstanceStatus = {
       id: setting.id,
       name: setting.serverName,
@@ -191,10 +194,17 @@ export class StorageMetricsService {
           ? await this.servarrService.getRadarrApiClient(setting.id)
           : await this.servarrService.getSonarrApiClient(setting.id);
 
-      const diskspace: ArrDiskspaceResource[] =
-        (await client.getDiskspaceWithRootFolders()) ?? [];
+      const [diskspace, rootFolders] = await Promise.all([
+        client.getDiskspaceWithRootFolders(),
+        client.getRootFolders(),
+      ]);
+      const rootFolderPaths = new Set(
+        (rootFolders ?? [])
+          .filter((folder) => folder.path)
+          .map((folder) => normalizeDiskPath(folder.path)),
+      );
 
-      const mounts: StorageDiskspaceEntry[] = diskspace.map((entry) => ({
+      const mounts: StorageDiskspaceEntry[] = (diskspace ?? []).map((entry) => ({
         instanceId: setting.id,
         instanceType: type,
         instanceName: setting.serverName,
@@ -208,6 +218,7 @@ export class StorageMetricsService {
       return {
         status: { ...baseStatus, ok: true, mountCount: mounts.length },
         mounts,
+        rootFolderPaths,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
@@ -218,29 +229,24 @@ export class StorageMetricsService {
       return {
         status: { ...baseStatus, error: message },
         mounts: [],
+        rootFolderPaths: new Set<string>(),
       };
     }
   }
 
   private computeTotals(
     mounts: StorageDiskspaceEntry[],
-    settings: Array<RadarrSettings | SonarrSettings>,
+    rootFolderPathsByInstance: Map<string, Set<string>>,
   ): StorageTotals {
-    const hostByInstance = new Map<number, string>();
-    for (const setting of settings) {
-      hostByInstance.set(setting.id, this.extractHost(setting.url));
-    }
-
     const seen = new Map<string, StorageDiskspaceEntry>();
 
-    for (const mount of mounts) {
+    for (const mount of this.selectMountsForTotals(
+      mounts,
+      rootFolderPathsByInstance,
+    )) {
       if (!mount.path) continue;
 
-      const host = hostByInstance.get(mount.instanceId) ?? '';
-      const key = this.buildDedupKey({
-        host,
-        path: normalizeDiskPath(mount.path),
-      });
+      const key = this.buildDedupKey(mount);
 
       const existing = seen.get(key);
       if (!existing) {
@@ -279,17 +285,60 @@ export class StorageMetricsService {
     };
   }
 
-  private extractHost(url: string | undefined): string {
-    if (!url) return '';
-    try {
-      return new URL(url).hostname.toLowerCase();
-    } catch {
-      return url.toLowerCase();
+  private selectMountsForTotals(
+    mounts: StorageDiskspaceEntry[],
+    rootFolderPathsByInstance: Map<string, Set<string>>,
+  ): StorageDiskspaceEntry[] {
+    const mountsByInstance = new Map<string, StorageDiskspaceEntry[]>();
+
+    for (const mount of mounts) {
+      const key = this.buildInstanceKey(mount.instanceType, mount.instanceId);
+      const instanceMounts = mountsByInstance.get(key) ?? [];
+      instanceMounts.push(mount);
+      mountsByInstance.set(key, instanceMounts);
     }
+
+    const selected: StorageDiskspaceEntry[] = [];
+
+    for (const [instanceKey, instanceMounts] of mountsByInstance) {
+      const rootFolderPaths = rootFolderPathsByInstance.get(instanceKey);
+      if (!rootFolderPaths || rootFolderPaths.size === 0) {
+        selected.push(...instanceMounts);
+        continue;
+      }
+
+      const rootFolderMounts = instanceMounts.filter(
+        (mount) =>
+          !!mount.path && rootFolderPaths.has(normalizeDiskPath(mount.path)),
+      );
+
+      selected.push(
+        ...(rootFolderMounts.length > 0 ? rootFolderMounts : instanceMounts),
+      );
+    }
+
+    return selected;
   }
 
-  private buildDedupKey(key: DedupKey): string {
-    return `${key.host}||${key.path}`;
+  private buildInstanceKey(type: 'radarr' | 'sonarr', id: number): string {
+    return `${type}||${id}`;
+  }
+
+  private buildDedupKey(mount: StorageDiskspaceEntry): string {
+    if (mount.hasAccurateTotalSpace) {
+      const label = mount.label?.trim().toLowerCase();
+
+      if (label) {
+        return `accurate-label||${label}||${mount.totalSpace}||${mount.freeSpace}`;
+      }
+
+      // Arr APIs do not expose a stable filesystem identifier, so for
+      // accurate totals we fall back to a capacity signature to avoid
+      // double-counting the same filesystem mounted at multiple paths.
+      return `accurate-capacity||${mount.totalSpace}||${mount.freeSpace}`;
+    }
+
+    return `path||${normalizeDiskPath(mount.path ?? '')}`;
   }
 
   private async getConfiguredMediaServer(): Promise<IMediaServerService> {

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
@@ -185,6 +185,7 @@ export class StorageMetricsService {
       return {
         status: { ...baseStatus, error: 'Instance is not fully configured' },
         mounts: [],
+        rootFolderPaths: new Set<string>(),
       };
     }
 

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
@@ -1,5 +1,4 @@
 import {
-  ArrDiskspaceResource,
   MediaItemType,
   MediaLibrary,
   MediaServerType,
@@ -29,19 +28,15 @@ import { CollectionMedia } from '../collections/entities/collection_media.entiti
 import { MaintainerrLogger } from '../logging/logs.service';
 import { RadarrSettings } from '../settings/entities/radarr_settings.entities';
 import { SonarrSettings } from '../settings/entities/sonarr_settings.entities';
-
-const LIBRARY_SIZES_CACHE_TTL_MS = 15 * 60 * 1000;
+import {
+  FREE_SPACE_BUCKET_BYTES,
+  LIBRARY_SIZES_CACHE_TTL_MS,
+} from './storage-metrics.constants';
 
 interface LibrarySizesCacheEntry {
   generatedAt: string;
   sizeBytesByLibrary: Record<string, number>;
   expiresAt: number;
-}
-
-interface InstanceMountResult {
-  status: StorageInstanceStatus;
-  mounts: StorageDiskspaceEntry[];
-  rootFolderPaths: Set<string>;
 }
 
 @Injectable()
@@ -86,29 +81,13 @@ export class StorageMetricsService {
     const rootFolderPathsByInstance = new Map<string, Set<string>>();
     const hostByInstance = new Map<string, string>();
 
-    for (const setting of radarrSettings) {
-      hostByInstance.set(
-        this.buildInstanceKey('radarr', setting.id),
-        this.extractHost(setting.url),
-      );
-    }
-
-    for (const setting of sonarrSettings) {
-      hostByInstance.set(
-        this.buildInstanceKey('sonarr', setting.id),
-        this.extractHost(setting.url),
-      );
-    }
-
     for (const result of mountResults) {
       instances.push(result.status);
       mounts.push(...result.mounts);
-
+      const instanceKey = `${result.status.type}||${result.status.id}`;
+      hostByInstance.set(instanceKey, result.host);
       if (result.rootFolderPaths.size > 0) {
-        rootFolderPathsByInstance.set(
-          this.buildInstanceKey(result.status.type, result.status.id),
-          result.rootFolderPaths,
-        );
+        rootFolderPathsByInstance.set(instanceKey, result.rootFolderPaths);
       }
     }
 
@@ -190,7 +169,12 @@ export class StorageMetricsService {
   private async fetchInstanceMounts(
     setting: RadarrSettings | SonarrSettings,
     type: 'radarr' | 'sonarr',
-  ): Promise<InstanceMountResult> {
+  ): Promise<{
+    status: StorageInstanceStatus;
+    mounts: StorageDiskspaceEntry[];
+    rootFolderPaths: Set<string>;
+    host: string;
+  }> {
     const baseStatus: StorageInstanceStatus = {
       id: setting.id,
       name: setting.serverName,
@@ -199,12 +183,13 @@ export class StorageMetricsService {
       error: null,
       mountCount: 0,
     };
+    const host = this.extractHost(setting.url);
+    const empty = { mounts: [], rootFolderPaths: new Set<string>(), host };
 
     if (!setting.url || !setting.apiKey) {
       return {
         status: { ...baseStatus, error: 'Instance is not fully configured' },
-        mounts: [],
-        rootFolderPaths: new Set<string>(),
+        ...empty,
       };
     }
 
@@ -214,17 +199,10 @@ export class StorageMetricsService {
           ? await this.servarrService.getRadarrApiClient(setting.id)
           : await this.servarrService.getSonarrApiClient(setting.id);
 
-      const [diskspace, rootFolders] = await Promise.all([
-        client.getDiskspaceWithRootFolders(),
-        client.getRootFolders(),
-      ]);
-      const rootFolderPaths = new Set(
-        (rootFolders ?? [])
-          .filter((folder) => folder.path)
-          .map((folder) => normalizeDiskPath(folder.path)),
-      );
+      const { mounts: diskspace, rootFolderPaths } =
+        await client.getDiskspaceAndRootFolders();
 
-      const mounts: StorageDiskspaceEntry[] = (diskspace ?? []).map((entry) => ({
+      const mounts: StorageDiskspaceEntry[] = diskspace.map((entry) => ({
         instanceId: setting.id,
         instanceType: type,
         instanceName: setting.serverName,
@@ -239,6 +217,7 @@ export class StorageMetricsService {
         status: { ...baseStatus, ok: true, mountCount: mounts.length },
         mounts,
         rootFolderPaths,
+        host,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
@@ -246,11 +225,7 @@ export class StorageMetricsService {
         `Failed to retrieve disk space for ${type} instance "${setting.serverName}"`,
       );
       this.logger.debug(error);
-      return {
-        status: { ...baseStatus, error: message },
-        mounts: [],
-        rootFolderPaths: new Set<string>(),
-      };
+      return { status: { ...baseStatus, error: message }, ...empty };
     }
   }
 
@@ -261,24 +236,25 @@ export class StorageMetricsService {
   ): StorageTotals {
     const seen = new Map<string, StorageDiskspaceEntry>();
 
-    for (const mount of this.selectMountsForTotals(
-      mounts,
-      rootFolderPathsByInstance,
-    )) {
+    for (const mount of mounts) {
       if (!mount.path) continue;
 
-      const instanceKey = this.buildInstanceKey(
-        mount.instanceType,
-        mount.instanceId,
-      );
-      const key = this.buildDedupKey(mount, hostByInstance.get(instanceKey));
+      const instanceKey = `${mount.instanceType}||${mount.instanceId}`;
+      const rootPaths = rootFolderPathsByInstance.get(instanceKey);
+      // When the instance exposes root folders, only count root-folder-backed
+      // mounts in the headline totals. Other /diskspace entries (e.g. download
+      // paths) remain visible in the per-instance mount list.
+      if (rootPaths?.size && !rootPaths.has(normalizeDiskPath(mount.path))) {
+        continue;
+      }
+
+      const host = hostByInstance.get(instanceKey) ?? '';
+      const key = this.buildTotalsDedupKey(mount, host);
 
       const existing = seen.get(key);
-      if (!existing) {
-        seen.set(key, mount);
-      } else if (
-        !existing.hasAccurateTotalSpace &&
-        mount.hasAccurateTotalSpace
+      if (
+        !existing ||
+        (!existing.hasAccurateTotalSpace && mount.hasAccurateTotalSpace)
       ) {
         seen.set(key, mount);
       }
@@ -296,82 +272,42 @@ export class StorageMetricsService {
       }
     }
 
-    const usedSpace = Math.max(totalSpace - freeSpace, 0);
-    const accurateTotalSpace =
-      seen.size > 0 && accurateMountCount === seen.size && totalSpace > 0;
-
     return {
       freeSpace,
       totalSpace,
-      usedSpace,
+      usedSpace: Math.max(totalSpace - freeSpace, 0),
       mountCount: seen.size,
       accurateMountCount,
-      accurateTotalSpace,
+      accurateTotalSpace:
+        seen.size > 0 && accurateMountCount === seen.size && totalSpace > 0,
     };
   }
 
-  private selectMountsForTotals(
-    mounts: StorageDiskspaceEntry[],
-    rootFolderPathsByInstance: Map<string, Set<string>>,
-  ): StorageDiskspaceEntry[] {
-    const mountsByInstance = new Map<string, StorageDiskspaceEntry[]>();
-
-    for (const mount of mounts) {
-      const key = this.buildInstanceKey(mount.instanceType, mount.instanceId);
-      const instanceMounts = mountsByInstance.get(key) ?? [];
-      instanceMounts.push(mount);
-      mountsByInstance.set(key, instanceMounts);
-    }
-
-    const selected: StorageDiskspaceEntry[] = [];
-
-    for (const [instanceKey, instanceMounts] of mountsByInstance) {
-      const rootFolderPaths = rootFolderPathsByInstance.get(instanceKey);
-      if (!rootFolderPaths || rootFolderPaths.size === 0) {
-        selected.push(...instanceMounts);
-        continue;
-      }
-
-      const rootFolderMounts = instanceMounts.filter(
-        (mount) =>
-          !!mount.path && rootFolderPaths.has(normalizeDiskPath(mount.path)),
-      );
-
-      selected.push(
-        ...(rootFolderMounts.length > 0 ? rootFolderMounts : instanceMounts),
-      );
-    }
-
-    return selected;
-  }
-
-  private buildInstanceKey(type: 'radarr' | 'sonarr', id: number): string {
-    return `${type}||${id}`;
-  }
-
-  private buildDedupKey(
+  private buildTotalsDedupKey(
     mount: StorageDiskspaceEntry,
-    host: string | undefined,
+    host: string,
   ): string {
-    if (mount.hasAccurateTotalSpace) {
-      const label = mount.label?.trim().toLowerCase();
-
-      if (label) {
-        return `${host ?? ''}||accurate-label||${label}||${mount.totalSpace}||${mount.freeSpace}`;
-      }
-
-      // Arr APIs do not expose a stable filesystem identifier, so for
-      // accurate totals we fall back to a capacity signature to avoid
-      // double-counting the same filesystem mounted at multiple paths.
-      return `${host ?? ''}||accurate-capacity||${mount.totalSpace}||${mount.freeSpace}`;
+    if (!mount.hasAccurateTotalSpace) {
+      return `${host}||path||${normalizeDiskPath(mount.path ?? '')}`;
     }
 
-    return `${host ?? ''}||path||${normalizeDiskPath(mount.path ?? '')}`;
+    const label = mount.label?.trim().toLowerCase();
+    if (label) {
+      return `${host}||label||${label}||${mount.totalSpace}`;
+    }
+
+    // Arr APIs do not expose a stable filesystem identifier. For accurate
+    // totals without a volume label, include a coarse free-space bucket so
+    // small cross-instance drift still merges while same-size disks with
+    // materially different usage stay distinct.
+    const freeSpaceBucket = Math.floor(
+      mount.freeSpace / FREE_SPACE_BUCKET_BYTES,
+    );
+    return `${host}||cap||${mount.totalSpace}||${freeSpaceBucket}`;
   }
 
   private extractHost(url: string | undefined): string {
     if (!url) return '';
-
     try {
       return new URL(url).hostname.toLowerCase();
     } catch {

--- a/apps/ui/src/components/StorageMetrics/index.tsx
+++ b/apps/ui/src/components/StorageMetrics/index.tsx
@@ -258,7 +258,8 @@ const StorageMetrics: React.FC = () => {
           <h2 className="sm-heading">Mounts by instance</h2>
           <p className="description">
             Disk space reported by each configured Radarr or Sonarr instance.
-            Mounts are deduplicated by host + path for the totals above.
+            Headline totals count only root-folder-backed mounts and merge
+            shared filesystems per host.
           </p>
 
           {!hasInstances ? (


### PR DESCRIPTION
## Summary

Fix storage headline totals when Sonarr and Radarr expose multiple root-folder paths that all point at the same underlying filesystem.

This update now:
- prefers root-folder-backed mounts when computing the headline total
- keys root-folder selection by `instanceType + instanceId` so Sonarr and Radarr IDs do not collide
- keeps the Arr root-folder merge logic shared in `ServarrApi`
- dedupes accurate mounts per host using the best available filesystem-like signature:
  - `label + totalSpace` when a stable volume label is present
  - otherwise `totalSpace + MiB-bucketed freeSpace` to absorb tiny cross-instance drift without collapsing obviously different same-size disks

Closes #2720.

## Root Cause

`getDiskspaceWithRootFolders()` can return multiple distinct paths like `/movies`, `/tv`, and `/downloads` for the same shared filesystem.

Before this change, `computeTotals()` deduped by normalized path, so those entries were summed independently even when they referred to the same media disk.

## Notes

Arr APIs do not expose a stable filesystem or device identifier in these payloads, so the totals logic still has to rely on a heuristic.

For accurate mounts without a label, the fallback now uses `totalSpace + MiB-bucketed freeSpace` as the filesystem signature. That fixes the shared-filesystem double-count while avoiding the stricter `totalSpace`-only collision on equal-capacity disks with materially different usage. Two separate unlabeled filesystems on the same host could still theoretically collide if they expose the same total space and land in the same free-space bucket.

## Validation

- Added focused unit coverage for:
  - shared-filesystem root folders being counted once
  - overlapping `radarr(1)` / `sonarr(1)` IDs not colliding
  - same-host free-space drift still merging shared filesystems
  - same-host equal-capacity disks with different usage staying distinct
  - inaccurate-total path dedupe
  - `getRootFolders()` returning `undefined` in the shared Servarr helper
- Ran:
  - `yarn workspace @maintainerr/server test --runInBand src/modules/storage-metrics/storage-metrics.service.spec.ts src/modules/api/servarr-api/common/servarr-api.service.spec.ts`
  - `yarn workspace @maintainerr/server tsc --noEmit`
  - `yarn workspace @maintainerr/server build`
- Result: all passed