### PR TITLE
fix(server): preserve watch history failure distinction

### DIFF
--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -766,7 +766,7 @@ describe('JellyfinAdapterService', () => {
       expect(debugSpy).toHaveBeenNthCalledWith(2, expect.any(Error));
     });
 
-    it('should fall back to Jellyfin played state when threshold cannot be loaded', async () => {
+    it('should re-throw when the played threshold cannot be loaded', async () => {
       jellyfinApiMocks.getUsers.mockResolvedValue({
         data: [{ Id: 'user-1', Name: 'Alice' }],
       });
@@ -787,9 +787,22 @@ describe('JellyfinAdapterService', () => {
         },
       });
 
-      const history = await service.getWatchHistory('item123');
+      await expect(service.getWatchHistory('item123')).rejects.toThrow(
+        'Configuration unavailable',
+      );
+    });
 
-      expect(history).toEqual([]);
+    it('should re-throw when the Jellyfin users lookup fails', async () => {
+      jellyfinApiMocks.getUsers.mockRejectedValue(
+        new Error('Users unavailable'),
+      );
+      jellyfinApiMocks.getConfiguration.mockResolvedValue({
+        data: { MaxResumePct: 95 },
+      });
+
+      await expect(service.getWatchHistory('item123')).rejects.toThrow(
+        'Users unavailable',
+      );
     });
 
     it('should keep Jellyfin played items when no percentage is available', async () => {

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -315,7 +315,7 @@ export class JellyfinAdapterService implements IMediaServerService {
     }
   }
 
-  async getUsers(): Promise<MediaUser[]> {
+  async getUsers(throwOnError = false): Promise<MediaUser[]> {
     if (!this.api) return [];
 
     try {
@@ -338,11 +338,18 @@ export class JellyfinAdapterService implements IMediaServerService {
     } catch (error) {
       this.logger.error('Failed to get Jellyfin users');
       this.logger.debug(error);
+
+      if (throwOnError) {
+        throw error;
+      }
+
       return [];
     }
   }
 
-  private async getPlayedCompletionThreshold(): Promise<number | undefined> {
+  private async getPlayedCompletionThreshold(
+    throwOnError = false,
+  ): Promise<number | undefined> {
     if (!this.api) return undefined;
 
     if (this.cache.data.has(JELLYFIN_CACHE_KEYS.PLAYED_THRESHOLD)) {
@@ -369,6 +376,11 @@ export class JellyfinAdapterService implements IMediaServerService {
     } catch (error) {
       this.logger.warn('Failed to get Jellyfin MaxResumePct');
       this.logger.debug(error);
+
+      if (throwOnError) {
+        throw error;
+      }
+
       return undefined;
     }
   }
@@ -848,43 +860,41 @@ export class JellyfinAdapterService implements IMediaServerService {
   async getWatchHistory(itemId: string): Promise<WatchRecord[]> {
     if (!this.api) return [];
 
-    try {
-      const playedCompletionThreshold =
-        await this.getPlayedCompletionThreshold();
-      const cacheKey = `${JELLYFIN_CACHE_KEYS.WATCH_HISTORY}:${playedCompletionThreshold ?? 'played'}:${itemId}`;
-      if (this.cache.data.has(cacheKey)) {
-        return this.cache.data.get<WatchRecord[]>(cacheKey) || [];
+    // Errors must propagate so callers can distinguish a real outage from a
+    // confirmed empty history. Returning [] here would misclassify failures as
+    // "never watched", which leaks into NOT_EXISTS checks and missing-value
+    // diagnostics in the rules layer.
+    const playedCompletionThreshold =
+      await this.getPlayedCompletionThreshold(true);
+    const cacheKey = `${JELLYFIN_CACHE_KEYS.WATCH_HISTORY}:${playedCompletionThreshold ?? 'played'}:${itemId}`;
+    if (this.cache.data.has(cacheKey)) {
+      return this.cache.data.get<WatchRecord[]>(cacheKey) || [];
+    }
+
+    const records: WatchRecord[] = [];
+
+    // Jellyfin watch state is user-scoped, so we aggregate item user data
+    // across all users and build a normalized watch history from that.
+    const userDataEntries = await this.getAllUserItemData(itemId, true);
+    userDataEntries.forEach(({ user, userData }) => {
+      if (!this.isCompletedWatch(userData, playedCompletionThreshold)) {
+        return;
       }
 
-      const records: WatchRecord[] = [];
+      records.push(
+        JellyfinMapper.toWatchRecord(
+          user.id,
+          itemId,
+          userData?.LastPlayedDate
+            ? new Date(userData.LastPlayedDate)
+            : undefined,
+          userData?.PlayedPercentage ?? undefined,
+        ),
+      );
+    });
 
-      // Jellyfin watch state is user-scoped, so we aggregate item user data
-      // across all users and build a normalized watch history from that.
-      const userDataEntries = await this.getAllUserItemData(itemId);
-      userDataEntries.forEach(({ user, userData }) => {
-        if (!this.isCompletedWatch(userData, playedCompletionThreshold)) {
-          return;
-        }
-
-        records.push(
-          JellyfinMapper.toWatchRecord(
-            user.id,
-            itemId,
-            userData?.LastPlayedDate
-              ? new Date(userData.LastPlayedDate)
-              : undefined,
-            userData?.PlayedPercentage ?? undefined,
-          ),
-        );
-      });
-
-      this.cache.data.set(cacheKey, records, JELLYFIN_CACHE_TTL.WATCH_HISTORY);
-      return records;
-    } catch (error) {
-      this.logger.error(`Failed to get watch history for ${itemId}`);
-      this.logger.debug(error);
-      return [];
-    }
+    this.cache.data.set(cacheKey, records, JELLYFIN_CACHE_TTL.WATCH_HISTORY);
+    return records;
   }
 
   async getWatchState(itemId: string): Promise<MediaWatchState> {
@@ -1028,8 +1038,9 @@ export class JellyfinAdapterService implements IMediaServerService {
    */
   private async mapUsersBatched<T>(
     fn: (user: MediaUser) => Promise<T>,
+    throwOnUserLookupError = false,
   ): Promise<T[]> {
-    const users = await this.getUsers();
+    const users = await this.getUsers(throwOnUserLookupError);
     const entries: T[] = [];
 
     for (
@@ -1060,11 +1071,15 @@ export class JellyfinAdapterService implements IMediaServerService {
    */
   private async getAllUserItemData(
     itemId: string,
+    throwOnUserLookupError = false,
   ): Promise<Array<{ user: MediaUser; userData?: UserItemDataDto }>> {
-    return this.mapUsersBatched(async (user) => ({
-      user,
-      userData: await this.getItemUserData(itemId, user.id),
-    }));
+    return this.mapUsersBatched(
+      async (user) => ({
+        user,
+        userData: await this.getItemUserData(itemId, user.id),
+      }),
+      throwOnUserLookupError,
+    );
   }
 
   /**

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
@@ -482,6 +482,24 @@ describe('JellyfinGetterService', () => {
       expect(response).toBeNull();
     });
 
+    it('should return undefined when watch history lookup fails', async () => {
+      const mediaItem = createMediaItem();
+
+      jellyfinAdapter.getMetadata.mockResolvedValue(mediaItem);
+      jellyfinAdapter.getWatchHistory.mockRejectedValue(
+        new Error('Jellyfin unavailable'),
+      );
+
+      const response = await jellyfinGetterService.get(
+        7,
+        mediaItem,
+        'movie',
+        createRulesDto({ dataType: 'movie' }),
+      );
+
+      expect(response).toBeUndefined();
+    });
+
     it('should aggregate the latest watched episode date for a show', async () => {
       const showItem = createMediaItem({
         id: 'show-1',

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -248,23 +248,19 @@ export class PlexGetterService {
             : null;
         }
         case 'lastViewedAt': {
-          return await this.plexApi
-            .getWatchHistory(metadata.ratingKey)
-            .then((seenby) => {
-              if (seenby.length > 0) {
-                return new Date(
-                  +seenby
-                    .map((el) => el.viewedAt)
-                    .sort()
-                    .reverse()[0] * 1000,
-                );
-              } else {
-                return null;
-              }
-            })
-            .catch(() => {
-              return null;
-            });
+          // Errors must surface so the outer catch returns `undefined` for an
+          // unknown watch state instead of collapsing the failure into a
+          // confirmed never-watched `null`.
+          const seenby = await this.plexApi.getWatchHistory(metadata.ratingKey);
+          if (seenby && seenby.length > 0) {
+            return new Date(
+              +seenby
+                .map((el) => el.viewedAt)
+                .sort()
+                .reverse()[0] * 1000,
+            );
+          }
+          return null;
         }
         case 'fileVideoResolution': {
           return metadata.Media[0].videoResolution


### PR DESCRIPTION
## Summary
- keep "no watch history" separate from "watch history lookup failed"
- make Jellyfin bubble up top-level user and threshold failures, while still tolerating per-user fan-out misses
- let the Plex getter surface watch-history failures to its existing fail-closed path
- add focused regression tests around the Jellyfin adapter and getter behavior

## Why
This change is mainly about not letting an outage look like "never watched".

If Plex or Jellyfin can't fetch watch history, the rules layer should treat that as an unknown state, not as empty history. Otherwise `NOT_EXISTS` checks and missing-value diagnostics can end up telling the wrong story.

Fixes #2724

## Validation
- `yarn test:runtime:jellyfin-sdk && npx jest --runInBand --testPathPatterns='rule.comparator.service.executeRulesWithData.spec.ts|jellyfin-adapter.service.spec.ts|jellyfin-getter.service.spec.ts'`
