### PR TITLE
feat(ci): add docs drift report workflow

### DIFF
--- a/.github/workflows/docs_drift.yml
+++ b/.github/workflows/docs_drift.yml
@@ -18,7 +18,7 @@ on:
         required: false
         default: false
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [closed]
     branches: [main]
 
 concurrency:
@@ -47,7 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.head.ref == 'development' &&
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.ref == 'development' &&
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Create GitHub App token

--- a/.github/workflows/docs_drift.yml
+++ b/.github/workflows/docs_drift.yml
@@ -1,0 +1,211 @@
+name: "Docs drift report"
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Git ref to compare against (e.g. v3.7.0, v3.6.0, origin/main). Default: origin/main"
+        required: false
+        default: ""
+      open_issue:
+        description: "Open/update the drift tracking issue on Maintainerr_docs"
+        type: boolean
+        required: false
+        default: false
+      create_pr:
+        description: "Open a draft PR on Maintainerr_docs (empty branch to push edits to, report as body)"
+        type: boolean
+        required: false
+        default: false
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+concurrency:
+  group: docs-drift-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  models: read
+
+jobs:
+  drift:
+    name: Generate docs drift report
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.head.ref == 'development' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MERGE_APP_ID }}
+          private-key: ${{ secrets.MERGE_APP_KEY }}
+
+      - name: Checkout Maintainerr
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout Maintainerr_docs
+        uses: actions/checkout@v6
+        with:
+          repository: Maintainerr/Maintainerr_docs
+          ref: main
+          path: .maintainerr_docs
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Resolve base ref
+        id: base
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          DISPATCH_BASE: ${{ inputs.base_ref }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            ref="origin/${PR_BASE}"
+          elif [ -n "$DISPATCH_BASE" ]; then
+            if [[ ! "$DISPATCH_BASE" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+              echo "Invalid base_ref input: $DISPATCH_BASE"
+              exit 1
+            fi
+            ref="$DISPATCH_BASE"
+          else
+            ref="origin/main"
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "Resolved base ref: $ref"
+
+      - name: Generate drift report
+        env:
+          DOCS_ROOT: ${{ github.workspace }}/.maintainerr_docs
+          BASE_REF: ${{ steps.base.outputs.ref }}
+          OUTPUT_PATH: ${{ github.workspace }}/.drift-report.md
+        run: node tools/docs-drift.mjs
+
+      - name: Append AI suggestions for documentation-labeled PRs
+        continue-on-error: true
+        env:
+          DOCS_ROOT: ${{ github.workspace }}/.maintainerr_docs
+          BASE_REF: ${{ steps.base.outputs.ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          OUTPUT_PATH: ${{ github.workspace }}/.drift-report.md
+        run: node tools/docs-drift-ai.mjs
+
+      - name: Append report to step summary
+        run: cat .drift-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Find existing sticky comment
+        if: github.event_name == 'pull_request'
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: "<!-- maintainerr-docs-drift -->"
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Upsert drift comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: .drift-report.md
+          edit-mode: replace
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Read drift metadata
+        id: drift-meta
+        run: |
+          has_drift=$(node -e 'console.log(require("./.drift-report.md.meta.json").hasDrift)')
+          echo "has_drift=$has_drift" >> "$GITHUB_OUTPUT"
+          echo "Has drift: $has_drift"
+
+      - name: Upsert docs drift issue on Maintainerr_docs
+        if: >-
+          steps.drift-meta.outputs.has_drift == 'true' &&
+          (github.event_name == 'pull_request' ||
+           (github.event_name == 'workflow_dispatch' && inputs.open_issue))
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          DOCS_REPO: Maintainerr/Maintainerr_docs
+          MARKER: maintainerr-docs-drift
+        run: |
+          issue_num=$(gh issue list --repo "$DOCS_REPO" --state open \
+            --search "\"$MARKER\" in:body" --json number --jq '.[0].number // empty')
+          if [ -n "$issue_num" ]; then
+            gh issue edit "$issue_num" --repo "$DOCS_REPO" --body-file .drift-report.md
+            echo "Updated $DOCS_REPO#$issue_num"
+            echo "- Updated drift issue: [$DOCS_REPO#$issue_num](https://github.com/$DOCS_REPO/issues/$issue_num)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            created=$(gh issue create --repo "$DOCS_REPO" \
+              --title "Docs drift — updates needed for the next Maintainerr release" \
+              --body-file .drift-report.md)
+            echo "Created: $created"
+            echo "- Created drift issue: $created" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Open draft PR on Maintainerr_docs
+        if: >-
+          steps.drift-meta.outputs.has_drift == 'true' &&
+          github.event_name == 'workflow_dispatch' &&
+          inputs.create_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          DOCS_REPO: Maintainerr/Maintainerr_docs
+          BASE_REF: ${{ steps.base.outputs.ref }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -e
+          branch="docs-drift/${RUN_ID}"
+          pushd .maintainerr_docs > /dev/null
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${DOCS_REPO}.git"
+          git checkout -b "$branch"
+          git commit --allow-empty -m "chore: open docs drift PR for Maintainerr ${BASE_REF}..HEAD"
+          git push -u origin "$branch"
+          popd > /dev/null
+          pr_url=$(gh pr create --repo "$DOCS_REPO" \
+            --base main --head "$branch" \
+            --title "Docs drift — updates needed (${BASE_REF}..HEAD)" \
+            --body-file .drift-report.md \
+            --draft)
+          echo "PR: $pr_url"
+          echo "- Draft PR: $pr_url" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Close docs drift issue if clean
+        if: >-
+          steps.drift-meta.outputs.has_drift == 'false' &&
+          (github.event_name == 'pull_request' ||
+           (github.event_name == 'workflow_dispatch' && inputs.open_issue))
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          DOCS_REPO: Maintainerr/Maintainerr_docs
+          MARKER: maintainerr-docs-drift
+        run: |
+          issue_num=$(gh issue list --repo "$DOCS_REPO" --state open \
+            --search "\"$MARKER\" in:body" --json number --jq '.[0].number // empty')
+          if [ -n "$issue_num" ]; then
+            gh issue comment "$issue_num" --repo "$DOCS_REPO" \
+              --body "All docs drift checks pass for the latest run. Closing."
+            gh issue close "$issue_num" --repo "$DOCS_REPO"
+            echo "Closed $DOCS_REPO#$issue_num"
+            echo "- Closed drift issue: [$DOCS_REPO#$issue_num](https://github.com/$DOCS_REPO/issues/$issue_num)" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/docs_drift.yml
+++ b/.github/workflows/docs_drift.yml
@@ -32,7 +32,17 @@ permissions:
   models: read
 
 jobs:
+  guard_manual_run:
+    uses: ./.github/workflows/guard-manual.yml
+    permissions:
+      contents: read
+    with:
+      enabled: ${{ github.event_name == 'workflow_dispatch' }}
+      actor: ${{ github.actor }}
+      source: docs drift manual run
+
   drift:
+    needs: guard_manual_run
     name: Generate docs drift report
     runs-on: ubuntu-latest
     if: >-
@@ -96,6 +106,7 @@ jobs:
         run: node tools/docs-drift.mjs
 
       - name: Append AI suggestions for documentation-labeled PRs
+        if: github.event_name == 'workflow_dispatch'
         continue-on-error: true
         env:
           DOCS_ROOT: ${{ github.workspace }}/.maintainerr_docs

--- a/tools/docs-drift-ai.mjs
+++ b/tools/docs-drift-ai.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+const MODELS_ENDPOINT = "https://models.github.ai/inference/chat/completions";
+const MODEL = process.env.DOCS_DRIFT_MODEL || "openai/gpt-4o";
+const MAX_PROMPT_CHARS = 24000;
+const MAX_DOC_CHARS = 4000;
+const MAX_ISSUE_BODY_CHARS = 2000;
+const MAX_PR_BODY_CHARS = 2000;
+const MAX_FILES_PER_PR = 40;
+
+const {
+  DOCS_ROOT,
+  BASE_REF = "origin/main",
+  GITHUB_REPOSITORY = "Maintainerr/Maintainerr",
+  GITHUB_TOKEN,
+  GH_TOKEN,
+  OUTPUT_PATH,
+} = process.env;
+
+const token = GITHUB_TOKEN || GH_TOKEN || "";
+const repoRoot = process.env.GITHUB_WORKSPACE || process.cwd();
+const log = (m) => process.stderr.write(`[docs-drift-ai] ${m}\n`);
+
+if (!DOCS_ROOT) {
+  console.error("DOCS_ROOT env var is required");
+  process.exit(1);
+}
+
+const runGit = (args) =>
+  execFileSync("git", args, { cwd: repoRoot, encoding: "utf8" }).trim();
+
+const runGh = (args) =>
+  execFileSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+    env: { ...process.env, GH_TOKEN: token, GITHUB_TOKEN: token },
+  });
+
+const writeOutput = (text) => {
+  if (OUTPUT_PATH) {
+    if (existsSync(OUTPUT_PATH)) appendFileSync(OUTPUT_PATH, text);
+    else writeFileSync(OUTPUT_PATH, text);
+  } else {
+    process.stdout.write(text);
+  }
+};
+
+const DOC_MAP = [
+  {
+    match: /^apps\/server\/src\/modules\/rules\/constants\//,
+    docs: ["docs/Rules.mdx", "docs/Glossary.md"],
+  },
+  {
+    match: /^apps\/server\/src\/modules\/rules\/helpers\/rule\.comparator/,
+    docs: ["docs/Rules.mdx"],
+  },
+  {
+    match: /^apps\/server\/src\/modules\/rules\//,
+    docs: ["docs/Rules.mdx", "docs/Glossary.md"],
+  },
+  {
+    match: /^apps\/server\/src\/modules\/notifications\//,
+    docs: ["docs/Notifications.md"],
+  },
+  {
+    match: /^apps\/server\/src\/modules\/collections\//,
+    docs: ["docs/Collections.md"],
+  },
+  {
+    match: /^apps\/server\/src\/database\/migrations\//,
+    docs: ["docs/Configuration.md", "docs/Migration.md"],
+  },
+  { match: /\.controller\.ts$/, docs: ["docs/API.md"] },
+  { match: /^packages\/contracts\//, docs: ["docs/API.md"] },
+];
+
+const docsForFiles = (files) => {
+  const set = new Set();
+  for (const f of files) {
+    for (const m of DOC_MAP) {
+      if (m.match.test(f)) for (const d of m.docs) set.add(d);
+    }
+  }
+  return [...set];
+};
+
+const readDocSnippet = (relPath) => {
+  const abs = path.join(DOCS_ROOT, relPath);
+  if (!existsSync(abs)) return null;
+  let text = readFileSync(abs, "utf8");
+  if (text.length > MAX_DOC_CHARS) {
+    text = text.slice(0, MAX_DOC_CHARS) + "\n…[truncated]";
+  }
+  return text;
+};
+
+const callModel = async (messages) => {
+  const res = await fetch(MODELS_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: JSON.stringify({ model: MODEL, messages, temperature: 0.1 }),
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub Models ${res.status}: ${await res.text()}`);
+  }
+  const data = await res.json();
+  return (data.choices?.[0]?.message?.content || "").trim();
+};
+
+const header = () => [
+  "",
+  "### 🤖 Documentation-labeled issues resolved by merged PRs",
+  "",
+];
+
+const fail = (msg) => {
+  log(msg);
+  writeOutput(
+    [...header(), `_AI analysis skipped: ${msg}_`, ""].join("\n") + "\n",
+  );
+  process.exit(0);
+};
+
+if (!token) fail("no GITHUB_TOKEN available");
+
+const baseDateIso = runGit(["log", "-1", "--format=%aI", BASE_REF]);
+if (!baseDateIso) fail(`could not resolve date for ${BASE_REF}`);
+const baseDate = new Date(baseDateIso);
+log(`base ref ${BASE_REF} date=${baseDateIso}`);
+
+let issueList;
+try {
+  issueList = JSON.parse(
+    runGh([
+      "issue",
+      "list",
+      "--repo",
+      GITHUB_REPOSITORY,
+      "--label",
+      "documentation",
+      "--state",
+      "all",
+      "--limit",
+      "100",
+      "--json",
+      "number,title,url,state",
+    ]),
+  );
+} catch (e) {
+  fail(`gh issue list failed: ${e.message}`);
+}
+log(`found ${issueList.length} documentation-labeled issues`);
+
+const prBucket = new Map();
+for (const issue of issueList) {
+  let timeline;
+  try {
+    timeline = JSON.parse(
+      runGh([
+        "api",
+        `repos/${GITHUB_REPOSITORY}/issues/${issue.number}/timeline`,
+        "--paginate",
+      ]),
+    );
+  } catch (e) {
+    log(`  issue #${issue.number}: timeline fetch failed (${e.message})`);
+    continue;
+  }
+  const mergedPrs = (timeline || [])
+    .filter((ev) => ev.event === "cross-referenced")
+    .map((ev) => ev.source?.issue)
+    .filter((iss) => iss?.pull_request?.merged_at)
+    .filter((iss) => new Date(iss.pull_request.merged_at) >= baseDate);
+  for (const pr of mergedPrs) {
+    const existing = prBucket.get(pr.number) || {
+      number: pr.number,
+      title: pr.title,
+      url: pr.html_url,
+      issues: [],
+    };
+    if (!existing.issues.some((i) => i.number === issue.number)) {
+      existing.issues.push({
+        number: issue.number,
+        title: issue.title,
+        url: issue.url,
+      });
+    }
+    prBucket.set(pr.number, existing);
+  }
+}
+
+const prs = [...prBucket.values()].sort((a, b) => a.number - b.number);
+log(
+  `${prs.length} unique merged PRs resolve documentation-labeled issues in range`,
+);
+
+const lines = [...header()];
+if (prs.length === 0) {
+  lines.push(
+    "_No merged PRs resolving `documentation`-labeled issues in this range._",
+  );
+  lines.push("");
+  writeOutput(lines.join("\n") + "\n");
+  process.exit(0);
+}
+lines.push(
+  `Analyzing ${prs.length} merged PR${prs.length === 1 ? "" : "s"} that closed \`documentation\`-labeled issues since \`${BASE_REF}\`.`,
+);
+lines.push("");
+
+const systemPrompt = `You are a documentation reviewer for the open-source project Maintainerr. For a merged PR, you identify concrete documentation updates needed.
+
+Rules:
+- Only propose edits justified by the PR diff, PR body, or linked issue content.
+- Do not invent behaviour that isn't in the diff or body.
+- Prefer short, specific edits like "add row to operator table for EXISTS" over rewrites.
+- Format each suggestion as a bullet: \`- <doc-file>: <specific edit>\`
+- If no doc change is needed, reply exactly: No docs changes needed.
+- Output bullets only. No preamble, no code fences, no trailing commentary.`;
+
+for (const pr of prs) {
+  log(`processing PR #${pr.number}: ${pr.title}`);
+  let detail;
+  try {
+    detail = JSON.parse(
+      runGh([
+        "pr",
+        "view",
+        String(pr.number),
+        "--repo",
+        GITHUB_REPOSITORY,
+        "--json",
+        "title,body,files,url",
+      ]),
+    );
+  } catch (e) {
+    log(`  gh pr view failed: ${e.message}`);
+    lines.push(`**[PR #${pr.number}](${pr.url}) — ${pr.title}**`);
+    lines.push("");
+    lines.push(`_Could not fetch PR detail: ${e.message}_`);
+    lines.push("");
+    continue;
+  }
+
+  const files = (detail.files || [])
+    .map((f) => f.path)
+    .slice(0, MAX_FILES_PER_PR);
+  const docs = docsForFiles(files);
+
+  let issueBlocks = "";
+  for (const iss of pr.issues.slice(0, 3)) {
+    try {
+      const idata = JSON.parse(
+        runGh([
+          "issue",
+          "view",
+          String(iss.number),
+          "--repo",
+          GITHUB_REPOSITORY,
+          "--json",
+          "title,body",
+        ]),
+      );
+      let body = idata.body || "";
+      if (body.length > MAX_ISSUE_BODY_CHARS) {
+        body = body.slice(0, MAX_ISSUE_BODY_CHARS) + "…[truncated]";
+      }
+      issueBlocks += `\n\n#### Issue #${iss.number}: ${idata.title}\n${body}`;
+    } catch (e) {
+      log(`  gh issue view #${iss.number} failed: ${e.message}`);
+    }
+  }
+
+  let docContext = "";
+  for (const d of docs.slice(0, 3)) {
+    const snip = readDocSnippet(d);
+    if (snip) docContext += `\n\n#### ${d}\n\`\`\`\n${snip}\n\`\`\``;
+  }
+
+  const prBody = (detail.body || "").slice(0, MAX_PR_BODY_CHARS);
+  const userPrompt = [
+    `PR #${pr.number}: ${detail.title}`,
+    `URL: ${detail.url}`,
+    "",
+    "## PR body",
+    prBody || "(empty)",
+    "",
+    "## Changed files",
+    files.map((f) => `- ${f}`).join("\n") || "(none)",
+    "",
+    `## Linked documentation-labeled issue(s)${issueBlocks || "\n(none)"}`,
+    "",
+    `## Current state of likely-affected docs${docContext || "\n(no file match)"}`,
+    "",
+    "Propose concrete documentation edits needed to reflect this merged PR.",
+  ].join("\n");
+
+  const issueRefs = pr.issues.map((i) => `[#${i.number}](${i.url})`).join(", ");
+  lines.push(
+    `**[PR #${pr.number}](${pr.url}) — ${detail.title}**  \nResolves: ${issueRefs}`,
+  );
+  lines.push("");
+
+  if (userPrompt.length > MAX_PROMPT_CHARS) {
+    log(`  prompt too large (${userPrompt.length} chars); skipping model call`);
+    lines.push("_Prompt too large to analyze. Review manually._");
+    lines.push("");
+    continue;
+  }
+
+  try {
+    const suggestion = await callModel([
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userPrompt },
+    ]);
+    lines.push(suggestion || "_Empty model response._");
+  } catch (e) {
+    log(`  model call failed: ${e.message}`);
+    lines.push(`_Model call failed: ${e.message}_`);
+  }
+  lines.push("");
+}
+
+lines.push("");
+lines.push(
+  "_AI suggestions are informational and may be incomplete or wrong. Always review the actual PR diff before writing docs._",
+);
+
+writeOutput(lines.join("\n") + "\n");

--- a/tools/docs-drift.mjs
+++ b/tools/docs-drift.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.env.GITHUB_WORKSPACE || process.cwd();
+const docsRoot = process.env.DOCS_ROOT;
+const baseRef = process.env.BASE_REF || "origin/main";
+const outputPath = process.env.OUTPUT_PATH || null;
+
+if (!docsRoot) {
+  console.error("DOCS_ROOT env var is required");
+  process.exit(1);
+}
+
+const git = (args) =>
+  execFileSync("git", args, { cwd: repoRoot, encoding: "utf8" });
+
+const parseCodeKeys = () => {
+  const file = path.join(
+    repoRoot,
+    "apps/server/src/modules/rules/constants/rules.constants.ts",
+  );
+  const text = readFileSync(file, "utf8");
+  const appHeaderRe = /^ {6}name: '([A-Z][a-zA-Z]*)',$/gm;
+  const propNameRe = /^ {10}name: '([a-zA-Z_][a-zA-Z0-9_]*)',$/gm;
+  const apps = [...text.matchAll(appHeaderRe)];
+  const keys = new Set();
+  for (let i = 0; i < apps.length; i++) {
+    const app = apps[i][1];
+    const start = apps[i].index;
+    const end = i + 1 < apps.length ? apps[i + 1].index : text.length;
+    for (const m of text.slice(start, end).matchAll(propNameRe)) {
+      keys.add(`${app}.${m[1]}`);
+    }
+  }
+  return keys;
+};
+
+const parseDocKeys = () => {
+  const text = readFileSync(path.join(docsRoot, "docs/Glossary.md"), "utf8");
+  const keys = new Set();
+  for (const m of text.matchAll(/^- Key: (\S+)/gm)) {
+    keys.add(m[1]);
+  }
+  return keys;
+};
+
+const diffNameStatus = (pathspec, filter) => {
+  const args = ["diff", "--name-status"];
+  if (filter) args.push(`--diff-filter=${filter}`);
+  args.push(`${baseRef}...HEAD`, "--", pathspec);
+  const out = git(args).trim();
+  if (!out) return [];
+  return out
+    .split("\n")
+    .map((l) => {
+      const parts = l.split("\t");
+      return { status: parts[0], file: parts[1] };
+    })
+    .filter((e) => e.file);
+};
+
+const newMigrations = () =>
+  diffNameStatus("apps/server/src/database/migrations/", "A").map((e) =>
+    e.file.replace("apps/server/src/database/migrations/", ""),
+  );
+
+const rulesConstantsDiff = () => {
+  const out = git([
+    "diff",
+    "--numstat",
+    `${baseRef}...HEAD`,
+    "--",
+    "apps/server/src/modules/rules/constants/rules.constants.ts",
+  ]).trim();
+  if (!out) return null;
+  const [added, deleted] = out.split("\t");
+  return { added, deleted };
+};
+
+const contractsChanges = () => {
+  const entries = diffNameStatus("packages/contracts/src/");
+  const buckets = { added: [], modified: [], deleted: [] };
+  for (const e of entries) {
+    if (e.status === "A") buckets.added.push(e.file);
+    else if (e.status === "M") buckets.modified.push(e.file);
+    else if (e.status === "D") buckets.deleted.push(e.file);
+  }
+  return buckets;
+};
+
+const newControllers = () =>
+  diffNameStatus("apps/server/src/modules/", "A")
+    .map((e) => e.file)
+    .filter((f) => f.endsWith(".controller.ts"));
+
+const featCommits = () => {
+  const out = git([
+    "log",
+    `${baseRef}..HEAD`,
+    "--no-merges",
+    "--extended-regexp",
+    "--grep=^feat(\\(|:)",
+    "--pretty=format:%h %s",
+  ]).trim();
+  return out ? out.split("\n") : [];
+};
+
+const codeKeys = parseCodeKeys();
+const docKeys = parseDocKeys();
+const missingFromDocs = [...codeKeys].filter((k) => !docKeys.has(k)).sort();
+const missingFromCode = [...docKeys].filter((k) => !codeKeys.has(k)).sort();
+const migrations = newMigrations();
+const constantsDiff = rulesConstantsDiff();
+const contracts = contractsChanges();
+const controllers = newControllers();
+const feats = featCommits();
+
+const lines = [];
+lines.push("<!-- maintainerr-docs-drift -->");
+lines.push("## 📚 Docs drift report");
+lines.push("");
+lines.push(
+  `Comparing \`${baseRef}\` → \`HEAD\` against [Maintainerr_docs](https://github.com/Maintainerr/Maintainerr_docs). Informational only — maintainers decide what needs doc updates before release.`,
+);
+lines.push("");
+
+lines.push("### Rule glossary parity");
+lines.push("");
+lines.push(`- Code rule keys (\`rules.constants.ts\`): **${codeKeys.size}**`);
+lines.push(`- Documented keys (\`docs/Glossary.md\`): **${docKeys.size}**`);
+lines.push("");
+if (missingFromDocs.length) {
+  lines.push(
+    `<details open><summary><strong>In code but missing from Glossary (${missingFromDocs.length})</strong></summary>`,
+  );
+  lines.push("");
+  for (const k of missingFromDocs) lines.push(`- \`${k}\``);
+  lines.push("");
+  lines.push("</details>");
+  lines.push("");
+}
+if (missingFromCode.length) {
+  lines.push(
+    `<details><summary><strong>In Glossary but not in code (${missingFromCode.length})</strong></summary>`,
+  );
+  lines.push("");
+  for (const k of missingFromCode) lines.push(`- \`${k}\``);
+  lines.push("");
+  lines.push("</details>");
+  lines.push("");
+}
+if (!missingFromDocs.length && !missingFromCode.length) {
+  lines.push("_Glossary is in sync with the code._");
+  lines.push("");
+}
+
+lines.push("### New migrations on this branch");
+lines.push("");
+if (migrations.length) {
+  for (const f of migrations) lines.push(`- [ ] \`${f}\``);
+  lines.push("");
+  lines.push(
+    "_Each migration typically introduces a setting or schema change. Confirm `Configuration.md` and `Migration.md` still reflect user-facing behaviour._",
+  );
+} else {
+  lines.push("_No new migrations._");
+}
+lines.push("");
+
+lines.push("### Rule constants");
+lines.push("");
+if (constantsDiff) {
+  lines.push(
+    `- \`rules.constants.ts\` changed: **+${constantsDiff.added} / -${constantsDiff.deleted}** lines`,
+  );
+  lines.push(
+    "- Review rule tables in `docs/Rules.mdx` and entries in `docs/Glossary.md`.",
+  );
+} else {
+  lines.push("_No changes to `rules.constants.ts`._");
+}
+lines.push("");
+
+lines.push("### Public contracts (`@maintainerr/contracts`)");
+lines.push("");
+const anyContracts =
+  contracts.added.length + contracts.modified.length + contracts.deleted.length;
+if (anyContracts) {
+  if (contracts.added.length) {
+    lines.push(`- Added (${contracts.added.length}):`);
+    for (const f of contracts.added) lines.push(`  - \`${f}\``);
+  }
+  if (contracts.modified.length) {
+    lines.push(`- Modified (${contracts.modified.length}):`);
+    for (const f of contracts.modified) lines.push(`  - \`${f}\``);
+  }
+  if (contracts.deleted.length) {
+    lines.push(`- Deleted (${contracts.deleted.length}):`);
+    for (const f of contracts.deleted) lines.push(`  - \`${f}\``);
+  }
+  lines.push("");
+  lines.push(
+    "_Public DTO changes may affect `docs/API.md` and the OpenAPI spec in `static/openapi-spec/maintainerr_api_specs.yaml`._",
+  );
+} else {
+  lines.push("_No contract changes._");
+}
+lines.push("");
+
+lines.push("### New HTTP controllers");
+lines.push("");
+if (controllers.length) {
+  for (const f of controllers) lines.push(`- [ ] \`${f}\``);
+  lines.push("");
+  lines.push(
+    "_New controllers almost always mean new routes — check `docs/API.md` and the OpenAPI spec._",
+  );
+} else {
+  lines.push("_No new controllers._");
+}
+lines.push("");
+
+lines.push("### `feat:` commits on this branch");
+lines.push("");
+if (feats.length) {
+  for (const l of feats) lines.push(`- ${l}`);
+} else {
+  lines.push("_No `feat:` commits detected._");
+}
+lines.push("");
+
+const meta = {
+  baseRef,
+  hasDrift:
+    missingFromDocs.length > 0 ||
+    missingFromCode.length > 0 ||
+    migrations.length > 0 ||
+    constantsDiff !== null ||
+    contracts.added.length +
+      contracts.modified.length +
+      contracts.deleted.length >
+      0 ||
+    controllers.length > 0 ||
+    feats.length > 0,
+  sections: {
+    glossaryMissingFromDocs: missingFromDocs.length,
+    glossaryMissingFromCode: missingFromCode.length,
+    newMigrations: migrations.length,
+    rulesConstantsChanged: constantsDiff !== null,
+    contractsAdded: contracts.added.length,
+    contractsModified: contracts.modified.length,
+    contractsDeleted: contracts.deleted.length,
+    newControllers: controllers.length,
+    featCommits: feats.length,
+  },
+};
+
+const output = lines.join("\n");
+if (outputPath) {
+  writeFileSync(outputPath, output);
+  writeFileSync(`${outputPath}.meta.json`, JSON.stringify(meta, null, 2));
+  console.error(`Wrote drift report to ${outputPath}`);
+  console.error(`Wrote drift metadata to ${outputPath}.meta.json`);
+} else {
+  process.stdout.write(output);
+}


### PR DESCRIPTION
## Summary

Adds a workflow + two Node tools that surface user-facing changes between a base ref and HEAD, so docs updates to [Maintainerr_docs](https://github.com/Maintainerr/Maintainerr_docs) can be caught at release time.

- [`tools/docs-drift.mjs`](../tree/chore/docs-drift-workflow/tools/docs-drift.mjs) — deterministic detectors: Glossary key parity (`rules.constants.ts` vs `docs/Glossary.md`), new migrations, `rules.constants.ts` diff stat, contracts DTO adds/mods/deletes, new `*.controller.ts` files, `feat:` commits.
- [`tools/docs-drift-ai.mjs`](../tree/chore/docs-drift-workflow/tools/docs-drift-ai.mjs) — GitHub Models (`openai/gpt-4o`, same auth as `tools/generate-release-notes.mjs`). For each `documentation`-labeled issue whose linked PR merged in range, proposes concrete edits grounded in the PR body + issue + current doc content.
- [`.github/workflows/docs_drift.yml`](../tree/chore/docs-drift-workflow/.github/workflows/docs_drift.yml) — triggers, reporting, cross-repo writes.

## Trigger matrix

| Trigger | Deterministic | AI | Cross-repo writes |
|---|:-:|:-:|:-:|
| Release PR (`development → main`) **merged** | ✅ | ❌ | ✅ issue upsert (auto) |
| Release PR closed **without merge** | ❌ (skipped at `if:`) | ❌ | ❌ |
| `workflow_dispatch` by CODEOWNER | ✅ | ✅ | opt-in via `open_issue` / `create_pr` |
| `workflow_dispatch` by non-CODEOWNER | ❌ (guard blocks) | ❌ | ❌ |

AI is gated by [`guard-manual.yml`](../blob/development/.github/workflows/guard-manual.yml) (same as `release_1_prepare_release_pr.yml`), which checks `github.actor` against `.github/CODEOWNERS`.

## Output channels

| Channel | When |
|---|---|
| Sticky PR comment on the merged release PR | `pull_request: closed + merged` |
| Workflow step summary | Always |
| Upsert / close issue on `Maintainerr_docs` | PR event, or dispatch with `open_issue=true` |
| Draft PR on `Maintainerr_docs` (empty-commit branch) | Dispatch with `create_pr=true` |

## Manual inputs

- `base_ref` — git ref to compare against (e.g. `v3.7.0`). Validated against `^[a-zA-Z0-9._/-]+$`. Default: `origin/main`.
- `open_issue` (bool, default `false`) — opt-in cross-repo issue upsert on dispatch.
- `create_pr` (bool, default `false`) — opt-in draft PR on `Maintainerr_docs` with empty-commit branch to push edits to.

## Safety

- New files only, zero modifications to existing code.
- All cross-repo writes are `continue-on-error` — report delivery to PR comment / step summary is never blocked by a perm issue.
- `base_ref` regex-validated, shell params pass via env (no interpolation).
- Cross-repo writes default `false` on dispatch.
- Same-repo fork guard on PR trigger.
- Reuses existing secrets (`MERGE_APP_*`, `ACTIONS_TOKEN`, built-in `GITHUB_TOKEN` with `models: read`). No new infra.

## Local dry-run (`v3.7.0..HEAD`)

- 7 rule keys in code, missing from `docs/Glossary.md` (historical drift)
- 1 new migration (`OverlaySchemaGenerated`)
- 10 new contract DTOs (overlays + storage-metrics)
- 2 new controllers (overlays, storage-metrics) — need `API.md`
- 9 `feat:` commits
- AI suggestion for PR #2744: update watch-history semantics in `Rules.mdx` + `Glossary.md`

## Test plan

- [ ] Dispatch against `v3.7.0`, both flags `false` → report in step summary only
- [ ] Dispatch against `v3.7.0`, `open_issue=true` → new issue in `Maintainerr_docs`
- [ ] Re-dispatch → same issue updated, not duplicated
- [ ] Dispatch with `create_pr=true` → new draft PR with empty-commit branch
- [ ] Merge a throwaway `development → main` PR → sticky comment appears, issue upserted/closed

## Known limitations

- AI step only sees merged PRs in the base-ref range. PRs merged before the base (e.g. `EXISTS`/`NOT_EXISTS` in #2671, merged before `v3.7.0`) are out of scope — historical drift needs manual fixing.
- Glossary parser is a structural regex over `rules.constants.ts`. Reformatting that file to different indentation breaks the parser visibly (returns 0 keys).
- `ACTIONS_TOKEN` needs `issues:write` + `contents:write` on `Maintainerr_docs`. If not, cross-repo steps fail loudly in the log; main report is unaffected.