### PR TITLE
chore(ci): clear deprecation warnings in workflow actions

### DIFF
--- a/.github/workflows/dependabot_merge.yml
+++ b/.github/workflows/dependabot_merge.yml
@@ -14,7 +14,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.MERGE_APP_ID }}
+          client-id: ${{ secrets.MERGE_APP_ID }}
           private-key: ${{ secrets.MERGE_APP_KEY }}
 
       - name: Dependabot metadata

--- a/.github/workflows/docs_drift.yml
+++ b/.github/workflows/docs_drift.yml
@@ -55,7 +55,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.MERGE_APP_ID }}
+          client-id: ${{ secrets.MERGE_APP_ID }}
           private-key: ${{ secrets.MERGE_APP_KEY }}
 
       - name: Checkout Maintainerr
@@ -74,7 +74,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/release_1_prepare_release_pr.yml
+++ b/.github/workflows/release_1_prepare_release_pr.yml
@@ -57,7 +57,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.MERGE_APP_ID }}
+          client-id: ${{ secrets.MERGE_APP_ID }}
           private-key: ${{ secrets.MERGE_APP_KEY }}
 
       - name: Checkout development

--- a/.github/workflows/release_2_5_execute_push_pr_to_main.yml
+++ b/.github/workflows/release_2_5_execute_push_pr_to_main.yml
@@ -334,7 +334,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.MERGE_APP_ID }}
+          client-id: ${{ secrets.MERGE_APP_ID }}
           private-key: ${{ secrets.MERGE_APP_KEY }}
 
       - name: Checkout development

--- a/.github/workflows/release_3_sync_back.yml
+++ b/.github/workflows/release_3_sync_back.yml
@@ -70,7 +70,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.MERGE_APP_ID }}
+          client-id: ${{ secrets.MERGE_APP_ID }}
           private-key: ${{ secrets.MERGE_APP_KEY }}
 
       - name: Checkout development

--- a/.github/workflows/release_5_publish.yml
+++ b/.github/workflows/release_5_publish.yml
@@ -58,7 +58,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.MERGE_APP_ID }}
+          client-id: ${{ secrets.MERGE_APP_ID }}
           private-key: ${{ secrets.MERGE_APP_KEY }}
 
       - name: Checkout


### PR DESCRIPTION
## Summary

Clears the two deprecation warnings that fire on every Actions run:

1. **\`actions/setup-node@v4\` → \`@v6\`** — v4 runs on Node 20, which is being forced to Node 24 from June 2026. Only [\`docs_drift.yml\`](../tree/chore/bump-deprecated-actions/.github/workflows/docs_drift.yml) still used v4; the rest of the repo was already on v6.
2. **\`app-id:\` → \`client-id:\`** in all six workflows that create a GitHub App token. The action deprecated \`app-id\` in favour of \`client-id\`.

## Why no secret changes

The action's entry point reads:
\`\`\`js
const clientId = core.getInput("client-id") || core.getInput("app-id");
\`\`\`
and passes whichever is set directly to \`@octokit/auth-app\`'s \`createAppAuth({ appId: clientId, ... })\`. Octokit accepts both a numeric App ID and a Client ID string for this field. So keeping the existing \`secrets.MERGE_APP_ID\` (which holds the numeric App ID) under the new \`client-id:\` input name works — the action just reads a different input key with the same value.

## Files touched

| File | Change |
|---|---|
| \`dependabot_merge.yml\` | app-id → client-id |
| \`docs_drift.yml\` | app-id → client-id, setup-node v4 → v6 |
| \`release_1_prepare_release_pr.yml\` | app-id → client-id |
| \`release_2_5_execute_push_pr_to_main.yml\` | app-id → client-id |
| \`release_3_sync_back.yml\` | app-id → client-id |
| \`release_5_publish.yml\` | app-id → client-id |

## Future hardening (not in this PR)

The action maintainer's canonical recommendation is to pass an actual **Client ID** (format \`Iv23ab…\`) rather than the numeric App ID. That would require adding a new \`MERGE_APP_CLIENT_ID\` secret and updating all references. Deliberately out of scope here — this PR is the zero-risk keyword rename that clears the warning without touching secrets.

## Test plan

- [ ] CI quality.yml + run_tests.yml pass on this PR
- [ ] After merge: run any workflow that creates an app token (e.g. dispatch \`Docs drift report\`) and confirm the two deprecation annotations are gone

## Audit note

Rest of the repo's actions are already on current versions:
\`actions/checkout@v6\`, \`actions/upload-artifact@v7\`, \`actions/download-artifact@v8\`, \`actions/github-script@v8\`, \`docker/*@v4+\`, \`peter-evans/*@current\`. No further bumps needed today.