### PR TITLE
fix(ui): useLockBodyScroll acquire/release behavior from modals

### DIFF
--- a/apps/ui/src/hooks/useLockBodyScroll.spec.tsx
+++ b/apps/ui/src/hooks/useLockBodyScroll.spec.tsx
@@ -1,0 +1,118 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { useLockBodyScroll } from './useLockBodyScroll'
+
+describe('useLockBodyScroll', () => {
+  beforeEach(() => {
+    // Reset body overflow before each test so tests are independent.
+    document.body.style.overflow = ''
+  })
+
+  afterEach(() => {
+    // Unmount all hooks, which triggers release() for any active locks.
+    cleanup()
+    // Ensure the DOM is clean regardless of test outcome.
+    document.body.style.overflow = ''
+  })
+
+  it('locks body overflow when mounted with isLocked=true', () => {
+    renderHook(() => useLockBodyScroll(true))
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('does not lock body overflow when isLocked=false', () => {
+    renderHook(() => useLockBodyScroll(false))
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('does not lock body overflow when disabled=true', () => {
+    renderHook(() => useLockBodyScroll(true, true))
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('restores body overflow after unmount (single lock)', () => {
+    const { unmount } = renderHook(() => useLockBodyScroll(true))
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('second concurrent lock is a no-op on overflow but increments counter', () => {
+    const { unmount: unmountA } = renderHook(() => useLockBodyScroll(true))
+    const { unmount: unmountB } = renderHook(() => useLockBodyScroll(true))
+
+    // Both are locked – overflow is hidden.
+    expect(document.body.style.overflow).toBe('hidden')
+
+    // Releasing the first lock should NOT restore scrolling yet.
+    unmountA()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    // Only after the last lock is released should scrolling be restored.
+    unmountB()
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('only the final release restores scrolling for three nested locks', () => {
+    const { unmount: unmountA } = renderHook(() => useLockBodyScroll(true))
+    const { unmount: unmountB } = renderHook(() => useLockBodyScroll(true))
+    const { unmount: unmountC } = renderHook(() => useLockBodyScroll(true))
+
+    expect(document.body.style.overflow).toBe('hidden')
+
+    unmountA()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    unmountB()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    unmountC()
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('toggling isLocked true→false releases the lock without unmounting', () => {
+    const { rerender } = renderHook(
+      ({ locked }: { locked: boolean }) => useLockBodyScroll(locked),
+      { initialProps: { locked: true } },
+    )
+
+    expect(document.body.style.overflow).toBe('hidden')
+
+    act(() => {
+      rerender({ locked: false })
+    })
+
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('toggling isLocked false→true acquires the lock without unmounting', () => {
+    const { rerender } = renderHook(
+      ({ locked }: { locked: boolean }) => useLockBodyScroll(locked),
+      { initialProps: { locked: false } },
+    )
+
+    expect(document.body.style.overflow).toBe('')
+
+    act(() => {
+      rerender({ locked: true })
+    })
+
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('enabling disabled prop while locked releases the lock', () => {
+    const { rerender } = renderHook(
+      ({ disabled }: { disabled: boolean }) =>
+        useLockBodyScroll(true, disabled),
+      { initialProps: { disabled: false } },
+    )
+
+    expect(document.body.style.overflow).toBe('hidden')
+
+    act(() => {
+      rerender({ disabled: true })
+    })
+
+    expect(document.body.style.overflow).toBe('')
+  })
+})

--- a/apps/ui/src/hooks/useLockBodyScroll.spec.tsx
+++ b/apps/ui/src/hooks/useLockBodyScroll.spec.tsx
@@ -91,6 +91,31 @@ describe('useLockBodyScroll', () => {
     expect(document.body.style.overflow).toBe('hidden')
   })
 
+  it('restores a pre-existing inline overflow value after the final release', () => {
+    document.body.style.overflow = 'scroll'
+
+    const { unmount } = renderHook(() => useLockBodyScroll(true))
+    expect(document.body.style.overflow).toBe('hidden')
+
+    unmount()
+    expect(document.body.style.overflow).toBe('scroll')
+  })
+
+  it('captures the pre-existing value only on the 0→1 transition, not on nested acquires', () => {
+    document.body.style.overflow = 'scroll'
+
+    // After the first mount, body becomes 'hidden'. If the nested acquire
+    // re-snapshotted that value, the final restore would leak 'hidden'
+    // instead of the 'scroll' captured at the 0→1 boundary.
+    const { unmount: unmountA } = renderHook(() => useLockBodyScroll(true))
+    const { unmount: unmountB } = renderHook(() => useLockBodyScroll(true))
+
+    unmountA()
+    unmountB()
+
+    expect(document.body.style.overflow).toBe('scroll')
+  })
+
   it('toggling isLocked true→false releases the lock without unmounting', () => {
     const { rerender } = renderHook(
       ({ locked }: { locked: boolean }) => useLockBodyScroll(locked),

--- a/apps/ui/src/hooks/useLockBodyScroll.spec.tsx
+++ b/apps/ui/src/hooks/useLockBodyScroll.spec.tsx
@@ -4,14 +4,11 @@ import { useLockBodyScroll } from './useLockBodyScroll'
 
 describe('useLockBodyScroll', () => {
   beforeEach(() => {
-    // Reset body overflow before each test so tests are independent.
     document.body.style.overflow = ''
   })
 
   afterEach(() => {
-    // Unmount all hooks, which triggers release() for any active locks.
     cleanup()
-    // Ensure the DOM is clean regardless of test outcome.
     document.body.style.overflow = ''
   })
 

--- a/apps/ui/src/hooks/useLockBodyScroll.spec.tsx
+++ b/apps/ui/src/hooks/useLockBodyScroll.spec.tsx
@@ -1,7 +1,11 @@
-import { act, cleanup, renderHook } from '@testing-library/react'
+import { cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { useLockBodyScroll } from './useLockBodyScroll'
 
+// The hook relies on a module-level lock counter. Tests rely on RTL's
+// cleanup() to unmount every renderHook result between tests, which drives
+// the counter back to 0 via the hook's own release path. The manual overflow
+// reset is a belt-and-braces safety net in case a test fails mid-assertion.
 describe('useLockBodyScroll', () => {
   beforeEach(() => {
     document.body.style.overflow = ''
@@ -75,9 +79,7 @@ describe('useLockBodyScroll', () => {
 
     expect(document.body.style.overflow).toBe('hidden')
 
-    act(() => {
-      rerender({ locked: false })
-    })
+    rerender({ locked: false })
 
     expect(document.body.style.overflow).toBe('')
   })
@@ -90,9 +92,7 @@ describe('useLockBodyScroll', () => {
 
     expect(document.body.style.overflow).toBe('')
 
-    act(() => {
-      rerender({ locked: true })
-    })
+    rerender({ locked: true })
 
     expect(document.body.style.overflow).toBe('hidden')
   })
@@ -106,9 +106,7 @@ describe('useLockBodyScroll', () => {
 
     expect(document.body.style.overflow).toBe('hidden')
 
-    act(() => {
-      rerender({ disabled: true })
-    })
+    rerender({ disabled: true })
 
     expect(document.body.style.overflow).toBe('')
   })

--- a/apps/ui/src/hooks/useLockBodyScroll.spec.tsx
+++ b/apps/ui/src/hooks/useLockBodyScroll.spec.tsx
@@ -1,19 +1,14 @@
 import { cleanup, renderHook } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { useLockBodyScroll } from './useLockBodyScroll'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  __resetLockBodyScrollForTests,
+  useLockBodyScroll,
+} from './useLockBodyScroll'
 
-// The hook relies on a module-level lock counter. Tests rely on RTL's
-// cleanup() to unmount every renderHook result between tests, which drives
-// the counter back to 0 via the hook's own release path. The manual overflow
-// reset is a belt-and-braces safety net in case a test fails mid-assertion.
 describe('useLockBodyScroll', () => {
-  beforeEach(() => {
-    document.body.style.overflow = ''
-  })
-
   afterEach(() => {
     cleanup()
-    document.body.style.overflow = ''
+    __resetLockBodyScrollForTests()
   })
 
   it('locks body overflow when mounted with isLocked=true', () => {
@@ -69,6 +64,31 @@ describe('useLockBodyScroll', () => {
 
     unmountC()
     expect(document.body.style.overflow).toBe('')
+  })
+
+  it('release order does not affect final overflow (covers the parent→child vs child→parent race)', () => {
+    const { unmount: unmountParent } = renderHook(() => useLockBodyScroll(true))
+    const { unmount: unmountChild } = renderHook(() => useLockBodyScroll(true))
+
+    expect(document.body.style.overflow).toBe('hidden')
+
+    // Parent (mounted first) releases before child — the scenario from #2748.
+    // The old snapshot-restore implementation would leave overflow='hidden'
+    // here because the child had captured 'hidden' as its "original" value.
+    unmountParent()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    unmountChild()
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('re-acquiring a lock after full release locks again', () => {
+    const { unmount: unmountFirst } = renderHook(() => useLockBodyScroll(true))
+    unmountFirst()
+    expect(document.body.style.overflow).toBe('')
+
+    renderHook(() => useLockBodyScroll(true))
+    expect(document.body.style.overflow).toBe('hidden')
   })
 
   it('toggling isLocked true→false releases the lock without unmounting', () => {

--- a/apps/ui/src/hooks/useLockBodyScroll.ts
+++ b/apps/ui/src/hooks/useLockBodyScroll.ts
@@ -1,11 +1,38 @@
 import { useEffect } from 'react'
 
 /**
+ * Module-level reference counter for active scroll locks.
+ *
+ * Using a counter (rather than snapshotting and restoring the previous
+ * overflow value) avoids a race condition that occurs when multiple
+ * simultaneously-mounted modals all unmount in the same React batch:
+ * the last cleanup to run would restore whatever overflow value it
+ * captured at mount time, which could be 'hidden' (captured while a
+ * parent lock was already active), leaving the body scroll locked after
+ * all modals have closed.
+ */
+let lockCount = 0
+
+const acquire = (): void => {
+  if (lockCount === 0) {
+    document.body.style.overflow = 'hidden'
+  }
+  lockCount++
+}
+
+const release = (): void => {
+  lockCount = Math.max(0, lockCount - 1)
+  if (lockCount === 0) {
+    document.body.style.overflow = ''
+  }
+}
+
+/**
  * Hook to lock the body scroll whenever a component is mounted or
  * whenever isLocked is set to true.
  *
- * You can pass in true always to cause a lock on mount/dismount of the component
- * using this hook.
+ * Multiple concurrent locks are safe: the body scroll is only restored
+ * once the last active lock is released.
  *
  * @param isLocked Toggle the scroll lock
  * @param disabled Disables the entire hook (allows conditional skipping of the lock)
@@ -15,14 +42,10 @@ export const useLockBodyScroll = (
   disabled?: boolean,
 ): void => {
   useEffect(() => {
-    const originalStyle = window.getComputedStyle(document.body).overflow
-    if (isLocked && !disabled) {
-      document.body.style.overflow = 'hidden'
-    }
+    if (!isLocked || disabled) return
+    acquire()
     return () => {
-      if (!disabled) {
-        document.body.style.overflow = originalStyle
-      }
+      release()
     }
   }, [isLocked, disabled])
 }

--- a/apps/ui/src/hooks/useLockBodyScroll.ts
+++ b/apps/ui/src/hooks/useLockBodyScroll.ts
@@ -1,20 +1,20 @@
 import { useEffect } from 'react'
 
 /**
- * Module-level reference counter for active scroll locks.
- *
- * Using a counter (rather than snapshotting and restoring the previous
- * overflow value) avoids a race condition that occurs when multiple
- * simultaneously-mounted modals all unmount in the same React batch:
- * the last cleanup to run would restore whatever overflow value it
- * captured at mount time, which could be 'hidden' (captured while a
- * parent lock was already active), leaving the body scroll locked after
- * all modals have closed.
+ * Module-level state. A single counter tracks how many consumers want the
+ * body locked; the inline overflow value that was present before the first
+ * lock is captured once on the 0→1 transition and restored once on the 1→0
+ * transition. This preserves the hook's original "restore the previous
+ * overflow" contract while avoiding the per-consumer snapshot race that
+ * left the body locked when sibling/parent modals unmounted in the same
+ * React batch.
  */
 let lockCount = 0
+let previousOverflow: string | null = null
 
 const acquire = (): void => {
   if (lockCount === 0) {
+    previousOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
   }
   lockCount++
@@ -23,18 +23,19 @@ const acquire = (): void => {
 const release = (): void => {
   lockCount = Math.max(0, lockCount - 1)
   if (lockCount === 0) {
-    document.body.style.overflow = ''
+    document.body.style.overflow = previousOverflow ?? ''
+    previousOverflow = null
   }
 }
 
 /**
  * Resets the module-level counter and clears the body overflow style.
- * Intended for test teardown only — tests that unmount via RTL's cleanup()
- * rely on this to avoid leaking counter state across cases when a test
- * throws mid-assertion before its hooks are tracked.
+ * Intended for test teardown only — keeps counter leaks from propagating
+ * across cases if a test throws before its hooks are tracked by RTL.
  */
 export const __resetLockBodyScrollForTests = (): void => {
   lockCount = 0
+  previousOverflow = null
   document.body.style.overflow = ''
 }
 

--- a/apps/ui/src/hooks/useLockBodyScroll.ts
+++ b/apps/ui/src/hooks/useLockBodyScroll.ts
@@ -28,6 +28,17 @@ const release = (): void => {
 }
 
 /**
+ * Resets the module-level counter and clears the body overflow style.
+ * Intended for test teardown only — tests that unmount via RTL's cleanup()
+ * rely on this to avoid leaking counter state across cases when a test
+ * throws mid-assertion before its hooks are tracked.
+ */
+export const __resetLockBodyScrollForTests = (): void => {
+  lockCount = 0
+  document.body.style.overflow = ''
+}
+
+/**
  * Hook to lock the body scroll whenever a component is mounted or
  * whenever isLocked is set to true.
  *


### PR DESCRIPTION
### Description & Design

** Please see note in AI Section on Validation before merge! **

This PR is to address the regression in #2748 introduced by PR #2730 that resulted in a break in scrolling if a item action was triggered manually. The problem was the fact that multiple modals were closing simultaneously, with the root cause being that their closure caused a race condition depending on order of closure (it appears the parent was closing before the child, so the child returned the lock on scrolling back to the state it found it when the child opened (locked) as the final action. 

This fix changes the process for useLockBodyScroll.ts. Originally, each modal when closing returned the scroll lock to the state it was when that modal opened. The new way will counter for modals open. On 0->1, it will lock the scrolling. Any additional increments do not make a change. Each modal closure de-increments by 1. When the counter returns to 0, the scroll lock is released -- negating any concern of a race condition on order of modal closure (Parent->Child vs Child->Parent)

Additionally, past the reported issue #2748 , the fix resulted in discovery of another case in the code base where a multi modal event could cause this race condition was around CommunityRuleModal->CommunityRuleUpload->"Upload Successful" modal (3 levels this time instead of 2, but similar condition could occur). This fix covers that as well with the same code change.

### Related issue

#2748  #2730 

### AI-Assisted Development

The root cause was discovered by GitHub Copilot using the Claude Sonnet 4.6 Model. Additionally the fix was drafted by the same. I have reviewed this cause and change, concur with both. I ran this in GH Codespaces and the app properly built and compiled along with tests running. **HOWEVER** I was not able to specifically validate via UAT this in the test environment due to the nature of GH Codespaces, combined with my existing production dataset being in an environment that I cannot develop or share from. _I am requesting that someone please validate that the Trigger Now button in the item modal correctly releases the scroll lock before merging this PR._ I was however able to add appropriate tests on this, and they pass.

### Checklist

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [X] I understand the code I am submitting and can explain how it works
- [X] I have performed a self-review of my code
- [X] I have linted and formatted my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

### How to test

Please describe the steps to test your changes, including any setup required.

1. Ensure there is data in your environment with enough titles that scrolling is necessary (based on window size)
2. Open a collection
3. Click a specific movie
4. Click Trigger Rule Action (Item Detail Modal)
5. Click Trigger Now (Confirmation Modal)
6. Ensure that scrolling now works on this or any other page you click through to in app. 

