### PR TITLE
ci(release): dispatch docs deploy via maintainerr-docs-bot App token

### DIFF
--- a/.github/workflows/docs_drift.yml
+++ b/.github/workflows/docs_drift.yml
@@ -58,6 +58,15 @@ jobs:
           client-id: ${{ secrets.MERGE_APP_ID }}
           private-key: ${{ secrets.MERGE_APP_KEY }}
 
+      - name: Create docs bot App token
+        id: docs-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: Maintainerr_docs
+
       - name: Checkout Maintainerr
         uses: actions/checkout@v6
         with:
@@ -153,7 +162,7 @@ jobs:
            (github.event_name == 'workflow_dispatch' && inputs.open_issue))
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          GH_TOKEN: ${{ steps.docs-app-token.outputs.token }}
           DOCS_REPO: Maintainerr/Maintainerr_docs
           MARKER: maintainerr-docs-drift
         run: |
@@ -178,7 +187,7 @@ jobs:
           inputs.create_pr
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          GH_TOKEN: ${{ steps.docs-app-token.outputs.token }}
           DOCS_REPO: Maintainerr/Maintainerr_docs
           BASE_REF: ${{ steps.base.outputs.ref }}
           RUN_ID: ${{ github.run_id }}
@@ -208,7 +217,7 @@ jobs:
            (github.event_name == 'workflow_dispatch' && inputs.open_issue))
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          GH_TOKEN: ${{ steps.docs-app-token.outputs.token }}
           DOCS_REPO: Maintainerr/Maintainerr_docs
           MARKER: maintainerr-docs-drift
         run: |

--- a/.github/workflows/release_5_publish.yml
+++ b/.github/workflows/release_5_publish.yml
@@ -286,12 +286,23 @@ jobs:
         id: package-version
         uses: martinbeentjes/npm-get-version-action@v1.3.1
 
+      - name: Create docs bot App token
+        id: docs-app-token
+        continue-on-error: true
+        if: ${{ steps.package-version.outputs.current-version != '' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: Maintainerr_docs
+
       - name: Docusaurus Deploy
         continue-on-error: true
         if: ${{ steps.package-version.outputs.current-version != '' }}
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ secrets.ACTIONS_TOKEN }}
+          token: ${{ steps.docs-app-token.outputs.token }}
           repository: Maintainerr/Maintainerr_docs
           event-type: maintainerr-release
           client-payload: |

--- a/.github/workflows/release_5_publish.yml
+++ b/.github/workflows/release_5_publish.yml
@@ -288,11 +288,10 @@ jobs:
 
       - name: Create docs bot App token
         id: docs-app-token
-        continue-on-error: true
         if: ${{ steps.package-version.outputs.current-version != '' }}
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.DOCS_APP_ID }}
+          client-id: ${{ secrets.DOCS_APP_ID }}
           private-key: ${{ secrets.DOCS_APP_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: Maintainerr_docs


### PR DESCRIPTION
## Summary
Retire the `ACTIONS_TOKEN` PAT for writes that target `Maintainerr/Maintainerr_docs`, replacing it with a short-lived App token minted at runtime from the `maintainerr-docs-bot` App.

- **`release_5_publish.yml`** — after-effects job now mints a docs-bot App token (scoped to `Maintainerr_docs` only) and uses it for the `repository_dispatch` to the docs repo. Dropped `continue-on-error` on the mint step so token failures surface instead of silently producing an empty token.
- **`docs_drift.yml`** — the three `gh` CLI steps that target `Maintainerr_docs` (upsert drift issue, open draft PR via `create_pr` input, close drift issue) now authenticate with the docs-bot App token instead of `ACTIONS_TOKEN`. The existing `MERGE_APP_*` token used for the Maintainerr side of this workflow is unchanged.

Uses `client-id:` to match the existing repo convention (`MERGE_APP_*`). `ACTIONS_TOKEN` is still referenced by `stale_issues.yml` and remains available for any not-yet-migrated paths.

## Prerequisites
- [ ] `DOCS_APP_ID` and `DOCS_APP_KEY` exist as repo/org secrets on `Maintainerr/Maintainerr`.
- [ ] `DOCS_APP_ID` holds the **OAuth Client ID** (e.g. `Iv23…`), matching how `MERGE_APP_ID` is stored.
- [ ] `maintainerr-docs-bot` App is installed on `Maintainerr/Maintainerr_docs` with:
  - Contents: Read & write (git push for the draft PR branch)
  - Issues: Read & write (upsert/close drift issue)
  - Pull requests: Read & write (open draft PR)
  - Metadata: Read (implicit)

## Test plan
- [ ] Run `Docs drift report` workflow manually with `create_pr: true` against a branch that has drift — confirm the draft PR appears on `Maintainerr_docs` authored by `maintainerr-docs-bot`.
- [ ] Run the same with `open_issue: true` and no drift — confirm issue close path still works under the new token.
- [ ] Run a dry-run release (or the next real release) and confirm the `Create docs bot App token` step succeeds and the subsequent `Docusaurus Deploy` dispatch fires against `Maintainerr_docs`.
- [ ] After a successful rollout, plan removal of `ACTIONS_TOKEN` from any remaining workflows that don't need a broader-scope PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)