### PR TITLE
fix(sonarr): unblock DELETE_SHOW_IF_EMPTY and surface cleanup skips

### DIFF
--- a/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -363,6 +363,92 @@ describe('SonarrActionHandler', () => {
     expect(mockedSonarrApi.deleteShow).not.toHaveBeenCalled();
   });
 
+  it('should not delete empty show when Seerr state is unknown', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE_SHOW_IF_EMPTY,
+      sonarrSettingsId: 1,
+      type: 'season',
+    });
+    const collectionMedia = createCollectionMediaWithMetadata(collection, {
+      tmdbId: 1,
+    });
+
+    mockMediaServerMetadata(collectionMedia.mediaData);
+    seerrApi.hasRemainingSeasonRequests.mockResolvedValue(undefined);
+
+    const series = createSonarrSeries({
+      id: 42,
+      status: 'ended',
+      seasons: [
+        { seasonNumber: 0, monitored: false },
+        { seasonNumber: 1, monitored: false },
+      ],
+      statistics: {
+        seasonCount: 1,
+        episodeFileCount: 0,
+        episodeCount: 10,
+        totalEpisodeCount: 10,
+        sizeOnDisk: 0,
+        percentOfEpisodes: 0,
+      },
+    });
+
+    const mockedSonarrApi = mockSonarrApi(servarrService, logger);
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(seerrApi.hasRemainingSeasonRequests).toHaveBeenCalledWith(
+      collectionMedia.tmdbId,
+      collectionMedia.mediaData.index,
+    );
+    expect(mockedSonarrApi.deleteShow).not.toHaveBeenCalled();
+  });
+
+  it('should not delete show when episode files still remain after season cleanup', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE_SHOW_IF_EMPTY,
+      sonarrSettingsId: 1,
+      type: 'season',
+    });
+    const collectionMedia = createCollectionMediaWithMetadata(collection, {
+      tmdbId: 1,
+    });
+
+    mockMediaServerMetadata(collectionMedia.mediaData);
+
+    const series = createSonarrSeries({
+      id: 42,
+      status: 'ended',
+      seasons: [
+        { seasonNumber: 0, monitored: false },
+        { seasonNumber: 1, monitored: false },
+        { seasonNumber: 2, monitored: true },
+      ],
+      statistics: {
+        seasonCount: 2,
+        episodeFileCount: 5,
+        episodeCount: 10,
+        totalEpisodeCount: 10,
+        sizeOnDisk: 0,
+        percentOfEpisodes: 0,
+      },
+    });
+
+    const mockedSonarrApi = mockSonarrApi(servarrService, logger);
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mockedSonarrApi.deleteShow).not.toHaveBeenCalled();
+  });
+
   it('should delete ended empty show when Seerr is not configured and no monitored seasons remain', async () => {
     const collection = createCollection({
       arrAction: ServarrAction.DELETE_SHOW_IF_EMPTY,

--- a/apps/server/src/modules/actions/sonarr-action-handler.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.ts
@@ -434,7 +434,17 @@ export class SonarrActionHandler {
   ): Promise<void> {
     const series = await this.refetchSeries(sonarrApiClient, lookupCandidate);
 
-    if (!series?.id || !this.isShowEmpty(series, 'files')) {
+    if (!series?.id) {
+      this.logger.debug(
+        `[Sonarr] Skipping empty-show cleanup: series refetch returned no result for ${lookupCandidate.providerKey} id ${lookupCandidate.id}`,
+      );
+      return;
+    }
+
+    if (!this.isShowEmpty(series, 'files')) {
+      this.logger.debug(
+        `[Sonarr] Show '${series.title}' still has ${series.statistics?.episodeFileCount ?? 0} episode file(s) - skipping show deletion`,
+      );
       return;
     }
 
@@ -448,8 +458,17 @@ export class SonarrActionHandler {
           removedSeasonNumber,
         );
 
-      // Bail on true (remaining requests) or undefined (Seerr lookup failed) — only delete on explicit false
-      if (hasRemainingRequests !== false) {
+      if (hasRemainingRequests === true) {
+        this.logger.debug(
+          `[Sonarr] Show '${series.title}' has other active Seerr season requests - skipping show deletion`,
+        );
+        return;
+      }
+
+      if (hasRemainingRequests === undefined) {
+        this.logger.debug(
+          `[Sonarr] Show '${series.title}' Seerr state could not be determined - skipping show deletion`,
+        );
         return;
       }
 
@@ -461,6 +480,9 @@ export class SonarrActionHandler {
     }
 
     if (!this.isShowEmptyAndEnded(series, 'monitored')) {
+      this.logger.debug(
+        `[Sonarr] Show '${series.title}' is not ended with all seasons unmonitored (status=${series.status}) - skipping show deletion`,
+      );
       return;
     }
 
@@ -476,7 +498,17 @@ export class SonarrActionHandler {
   ): Promise<void> {
     const series = await this.refetchSeries(sonarrApiClient, lookupCandidate);
 
-    if (!series || !this.isShowEmptyAndEnded(series, 'monitored')) {
+    if (!series) {
+      this.logger.debug(
+        `[Sonarr] Skipping empty-show unmonitor: series refetch returned no result for ${lookupCandidate.providerKey} id ${lookupCandidate.id}`,
+      );
+      return;
+    }
+
+    if (!this.isShowEmptyAndEnded(series, 'monitored')) {
+      this.logger.debug(
+        `[Sonarr] Show '${series.title}' is not ended with all seasons unmonitored (status=${series.status}) - skipping show unmonitor`,
+      );
       return;
     }
 

--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.spec.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.spec.ts
@@ -165,4 +165,46 @@ describe('SeerrApiService', () => {
       undefined,
     );
   });
+
+  it('should return false when the show has no Seerr mediaInfo', async () => {
+    jest.spyOn(service, 'getShow').mockResolvedValue({
+      id: 1,
+      firstAirDate: new Date('2020-01-01'),
+    });
+
+    await expect(service.hasRemainingSeasonRequests(100, 1)).resolves.toBe(
+      false,
+    );
+  });
+
+  it('should return false when the show has mediaInfo but no requests', async () => {
+    jest.spyOn(service, 'getShow').mockResolvedValue({
+      id: 1,
+      mediaInfo: {
+        id: 1,
+        tmdbId: 100,
+        tvdbId: 200,
+        status: 1,
+        updatedAt: '2026-03-14T00:00:00.000Z',
+        mediaAddedAt: '2026-03-14T00:00:00.000Z',
+        externalServiceId: 1,
+        externalServiceId4k: 1,
+        mediaType: 'tv',
+        requests: [],
+      },
+      firstAirDate: new Date('2020-01-01'),
+    });
+
+    await expect(service.hasRemainingSeasonRequests(100, 1)).resolves.toBe(
+      false,
+    );
+  });
+
+  it('should return undefined when getShow returns undefined (communication failure)', async () => {
+    jest.spyOn(service, 'getShow').mockResolvedValue(undefined);
+
+    await expect(service.hasRemainingSeasonRequests(100, 1)).resolves.toBe(
+      undefined,
+    );
+  });
 });

--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
@@ -342,14 +342,24 @@ export class SeerrApiService {
     try {
       const media = await this.getShow(tmdbid);
 
-      if (!media?.mediaInfo) {
+      // getShow returns undefined only on communication failure or falsy id;
+      // the show being untracked still yields a response with mediaInfo == null.
+      if (!media) {
         return undefined;
+      }
+
+      if (!media.mediaInfo) {
+        return false;
       }
 
       const requests = media.mediaInfo.requests ?? [];
 
       return requests
-        .filter((request) => request.status !== SeerrRequestStatus.DECLINED)
+        .filter(
+          (request) =>
+            request.status !== SeerrRequestStatus.DECLINED &&
+            request.status !== SeerrRequestStatus.COMPLETED,
+        )
         .some((request) =>
           request.seasons.some(
             (season) =>


### PR DESCRIPTION
## Summary

Fixes #2757. `DELETE_SHOW_IF_EMPTY` silently bailed when Seerr was configured but the show wasn't tracked in Seerr, or when all Seerr requests were already `COMPLETED`. The bail paths also had no logs, so users had nothing to debug with.

## Fix

- `hasRemainingSeasonRequests`: return `false` when `mediaInfo` is null (show not tracked in Seerr — nothing to protect), keep `undefined` only for real communication failures.
- Outer request filter now also excludes `COMPLETED` requests.
- Add `debug` log at every bail path in `deleteShowIfEmpty` / `unmonitorShowIfEmptyAndEnded`.
- Spec coverage for untracked show, empty requests, comm failure, Seerr state unknown, and files-still-remain.

PR #2618's design intent (Seerr is the authority when configured, ended shows included) is preserved.

## Test plan

- [x] `yarn test --filter=@maintainerr/server` — 1017 pass
- [x] `yarn lint` — clean
- [ ] Manual: ended + empty show not tracked in Seerr → deletes
- [ ] Manual: continuing show with a Pending/Approved request for another season → not deleted
- [ ] Manual: Seerr unreachable → not deleted (debug log explains why)
