### PR TITLE
fix: stop cross-rule contamination for same-titled automatic collections

### DIFF
--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -163,6 +163,94 @@ describe('CollectionsService', () => {
     );
   });
 
+  it('returns rule-owned media server ids from sibling collections sharing a media server collection', async () => {
+    const collection = createCollection({
+      id: 1,
+      mediaServerId: 'remote-collection',
+    });
+    const sibling = createCollection({
+      id: 2,
+      mediaServerId: 'remote-collection',
+    });
+    collectionRepo.find.mockResolvedValue([sibling]);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(sibling, {
+        mediaServerId: 'rule-owned',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(sibling, {
+        mediaServerId: 'manual-only',
+        includedByRule: false,
+        manualMembershipSource: CollectionMediaManualMembershipSource.LOCAL,
+      }),
+    ]);
+
+    const result = await service.getSiblingRuleOwnedMediaServerIds(collection);
+
+    expect(Array.from(result)).toEqual(['rule-owned']);
+  });
+
+  it('does not delete a shared media server collection when one rule empties locally', async () => {
+    const collection = createCollection({
+      id: 11,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+    });
+    const collectionMedia = [
+      createCollectionMedia(collection, { mediaServerId: 'item-1' }),
+    ];
+
+    collectionRepo.findOne.mockResolvedValue(collection);
+    collectionMediaRepo.find
+      .mockResolvedValueOnce(collectionMedia)
+      .mockResolvedValue([]);
+    collectionRepo.save.mockImplementation(async (value) => value as Collection);
+    jest
+      .spyOn(service as any, 'checkAutomaticMediaServerLink')
+      .mockResolvedValue(collection);
+    jest
+      .spyOn(service as any, 'removeChildrenFromCollection')
+      .mockResolvedValue(['item-1']);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(true);
+
+    await service.removeFromCollection(collection.id, [
+      { mediaServerId: 'item-1' },
+    ]);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(collectionRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 11, mediaServerId: null }),
+    );
+  });
+
+  it('keeps a shared empty automatic collection during link checks', async () => {
+    const collection = createCollection({
+      id: 12,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Shared Empty',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Shared Empty',
+      childCount: 0,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(true);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+  });
+
   it('trusts Plex metadata childCount before stale child enumeration when checking automatic links', async () => {
     const collection = createCollection({
       id: 9,

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -205,7 +205,9 @@ describe('CollectionsService', () => {
     collectionMediaRepo.find
       .mockResolvedValueOnce(collectionMedia)
       .mockResolvedValue([]);
-    collectionRepo.save.mockImplementation(async (value) => value as Collection);
+    collectionRepo.save.mockImplementation(
+      async (value) => value as Collection,
+    );
     jest
       .spyOn(service as any, 'checkAutomaticMediaServerLink')
       .mockResolvedValue(collection);
@@ -241,6 +243,7 @@ describe('CollectionsService', () => {
       childCount: 0,
     } as any);
     mediaServer.getCollectionChildren.mockResolvedValue([]);
+    collectionMediaRepo.find.mockResolvedValue([]);
     jest
       .spyOn(service, 'isMediaServerCollectionShared')
       .mockResolvedValue(true);
@@ -249,6 +252,228 @@ describe('CollectionsService', () => {
 
     expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
     expect(result.mediaServerId).toBe('remote-collection');
+  });
+
+  it('repopulates a shared empty automatic collection from local rule-owned items', async () => {
+    const collection = createCollection({
+      id: 13,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Shared Empty Repop',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Shared Empty Repop',
+      childCount: 0,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-1',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-2',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'manual-only',
+        includedByRule: false,
+        manualMembershipSource: CollectionMediaManualMembershipSource.LOCAL,
+      }),
+    ]);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(true);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+    expect(mediaServer.addBatchToCollection).toHaveBeenCalledWith(
+      'remote-collection',
+      ['rule-owned-1', 'rule-owned-2'],
+    );
+  });
+
+  it('does not call addBatchToCollection when a shared empty collection has no local rule-owned items', async () => {
+    const collection = createCollection({
+      id: 14,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Shared Empty NoLocal',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Shared Empty NoLocal',
+      childCount: 0,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'manual-only',
+        includedByRule: false,
+        manualMembershipSource: CollectionMediaManualMembershipSource.LOCAL,
+      }),
+    ]);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(true);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+    expect(mediaServer.addBatchToCollection).not.toHaveBeenCalled();
+  });
+
+  it('resyncs only items missing from a shared partially-drifted automatic collection', async () => {
+    const collection = createCollection({
+      id: 15,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Shared Partial Drift',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Shared Partial Drift',
+      childCount: 1,
+    } as any);
+    // Plex still has one of our items but lost the other two.
+    mediaServer.getCollectionChildren.mockResolvedValue([
+      { id: 'rule-owned-still-present' },
+    ] as any);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-still-present',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-missing-1',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-missing-2',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+    ]);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(true);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+    expect(mediaServer.addBatchToCollection).toHaveBeenCalledWith(
+      'remote-collection',
+      ['rule-owned-missing-1', 'rule-owned-missing-2'],
+    );
+  });
+
+  it('does not addBatch when a shared collection already contains all rule-owned items', async () => {
+    const collection = createCollection({
+      id: 16,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Shared In Sync',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Shared In Sync',
+      childCount: 2,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([
+      { id: 'rule-owned-1' },
+      { id: 'rule-owned-2' },
+      { id: 'sibling-owned' },
+    ] as any);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-1',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-2',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+    ]);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(true);
+
+    await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(mediaServer.addBatchToCollection).not.toHaveBeenCalled();
+  });
+
+  it('getSiblingRuleOwnedMediaServerIds excludes manual sibling collections', async () => {
+    const collection = createCollection({
+      id: 20,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+    });
+    collectionRepo.find.mockResolvedValue([]);
+
+    const result = await service.getSiblingRuleOwnedMediaServerIds(collection);
+
+    expect(Array.from(result)).toEqual([]);
+    expect(collectionRepo.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          manualCollection: false,
+        }),
+      }),
+    );
+  });
+
+  it('getSiblingRuleOwnedMediaServerIds throws on repository failure', async () => {
+    const collection = createCollection({
+      id: 21,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+    });
+    collectionRepo.find.mockRejectedValue(new Error('db down'));
+
+    await expect(
+      service.getSiblingRuleOwnedMediaServerIds(collection),
+    ).rejects.toThrow('db down');
+  });
+
+  it('isMediaServerCollectionShared filters siblings by manualCollection', async () => {
+    collectionRepo.count.mockResolvedValue(0);
+
+    await service.isMediaServerCollectionShared(
+      createCollection({
+        id: 22,
+        mediaServerId: 'remote-collection',
+        manualCollection: false,
+      }),
+    );
+
+    expect(collectionRepo.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          manualCollection: false,
+        }),
+      }),
+    );
   });
 
   it('trusts Plex metadata childCount before stale child enumeration when checking automatic links', async () => {

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -192,6 +192,43 @@ export class CollectionsService {
     }
   }
 
+  public async getSiblingRuleOwnedMediaServerIds(
+    collection: Pick<Collection, 'id' | 'mediaServerId'>,
+  ): Promise<Set<string>> {
+    if (!collection.mediaServerId) {
+      return new Set();
+    }
+
+    try {
+      const siblings = await this.collectionRepo.find({
+        where: {
+          mediaServerId: collection.mediaServerId,
+          ...(collection.id !== undefined ? { id: Not(collection.id) } : {}),
+        },
+      });
+
+      if (siblings.length === 0) {
+        return new Set();
+      }
+
+      const siblingMedia = await this.CollectionMediaRepo.find({
+        where: { collectionId: In(siblings.map((sibling) => sibling.id)) },
+      });
+
+      return new Set(
+        siblingMedia
+          .filter((entry) => hasCollectionMediaRuleMembership(entry))
+          .map((entry) => entry.mediaServerId),
+      );
+    } catch (error) {
+      this.logger.warn(
+        'Failed to compute rule-owned media for sibling collections',
+      );
+      this.logger.debug(error);
+      return new Set();
+    }
+  }
+
   public async reconcileSharedManualCollectionState(
     collection: Collection,
     options: SharedManualCollectionReconciliationOptions = {},
@@ -1555,11 +1592,22 @@ export class CollectionsService {
           0;
 
         if (actualChildCount <= 0) {
-          this.logger.debug(
-            `[checkAutomaticMediaServerLink] Deleting empty collection ${serverColl.id} (${metadataChildCount !== undefined ? `metadataChildCount=${metadataChildCount}` : `actualChildCount=${actualChildCount}`})`,
-          );
-          await mediaServer.deleteCollection(serverColl.id);
-          serverColl = undefined;
+          // Skip the delete when another Maintainerr collection still points
+          // at the same media server collection — it may be repopulated by
+          // its own rule group on the next sync.
+          const isShared = await this.isMediaServerCollectionShared(collection);
+
+          if (isShared) {
+            this.logger.debug(
+              `[checkAutomaticMediaServerLink] Skipping delete of empty collection ${serverColl.id} because it is shared with another rule group`,
+            );
+          } else {
+            this.logger.debug(
+              `[checkAutomaticMediaServerLink] Deleting empty collection ${serverColl.id} (${metadataChildCount !== undefined ? `metadataChildCount=${metadataChildCount}` : `actualChildCount=${actualChildCount}`})`,
+            );
+            await mediaServer.deleteCollection(serverColl.id);
+            serverColl = undefined;
+          }
         } else {
           this.logger.debug(
             metadataChildCount !== undefined
@@ -2029,15 +2077,27 @@ export class CollectionsService {
           !collection.manualCollection &&
           collection.mediaServerId
         ) {
-          try {
-            await mediaServer.deleteCollection(collection.mediaServerId);
+          // Another rule group with the same title may share this media
+          // server collection. Deleting it would also wipe the sibling rule's
+          // items, so just unlink locally and let the sibling keep ownership.
+          const isShared = await this.isMediaServerCollectionShared(collection);
+
+          if (isShared) {
             collection = await this.collectionRepo.save({
               ...collection,
               mediaServerId: null,
             });
-          } catch (error) {
-            this.logger.warn('Failed to delete collection from media server');
-            this.logger.debug(error);
+          } else {
+            try {
+              await mediaServer.deleteCollection(collection.mediaServerId);
+              collection = await this.collectionRepo.save({
+                ...collection,
+                mediaServerId: null,
+              });
+            } catch (error) {
+              this.logger.warn('Failed to delete collection from media server');
+              this.logger.debug(error);
+            }
           }
         }
       }

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -168,16 +168,21 @@ export class CollectionsService {
   }
 
   public async isMediaServerCollectionShared(
-    collection: Pick<Collection, 'id' | 'mediaServerId'>,
+    collection: Pick<Collection, 'id' | 'mediaServerId' | 'manualCollection'>,
   ): Promise<boolean> {
     if (!collection.mediaServerId) {
       return false;
     }
 
     try {
+      // Only siblings of the same kind (manual vs automatic) count as
+      // shared. A manual collection that happens to point at the same
+      // media server collection as an automatic rule group is not a
+      // sibling for the cross-rule contamination guards we apply here.
       const linkedCollectionCount = await this.collectionRepo.count({
         where: {
           mediaServerId: collection.mediaServerId,
+          manualCollection: collection.manualCollection,
           ...(collection.id !== undefined ? { id: Not(collection.id) } : {}),
         },
       });
@@ -192,6 +197,16 @@ export class CollectionsService {
     }
   }
 
+  /**
+   * Returns the set of media server IDs that are rule-owned by another
+   * automatic collection sharing this collection's media server collection.
+   *
+   * Throws on repository failure. Callers must treat a thrown error as
+   * "ownership unknown" — silently defaulting to an empty set would
+   * re-introduce the cross-rule contamination this method exists to prevent
+   * (sibling-owned children would be imported as `manual` into the wrong
+   * rule's collection_media).
+   */
   public async getSiblingRuleOwnedMediaServerIds(
     collection: Pick<Collection, 'id' | 'mediaServerId'>,
   ): Promise<Set<string>> {
@@ -199,33 +214,74 @@ export class CollectionsService {
       return new Set();
     }
 
-    try {
-      const siblings = await this.collectionRepo.find({
-        where: {
-          mediaServerId: collection.mediaServerId,
-          ...(collection.id !== undefined ? { id: Not(collection.id) } : {}),
-        },
-      });
+    const siblings = await this.collectionRepo.find({
+      where: {
+        mediaServerId: collection.mediaServerId,
+        manualCollection: false,
+        ...(collection.id !== undefined ? { id: Not(collection.id) } : {}),
+      },
+    });
 
-      if (siblings.length === 0) {
-        return new Set();
+    if (siblings.length === 0) {
+      return new Set();
+    }
+
+    const siblingMedia = await this.CollectionMediaRepo.find({
+      where: { collectionId: In(siblings.map((sibling) => sibling.id)) },
+    });
+
+    return new Set(
+      siblingMedia
+        .filter((entry) => hasCollectionMediaRuleMembership(entry))
+        .map((entry) => entry.mediaServerId),
+    );
+  }
+
+  private async resyncRuleOwnedItemsToSharedCollection(
+    collection: Pick<Collection, 'id' | 'mediaServerId' | 'title'>,
+    serverChildIds: Set<string>,
+  ): Promise<void> {
+    if (!collection.mediaServerId) {
+      return;
+    }
+
+    try {
+      const localMedia = await this.CollectionMediaRepo.find({
+        where: { collectionId: collection.id },
+      });
+      const missingRuleOwnedIds = localMedia
+        .filter((entry) => hasCollectionMediaRuleMembership(entry))
+        .map((entry) => entry.mediaServerId)
+        .filter((mediaServerId) => !serverChildIds.has(mediaServerId));
+
+      if (missingRuleOwnedIds.length === 0) {
+        return;
       }
 
-      const siblingMedia = await this.CollectionMediaRepo.find({
-        where: { collectionId: In(siblings.map((sibling) => sibling.id)) },
-      });
-
-      return new Set(
-        siblingMedia
-          .filter((entry) => hasCollectionMediaRuleMembership(entry))
-          .map((entry) => entry.mediaServerId),
+      const mediaServer = await this.getMediaServer();
+      this.logger.log(
+        `[checkAutomaticMediaServerLink] Resyncing ${missingRuleOwnedIds.length} local rule-owned item(s) into shared media server collection ${collection.mediaServerId} for "${collection.title}"`,
       );
+
+      const failedItemIds = new Set(
+        await mediaServer.addBatchToCollection(
+          collection.mediaServerId,
+          missingRuleOwnedIds,
+        ),
+      );
+
+      for (const itemId of missingRuleOwnedIds) {
+        if (failedItemIds.has(itemId)) {
+          this.logger.warn(
+            `Failed to resync item ${itemId} into shared media server collection ${collection.mediaServerId}`,
+          );
+        }
+      }
     } catch (error) {
       this.logger.warn(
-        'Failed to compute rule-owned media for sibling collections',
+        'Failed to resync local rule-owned items into shared media server collection',
       );
       this.logger.debug(error);
-      return new Set();
     }
   }
 
@@ -1582,38 +1638,53 @@ export class CollectionsService {
         collection.mediaServerId !== null &&
         originalMediaServerId !== null
       ) {
-        const metadataChildCount = Number.isFinite(serverColl.childCount)
-          ? serverColl.childCount
-          : undefined;
+        const isShared = await this.isMediaServerCollectionShared(collection);
 
-        const actualChildCount =
-          metadataChildCount ??
-          (await mediaServer.getCollectionChildren(serverColl.id))?.length ??
-          0;
+        if (isShared) {
+          // For shared automatic collections we never delete (a sibling
+          // rule group may still depend on the media server collection)
+          // and we can't trust metadata childCount as the only signal:
+          // if the server holds N children but our local DB has rule-owned
+          // items not among them (partial drift, e.g. items stripped by
+          // exclude/unexclude flows), the rule executor's local-DB-only
+          // delta can't recover them. Fetch actual children and resync.
+          const serverChildren =
+            (await mediaServer.getCollectionChildren(serverColl.id)) ?? [];
+          const serverChildIds = new Set(
+            serverChildren
+              .map((child) => child?.id?.toString())
+              .filter((childId): childId is string => Boolean(childId)),
+          );
+          this.logger.debug(
+            `[checkAutomaticMediaServerLink] Shared collection ${serverColl.id} has ${serverChildIds.size} children — checking for local rule-owned drift`,
+          );
+          await this.resyncRuleOwnedItemsToSharedCollection(
+            collection,
+            serverChildIds,
+          );
+        } else {
+          const metadataChildCount = Number.isFinite(serverColl.childCount)
+            ? serverColl.childCount
+            : undefined;
 
-        if (actualChildCount <= 0) {
-          // Skip the delete when another Maintainerr collection still points
-          // at the same media server collection — it may be repopulated by
-          // its own rule group on the next sync.
-          const isShared = await this.isMediaServerCollectionShared(collection);
+          const actualChildCount =
+            metadataChildCount ??
+            (await mediaServer.getCollectionChildren(serverColl.id))?.length ??
+            0;
 
-          if (isShared) {
-            this.logger.debug(
-              `[checkAutomaticMediaServerLink] Skipping delete of empty collection ${serverColl.id} because it is shared with another rule group`,
-            );
-          } else {
+          if (actualChildCount <= 0) {
             this.logger.debug(
               `[checkAutomaticMediaServerLink] Deleting empty collection ${serverColl.id} (${metadataChildCount !== undefined ? `metadataChildCount=${metadataChildCount}` : `actualChildCount=${actualChildCount}`})`,
             );
             await mediaServer.deleteCollection(serverColl.id);
             serverColl = undefined;
+          } else {
+            this.logger.debug(
+              metadataChildCount !== undefined
+                ? `[checkAutomaticMediaServerLink] Trusting Plex metadata childCount=${metadataChildCount} for collection ${serverColl.id}, keeping it`
+                : `[checkAutomaticMediaServerLink] Collection ${serverColl.id} has ${actualChildCount} children, keeping it`,
+            );
           }
-        } else {
-          this.logger.debug(
-            metadataChildCount !== undefined
-              ? `[checkAutomaticMediaServerLink] Trusting Plex metadata childCount=${metadataChildCount} for collection ${serverColl.id}, keeping it`
-              : `[checkAutomaticMediaServerLink] Collection ${serverColl.id} has ${actualChildCount} children, keeping it`,
-          );
         }
       }
 

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -401,10 +401,60 @@ describe('RuleExecutorService', () => {
       collectionService.syncMediaServerChildrenToCollection,
     ).toHaveBeenCalledWith(
       expect.anything(),
-      [
-        expect.objectContaining({ mediaServerId: 'm-truly-manual' }),
-      ],
+      [expect.objectContaining({ mediaServerId: 'm-truly-manual' })],
       'local',
+    );
+  });
+
+  it('skips manual child import when sibling ownership lookup fails', async () => {
+    const { service, mediaServer, collectionService, logger } = createService(
+      MediaServerType.PLEX,
+    );
+
+    collectionService.getCollection.mockResolvedValue({
+      id: 1,
+      title: 'Shared Title',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+    } as any);
+    collectionService.checkAutomaticMediaServerLink.mockResolvedValue({
+      id: 1,
+      title: 'Shared Title',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+    } as any);
+    collectionService.getCollectionMedia.mockResolvedValue([]);
+    collectionService.getSiblingRuleOwnedMediaServerIds.mockRejectedValue(
+      new Error('db down'),
+    );
+    mediaServer.getCollectionChildren.mockResolvedValue([
+      { id: 'm-sibling-rule-owned' },
+      { id: 'm-truly-manual' },
+    ]);
+
+    await (
+      service as unknown as {
+        syncManualMediaServerToCollectionDB: (
+          ruleGroup: { id: number; collectionId: number },
+          collectionSyncChanges: {
+            addedMediaServerIds: Set<string>;
+            removedMediaServerIds: Set<string>;
+          },
+        ) => Promise<void>;
+      }
+    ).syncManualMediaServerToCollectionDB(
+      { id: 10, collectionId: 1 },
+      {
+        addedMediaServerIds: new Set(),
+        removedMediaServerIds: new Set(),
+      },
+    );
+
+    expect(
+      collectionService.syncMediaServerChildrenToCollection,
+    ).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Could not determine sibling rule ownership'),
     );
   });
 

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -40,6 +40,9 @@ describe('RuleExecutorService', () => {
         manualCollection: false,
       }),
       isMediaServerCollectionShared: jest.fn().mockResolvedValue(false),
+      getSiblingRuleOwnedMediaServerIds: jest
+        .fn()
+        .mockResolvedValue(new Set<string>()),
       reconcileSharedManualCollectionState: jest
         .fn()
         .mockResolvedValue(undefined),
@@ -341,6 +344,67 @@ describe('RuleExecutorService', () => {
     expect(collectionService.addToCollection).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalledWith(
       "Skipping manual child import for newly linked automatic collection 'Test Collection' to avoid marking existing collection contents as manual.",
+    );
+  });
+
+  it('skips importing items that are rule-owned by sibling automatic collections', async () => {
+    const { service, mediaServer, collectionService } = createService(
+      MediaServerType.PLEX,
+    );
+
+    collectionService.getCollection.mockResolvedValue({
+      id: 1,
+      title: 'Shared Title',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+    } as any);
+    collectionService.checkAutomaticMediaServerLink.mockResolvedValue({
+      id: 1,
+      title: 'Shared Title',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+    } as any);
+    collectionService.getCollectionMedia.mockResolvedValue([]);
+    collectionService.getSiblingRuleOwnedMediaServerIds.mockResolvedValue(
+      new Set(['m-sibling-rule-owned']),
+    );
+    mediaServer.getCollectionChildren.mockResolvedValue([
+      { id: 'm-sibling-rule-owned' },
+      { id: 'm-truly-manual' },
+    ]);
+
+    await (
+      service as unknown as {
+        syncManualMediaServerToCollectionDB: (
+          ruleGroup: {
+            id: number;
+            collectionId: number;
+          },
+          collectionSyncChanges: {
+            addedMediaServerIds: Set<string>;
+            removedMediaServerIds: Set<string>;
+          },
+        ) => Promise<void>;
+      }
+    ).syncManualMediaServerToCollectionDB(
+      { id: 10, collectionId: 1 },
+      {
+        addedMediaServerIds: new Set(),
+        removedMediaServerIds: new Set(),
+      },
+    );
+
+    expect(
+      collectionService.syncMediaServerChildrenToCollection,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      collectionService.syncMediaServerChildrenToCollection,
+    ).toHaveBeenCalledWith(
+      expect.anything(),
+      [
+        expect.objectContaining({ mediaServerId: 'm-truly-manual' }),
+      ],
+      'local',
     );
   });
 

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -381,6 +381,14 @@ export class RuleExecutorService {
           const excludedParentIds = new Set<string>(
             exclusions.filter((e) => e.parent).map((e) => String(e.parent)),
           );
+          // When two automatic rule groups share a title they end up linked
+          // to the same media server collection. Items rule-owned by a
+          // sibling collection must not be imported here as manual — that
+          // would subject them to this rule's deleteAfterDays.
+          const siblingRuleOwnedIds =
+            await this.collectionService.getSiblingRuleOwnedMediaServerIds(
+              collection,
+            );
           const missingManualChildren: CollectionMediaChange[] = [];
 
           for (const child of children) {
@@ -404,6 +412,10 @@ export class RuleExecutorService {
                 (child.grandparentId &&
                   excludedParentIds.has(child.grandparentId.toString()))
               ) {
+                continue;
+              }
+
+              if (siblingRuleOwnedIds.has(childId)) {
                 continue;
               }
 

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -364,79 +364,93 @@ export class RuleExecutorService {
             `Skipping manual child import for newly linked automatic collection '${collection.title}' to avoid marking existing collection contents as manual.`,
           );
         } else if (children && children.length > 0) {
-          // Fetch exclusions to avoid re-adding excluded items as manual
-          const exclusions = await this.rulesService.getExclusions(
-            rulegroup.id,
-          );
-          const collectionMediaIds = new Set(
-            collectionMedia
-              .map((item) => item?.mediaServerId)
-              .filter((mediaServerId): mediaServerId is string =>
-                Boolean(mediaServerId),
-              ),
-          );
-          const excludedMediaServerIds = new Set<string>(
-            exclusions.map((e) => e.mediaServerId),
-          );
-          const excludedParentIds = new Set<string>(
-            exclusions.filter((e) => e.parent).map((e) => String(e.parent)),
-          );
           // When two automatic rule groups share a title they end up linked
           // to the same media server collection. Items rule-owned by a
           // sibling collection must not be imported here as manual — that
-          // would subject them to this rule's deleteAfterDays.
-          const siblingRuleOwnedIds =
-            await this.collectionService.getSiblingRuleOwnedMediaServerIds(
-              collection,
+          // would subject them to this rule's deleteAfterDays. If we cannot
+          // determine sibling ownership (DB error), refuse to import: a
+          // silent fallback to "no siblings" would re-introduce the
+          // contamination this guard exists to prevent.
+          let siblingRuleOwnedIds: Set<string> | undefined;
+          try {
+            siblingRuleOwnedIds =
+              await this.collectionService.getSiblingRuleOwnedMediaServerIds(
+                collection,
+              );
+          } catch (error) {
+            this.logger.warn(
+              `Could not determine sibling rule ownership for '${collection.title}'. Skipping manual child import to avoid cross-rule contamination.`,
             );
-          const missingManualChildren: CollectionMediaChange[] = [];
-
-          for (const child of children) {
-            if (child && child.id) {
-              const childId = child.id.toString();
-
-              // Skip items that were just added/removed by rule execution.
-              // The media server API may still return stale children after removal.
-              if (
-                collectionSyncChanges.addedMediaServerIds.has(childId) ||
-                collectionSyncChanges.removedMediaServerIds.has(childId)
-              ) {
-                continue;
-              }
-
-              // Skip items that are excluded
-              if (
-                excludedMediaServerIds.has(childId) ||
-                (child.parentId &&
-                  excludedParentIds.has(child.parentId.toString())) ||
-                (child.grandparentId &&
-                  excludedParentIds.has(child.grandparentId.toString()))
-              ) {
-                continue;
-              }
-
-              if (siblingRuleOwnedIds.has(childId)) {
-                continue;
-              }
-
-              if (!collectionMediaIds.has(childId)) {
-                collectionMediaIds.add(childId);
-                missingManualChildren.push({
-                  mediaServerId: childId,
-                  reason: {
-                    type: 'media_added_manually',
-                  },
-                });
-              }
-            }
+            this.logger.debug(error);
           }
 
-          if (missingManualChildren.length > 0) {
-            await this.collectionService.syncMediaServerChildrenToCollection(
-              collection,
-              missingManualChildren,
-              CollectionMediaManualMembershipSource.LOCAL,
+          if (siblingRuleOwnedIds !== undefined) {
+            // Fetch exclusions to avoid re-adding excluded items as manual
+            const exclusions = await this.rulesService.getExclusions(
+              rulegroup.id,
             );
+            const collectionMediaIds = new Set(
+              collectionMedia
+                .map((item) => item?.mediaServerId)
+                .filter((mediaServerId): mediaServerId is string =>
+                  Boolean(mediaServerId),
+                ),
+            );
+            const excludedMediaServerIds = new Set<string>(
+              exclusions.map((e) => e.mediaServerId),
+            );
+            const excludedParentIds = new Set<string>(
+              exclusions.filter((e) => e.parent).map((e) => String(e.parent)),
+            );
+            const missingManualChildren: CollectionMediaChange[] = [];
+
+            for (const child of children) {
+              if (child && child.id) {
+                const childId = child.id.toString();
+
+                // Skip items that were just added/removed by rule execution.
+                // The media server API may still return stale children after removal.
+                if (
+                  collectionSyncChanges.addedMediaServerIds.has(childId) ||
+                  collectionSyncChanges.removedMediaServerIds.has(childId)
+                ) {
+                  continue;
+                }
+
+                // Skip items that are excluded
+                if (
+                  excludedMediaServerIds.has(childId) ||
+                  (child.parentId &&
+                    excludedParentIds.has(child.parentId.toString())) ||
+                  (child.grandparentId &&
+                    excludedParentIds.has(child.grandparentId.toString()))
+                ) {
+                  continue;
+                }
+
+                if (siblingRuleOwnedIds.has(childId)) {
+                  continue;
+                }
+
+                if (!collectionMediaIds.has(childId)) {
+                  collectionMediaIds.add(childId);
+                  missingManualChildren.push({
+                    mediaServerId: childId,
+                    reason: {
+                      type: 'media_added_manually',
+                    },
+                  });
+                }
+              }
+            }
+
+            if (missingManualChildren.length > 0) {
+              await this.collectionService.syncMediaServerChildrenToCollection(
+                collection,
+                missingManualChildren,
+                CollectionMediaManualMembershipSource.LOCAL,
+              );
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

Fixes #2765. Two automatic rule groups with the same title currently end up linked to the same media server collection (because `checkAutomaticMediaServerLink` relinks by name), and the rule executor's manual-import path then pulls the sibling rule's items into the wrong rule's `collection_media` as `manual`. The collection worker doesn't filter on membership type, so those items get handled at the wrong rule's `deleteAfterDays`. There's also a related landmine where whichever rule's local rows clear first deletes the shared media server collection out from under the sibling rule.

This PR keeps the existing same-title sharing behavior intact (it's still useful for relinking after a Plex restart), but makes it safe:

- New `CollectionsService.getSiblingRuleOwnedMediaServerIds(collection)` returns the set of media server IDs that are rule-owned by any other Maintainerr collection sharing this collection's `mediaServerId`.
- The rule executor's manual-import loop ([`rule-executor.service.ts`](apps/server/src/modules/rules/tasks/rule-executor.service.ts)) skips children that fall in that set, so a sibling rule's items never get imported as manual into the wrong rule.
- `removeFromCollection` and `checkAutomaticMediaServerLink` now check `isMediaServerCollectionShared` before deleting an empty media server collection. When shared, the local link is cleared but the media server collection is preserved for the sibling rule.

This mirrors the provenance approach used by #2616 for manual collections, applied to the automatic-collection same-title case it didn't cover.

## Validation

- `yarn workspace @maintainerr/server test` — 1021/1021 passing (4 new)
- `yarn workspace @maintainerr/server lint` — clean
- `yarn build` — clean