### PR TITLE
Add Reddit release posting workflow

### DIFF
--- a/.github/workflows/reddit_release_post.yml
+++ b/.github/workflows/reddit_release_post.yml
@@ -1,0 +1,75 @@
+name: Reddit Release Post
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Git tag to post when running manually
+        required: false
+        type: string
+      subreddit:
+        description: Override the target subreddit
+        required: false
+        type: string
+      post_kind:
+        description: Submit a self post or a link post
+        required: false
+        default: self
+        type: choice
+        options:
+          - self
+          - link
+      dry_run:
+        description: Build the release post but do not submit it
+        required: false
+        default: false
+        type: boolean
+      allow_repost:
+        description: Allow posting even when a recent duplicate is detected
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reddit-release-post-${{ github.event.release.tag_name || inputs.release_tag || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  post_release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Activate corepack
+        run: |
+          corepack install
+          corepack enable
+
+      - name: Install dependencies
+        run: yarn --immutable
+
+      - name: Preview or submit Reddit release post
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}
+          REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
+          REDDIT_USERNAME: ${{ secrets.REDDIT_USERNAME }}
+          REDDIT_PASSWORD: ${{ secrets.REDDIT_PASSWORD }}
+          REDDIT_SUBREDDIT: ${{ inputs.subreddit || vars.REDDIT_SUBREDDIT }}
+          REDDIT_POST_KIND: ${{ inputs.post_kind || 'self' }}
+          REDDIT_ALLOW_REPOST: ${{ inputs.allow_repost }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: node tools/reddit-release-post.mjs

--- a/docs/reddit-release-bot.md
+++ b/docs/reddit-release-bot.md
@@ -1,0 +1,121 @@
+# Reddit Release Bot
+
+This repository includes a GitHub Actions path for posting release announcements to Reddit:
+
+- `.github/workflows/reddit_release_post.yml`: runs on `release.published` and can also be triggered manually.
+- `tools/reddit-release-post.mjs`: workflow entry point.
+- `tools/reddit-release-lib.mjs`: shared release lookup, duplicate detection, and Reddit submission logic.
+
+## Reddit setup
+
+Create the Reddit account and subreddit manually. For the bot app itself, create a Reddit OAuth app at `https://www.reddit.com/prefs/apps` and select the `script` app type. Reddit's script app flow is intended for a bot you run on infrastructure you control.
+
+Recommended setup order:
+
+1. Create and verify the Reddit account.
+2. Create the subreddit.
+3. Configure the subreddit so the bot account can post release announcements.
+4. Create the Reddit `script` app for that account.
+5. Add the Reddit credentials and subreddit name to GitHub.
+6. Run the workflow once in `dry_run` mode.
+
+### Subreddit
+
+Yes, the next step is the subreddit.
+
+Create a subreddit that the bot account controls, or at least one where it is explicitly allowed to post. For the default workflow behavior, the cleanest setup is:
+
+- the bot account is a moderator of the subreddit
+- text posts are allowed if you plan to keep `REDDIT_POST_KIND=self`
+- the subreddit rules allow release announcement posts
+- post flair is optional unless you want every release post tagged
+
+If you require flair for submissions, note the flair template ID and set `REDDIT_POST_FLAIR_ID` in the workflow environment later.
+
+### Reddit app
+
+After the subreddit exists, open `https://www.reddit.com/prefs/apps` while logged into the bot account and create an app with these settings:
+
+- app type: `script`
+- name: anything descriptive, for example `Maintainerr Release Bot`
+- redirect URI: any placeholder URI is fine for a script app, for example `http://localhost:8080`
+
+Save the generated client ID and client secret. Those are the values used for `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET`.
+
+### GitHub configuration
+
+Set these secrets in GitHub Actions before enabling the workflow:
+
+- `REDDIT_CLIENT_ID`
+- `REDDIT_CLIENT_SECRET`
+- `REDDIT_USERNAME`
+- `REDDIT_PASSWORD`
+
+Set this repository variable, or pass it as a manual workflow input:
+
+- `REDDIT_SUBREDDIT`
+
+If your subreddit requires flair, also set one or both of these environment values where you run the bot:
+
+- `REDDIT_POST_FLAIR_ID`
+- `REDDIT_POST_FLAIR_TEXT`
+
+Use a descriptive Reddit user-agent. If you do not set `REDDIT_USER_AGENT`, the bot generates one from the configured username.
+
+### First run
+
+Once the subreddit and app are ready, run the workflow manually with `dry_run: true` first. That lets you confirm:
+
+- the Reddit login works
+- the subreddit name is correct
+- the generated title/body look right
+- duplicate detection behaves as expected
+
+When the dry run looks correct, rerun without `dry_run` to publish the first post.
+
+## Workflow inputs
+
+The bot reads GitHub release information from one of these sources:
+
+1. `GITHUB_EVENT_PATH` when running inside the release workflow
+2. `RELEASE_TAG` plus `GITHUB_REPOSITORY`
+3. Manual workflow inputs
+
+Supported environment variables:
+
+- `GITHUB_REPOSITORY`
+- `GITHUB_TOKEN` or `GH_TOKEN`
+- `RELEASE_TAG`
+- `REDDIT_SUBREDDIT`
+- `REDDIT_POST_KIND` as `self` or `link`
+- `REDDIT_POST_TITLE_TEMPLATE`
+- `REDDIT_POST_BODY_TEMPLATE`
+- `REDDIT_ALLOW_REPOST`
+- `REDDIT_RELEASE_NOTES_MAX_CHARS`
+- `REDDIT_POST_NSFW`
+- `REDDIT_POST_SPOILER`
+- `REDDIT_POST_SEND_REPLIES`
+
+Template placeholders:
+
+- `{{releaseName}}`
+- `{{releaseTag}}`
+- `{{repo}}`
+- `{{repoName}}`
+- `{{releaseUrl}}`
+- `{{releaseBody}}`
+- `{{marker}}`
+
+The default self-post body includes a hidden marker so reruns can detect duplicates in the subreddit's recent posts.
+
+## GitHub Actions workflow
+
+The workflow runs automatically on `release.published` and can also be triggered manually. Manual runs let you override:
+
+- release tag
+- subreddit
+- post kind
+- dry-run mode
+- duplicate repost behavior
+
+Start with `dry_run: true` until the bot account is approved in your subreddit and the formatting looks right.

--- a/tools/reddit-release-lib.mjs
+++ b/tools/reddit-release-lib.mjs
@@ -1,0 +1,577 @@
+import { readFileSync } from 'node:fs';
+
+const GITHUB_API_BASE_URL = 'https://api.github.com';
+const REDDIT_AUTH_BASE_URL = 'https://www.reddit.com';
+const REDDIT_OAUTH_BASE_URL = 'https://oauth.reddit.com';
+const DEFAULT_RELEASE_NOTES_MAX_CHARS = 8000;
+const DEFAULT_RECENT_POST_LIMIT = 25;
+
+const requiredEnv = (env, key) => {
+  const value = env[key]?.trim();
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+};
+
+const optionalValue = (value) => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const normalized = String(value).trim();
+  return normalized ? normalized : undefined;
+};
+
+const parseBoolean = (value, defaultValue = false) => {
+  if (value === undefined || value === null || value === '') {
+    return defaultValue;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return defaultValue;
+};
+
+const parseInteger = (value, defaultValue) => {
+  if (value === undefined || value === null || value === '') {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+};
+
+const buildUserAgent = (env) => {
+  const explicit = optionalValue(env.REDDIT_USER_AGENT);
+  if (explicit) {
+    return explicit;
+  }
+
+  const username = optionalValue(env.REDDIT_USERNAME) ?? 'maintainerr';
+  const appId = optionalValue(env.REDDIT_APP_ID) ?? 'maintainerr.release-bot';
+  const version = optionalValue(env.REDDIT_APP_VERSION) ?? '0.1.0';
+  const platform = optionalValue(env.REDDIT_APP_PLATFORM) ?? 'script';
+  return `${platform}:${appId}:${version} (by /u/${username})`;
+};
+
+const withRawJson = (url) => {
+  if (!url.searchParams.has('raw_json')) {
+    url.searchParams.set('raw_json', '1');
+  }
+  return url;
+};
+
+const createHeaders = (headers) => {
+  const normalized = new Headers(headers ?? {});
+  if (!normalized.has('accept')) {
+    normalized.set('accept', 'application/json');
+  }
+  return normalized;
+};
+
+const parseJsonResponse = async (response) => {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `Expected JSON response from ${response.url}, received: ${text.slice(0, 400)}`,
+    );
+  }
+};
+
+const getRateLimit = (response) => ({
+  used: response.headers.get('x-ratelimit-used'),
+  remaining: response.headers.get('x-ratelimit-remaining'),
+  resetSeconds: response.headers.get('x-ratelimit-reset'),
+});
+
+const fetchJson = async (url, options = {}) => {
+  const response = await fetch(url, {
+    ...options,
+    headers: createHeaders(options.headers),
+  });
+  const json = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    const details = json ? JSON.stringify(json) : response.statusText;
+    throw new Error(`HTTP ${response.status} from ${url}: ${details}`);
+  }
+
+  return {
+    json,
+    rateLimit: getRateLimit(response),
+  };
+};
+
+const readGithubEventRelease = (eventPath) => {
+  const payload = JSON.parse(readFileSync(eventPath, 'utf8'));
+  return payload.release ?? null;
+};
+
+const getGithubHeaders = (token) => {
+  const headers = {
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+};
+
+const resolveReleaseFromGithub = async ({ repo, tag, token }) => {
+  const releaseUrl = new URL(
+    `${GITHUB_API_BASE_URL}/repos/${repo}/releases/tags/${encodeURIComponent(tag)}`,
+  );
+  const { json } = await fetchJson(releaseUrl, {
+    headers: getGithubHeaders(token),
+  });
+  return json;
+};
+
+const trimReleaseNotes = (body, maxChars) => {
+  const normalized = (body ?? '').trim();
+  if (!normalized) {
+    return 'Release notes were not provided in the GitHub release payload.';
+  }
+
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, maxChars).trimEnd()}\n\n...`; 
+};
+
+const applyTemplate = (template, values) => {
+  let output = template;
+  for (const [key, value] of Object.entries(values)) {
+    output = output.split(`{{${key}}}`).join(value ?? '');
+  }
+  return output;
+};
+
+const getRepoName = (repo) => {
+  const slashIndex = repo.indexOf('/');
+  return slashIndex >= 0 ? repo.slice(slashIndex + 1) : repo;
+};
+
+const createMarker = ({ repo, tag }) => `<!-- release-bot:${repo}:${tag} -->`;
+
+const buildDefaultTitle = ({ release, repo }) => {
+  const repoName = getRepoName(repo);
+  const version = release.name?.trim() || release.tag_name;
+  return `${repoName} ${version} is out`;
+};
+
+const buildDefaultBody = ({ release, repo, marker, maxChars }) => {
+  const repoName = getRepoName(repo);
+  const version = release.name?.trim() || release.tag_name;
+  const notes = trimReleaseNotes(release.body, maxChars);
+
+  return [
+    `${repoName} ${version} has been released.`,
+    '',
+    notes,
+    '',
+    `Release page: ${release.html_url}`,
+    marker,
+  ].join('\n');
+};
+
+const createPostPayload = ({ release, repo, kind, titleTemplate, bodyTemplate, maxChars }) => {
+  const marker = createMarker({ repo, tag: release.tag_name });
+  const values = {
+    releaseName: release.name?.trim() || release.tag_name,
+    releaseTag: release.tag_name,
+    repo,
+    repoName: getRepoName(repo),
+    releaseUrl: release.html_url,
+    releaseBody: trimReleaseNotes(release.body, maxChars),
+    marker,
+  };
+
+  const title = optionalValue(titleTemplate)
+    ? applyTemplate(titleTemplate, values)
+    : buildDefaultTitle({ release, repo });
+
+  const body = kind === 'self'
+    ? optionalValue(bodyTemplate)
+      ? applyTemplate(bodyTemplate, values)
+      : buildDefaultBody({ release, repo, marker, maxChars })
+    : undefined;
+
+  return {
+    kind,
+    title,
+    body,
+    url: kind === 'link' ? release.html_url : undefined,
+    marker,
+  };
+};
+
+const formatRedditJsonErrors = (json) => {
+  const errors = json?.json?.errors;
+  if (!Array.isArray(errors) || errors.length === 0) {
+    return undefined;
+  }
+
+  return errors
+    .map((entry) => {
+      if (!Array.isArray(entry)) {
+        return String(entry);
+      }
+      return entry.filter(Boolean).join(': ');
+    })
+    .join('; ');
+};
+
+const createBasicAuthHeader = (clientId, clientSecret) => {
+  const token = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+  return `Basic ${token}`;
+};
+
+const getScriptCredentials = (env, overrides) => ({
+  clientId: overrides.clientId ?? requiredEnv(env, 'REDDIT_CLIENT_ID'),
+  clientSecret: overrides.clientSecret ?? requiredEnv(env, 'REDDIT_CLIENT_SECRET'),
+  username: overrides.username ?? requiredEnv(env, 'REDDIT_USERNAME'),
+  password: overrides.password ?? requiredEnv(env, 'REDDIT_PASSWORD'),
+  userAgent: overrides.userAgent ?? buildUserAgent(env),
+});
+
+const fetchRedditAccessToken = async (env, overrides = {}) => {
+  const credentials = getScriptCredentials(env, overrides);
+  const body = new URLSearchParams({
+    grant_type: 'password',
+    username: credentials.username,
+    password: credentials.password,
+  });
+
+  const { json, rateLimit } = await fetchJson(`${REDDIT_AUTH_BASE_URL}/api/v1/access_token`, {
+    method: 'POST',
+    headers: {
+      authorization: createBasicAuthHeader(credentials.clientId, credentials.clientSecret),
+      'content-type': 'application/x-www-form-urlencoded',
+      'user-agent': credentials.userAgent,
+    },
+    body,
+  });
+
+  if (!json?.access_token) {
+    throw new Error(`Reddit token response did not include an access token: ${JSON.stringify(json)}`);
+  }
+
+  return {
+    accessToken: json.access_token,
+    rateLimit,
+    userAgent: credentials.userAgent,
+  };
+};
+
+const redditRequest = async ({ path, method = 'GET', token, userAgent, form, query }) => {
+  const url = withRawJson(new URL(`${REDDIT_OAUTH_BASE_URL}${path}`));
+
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined && value !== null && value !== '') {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  const headers = {
+    authorization: `bearer ${token}`,
+    'user-agent': userAgent,
+  };
+
+  const options = {
+    method,
+    headers,
+  };
+
+  if (form) {
+    headers['content-type'] = 'application/x-www-form-urlencoded';
+    options.body = new URLSearchParams(form);
+  }
+
+  return fetchJson(url, options);
+};
+
+const getSubredditDetails = async ({ subreddit, token, userAgent }) => {
+  const { json } = await redditRequest({
+    path: `/r/${encodeURIComponent(subreddit)}/about.json`,
+    token,
+    userAgent,
+  });
+  return json?.data ?? null;
+};
+
+const listRecentPosts = async ({ subreddit, token, userAgent, limit }) => {
+  const { json, rateLimit } = await redditRequest({
+    path: `/r/${encodeURIComponent(subreddit)}/new.json`,
+    token,
+    userAgent,
+    query: { limit },
+  });
+
+  const children = json?.data?.children ?? [];
+  return {
+    posts: children.map((item) => item.data).filter(Boolean),
+    rateLimit,
+  };
+};
+
+const findExistingPost = ({ posts, marker, title, releaseUrl }) => {
+  for (const post of posts) {
+    if (post.selftext?.includes(marker)) {
+      return post;
+    }
+    if (post.url === releaseUrl) {
+      return post;
+    }
+    if (post.title === title) {
+      return post;
+    }
+  }
+
+  return null;
+};
+
+const buildPermalink = (permalink) => {
+  if (!permalink) {
+    return undefined;
+  }
+  return `https://www.reddit.com${permalink}`;
+};
+
+export const resolveRuntimeOptions = ({ env = process.env, overrides = {} } = {}) => {
+  const repo = overrides.repo ?? optionalValue(env.GITHUB_REPOSITORY);
+  const releaseTag =
+    overrides.releaseTag ??
+    optionalValue(env.RELEASE_TAG) ??
+    optionalValue(env.GITHUB_REF_NAME);
+
+  return {
+    repo,
+    releaseTag,
+    subreddit: overrides.subreddit ?? optionalValue(env.REDDIT_SUBREDDIT),
+    kind: overrides.kind ?? optionalValue(env.REDDIT_POST_KIND) ?? 'self',
+    titleTemplate: overrides.titleTemplate ?? env.REDDIT_POST_TITLE_TEMPLATE,
+    bodyTemplate: overrides.bodyTemplate ?? env.REDDIT_POST_BODY_TEMPLATE,
+    dryRun: overrides.dryRun ?? parseBoolean(env.DRY_RUN, false),
+    allowRepost: overrides.allowRepost ?? parseBoolean(env.REDDIT_ALLOW_REPOST, false),
+    maxReleaseNotesChars:
+      overrides.maxReleaseNotesChars ??
+      parseInteger(env.REDDIT_RELEASE_NOTES_MAX_CHARS, DEFAULT_RELEASE_NOTES_MAX_CHARS),
+    flairId: overrides.flairId ?? optionalValue(env.REDDIT_POST_FLAIR_ID),
+    flairText: overrides.flairText ?? optionalValue(env.REDDIT_POST_FLAIR_TEXT),
+    nsfw: overrides.nsfw ?? parseBoolean(env.REDDIT_POST_NSFW, false),
+    spoiler: overrides.spoiler ?? parseBoolean(env.REDDIT_POST_SPOILER, false),
+    sendReplies: overrides.sendReplies ?? parseBoolean(env.REDDIT_POST_SEND_REPLIES, true),
+    recentPostLimit:
+      overrides.recentPostLimit ??
+      parseInteger(env.REDDIT_RECENT_POST_LIMIT, DEFAULT_RECENT_POST_LIMIT),
+    githubToken:
+      overrides.githubToken ?? optionalValue(env.GITHUB_TOKEN) ?? optionalValue(env.GH_TOKEN),
+    eventPath: overrides.eventPath ?? optionalValue(env.GITHUB_EVENT_PATH),
+    env,
+  };
+};
+
+export const resolveRelease = async (options) => {
+  if (options.release && typeof options.release === 'object') {
+    return options.release;
+  }
+
+  if (options.eventPath) {
+    const releaseFromEvent = readGithubEventRelease(options.eventPath);
+    if (releaseFromEvent) {
+      return releaseFromEvent;
+    }
+  }
+
+  if (!options.repo) {
+    throw new Error('Unable to resolve a GitHub release without GITHUB_REPOSITORY or an explicit repo override.');
+  }
+
+  if (!options.releaseTag) {
+    throw new Error('Unable to resolve a GitHub release without RELEASE_TAG, GITHUB_REF_NAME, or a release event payload.');
+  }
+
+  return resolveReleaseFromGithub({
+    repo: options.repo,
+    tag: options.releaseTag,
+    token: options.githubToken,
+  });
+};
+
+export const previewReleasePost = async (overrides = {}) => {
+  const options = resolveRuntimeOptions({ overrides });
+  if (!options.subreddit) {
+    throw new Error('A subreddit is required. Set REDDIT_SUBREDDIT or pass a subreddit override.');
+  }
+
+  if (!['self', 'link'].includes(options.kind)) {
+    throw new Error(`Unsupported REDDIT_POST_KIND: ${options.kind}`);
+  }
+
+  const release = await resolveRelease({ ...options, ...overrides });
+  const redditAuth = await fetchRedditAccessToken(options.env, overrides);
+  const subreddit = await getSubredditDetails({
+    subreddit: options.subreddit,
+    token: redditAuth.accessToken,
+    userAgent: redditAuth.userAgent,
+  });
+
+  const post = createPostPayload({
+    release,
+    repo: options.repo,
+    kind: options.kind,
+    titleTemplate: options.titleTemplate,
+    bodyTemplate: options.bodyTemplate,
+    maxChars: options.maxReleaseNotesChars,
+  });
+
+  const recent = await listRecentPosts({
+    subreddit: options.subreddit,
+    token: redditAuth.accessToken,
+    userAgent: redditAuth.userAgent,
+    limit: options.recentPostLimit,
+  });
+
+  const existingPost = findExistingPost({
+    posts: recent.posts,
+    marker: post.marker,
+    title: post.title,
+    releaseUrl: release.html_url,
+  });
+
+  return {
+    repo: options.repo,
+    subreddit: options.subreddit,
+    release: {
+      tag: release.tag_name,
+      name: release.name,
+      url: release.html_url,
+      prerelease: Boolean(release.prerelease),
+      draft: Boolean(release.draft),
+    },
+    subredditDetails: subreddit
+      ? {
+          title: subreddit.title,
+          subscribers: subreddit.subscribers,
+          over18: subreddit.over18,
+        }
+      : undefined,
+    post,
+    duplicate: existingPost
+      ? {
+          title: existingPost.title,
+          permalink: buildPermalink(existingPost.permalink),
+          createdUtc: existingPost.created_utc,
+        }
+      : null,
+    rateLimit: recent.rateLimit,
+  };
+};
+
+export const submitReleasePost = async (overrides = {}) => {
+  const preview = await previewReleasePost(overrides);
+  const options = resolveRuntimeOptions({ overrides });
+
+  if (preview.duplicate && !options.allowRepost) {
+    return {
+      status: 'skipped',
+      reason: 'duplicate-release-post-detected',
+      preview,
+    };
+  }
+
+  if (options.dryRun) {
+    return {
+      status: 'dry-run',
+      preview,
+    };
+  }
+
+  const redditAuth = await fetchRedditAccessToken(options.env, overrides);
+  const form = {
+    api_type: 'json',
+    kind: preview.post.kind,
+    sr: preview.subreddit,
+    title: preview.post.title,
+    sendreplies: String(Boolean(options.sendReplies)),
+    nsfw: String(Boolean(options.nsfw)),
+    spoiler: String(Boolean(options.spoiler)),
+    resubmit: String(Boolean(options.allowRepost)),
+  };
+
+  if (preview.post.kind === 'self') {
+    form.text = preview.post.body ?? '';
+  }
+
+  if (preview.post.kind === 'link') {
+    form.url = preview.post.url ?? preview.release.url;
+  }
+
+  if (options.flairId) {
+    form.flair_id = options.flairId;
+  }
+
+  if (options.flairText) {
+    form.flair_text = options.flairText;
+  }
+
+  const { json, rateLimit } = await redditRequest({
+    path: '/api/submit',
+    method: 'POST',
+    token: redditAuth.accessToken,
+    userAgent: redditAuth.userAgent,
+    form,
+  });
+
+  const errorText = formatRedditJsonErrors(json);
+  if (errorText) {
+    throw new Error(`Reddit rejected the submission: ${errorText}`);
+  }
+
+  const recent = await listRecentPosts({
+    subreddit: preview.subreddit,
+    token: redditAuth.accessToken,
+    userAgent: redditAuth.userAgent,
+    limit: options.recentPostLimit,
+  });
+
+  const submittedPost = findExistingPost({
+    posts: recent.posts,
+    marker: preview.post.marker,
+    title: preview.post.title,
+    releaseUrl: preview.release.url,
+  });
+
+  return {
+    status: 'posted',
+    preview,
+    submittedPost: submittedPost
+      ? {
+          title: submittedPost.title,
+          permalink: buildPermalink(submittedPost.permalink),
+          id: submittedPost.id,
+        }
+      : undefined,
+    rateLimit,
+  };
+};

--- a/tools/reddit-release-post.mjs
+++ b/tools/reddit-release-post.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { previewReleasePost, submitReleasePost } from './reddit-release-lib.mjs';
+
+const HELP_TEXT = `Usage: node tools/reddit-release-post.mjs [options]
+
+Options:
+  --dry-run                 Build and validate the release post without submitting it
+  --release-tag <tag>       GitHub release tag to post
+  --repo <owner/name>       GitHub repository, defaults to GITHUB_REPOSITORY
+  --subreddit <name>        Target subreddit, defaults to REDDIT_SUBREDDIT
+  --kind <self|link>        Submit a self post or link post
+  --title-template <text>   Title template with {{releaseTag}}, {{repoName}}, {{releaseUrl}}
+  --body-template <text>    Body template with {{releaseBody}}, {{marker}}, {{releaseUrl}}
+  --allow-repost            Allow reposting when a matching recent post already exists
+  --help                    Show this message
+`;
+
+const parseArgs = (argv) => {
+  const args = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const key = token.slice(2);
+    if (['dry-run', 'allow-repost', 'help'].includes(key)) {
+      args[key] = true;
+      continue;
+    }
+
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    args[key] = value;
+    index += 1;
+  }
+
+  return args;
+};
+
+const mapArgsToOverrides = (args) => ({
+  repo: args.repo,
+  releaseTag: args['release-tag'],
+  subreddit: args.subreddit,
+  kind: args.kind,
+  titleTemplate: args['title-template'],
+  bodyTemplate: args['body-template'],
+  dryRun: args['dry-run'],
+  allowRepost: args['allow-repost'],
+});
+
+const main = async () => {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(HELP_TEXT);
+    return;
+  }
+
+  const overrides = mapArgsToOverrides(args);
+  const result = args['dry-run'] ? await previewReleasePost(overrides) : await submitReleasePost(overrides);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+};
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow for posting new releases to Reddit, along with the minimal Node scripts and setup guide needed to run it.

## What changed
- add `.github/workflows/reddit_release_post.yml` to run on `release.published` or manually
- add `tools/reddit-release-post.mjs` and `tools/reddit-release-lib.mjs` for release lookup, duplicate detection, and Reddit submission
- add `docs/reddit-release-bot.md` with account, subreddit, app, GitHub secret, and dry-run setup steps

## Notes
- scoped to the workflow-only path; no MCP/local server surface is included
- intended to be configured first with `dry_run: true` before enabling live posting