### PR TITLE
fix(plex): bound request timeout and surface watch-history errors

### DIFF
--- a/apps/server/src/modules/api/lib/plexApi.spec.ts
+++ b/apps/server/src/modules/api/lib/plexApi.spec.ts
@@ -46,4 +46,17 @@ describe('PlexApi', () => {
     expect(headers['X-Plex-Client-Identifier']).toBeUndefined();
     expect(axiosRetry).toHaveBeenCalledTimes(1);
   });
+
+  it('forwards the configured timeout to axios so wedged Plex sockets cannot stall callers indefinitely', () => {
+    new PlexApi({
+      hostname: 'plex.local',
+      port: 32400,
+      token: 'token',
+      timeout: 30000,
+    });
+
+    expect(axios.create).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 30000 }),
+    );
+  });
 });

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -384,10 +384,17 @@ describe('PlexAdapterService', () => {
   });
 
   describe('getWatchHistory', () => {
-    it('should return empty array when PlexApiService returns undefined', async () => {
-      plexApi.getWatchHistory.mockResolvedValue(undefined);
+    it('should return empty array when Plex returned no history entries', async () => {
+      plexApi.getWatchHistory.mockResolvedValue([]);
       const history = await service.getWatchHistory('item123');
       expect(history).toEqual([]);
+    });
+
+    it('should propagate errors so callers can distinguish a real outage from a confirmed empty history', async () => {
+      plexApi.getWatchHistory.mockRejectedValue(new Error('plex unreachable'));
+      await expect(service.getWatchHistory('item123')).rejects.toThrow(
+        'plex unreachable',
+      );
     });
 
     it('should map Plex watch history to WatchRecord array', async () => {

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -219,7 +219,6 @@ export class PlexAdapterService implements IMediaServerService {
 
   async getWatchHistory(itemId: string): Promise<WatchRecord[]> {
     const history = await this.plexApi.getWatchHistory(itemId);
-    if (!history) return [];
     return history.map(PlexMapper.toWatchRecord);
   }
 
@@ -230,7 +229,7 @@ export class PlexAdapterService implements IMediaServerService {
   ): Promise<MediaWatchState> {
     const history = await this.plexApi.getWatchHistory(itemId, false);
 
-    if (history && history.length > 0) {
+    if (history.length > 0) {
       return {
         viewCount: history.length,
         isWatched: true,

--- a/apps/server/src/modules/api/plex-api/plex-api.constants.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.constants.ts
@@ -2,3 +2,8 @@ export const PLEX_PAGE_SIZE = {
   DEFAULT: 50,
   WATCHLIST: 100,
 } as const;
+
+// Bounds runtime Plex socket reads so a wedged request can't stall the rule
+// executor indefinitely. Connection probes use the shorter
+// CONNECTION_TEST_TIMEOUT_MS; this applies to the long-lived runtime client.
+export const PLEX_REQUEST_TIMEOUT_MS = 30_000;

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -49,7 +49,7 @@ import {
   PlexDevice,
   PlexStatusResponse,
 } from './interfaces/server.interface';
-import { PLEX_PAGE_SIZE } from './plex-api.constants';
+import { PLEX_PAGE_SIZE, PLEX_REQUEST_TIMEOUT_MS } from './plex-api.constants';
 
 type PlexApiSettings = SettingsService &
   Pick<
@@ -236,6 +236,7 @@ export class PlexApiService {
         port: settingsPlex.port,
         https: settingsPlex.useSsl,
         token: plexToken,
+        timeout: PLEX_REQUEST_TIMEOUT_MS,
       });
 
       const machineId = await this.setMachineId();
@@ -323,6 +324,7 @@ export class PlexApiService {
           port: conn.port,
           https: conn.protocol === 'https',
           token: plexToken,
+          timeout: PLEX_REQUEST_TIMEOUT_MS,
         });
 
         await this.settings.updatePlexConnectionDetails({
@@ -729,22 +731,19 @@ export class PlexApiService {
     itemId: string,
     useCache: boolean = true,
   ): Promise<PlexSeenBy[]> {
-    try {
-      const response: PlexLibraryResponse =
-        await this.plexClient.queryAll<PlexLibraryResponse>(
-          {
-            uri: `/status/sessions/history/all?sort=viewedAt:desc&metadataItemID=${itemId}`,
-          },
-          useCache,
-        );
-      return response.MediaContainer.Metadata as PlexSeenBy[];
-    } catch (error) {
-      this.logger.error(
-        'Plex api communication failure.. Is the application running?',
+    // Errors must propagate so callers can distinguish a real outage from a
+    // confirmed empty history. Returning [] (or undefined) here would
+    // misclassify failures as "never watched", which leaks into NOT_EXISTS
+    // checks and missing-value diagnostics in the rules layer. Mirrors the
+    // Jellyfin adapter's getWatchHistory contract.
+    const response: PlexLibraryResponse =
+      await this.plexClient.queryAll<PlexLibraryResponse>(
+        {
+          uri: `/status/sessions/history/all?sort=viewedAt:desc&metadataItemID=${itemId}`,
+        },
+        useCache,
       );
-      this.logger.debug(error);
-      return undefined;
-    }
+    return (response?.MediaContainer?.Metadata as PlexSeenBy[]) ?? [];
   }
 
   public async getCollections(

--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -6,6 +6,7 @@ import { PlexMetadata } from '../../api/plex-api/interfaces/media.interface';
 import { PlexApiService } from '../../api/plex-api/plex-api.service';
 import { PlexGetterService } from './plex-getter.service';
 
+const SEEN_BY_PROP_ID = 1;
 const VIEWCOUNT_PROP_ID = 5;
 const ISWATCHED_PROP_ID = 43;
 const PLEX_ITEM_ID = 'plex-item-123';
@@ -285,6 +286,57 @@ describe('PlexGetterService', () => {
       expect(result).toEqual(new Date(1_690_000_000 * 1000));
       expect(plexApi.getCollectionChildren).toHaveBeenCalledTimes(1);
       expect(plexApi.getCollectionChildren).toHaveBeenCalledWith('coll-1');
+    });
+  });
+
+  describe('seenBy (id 1)', () => {
+    it('maps watch-history account ids to known Plex usernames', async () => {
+      plexApi.getMetadata.mockResolvedValue(makeMetadata());
+      plexApi.getCorrectedUsers.mockResolvedValue([
+        { plexId: 1, username: 'alice' },
+        { plexId: 2, username: 'bob' },
+      ] as never);
+      plexApi.getWatchHistory.mockResolvedValue([
+        { accountID: '1' },
+        { accountID: '2' },
+      ] as never);
+
+      const result = await service.get(
+        SEEN_BY_PROP_ID,
+        createMediaItem({ type: 'movie' }),
+      );
+
+      expect(result).toEqual(['alice', 'bob']);
+    });
+
+    it('returns [] for confirmed-empty history (no one has watched the item)', async () => {
+      plexApi.getMetadata.mockResolvedValue(makeMetadata());
+      plexApi.getCorrectedUsers.mockResolvedValue([
+        { plexId: 1, username: 'alice' },
+      ] as never);
+      plexApi.getWatchHistory.mockResolvedValue([]);
+
+      const result = await service.get(
+        SEEN_BY_PROP_ID,
+        createMediaItem({ type: 'movie' }),
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns undefined when watch-history lookup fails so the comparator skips the item rather than misclassifying it as "viewed by no one"', async () => {
+      plexApi.getMetadata.mockResolvedValue(makeMetadata());
+      plexApi.getCorrectedUsers.mockResolvedValue([
+        { plexId: 1, username: 'alice' },
+      ] as never);
+      plexApi.getWatchHistory.mockRejectedValue(new Error('plex unreachable'));
+
+      const result = await service.get(
+        SEEN_BY_PROP_ID,
+        createMediaItem({ type: 'movie' }),
+      );
+
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -4,10 +4,7 @@ import {
   RuleValueType,
 } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
-import {
-  PlexSeenBy,
-  SimplePlexUser,
-} from '../../..//modules/api/plex-api/interfaces/library.interfaces';
+import { SimplePlexUser } from '../../..//modules/api/plex-api/interfaces/library.interfaces';
 import { PlexApiService } from '../../../modules/api/plex-api/plex-api.service';
 import { PlexAdapterService } from '../../api/media-server/plex/plex-adapter.service';
 import { PlexMetadata } from '../../api/plex-api/interfaces/media.interface';
@@ -80,21 +77,17 @@ export class PlexGetterService {
           return metadata.addedAt ? new Date(+metadata.addedAt * 1000) : null;
         }
         case 'seenBy': {
+          // Errors must surface so the outer catch returns `undefined` for an
+          // unknown viewer set instead of collapsing the failure into a
+          // confirmed empty `[]`. Same contract as `lastViewedAt` (id 7).
           const plexUsers = await this.plexApi.getCorrectedUsers(false);
-
-          const viewers: PlexSeenBy[] = await this.plexApi
-            .getWatchHistory(metadata.ratingKey)
-            .catch(() => {
-              return null;
-            });
-          if (viewers) {
-            const viewerIds = viewers.map((el) => +el.accountID);
-            return plexUsers
-              .filter((el) => viewerIds.includes(el.plexId))
-              .map((el) => el.username);
-          } else {
-            return [];
-          }
+          const viewers = await this.plexApi.getWatchHistory(
+            metadata.ratingKey,
+          );
+          const viewerIds = viewers.map((el) => +el.accountID);
+          return plexUsers
+            .filter((el) => viewerIds.includes(el.plexId))
+            .map((el) => el.username);
         }
         case 'releaseDate': {
           return new Date(metadata.originallyAvailableAt)
@@ -297,11 +290,12 @@ export class PlexGetterService {
               season.ratingKey,
             );
             for (const episode of episodes) {
-              const viewers: PlexSeenBy[] = await this.plexApi
-                .getWatchHistory(episode.ratingKey)
-                .catch(() => {
-                  return null;
-                });
+              // Errors propagate to the outer catch — silently treating a
+              // failed lookup as "no viewers" would drop genuine viewers from
+              // `allViewers` and mark the show as unwatched-by-everyone.
+              const viewers = await this.plexApi.getWatchHistory(
+                episode.ratingKey,
+              );
 
               const arrLength = allViewers.length - 1;
               allViewers
@@ -309,7 +303,6 @@ export class PlexGetterService {
                 .reverse()
                 .forEach((el, idx) => {
                   if (
-                    !viewers ||
                     !viewers.find((viewEl) => el.plexId === viewEl.accountID)
                   ) {
                     allViewers.splice(arrLength - idx, 1);
@@ -813,10 +806,12 @@ export class PlexGetterService {
               coll.ratingKey,
             );
             for (const child of children ?? []) {
-              const history = await this.plexApi
-                .getWatchHistory(child.ratingKey)
-                .catch(() => null);
-              if (!history) continue;
+              // Errors propagate to the outer catch so a transient lookup
+              // failure doesn't silently understate `latest` and trigger a
+              // false delete on a recently-watched sibling collection.
+              const history = await this.plexApi.getWatchHistory(
+                child.ratingKey,
+              );
               for (const entry of history) {
                 if (entry.viewedAt && +entry.viewedAt > latest) {
                   latest = +entry.viewedAt;


### PR DESCRIPTION
## Summary

- Adds `PLEX_REQUEST_TIMEOUT_MS` (30s) to the runtime PlexApi client. Previously had no socket timeout, so a wedged Plex request could hang the rule executor forever ([#2771](https://github.com/Maintainerr/Maintainerr/issues/2771)).
- Aligns `plexApi.getWatchHistory` with the Jellyfin adapter's contract: errors propagate so callers can distinguish a real outage from a confirmed empty history. Removes silent `.catch(() => null)` swallowers in `seenBy`, `sw_allEpisodesSeenBy`, and `collection_siblings_lastViewedAt` that previously turned transient lookup failures into "viewed by no one" — leaking into `NOT_EXISTS` checks and missing-value diagnostics.

Refs #2771