### PR TITLE
fix(ui): unblock tsc and fix the type errors it was hiding

### DIFF
--- a/apps/ui/src/components/Collection/CollectionDetail/CollectionInfo/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/CollectionInfo/index.tsx
@@ -4,13 +4,10 @@ import {
   SortAscendingIcon,
   SortDescendingIcon,
 } from '@heroicons/react/outline'
-import { DocumentTextIcon } from '@heroicons/react/solid'
 import {
-  CollectionLogDto,
   CollectionLogMetaMediaAddedByRule,
   CollectionLogMetaMediaRemovedByRule,
   ECollectionLogType,
-  isMetaActionedByRule,
 } from '@maintainerr/contracts'
 import { useRef, useState } from 'react'
 import YAML from 'yaml'

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.spec.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.spec.tsx
@@ -16,7 +16,7 @@ describe('ArrAction', () => {
     useServarrSettingsMock.mockReturnValue({
       data: [],
       isLoading: false,
-    } as ReturnType<typeof useServarrSettings>)
+    } as unknown as ReturnType<typeof useServarrSettings>)
   })
 
   afterEach(() => {
@@ -30,7 +30,7 @@ describe('ArrAction', () => {
       data: undefined,
       isLoading: true,
       isFetching: true,
-    } as ReturnType<typeof useServarrSettings>)
+    } as unknown as ReturnType<typeof useServarrSettings>)
 
     render(
       <ArrAction
@@ -60,7 +60,7 @@ describe('ArrAction', () => {
       data: [],
       isLoading: false,
       isFetching: false,
-    } as ReturnType<typeof useServarrSettings>)
+    } as unknown as ReturnType<typeof useServarrSettings>)
 
     render(
       <ArrAction

--- a/apps/ui/src/pages/CollectionMediaPage.spec.tsx
+++ b/apps/ui/src/pages/CollectionMediaPage.spec.tsx
@@ -7,6 +7,11 @@ describe('CollectionMediaPage', () => {
       id: 'episode-1',
       title: 'Episode 1',
       type: 'episode' as const,
+      guid: 'test-guid-1',
+      addedAt: new Date('2026-04-20T00:00:00.000Z'),
+      providerIds: {},
+      mediaSources: [],
+      library: { id: 'lib-1', title: 'Test Library' },
       maintainerrIsManual: false,
     }
 

--- a/apps/ui/src/pages/CollectionsListPage.spec.tsx
+++ b/apps/ui/src/pages/CollectionsListPage.spec.tsx
@@ -81,7 +81,7 @@ describe('CollectionsListPage', () => {
     useCollectionsMock.mockReset()
     useQueryClientMock.mockReturnValue({
       fetchQuery,
-    } as ReturnType<typeof useQueryClient>)
+    } as unknown as ReturnType<typeof useQueryClient>)
 
     useCollectionsMock.mockReturnValue({
       data: [

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
## Summary

- `apps/ui/tsconfig.json` had `ignoreDeprecations: "6.0"`, which is invalid for TypeScript 5.x. tsc was bailing before type-checking, so CI exited 0 while never scanning a file — hiding 8 real errors.
- Removed the invalid option (no deprecated options remain in this tsconfig that need silencing).
- Removed 3 unused imports in `CollectionInfo/index.tsx`.
- Added the missing `MediaItem` fields (`guid`, `addedAt`, `providerIds`, `mediaSources`, `library`) to the `CollectionMediaPage` test fixture.
- Updated the `UseQueryResult` / `QueryClient` mock casts in two specs to use the project's existing `as unknown as ...` double-cast pattern (matches 12 other specs).

A follow-up issue is being filed to consider replacing the partial-cast spec mock convention with fully-typed mock helpers — separate decision, not in scope here.