### PR TITLE
Fix overlay SSE EPIPE handling

### DIFF
--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -1580,25 +1580,15 @@ export class PlexApiService {
       ':' +
       settings.port;
 
-    try {
-      await axios.post(
-        `${baseUrl}/library/metadata/${plexId}/posters`,
-        buffer,
-        {
-          headers: {
-            'X-Plex-Token': settings.auth_token,
-            'Content-Type': contentType,
-          },
-          maxBodyLength: Infinity,
-          maxContentLength: Infinity,
-          timeout: 120000,
-        },
-      );
-    } catch (error) {
-      this.logger.warn(`Failed to upload Plex poster for item ${plexId}`, error);
-      this.logger.debug(error);
-      throw error;
-    }
+    await axios.post(`${baseUrl}/library/metadata/${plexId}/posters`, buffer, {
+      headers: {
+        'X-Plex-Token': settings.auth_token,
+        'Content-Type': contentType,
+      },
+      maxBodyLength: Infinity,
+      maxContentLength: Infinity,
+      timeout: 120000,
+    });
   }
 
   /**
@@ -1622,9 +1612,9 @@ export class PlexApiService {
         timeout: 30000,
       });
       return true;
-    } catch (err) {
-      this.logger.warn(`Failed to select poster ${uploadId} for ${plexId}`, err);
-      this.logger.debug(err);
+    } catch (error) {
+      this.logger.warn(`Failed to select poster ${uploadId} for ${plexId}`);
+      this.logger.debug(error);
       return false;
     }
   }

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -1580,15 +1580,25 @@ export class PlexApiService {
       ':' +
       settings.port;
 
-    await axios.post(`${baseUrl}/library/metadata/${plexId}/posters`, buffer, {
-      headers: {
-        'X-Plex-Token': settings.auth_token,
-        'Content-Type': contentType,
-      },
-      maxBodyLength: Infinity,
-      maxContentLength: Infinity,
-      timeout: 120000,
-    });
+    try {
+      await axios.post(
+        `${baseUrl}/library/metadata/${plexId}/posters`,
+        buffer,
+        {
+          headers: {
+            'X-Plex-Token': settings.auth_token,
+            'Content-Type': contentType,
+          },
+          maxBodyLength: Infinity,
+          maxContentLength: Infinity,
+          timeout: 120000,
+        },
+      );
+    } catch (error) {
+      this.logger.warn(`Failed to upload Plex poster for item ${plexId}`, error);
+      this.logger.debug(error);
+      throw error;
+    }
   }
 
   /**
@@ -1613,7 +1623,7 @@ export class PlexApiService {
       });
       return true;
     } catch (err) {
-      this.logger.warn(`Failed to select poster ${uploadId} for ${plexId}`);
+      this.logger.warn(`Failed to select poster ${uploadId} for ${plexId}`, err);
       this.logger.debug(err);
       return false;
     }

--- a/apps/server/src/modules/events/events.controller.spec.ts
+++ b/apps/server/src/modules/events/events.controller.spec.ts
@@ -1,0 +1,74 @@
+import { MessageEvent as NestMessageEvent, RawBodyRequest } from '@nestjs/common';
+import { Response } from 'express';
+import { EventEmitter } from 'events';
+import { IncomingMessage } from 'http';
+import { EventsBufferService } from './events-buffer.service';
+import { EventsController } from './events.controller';
+
+class MockSocket extends EventEmitter {
+  setKeepAlive = jest.fn();
+  setNoDelay = jest.fn();
+  setTimeout = jest.fn();
+}
+
+class MockResponse extends EventEmitter {
+  destroyed = false;
+  socket = new MockSocket();
+  writableEnded = false;
+
+  end = jest.fn(() => {
+    this.writableEnded = true;
+  });
+
+  flushHeaders = jest.fn();
+  set = jest.fn();
+  write = jest.fn(
+    (_chunk: string, callback?: (error?: Error | null) => void) => {
+      callback?.(null);
+      return true;
+    },
+  );
+}
+
+const buildRequest = (): RawBodyRequest<IncomingMessage> =>
+  ({
+    headers: {},
+    socket: new MockSocket(),
+  }) as unknown as RawBodyRequest<IncomingMessage>;
+
+describe('EventsController', () => {
+  it('removes SSE clients when writing to a closed stream fails', async () => {
+    const eventsBufferService = {
+      parseLastEventId: jest.fn().mockReturnValue(undefined),
+      getEventsAfter: jest.fn().mockReturnValue([]),
+      buildBufferedEvent: jest
+        .fn()
+        .mockImplementation(
+          (message: Omit<NestMessageEvent, 'id'>): NestMessageEvent => ({
+            ...message,
+            id: '1',
+          }),
+        ),
+    } as unknown as jest.Mocked<EventsBufferService>;
+    const controller = new EventsController(eventsBufferService);
+    const response = new MockResponse();
+
+    await controller.stream(response as unknown as Response, buildRequest());
+
+    const clientId = [...controller.connectedClients.keys()][0];
+    const epipeError = Object.assign(new Error('write EPIPE'), {
+      code: 'EPIPE',
+    });
+    response.write.mockImplementationOnce(() => {
+      throw epipeError;
+    });
+
+    expect(() =>
+      controller.sendDataToClient(clientId, {
+        type: 'test.event',
+        data: { ok: true },
+      }),
+    ).not.toThrow();
+    expect(controller.connectedClients.size).toBe(0);
+  });
+});

--- a/apps/server/src/modules/events/events.controller.spec.ts
+++ b/apps/server/src/modules/events/events.controller.spec.ts
@@ -1,7 +1,11 @@
-import { MessageEvent as NestMessageEvent, RawBodyRequest } from '@nestjs/common';
+import {
+  MessageEvent as NestMessageEvent,
+  RawBodyRequest,
+} from '@nestjs/common';
 import { Response } from 'express';
 import { EventEmitter } from 'events';
 import { IncomingMessage } from 'http';
+import { createMockLogger } from '../../../test/utils/data';
 import { EventsBufferService } from './events-buffer.service';
 import { EventsController } from './events.controller';
 
@@ -41,16 +45,17 @@ describe('EventsController', () => {
     const eventsBufferService = {
       parseLastEventId: jest.fn().mockReturnValue(undefined),
       getEventsAfter: jest.fn().mockReturnValue([]),
-      buildBufferedEvent: jest
-        .fn()
-        .mockImplementation(
-          (message: Omit<NestMessageEvent, 'id'>): NestMessageEvent => ({
-            ...message,
-            id: '1',
-          }),
-        ),
+      buildBufferedEvent: jest.fn().mockImplementation(
+        (message: Omit<NestMessageEvent, 'id'>): NestMessageEvent => ({
+          ...message,
+          id: '1',
+        }),
+      ),
     } as unknown as jest.Mocked<EventsBufferService>;
-    const controller = new EventsController(eventsBufferService);
+    const controller = new EventsController(
+      eventsBufferService,
+      createMockLogger(),
+    );
     const response = new MockResponse();
 
     await controller.stream(response as unknown as Response, buildRequest());

--- a/apps/server/src/modules/events/events.controller.ts
+++ b/apps/server/src/modules/events/events.controller.ts
@@ -21,7 +21,11 @@ import {
 import { OnEvent } from '@nestjs/event-emitter';
 import { Response } from 'express';
 import { IncomingMessage } from 'http';
-import { interval, map, Subject } from 'rxjs';
+import { interval, Subscription } from 'rxjs';
+import {
+  createSseStreamClient,
+  SseStreamClient,
+} from '../../utils/sse-stream';
 import { EventsBufferService } from './events-buffer.service';
 
 @Controller('/api/events')
@@ -31,7 +35,7 @@ export class EventsController implements BeforeApplicationShutdown {
 
   connectedClients = new Map<
     string,
-    { close: () => void; subject: Subject<NestMessageEvent> }
+    SseStreamClient
   >();
 
   async beforeApplicationShutdown() {
@@ -54,39 +58,6 @@ export class EventsController implements BeforeApplicationShutdown {
       request.socket.setTimeout(0);
     }
 
-    const subject = new Subject<NestMessageEvent>();
-    const observer = {
-      next: (msg: NestMessageEvent) => {
-        if (msg.type) response.write(`event: ${msg.type}\n`);
-        if (msg.id) response.write(`id: ${msg.id}\n`);
-        if (msg.retry) response.write(`retry: ${msg.retry}\n`);
-
-        response.write(`data: ${JSON.stringify(msg.data)}\n\n`);
-      },
-    };
-
-    subject.subscribe(observer);
-
-    const clientKey = String(Math.random());
-    this.connectedClients.set(clientKey, {
-      close: () => {
-        response.end();
-      },
-      subject,
-    });
-
-    // Send data to the client every 30s to keep the connection alive
-    const pingSubscription = interval(30 * 1000)
-      .pipe(map(() => response.write(': ping\n\n')))
-      .subscribe();
-
-    response.on('close', () => {
-      subject.complete();
-      pingSubscription.unsubscribe();
-      this.connectedClients.delete(clientKey);
-      response.end();
-    });
-
     response.set({
       'Cache-Control':
         'private, no-cache, no-store, must-revalidate, max-age=0, no-transform',
@@ -95,7 +66,27 @@ export class EventsController implements BeforeApplicationShutdown {
     });
 
     response.flushHeaders();
-    response.write('\n');
+
+    const clientKey = String(Math.random());
+    const subscriptions: { ping?: Subscription } = {};
+    const client = createSseStreamClient({
+      response,
+      onClose: () => {
+        subscriptions.ping?.unsubscribe();
+        this.connectedClients.delete(clientKey);
+      },
+    });
+
+    this.connectedClients.set(clientKey, client);
+
+    // Send data to the client every 30s to keep the connection alive.
+    subscriptions.ping = interval(30 * 1000).subscribe(() => {
+      client.writeRaw(': ping\n\n');
+    });
+
+    if (!client.writeRaw('\n')) {
+      return;
+    }
 
     const bufferedEvents = this.eventsBufferService.getEventsAfter(lastEventId);
 

--- a/apps/server/src/modules/events/events.controller.ts
+++ b/apps/server/src/modules/events/events.controller.ts
@@ -22,21 +22,21 @@ import { OnEvent } from '@nestjs/event-emitter';
 import { Response } from 'express';
 import { IncomingMessage } from 'http';
 import { interval, Subscription } from 'rxjs';
-import {
-  createSseStreamClient,
-  SseStreamClient,
-} from '../../utils/sse-stream';
+import { createSseStreamClient, SseStreamClient } from '../../utils/sse-stream';
+import { MaintainerrLogger } from '../logging/logs.service';
 import { EventsBufferService } from './events-buffer.service';
 
 @Controller('/api/events')
 export class EventsController implements BeforeApplicationShutdown {
   private mostRecentEvent: NestMessageEvent | null = null;
-  constructor(private readonly eventsBufferService: EventsBufferService) {}
+  constructor(
+    private readonly eventsBufferService: EventsBufferService,
+    private readonly logger: MaintainerrLogger,
+  ) {
+    this.logger.setContext(EventsController.name);
+  }
 
-  connectedClients = new Map<
-    string,
-    SseStreamClient
-  >();
+  connectedClients = new Map<string, SseStreamClient>();
 
   async beforeApplicationShutdown() {
     for (const [, client] of this.connectedClients) {
@@ -75,18 +75,21 @@ export class EventsController implements BeforeApplicationShutdown {
         subscriptions.ping?.unsubscribe();
         this.connectedClients.delete(clientKey);
       },
+      onError: (error) => {
+        this.logger.debug(error);
+      },
     });
 
     this.connectedClients.set(clientKey, client);
+
+    if (!client.writeRaw('\n')) {
+      return;
+    }
 
     // Send data to the client every 30s to keep the connection alive.
     subscriptions.ping = interval(30 * 1000).subscribe(() => {
       client.writeRaw(': ping\n\n');
     });
-
-    if (!client.writeRaw('\n')) {
-      return;
-    }
 
     const bufferedEvents = this.eventsBufferService.getEventsAfter(lastEventId);
 
@@ -128,13 +131,13 @@ export class EventsController implements BeforeApplicationShutdown {
     });
 
     for (const [, client] of this.connectedClients) {
-      client.subject.next(eventMessage);
+      client.send(eventMessage);
     }
 
     this.mostRecentEvent = eventMessage;
   }
 
   sendDataToClient(clientId: string, message: NestMessageEvent) {
-    this.connectedClients.get(clientId)?.subject.next(message);
+    this.connectedClients.get(clientId)?.send(message);
   }
 }

--- a/apps/server/src/modules/logging/logs.controller.spec.ts
+++ b/apps/server/src/modules/logging/logs.controller.spec.ts
@@ -1,0 +1,75 @@
+import {
+  MessageEvent as NestMessageEvent,
+  RawBodyRequest,
+} from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Response } from 'express';
+import { EventEmitter } from 'events';
+import { IncomingMessage } from 'http';
+import { createMockLogger } from '../../../test/utils/data';
+import { LogSettingsService } from './logs.service';
+import { LogsController } from './logs.controller';
+
+class MockSocket extends EventEmitter {
+  setKeepAlive = jest.fn();
+  setNoDelay = jest.fn();
+  setTimeout = jest.fn();
+}
+
+class MockResponse extends EventEmitter {
+  destroyed = false;
+  socket = new MockSocket();
+  writableEnded = false;
+
+  end = jest.fn(() => {
+    this.writableEnded = true;
+  });
+
+  flushHeaders = jest.fn();
+  set = jest.fn();
+  write = jest.fn(
+    (_chunk: string, callback?: (error?: Error | null) => void) => {
+      callback?.(null);
+      return true;
+    },
+  );
+}
+
+const buildRequest = (): RawBodyRequest<IncomingMessage> =>
+  ({
+    socket: new MockSocket(),
+  }) as unknown as RawBodyRequest<IncomingMessage>;
+
+describe('LogsController', () => {
+  it('removes SSE clients when writing a log event to a closed stream fails', async () => {
+    const eventEmitter = new EventEmitter2();
+    const controller = new LogsController(
+      {} as unknown as LogSettingsService,
+      eventEmitter,
+      createMockLogger(),
+    );
+    const response = new MockResponse();
+
+    await controller.stream(response as unknown as Response, buildRequest());
+
+    const epipeError = Object.assign(new Error('write EPIPE'), {
+      code: 'EPIPE',
+    });
+    response.write.mockImplementationOnce(() => {
+      throw epipeError;
+    });
+
+    const clientId = [...controller.connectedClients.keys()][0];
+    const message: NestMessageEvent = {
+      type: 'log',
+      data: {
+        date: new Date('2026-04-27T00:01:28.000Z'),
+        level: 'INFO',
+        message: 'Overlay processor started',
+      },
+    };
+
+    expect(() => controller.sendDataToClient(clientId, message)).not.toThrow();
+    expect(controller.connectedClients.size).toBe(0);
+  });
+});

--- a/apps/server/src/modules/logging/logs.controller.ts
+++ b/apps/server/src/modules/logging/logs.controller.ts
@@ -42,10 +42,7 @@ import {
   switchMap,
 } from 'rxjs';
 import { Readable } from 'stream';
-import {
-  createSseStreamClient,
-  SseStreamClient,
-} from '../../utils/sse-stream';
+import { createSseStreamClient, SseStreamClient } from '../../utils/sse-stream';
 import { formatLogMessage } from './logFormatting';
 import { LogSettingsService, MaintainerrLogger } from './logs.service';
 
@@ -66,10 +63,7 @@ export class LogsController implements BeforeApplicationShutdown {
     this.logger.setContext(LogsController.name);
   }
 
-  connectedClients = new Map<
-    string,
-    SseStreamClient
-  >();
+  connectedClients = new Map<string, SseStreamClient>();
 
   async beforeApplicationShutdown() {
     for (const [, client] of this.connectedClients) {
@@ -109,6 +103,9 @@ export class LogsController implements BeforeApplicationShutdown {
         subscriptions.ping?.unsubscribe();
         subscriptions.logEvents?.unsubscribe();
         this.connectedClients.delete(clientKey);
+      },
+      onError: (error) => {
+        this.logger.debug(error);
       },
     });
 
@@ -244,7 +241,7 @@ export class LogsController implements BeforeApplicationShutdown {
   }
 
   sendDataToClient(clientId: string, message: NestMessageEvent) {
-    this.connectedClients.get(clientId)?.subject.next(message);
+    this.connectedClients.get(clientId)?.send(message);
   }
 
   @Get('files')

--- a/apps/server/src/modules/logging/logs.controller.ts
+++ b/apps/server/src/modules/logging/logs.controller.ts
@@ -38,10 +38,14 @@ import {
   map,
   mergeMap,
   of,
-  Subject,
+  Subscription,
   switchMap,
 } from 'rxjs';
 import { Readable } from 'stream';
+import {
+  createSseStreamClient,
+  SseStreamClient,
+} from '../../utils/sse-stream';
 import { formatLogMessage } from './logFormatting';
 import { LogSettingsService, MaintainerrLogger } from './logs.service';
 
@@ -64,7 +68,7 @@ export class LogsController implements BeforeApplicationShutdown {
 
   connectedClients = new Map<
     string,
-    { close: () => void; subject: Subject<NestMessageEvent> }
+    SseStreamClient
   >();
 
   async beforeApplicationShutdown() {
@@ -85,36 +89,6 @@ export class LogsController implements BeforeApplicationShutdown {
       request.socket.setTimeout(0);
     }
 
-    const subject = new Subject<NestMessageEvent>();
-
-    const observer = {
-      next: (msg: NestMessageEvent) => {
-        if (msg.type) response.write(`event: ${msg.type}\n`);
-        if (msg.id) response.write(`id: ${msg.id}\n`);
-        if (msg.retry) response.write(`retry: ${msg.retry}\n`);
-
-        response.write(`data: ${JSON.stringify(msg.data)}\n\n`);
-      },
-    };
-
-    subject.subscribe(observer);
-
-    const clientKey = String(Math.random());
-    this.connectedClients.set(clientKey, {
-      close: () => {
-        response.end();
-      },
-      subject,
-    });
-
-    response.on('close', () => {
-      subject.complete();
-      pingSubscription.unsubscribe();
-      logEventStreamSubscription.unsubscribe();
-      this.connectedClients.delete(clientKey);
-      response.end();
-    });
-
     response.set({
       'Cache-Control':
         'private, no-cache, no-store, must-revalidate, max-age=0, no-transform',
@@ -123,7 +97,25 @@ export class LogsController implements BeforeApplicationShutdown {
     });
 
     response.flushHeaders();
-    response.write('\n');
+
+    const clientKey = String(Math.random());
+    const subscriptions: {
+      ping?: Subscription;
+      logEvents?: Subscription;
+    } = {};
+    const client = createSseStreamClient({
+      response,
+      onClose: () => {
+        subscriptions.ping?.unsubscribe();
+        subscriptions.logEvents?.unsubscribe();
+        this.connectedClients.delete(clientKey);
+      },
+    });
+
+    this.connectedClients.set(clientKey, client);
+    if (!client.writeRaw('\n')) {
+      return;
+    }
 
     const currentLogFile = new Promise<string | undefined>(
       (resolve, reject) => {
@@ -241,14 +233,14 @@ export class LogsController implements BeforeApplicationShutdown {
       ),
     );
 
-    const logEventStreamSubscription = logEventStream
+    subscriptions.logEvents = logEventStream
       .pipe(map((x) => this.sendDataToClient(clientKey, x)))
       .subscribe();
 
-    // Send data to the client every 30s to keep the connection alive
-    const pingSubscription = interval(30 * 1000)
-      .pipe(map(() => response.write(': ping\n\n')))
-      .subscribe();
+    // Send data to the client every 30s to keep the connection alive.
+    subscriptions.ping = interval(30 * 1000).subscribe(() => {
+      client.writeRaw(': ping\n\n');
+    });
   }
 
   sendDataToClient(clientId: string, message: NestMessageEvent) {

--- a/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
@@ -354,6 +354,73 @@ describe('OverlayProcessorService', () => {
     expect(eventEmitter.emit).not.toHaveBeenCalled();
   });
 
+  it('counts stale-state restore failures as errors and keeps retry state during process-all runs', async () => {
+    const epipeError = Object.assign(new Error('write EPIPE'), {
+      code: 'EPIPE',
+    });
+    const settingsService = {
+      getSettings: jest.fn().mockResolvedValue({ enabled: true }),
+    };
+    const stateService = {
+      getAllStates: jest
+        .fn()
+        .mockResolvedValue([{ collectionId: 42, mediaServerId: 'media-1' }]),
+      removeState: jest.fn().mockResolvedValue(undefined),
+    };
+    const collection = createCollection({
+      id: 1,
+      title: 'Overlay run',
+      type: 'movie',
+      deleteAfterDays: null,
+    });
+    collection.collectionMedia = [];
+    const collectionsService = {
+      getCollectionsWithOverlayEnabled: jest
+        .fn()
+        .mockResolvedValue([collection]),
+    };
+    const provider = makeProvider({
+      uploadImage: jest.fn().mockRejectedValue(epipeError),
+    });
+    const providerFactory = makeProviderFactory(provider);
+    const eventEmitter = { emit: jest.fn() };
+
+    const service = new OverlayProcessorService(
+      providerFactory as any,
+      collectionsService as any,
+      settingsService as any,
+      stateService as any,
+      {} as any,
+      {} as any,
+      eventEmitter as any,
+      createMockLogger(),
+    );
+
+    jest
+      .spyOn(service as any, 'loadOriginalPoster')
+      .mockReturnValue(Buffer.from('poster'));
+    const deleteSpy = jest
+      .spyOn(service as any, 'deleteOriginalPoster')
+      .mockImplementation(() => {});
+
+    const result = await service.processAllCollections();
+
+    expect(result).toEqual({
+      processed: 0,
+      reverted: 0,
+      skipped: 0,
+      errors: 1,
+    });
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(stateService.removeState).not.toHaveBeenCalled();
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      MaintainerrEvent.OverlayHandler_Finished,
+    );
+    expect(eventEmitter.emit).not.toHaveBeenCalledWith(
+      MaintainerrEvent.OverlayHandler_Failed,
+    );
+  });
+
   it('emits one aggregated overlay reverted notification for reset-all runs', async () => {
     const stateService = {
       getAllStates: jest.fn().mockResolvedValue([

--- a/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
@@ -475,6 +475,49 @@ describe('OverlayProcessorService', () => {
     ).toHaveLength(1);
   });
 
+  it('keeps overlay state on reset when individual uploads fail so retries are possible', async () => {
+    const stateService = {
+      getAllStates: jest
+        .fn()
+        .mockResolvedValue([{ collectionId: 1, mediaServerId: 'media-1' }]),
+      clearAllStates: jest.fn().mockResolvedValue(undefined),
+      removeState: jest.fn().mockResolvedValue(undefined),
+    };
+    const provider = makeProvider({
+      uploadImage: jest.fn().mockRejectedValue(new Error('upload failed')),
+    });
+    const providerFactory = makeProviderFactory(provider);
+    const eventEmitter = { emit: jest.fn() };
+
+    const service = new OverlayProcessorService(
+      providerFactory as any,
+      {} as any,
+      {} as any,
+      stateService as any,
+      {} as any,
+      {} as any,
+      eventEmitter as any,
+      createMockLogger(),
+    );
+
+    jest
+      .spyOn(service as any, 'loadOriginalPoster')
+      .mockReturnValue(Buffer.from('poster'));
+    const deleteSpy = jest
+      .spyOn(service as any, 'deleteOriginalPoster')
+      .mockImplementation(() => {});
+
+    await service.resetAllOverlays();
+
+    expect(stateService.clearAllStates).not.toHaveBeenCalled();
+    expect(stateService.removeState).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(eventEmitter.emit).not.toHaveBeenCalledWith(
+      MaintainerrEvent.Overlay_Reverted,
+      expect.anything(),
+    );
+  });
+
   it('deduplicates media items in aggregated overlay reverted notifications', async () => {
     const stateService = {
       getAllStates: jest.fn().mockResolvedValue([

--- a/apps/server/src/modules/overlays/overlay-processor.service.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.ts
@@ -33,10 +33,7 @@ export interface ProcessorRunResult {
   errors: number;
 }
 
-interface RevertItemResult {
-  restored: boolean;
-  failed: boolean;
-}
+type RevertItemResult = 'restored' | 'failed' | 'no-backup';
 
 @Injectable()
 export class OverlayProcessorService {
@@ -146,7 +143,7 @@ export class OverlayProcessorService {
         `No saved original poster for ${mediaServerId}, cannot restore`,
       );
       await this.stateService.removeState(collectionId, mediaServerId);
-      return { restored: false, failed: false };
+      return 'no-backup';
     }
 
     try {
@@ -154,16 +151,15 @@ export class OverlayProcessorService {
     } catch (error) {
       this.logger.warn(
         `Failed to restore original poster for ${mediaServerId}; keeping backup for retry`,
-        error,
       );
       this.logger.debug(error);
-      return { restored: false, failed: true };
+      return 'failed';
     }
 
     this.logger.log(`Restored original poster for item ${mediaServerId}`);
     this.deleteOriginalPoster(mediaServerId);
     await this.stateService.removeState(collectionId, mediaServerId);
-    return { restored: true, failed: false };
+    return 'restored';
   }
 
   async revertCollection(collectionId: number): Promise<number> {
@@ -202,13 +198,12 @@ export class OverlayProcessorService {
           provider,
         );
 
-        if (result.restored) {
+        if (result === 'restored') {
           reverted.push({ mediaServerId: item.mediaServerId });
         }
       } catch (error) {
         this.logger.warn(
           `Failed to revert overlay for ${item.mediaServerId}; continuing batch`,
-          error,
         );
         this.logger.debug(error);
       }
@@ -411,16 +406,15 @@ export class OverlayProcessorService {
               provider,
             );
 
-            if (result.restored) {
+            if (result === 'restored') {
               this.addUniqueMediaItem(revertedMediaItems, state.mediaServerId);
               totalResult.reverted++;
-            } else if (result.failed) {
+            } else if (result === 'failed') {
               totalResult.errors++;
             }
           } catch (error) {
             this.logger.warn(
               `Failed to revert stale overlay state for ${state.mediaServerId}; continuing run`,
-              error,
             );
             this.logger.debug(error);
             totalResult.errors++;
@@ -501,13 +495,12 @@ export class OverlayProcessorService {
           provider,
         );
 
-        if (result.restored) {
+        if (result === 'restored') {
           this.addUniqueMediaItem(revertedMediaItems, state.mediaServerId);
         }
       } catch (error) {
         this.logger.warn(
           `Failed to reset overlay for ${state.mediaServerId}; keeping state for retry`,
-          error,
         );
         this.logger.debug(error);
       }

--- a/apps/server/src/modules/overlays/overlay-processor.service.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.ts
@@ -33,6 +33,11 @@ export interface ProcessorRunResult {
   errors: number;
 }
 
+interface RevertItemResult {
+  restored: boolean;
+  failed: boolean;
+}
+
 @Injectable()
 export class OverlayProcessorService {
   public status: ProcessorStatus = 'idle';
@@ -119,8 +124,8 @@ export class OverlayProcessorService {
   // ── Revert ────────────────────────────────────────────────────────────────
 
   /**
-   * Revert one item. Returns `true` when the original poster was restored,
-   * so callers can decide whether to emit an event and/or aggregate.
+   * Revert one item. Reports whether the original poster was restored or the
+   * restore failed, so callers can emit events and count retryable failures.
    *
    * Failure handling:
    *  - No backup on disk → nothing we can do; clear state so we stop tracking.
@@ -133,7 +138,7 @@ export class OverlayProcessorService {
     collectionId: number,
     mediaServerId: string,
     provider: IOverlayProvider,
-  ): Promise<boolean> {
+  ): Promise<RevertItemResult> {
     const originalBuf = this.loadOriginalPoster(mediaServerId);
 
     if (!originalBuf) {
@@ -141,7 +146,7 @@ export class OverlayProcessorService {
         `No saved original poster for ${mediaServerId}, cannot restore`,
       );
       await this.stateService.removeState(collectionId, mediaServerId);
-      return false;
+      return { restored: false, failed: false };
     }
 
     try {
@@ -149,15 +154,16 @@ export class OverlayProcessorService {
     } catch (error) {
       this.logger.warn(
         `Failed to restore original poster for ${mediaServerId}; keeping backup for retry`,
+        error,
       );
       this.logger.debug(error);
-      return false;
+      return { restored: false, failed: true };
     }
 
     this.logger.log(`Restored original poster for item ${mediaServerId}`);
     this.deleteOriginalPoster(mediaServerId);
     await this.stateService.removeState(collectionId, mediaServerId);
-    return true;
+    return { restored: true, failed: false };
   }
 
   async revertCollection(collectionId: number): Promise<number> {
@@ -189,14 +195,22 @@ export class OverlayProcessorService {
 
     const reverted: { mediaServerId: string }[] = [];
     for (const item of mediaItems) {
-      if (
-        await this.revertItemInternal(
+      try {
+        const result = await this.revertItemInternal(
           collectionId,
           item.mediaServerId,
           provider,
-        )
-      ) {
-        reverted.push({ mediaServerId: item.mediaServerId });
+        );
+
+        if (result.restored) {
+          reverted.push({ mediaServerId: item.mediaServerId });
+        }
+      } catch (error) {
+        this.logger.warn(
+          `Failed to revert overlay for ${item.mediaServerId}; continuing batch`,
+          error,
+        );
+        this.logger.debug(error);
       }
     }
 
@@ -390,15 +404,27 @@ export class OverlayProcessorService {
           this.logger.log(
             `Item ${state.mediaServerId} no longer in any overlay collection, reverting`,
           );
-          const restored = await this.revertItemInternal(
-            state.collectionId,
-            state.mediaServerId,
-            provider,
-          );
-          if (restored) {
-            this.addUniqueMediaItem(revertedMediaItems, state.mediaServerId);
+          try {
+            const result = await this.revertItemInternal(
+              state.collectionId,
+              state.mediaServerId,
+              provider,
+            );
+
+            if (result.restored) {
+              this.addUniqueMediaItem(revertedMediaItems, state.mediaServerId);
+              totalResult.reverted++;
+            } else if (result.failed) {
+              totalResult.errors++;
+            }
+          } catch (error) {
+            this.logger.warn(
+              `Failed to revert stale overlay state for ${state.mediaServerId}; continuing run`,
+              error,
+            );
+            this.logger.debug(error);
+            totalResult.errors++;
           }
-          totalResult.reverted++;
         }
       }
 
@@ -468,17 +494,24 @@ export class OverlayProcessorService {
     const allStates = await this.stateService.getAllStates();
     const revertedMediaItems: { mediaServerId: string }[] = [];
     for (const state of allStates) {
-      const restored = await this.revertItemInternal(
-        state.collectionId,
-        state.mediaServerId,
-        provider,
-      );
-      if (restored) {
-        this.addUniqueMediaItem(revertedMediaItems, state.mediaServerId);
+      try {
+        const result = await this.revertItemInternal(
+          state.collectionId,
+          state.mediaServerId,
+          provider,
+        );
+
+        if (result.restored) {
+          this.addUniqueMediaItem(revertedMediaItems, state.mediaServerId);
+        }
+      } catch (error) {
+        this.logger.warn(
+          `Failed to reset overlay for ${state.mediaServerId}; keeping state for retry`,
+          error,
+        );
+        this.logger.debug(error);
       }
     }
-
-    await this.stateService.clearAllStates();
 
     if (revertedMediaItems.length > 0) {
       this.eventEmitter.emit(
@@ -487,7 +520,7 @@ export class OverlayProcessorService {
       );
     }
 
-    this.logger.log('All overlays reset and state cleared');
+    this.logger.log('Overlay reset complete');
   }
 
   // ── Template-based overlay application ────────────────────────────────────

--- a/apps/server/src/utils/sse-stream.ts
+++ b/apps/server/src/utils/sse-stream.ts
@@ -1,6 +1,5 @@
 import { MessageEvent as NestMessageEvent } from '@nestjs/common';
 import { Response } from 'express';
-import { Subject } from 'rxjs';
 
 type SseStreamClientOptions = {
   response: Response;
@@ -10,7 +9,7 @@ type SseStreamClientOptions = {
 
 export type SseStreamClient = {
   close: () => void;
-  subject: Subject<NestMessageEvent>;
+  send: (message: NestMessageEvent) => boolean;
   writeRaw: (chunk: string) => boolean;
 };
 
@@ -34,7 +33,6 @@ export const createSseStreamClient = ({
   onClose,
   onError,
 }: SseStreamClientOptions): SseStreamClient => {
-  const subject = new Subject<NestMessageEvent>();
   const socket = response.socket;
   let closed = false;
 
@@ -45,8 +43,6 @@ export const createSseStreamClient = ({
     response.off('close', handleClose);
     response.off('error', handleError);
     socket?.off('error', handleError);
-    subject.complete();
-    subscription.unsubscribe();
 
     if (endResponse && isResponseWritable(response)) {
       try {
@@ -81,7 +77,7 @@ export const createSseStreamClient = ({
     }
   };
 
-  const writeMessage = (message: NestMessageEvent): boolean => {
+  const send = (message: NestMessageEvent): boolean => {
     for (const chunk of formatSseMessage(message)) {
       if (!writeRaw(chunk)) {
         return false;
@@ -99,18 +95,13 @@ export const createSseStreamClient = ({
     fail(error);
   }
 
-  const subscription = subject.subscribe({
-    next: writeMessage,
-    error: fail,
-  });
-
   response.once('close', handleClose);
   response.once('error', handleError);
   socket?.once('error', handleError);
 
   return {
     close: () => finish(true),
-    subject,
+    send,
     writeRaw,
   };
 };

--- a/apps/server/src/utils/sse-stream.ts
+++ b/apps/server/src/utils/sse-stream.ts
@@ -1,0 +1,116 @@
+import { MessageEvent as NestMessageEvent } from '@nestjs/common';
+import { Response } from 'express';
+import { Subject } from 'rxjs';
+
+type SseStreamClientOptions = {
+  response: Response;
+  onClose: () => void;
+  onError?: (error: unknown) => void;
+};
+
+export type SseStreamClient = {
+  close: () => void;
+  subject: Subject<NestMessageEvent>;
+  writeRaw: (chunk: string) => boolean;
+};
+
+const isResponseWritable = (response: Response): boolean =>
+  !response.destroyed && !response.writableEnded;
+
+const formatSseMessage = (message: NestMessageEvent): string[] => {
+  const chunks: string[] = [];
+
+  if (message.type) chunks.push(`event: ${message.type}\n`);
+  if (message.id) chunks.push(`id: ${message.id}\n`);
+  if (message.retry) chunks.push(`retry: ${message.retry}\n`);
+
+  chunks.push(`data: ${JSON.stringify(message.data)}\n\n`);
+
+  return chunks;
+};
+
+export const createSseStreamClient = ({
+  response,
+  onClose,
+  onError,
+}: SseStreamClientOptions): SseStreamClient => {
+  const subject = new Subject<NestMessageEvent>();
+  const socket = response.socket;
+  let closed = false;
+
+  const finish = (endResponse: boolean): void => {
+    if (closed) return;
+
+    closed = true;
+    response.off('close', handleClose);
+    response.off('error', handleError);
+    socket?.off('error', handleError);
+    subject.complete();
+    subscription.unsubscribe();
+
+    if (endResponse && isResponseWritable(response)) {
+      try {
+        response.end();
+      } catch (error) {
+        onError?.(error);
+      }
+    }
+
+    onClose();
+  };
+
+  const fail = (error: unknown): void => {
+    onError?.(error);
+    finish(false);
+  };
+
+  const writeRaw = (chunk: string): boolean => {
+    if (closed || !isResponseWritable(response)) {
+      finish(false);
+      return false;
+    }
+
+    try {
+      response.write(chunk, (error?: Error | null) => {
+        if (error) fail(error);
+      });
+      return true;
+    } catch (error) {
+      fail(error);
+      return false;
+    }
+  };
+
+  const writeMessage = (message: NestMessageEvent): boolean => {
+    for (const chunk of formatSseMessage(message)) {
+      if (!writeRaw(chunk)) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  function handleClose(): void {
+    finish(false);
+  }
+
+  function handleError(error: Error): void {
+    fail(error);
+  }
+
+  const subscription = subject.subscribe({
+    next: writeMessage,
+    error: fail,
+  });
+
+  response.once('close', handleClose);
+  response.once('error', handleError);
+  socket?.once('error', handleError);
+
+  return {
+    close: () => finish(true),
+    subject,
+    writeRaw,
+  };
+};


### PR DESCRIPTION
### Description & Design

This change fixes a server crash during overlay `Run Now` runs when poster restore/revert work hits a broken stream or transient Plex upload failure.

The fix has two parts:

- Adds a shared guarded SSE stream writer for logs/events so closed clients and `EPIPE` write failures clean up the client instead of reaching `uncaughtException`.
- Hardens overlay revert handling so stale overlay-state restore failures are counted as errors, the original poster backup and state are kept for retry, and the processor continues with the remaining items.

This approach keeps the fix narrow and server-side. It avoids changing public APIs, contracts, database schema, or UI behaviour, and follows the existing retry-safe overlay design: only clear backup/state after a confirmed restore.

Trade-offs and edge cases:

- Failed restores now report as overlay run errors rather than successful reverts.
- If no backup exists, state is still cleared because there is nothing left to retry.
- Reset/revert paths continue best-effort behaviour and log failures with useful error detail.
- SSE clients that fail writes are removed immediately, which is preferable to keeping dead connections around.

### Related issue

Fixes #2780

### AI-Assisted Development

This PR was AI-assisted using Codex.

AI assistance was used to trace the issue, inspect the overlay revert and SSE streaming paths, draft the implementation, and add focused regression tests. I reviewed the relevant server code paths, kept the changes scoped to the existing architecture, validated that backup/state preservation still works, and ran the project quality gates.

This solution fits the project's standards because it uses existing NestJS/RxJS patterns, avoids new dependencies, keeps changes small and reviewable, preserves retry-safe overlay behaviour, and adds targeted tests for the reported failure mode.

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I understand the code I am submitting and can explain how it works
- [x] I have performed a self-review of my code
- [x] I have linted and formatted my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

### How to test

1. Run lint and type checks:
   `yarn lint`
   `yarn check-types`

2. Run the focused regression tests:
   `yarn --cwd apps/server jest --runTestsByPath src/modules/overlays/overlay-processor.service.spec.ts src/modules/events/events.controller.spec.ts src/modules/logging/logs.controller.spec.ts`

3. Build the workspace:
   `yarn build`

4. Manual verification, if available:
   - Configure overlays with Plex.
   - Ensure at least one saved overlay state refers to an item no longer in any overlay-enabled collection.
   - Open the UI logs page, then trigger **Overlays → Run Now**.
   - Confirm the server does not crash if poster restore fails or the log/event stream disconnects.

### Additional context

`yarn build` passes. The UI build may still print the existing Vite large chunk warning; this change does not introduce a new warning.
