### PR TITLE
feat: cache jellyfin collections

### DIFF
--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -24,6 +24,7 @@ const jellyfinApiMocks = {
   getItems: jest.fn(),
   getItem: jest.fn(),
   getItemUserData: jest.fn(),
+  updateItem: jest.fn(),
   refreshItem: jest.fn(),
   getItemImage: jest.fn(),
   setItemImage: jest.fn(),
@@ -72,10 +73,12 @@ jest.mock('@jellyfin/sdk/lib/generated-client/models', () => ({
     ProviderIds: 'ProviderIds',
     Path: 'Path',
     DateCreated: 'DateCreated',
+    ChildCount: 'ChildCount',
     MediaSources: 'MediaSources',
     Genres: 'Genres',
     Tags: 'Tags',
     Overview: 'Overview',
+    ParentId: 'ParentId',
     People: 'People',
   },
   LocationType: {
@@ -146,6 +149,9 @@ jest.mock('@jellyfin/sdk/lib/utils/api/index.js', () => ({
       collectionApiMocks.addToCollection(...args),
     removeFromCollection: (...args: unknown[]) =>
       collectionApiMocks.removeFromCollection(...args),
+  })),
+  getItemUpdateApi: jest.fn().mockImplementation(() => ({
+    updateItem: (...args: unknown[]) => jellyfinApiMocks.updateItem(...args),
   })),
   getItemRefreshApi: jest.fn().mockImplementation(() => ({
     refreshItem: (...args: unknown[]) => jellyfinApiMocks.refreshItem(...args),
@@ -220,6 +226,7 @@ describe('JellyfinAdapterService', () => {
     });
     jellyfinApiMocks.getItems.mockResolvedValue({ data: { Items: [] } });
     jellyfinApiMocks.getItem.mockResolvedValue({ data: undefined });
+    jellyfinApiMocks.updateItem.mockResolvedValue(undefined);
     jellyfinApiMocks.refreshItem.mockResolvedValue(undefined);
     collectionApiMocks.createCollection.mockResolvedValue({
       data: { Id: 'collection-1' },
@@ -1629,6 +1636,180 @@ describe('JellyfinAdapterService', () => {
       });
       expect(jellyfinApiMocks.deleteItem).toHaveBeenCalledWith({
         itemId: 'collection-1',
+      });
+    });
+
+    describe('caching', () => {
+      it('caches non-empty getCollections results and serves them on the next call', async () => {
+        jellyfinApiMocks.getItems.mockResolvedValueOnce({
+          data: {
+            Items: [
+              {
+                Id: 'collection-1',
+                Name: 'C1',
+                ChildCount: 2,
+                ParentId: 'library-1',
+              },
+            ],
+          },
+        });
+
+        await service.getCollections('library-1');
+
+        expect(jellyfinApiMocks.getItems).toHaveBeenCalledWith(
+          expect.objectContaining({ parentId: 'library-1' }),
+        );
+
+        expect(jellyfinCacheMocks.data.set).toHaveBeenCalledWith(
+          'jellyfin:collections:library-1',
+          expect.arrayContaining([
+            expect.objectContaining({ id: 'collection-1' }),
+          ]),
+          600,
+        );
+
+        const cached = [{ id: 'cached', title: 'Cached' }];
+        jellyfinCacheMocks.data.get.mockReturnValueOnce(cached);
+
+        const second = await service.getCollections('library-1');
+        expect(second).toBe(cached);
+        // Only the first call hit the API
+        expect(jellyfinApiMocks.getItems).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not cache an empty getCollections result', async () => {
+        jellyfinApiMocks.getItems.mockResolvedValueOnce({
+          data: { Items: [] },
+        });
+
+        await service.getCollections('library-1');
+
+        expect(jellyfinCacheMocks.data.set).not.toHaveBeenCalledWith(
+          'jellyfin:collections:library-1',
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+
+      it('does not cache an empty getCollectionChildren result', async () => {
+        // Both parentId and recursive lookups return zero items
+        jellyfinApiMocks.getItems.mockResolvedValue({ data: { Items: [] } });
+
+        await service.getCollectionChildren('collection-1');
+
+        expect(jellyfinCacheMocks.data.set).not.toHaveBeenCalledWith(
+          'jellyfin:collections:children:collection-1',
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+
+      it('invalidates the children cache after addToCollection', async () => {
+        await service.addToCollection('collection-1', 'item-1');
+
+        expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
+          'jellyfin:collections:children:collection-1',
+        );
+      });
+
+      it('invalidates the children cache once after addBatchToCollection (multi-chunk)', async () => {
+        const items = Array.from(
+          { length: JELLYFIN_BATCH_SIZE.COLLECTION_MUTATION + 1 },
+          (_, i) => `item-${i}`,
+        );
+
+        await service.addBatchToCollection('collection-1', items);
+
+        const childInvalidations =
+          jellyfinCacheMocks.data.del.mock.calls.filter(
+            (call) => call[0] === 'jellyfin:collections:children:collection-1',
+          );
+        expect(childInvalidations).toHaveLength(1);
+      });
+
+      it('invalidates the children cache after removeBatchFromCollection', async () => {
+        await service.removeBatchFromCollection('collection-1', ['item-1']);
+
+        expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
+          'jellyfin:collections:children:collection-1',
+        );
+      });
+
+      it('invalidates the per-library collections cache after createCollection', async () => {
+        collectionApiMocks.createCollection.mockResolvedValueOnce({
+          data: { Id: 'collection-new' },
+        });
+
+        await service.createCollection({
+          libraryId: 'library-1',
+          title: 'New',
+          type: 'movie',
+        });
+
+        expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
+          'jellyfin:collections:library-1',
+        );
+      });
+
+      it('invalidates the per-library collections cache after updateCollection', async () => {
+        jellyfinApiMocks.getItems
+          .mockResolvedValueOnce({
+            data: {
+              Items: [
+                {
+                  Id: 'collection-1',
+                  Name: 'Old Name',
+                  ParentId: 'library-1',
+                  Tags: [],
+                  Genres: [],
+                  Studios: [],
+                  People: [],
+                },
+              ],
+            },
+          })
+          .mockResolvedValueOnce({
+            data: {
+              Items: [
+                {
+                  Id: 'collection-1',
+                  Name: 'New Name',
+                  ParentId: 'library-1',
+                },
+              ],
+            },
+          });
+
+        await service.updateCollection({
+          collectionId: 'collection-1',
+          libraryId: 'library-1',
+          title: 'New Name',
+          summary: 'Updated summary',
+          sortTitle: 'New Name',
+        });
+
+        expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
+          'jellyfin:collections:library-1',
+        );
+      });
+
+      it('clears every per-library collections entry on deleteCollection (libraryId unknown) and the children cache', async () => {
+        jellyfinCacheMocks.data.keys.mockReturnValueOnce([
+          'jellyfin:collections:library-1',
+          'jellyfin:collections:library-2',
+          'jellyfin:collections:children:collection-99',
+          'jellyfin:users',
+        ]);
+
+        await service.deleteCollection('collection-1');
+
+        expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith([
+          'jellyfin:collections:library-1',
+          'jellyfin:collections:library-2',
+        ]);
+        expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
+          'jellyfin:collections:children:collection-1',
+        );
       });
     });
   });

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -1272,31 +1272,45 @@ export class JellyfinAdapterService implements IMediaServerService {
   async getCollections(libraryId: string): Promise<MediaCollection[]> {
     if (!this.api) return [];
 
-    try {
-      const userId = await this.getUserId();
-      const response = await getItemsApi(this.api).getItems({
-        userId,
-        includeItemTypes: [BaseItemKind.BoxSet],
-        recursive: true,
-        fields: [
-          ItemFields.Overview,
-          ItemFields.DateCreated,
-          ItemFields.ChildCount,
-        ],
-      });
+    const cacheKey = `${JELLYFIN_CACHE_KEYS.COLLECTIONS}:${libraryId}`;
+    let allCollections = this.cache.data.get<MediaCollection[]>(cacheKey);
 
-      const collections = (response.data.Items || []).map(
-        JellyfinMapper.toMediaCollection,
-      );
+    if (!allCollections) {
+      allCollections = [];
 
-      return collections.filter(
-        (collection): collection is MediaCollection => collection !== null,
-      );
-    } catch (error) {
-      this.logger.error(`Failed to get collections for ${libraryId}`);
-      this.logger.debug(error);
-      return [];
+      try {
+        const userId = await this.getUserId();
+        const response = await getItemsApi(this.api).getItems({
+          userId,
+          includeItemTypes: [BaseItemKind.BoxSet],
+          recursive: true,
+          fields: [
+            ItemFields.Overview,
+            ItemFields.DateCreated,
+            ItemFields.ChildCount,
+          ],
+        });
+
+        const collections = (response.data.Items || []).map(
+          JellyfinMapper.toMediaCollection,
+        );
+
+        allCollections = collections.filter(
+          (collection): collection is MediaCollection => collection !== null,
+        );
+        this.cache.data.set(
+          cacheKey,
+          allCollections,
+          JELLYFIN_CACHE_TTL.COLLECTIONS,
+        );
+      } catch (error) {
+        this.logger.error(`Failed to get collections for ${libraryId}`);
+        this.logger.debug(error);
+        return [];
+      }
     }
+
+    return allCollections;
   }
 
   async getCollection(
@@ -1389,72 +1403,89 @@ export class JellyfinAdapterService implements IMediaServerService {
   async getCollectionChildren(collectionId: string): Promise<MediaItem[]> {
     if (!this.api) return [];
 
-    try {
-      const userId = await this.getUserId();
+    const cacheKey = `${JELLYFIN_CACHE_KEYS.COLLECTIONS}:children:${collectionId}`;
+    let allCollectionChildren = this.cache.data.get<MediaItem[]>(cacheKey);
 
-      // For BoxSets in Jellyfin, we need to use the Items endpoint
-      // with the collection's ID as parentId AND a userId
-      const response = await this.retryLibraryRequestOnce(
-        `get Jellyfin collection children for ${collectionId}`,
-        async () =>
-          await getItemsApi(this.api!).getItems({
-            userId,
-            parentId: collectionId,
-            fields: [
-              ItemFields.ProviderIds,
-              ItemFields.Path,
-              ItemFields.DateCreated,
-            ],
-            enableUserData: true,
-            recursive: false,
-          }),
-      );
+    if (!allCollectionChildren) {
+      allCollectionChildren = [];
 
-      // If parentId approach returns nothing, try recursive search
-      if (!response.data.Items?.length) {
-        const itemsResponse = await this.retryLibraryRequestOnce(
-          `get Jellyfin collection children recursively for ${collectionId}`,
+      try {
+        const userId = await this.getUserId();
+
+        // For BoxSets in Jellyfin, we need to use the Items endpoint
+        // with the collection's ID as parentId AND a userId
+        const response = await this.retryLibraryRequestOnce(
+          `get Jellyfin collection children for ${collectionId}`,
           async () =>
             await getItemsApi(this.api!).getItems({
               userId,
               parentId: collectionId,
-              recursive: true,
-              includeItemTypes: [
-                BaseItemKind.Movie,
-                BaseItemKind.Series,
-                BaseItemKind.Season,
-                BaseItemKind.Episode,
-              ],
               fields: [
                 ItemFields.ProviderIds,
                 ItemFields.Path,
                 ItemFields.DateCreated,
               ],
               enableUserData: true,
+              recursive: false,
             }),
         );
 
-        if (itemsResponse.data.Items?.length) {
-          return (itemsResponse.data.Items || []).map(
+        // If parentId approach returns nothing, try recursive search
+        if (!response.data.Items?.length) {
+          const itemsResponse = await this.retryLibraryRequestOnce(
+            `get Jellyfin collection children recursively for ${collectionId}`,
+            async () =>
+              await getItemsApi(this.api!).getItems({
+                userId,
+                parentId: collectionId,
+                recursive: true,
+                includeItemTypes: [
+                  BaseItemKind.Movie,
+                  BaseItemKind.Series,
+                  BaseItemKind.Season,
+                  BaseItemKind.Episode,
+                ],
+                fields: [
+                  ItemFields.ProviderIds,
+                  ItemFields.Path,
+                  ItemFields.DateCreated,
+                ],
+                enableUserData: true,
+              }),
+          );
+
+          if (itemsResponse.data.Items?.length) {
+            allCollectionChildren = (itemsResponse.data.Items || []).map(
+              JellyfinMapper.toMediaItem,
+            );
+          }
+        } else {
+          allCollectionChildren = (response.data.Items || []).map(
             JellyfinMapper.toMediaItem,
           );
         }
-      }
 
-      return (response.data.Items || []).map(JellyfinMapper.toMediaItem);
-    } catch (error) {
-      if (
-        error instanceof AxiosError &&
-        (error.response?.status === 400 || error.response?.status === 404)
-      ) {
-        throw error;
+        this.cache.data.set(
+          cacheKey,
+          allCollectionChildren,
+          JELLYFIN_CACHE_TTL.COLLECTIONS,
+        );
+      } catch (error) {
+        if (
+          error instanceof AxiosError &&
+          (error.response?.status === 400 || error.response?.status === 404)
+        ) {
+          throw error;
+        }
+        this.logger.error(
+          `Failed to get collection children for ${collectionId}`,
+          error,
+        );
+        return [];
       }
-      this.logger.error(
-        `Failed to get collection children for ${collectionId}`,
-        error,
-      );
-      return [];
     }
+
+    return allCollectionChildren;
   }
 
   private async addToCollectionInternal(

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -1282,12 +1282,14 @@ export class JellyfinAdapterService implements IMediaServerService {
         const userId = await this.getUserId();
         const response = await getItemsApi(this.api).getItems({
           userId,
+          parentId: libraryId,
           includeItemTypes: [BaseItemKind.BoxSet],
           recursive: true,
           fields: [
             ItemFields.Overview,
             ItemFields.DateCreated,
             ItemFields.ChildCount,
+            ItemFields.ParentId,
           ],
         });
 
@@ -1298,11 +1300,15 @@ export class JellyfinAdapterService implements IMediaServerService {
         allCollections = collections.filter(
           (collection): collection is MediaCollection => collection !== null,
         );
-        this.cache.data.set(
-          cacheKey,
-          allCollections,
-          JELLYFIN_CACHE_TTL.COLLECTIONS,
-        );
+        // Skip caching empty results so a transient zero-collection response
+        // (e.g. mid-library-scan) can't mask a just-created entry.
+        if (allCollections.length > 0) {
+          this.cache.data.set(
+            cacheKey,
+            allCollections,
+            JELLYFIN_CACHE_TTL.COLLECTIONS,
+          );
+        }
       } catch (error) {
         this.logger.error(`Failed to get collections for ${libraryId}`);
         this.logger.debug(error);
@@ -1368,6 +1374,8 @@ export class JellyfinAdapterService implements IMediaServerService {
         throw new Error('Collection created but no ID returned');
       }
 
+      this.invalidateCollectionsCache(params.libraryId);
+
       // Note: No refresh needed - Jellyfin auto-generates composite images
       // when items are added (as long as isLocked: true, which we set above).
 
@@ -1393,6 +1401,9 @@ export class JellyfinAdapterService implements IMediaServerService {
 
     try {
       await getLibraryApi(this.api).deleteItem({ itemId: collectionId });
+      // libraryId not known here; clear all per-library entries.
+      this.invalidateCollectionsCache();
+      this.invalidateCollectionChildrenCache(collectionId);
     } catch (error) {
       this.logger.error(`Failed to delete collection ${collectionId}`);
       this.logger.debug(error);
@@ -1465,11 +1476,15 @@ export class JellyfinAdapterService implements IMediaServerService {
           );
         }
 
-        this.cache.data.set(
-          cacheKey,
-          allCollectionChildren,
-          JELLYFIN_CACHE_TTL.COLLECTIONS,
-        );
+        // Skip caching empty results: Jellyfin may briefly return [] for a
+        // freshly-created collection while indexing.
+        if (allCollectionChildren.length > 0) {
+          this.cache.data.set(
+            cacheKey,
+            allCollectionChildren,
+            JELLYFIN_CACHE_TTL.COLLECTIONS,
+          );
+        }
       } catch (error) {
         if (
           error instanceof AxiosError &&
@@ -1486,6 +1501,25 @@ export class JellyfinAdapterService implements IMediaServerService {
     }
 
     return allCollectionChildren;
+  }
+
+  private invalidateCollectionsCache(libraryId?: string): void {
+    if (libraryId) {
+      this.cache.data.del(`${JELLYFIN_CACHE_KEYS.COLLECTIONS}:${libraryId}`);
+      return;
+    }
+    const prefix = `${JELLYFIN_CACHE_KEYS.COLLECTIONS}:`;
+    const childrenPrefix = `${JELLYFIN_CACHE_KEYS.COLLECTIONS}:children:`;
+    const stale = this.cache.data
+      .keys()
+      .filter((k) => k.startsWith(prefix) && !k.startsWith(childrenPrefix));
+    if (stale.length > 0) this.cache.data.del(stale);
+  }
+
+  private invalidateCollectionChildrenCache(collectionId: string): void {
+    this.cache.data.del(
+      `${JELLYFIN_CACHE_KEYS.COLLECTIONS}:children:${collectionId}`,
+    );
   }
 
   private async addToCollectionInternal(
@@ -1513,6 +1547,7 @@ export class JellyfinAdapterService implements IMediaServerService {
 
   async addToCollection(collectionId: string, itemId: string): Promise<void> {
     await this.addToCollectionInternal(collectionId, itemId, true);
+    this.invalidateCollectionChildrenCache(collectionId);
   }
 
   async addBatchToCollection(
@@ -1550,6 +1585,8 @@ export class JellyfinAdapterService implements IMediaServerService {
         `Jellyfin batch add fallback left ${failedIds.length} failed item(s) for collection ${collectionId}`,
       );
     }
+
+    this.invalidateCollectionChildrenCache(collectionId);
 
     return failedIds;
   }
@@ -1599,6 +1636,7 @@ export class JellyfinAdapterService implements IMediaServerService {
         collectionId,
         ids: [itemId],
       });
+      this.invalidateCollectionChildrenCache(collectionId);
     } catch (error) {
       this.logger.error(
         `Failed to remove ${itemId} from collection ${collectionId}`,
@@ -1632,6 +1670,8 @@ export class JellyfinAdapterService implements IMediaServerService {
         failedIds.push(...chunk);
       }
     }
+
+    this.invalidateCollectionChildrenCache(collectionId);
 
     return failedIds;
   }
@@ -1700,6 +1740,7 @@ export class JellyfinAdapterService implements IMediaServerService {
           ItemFields.Overview,
           ItemFields.DateCreated,
           ItemFields.ChildCount,
+          ItemFields.ParentId,
         ],
       });
 
@@ -1707,6 +1748,8 @@ export class JellyfinAdapterService implements IMediaServerService {
       if (!collection) {
         throw new Error(`Collection ${params.collectionId} not found`);
       }
+
+      this.invalidateCollectionsCache(params.libraryId);
 
       return JellyfinMapper.toMediaCollection(collection);
     } catch (error) {

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin.constants.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin.constants.ts
@@ -5,6 +5,7 @@ export const JELLYFIN_CACHE_TTL = {
   USERS: 1800000,
   LIBRARIES: 1800000,
   STATUS: 60000,
+  COLLECTIONS: 600,
 } as const;
 
 export const JELLYFIN_BATCH_SIZE = {
@@ -37,6 +38,7 @@ export const JELLYFIN_CACHE_KEYS = {
   USERS: 'jellyfin:users',
   LIBRARIES: 'jellyfin:libraries',
   STATUS: 'jellyfin:status',
+  COLLECTIONS: 'jellyfin:collections',
 } as const;
 
 /**


### PR DESCRIPTION
### Description & Design

Stores jellyfin collections and collection children to cache to avoid excessive repeat queries during rules that look at collections.

### Related issue

### AI-Assisted Development

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I understand the code I am submitting and can explain how it works
- [x] I have performed a self-review of my code
- [x] I have linted and formatted my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

### How to test

Please describe the steps to test your changes, including any setup required.

1. Add a rule targeting Jellyfin collections
2. Run rule

### Additional context

Currently, rules that target Jellyfin collections result in a query for all collections and a query for each collection's children, repeated for every item processed. This quickly balloons and results in excessively long runtimes. For example, targeting a library with 500 items and 50 collections would result in 25,500 queries per rule run. With caching, this is reduced to 51 calls.
