### PR TITLE
fix: unstick rules-collections lock and clarify sw_watchers labels

### DIFF
--- a/apps/server/src/modules/rules/constants/rules.constants.ts
+++ b/apps/server/src/modules/rules/constants/rules.constants.ts
@@ -213,7 +213,7 @@ export class RuleConstants {
         {
           id: 12,
           name: 'sw_allEpisodesSeenBy',
-          humanName: '[list] Users that saw all available episodes',
+          humanName: '[list] Users that watched every episode',
           mediaType: MediaType.SHOW,
           type: RuleType.TEXT_LIST, // return usernames []
           showType: ['show', 'season'],
@@ -260,7 +260,7 @@ export class RuleConstants {
         {
           id: 18,
           name: 'sw_watchers',
-          humanName: '[list] Users that watch the show/season/episode',
+          humanName: '[list] Users that watched at least one episode',
           mediaType: MediaType.SHOW,
           type: RuleType.TEXT_LIST, // return usernames []
           showType: ['show', 'season', 'episode'],
@@ -979,7 +979,7 @@ export class RuleConstants {
         {
           id: 1,
           name: 'sw_allEpisodesSeenBy',
-          humanName: '[list] Users that saw all available episodes',
+          humanName: '[list] Users that watched every episode',
           mediaType: MediaType.SHOW,
           type: RuleType.TEXT_LIST, // return usernames []
           showType: ['show', 'season'],
@@ -1031,7 +1031,7 @@ export class RuleConstants {
         {
           id: 8,
           name: 'sw_watchers',
-          humanName: '[list] Users that watch the show/season/episode',
+          humanName: '[list] Users that watched at least one episode',
           mediaType: MediaType.SHOW,
           type: RuleType.TEXT_LIST, // return usernames []
           showType: ['show', 'season', 'episode'],
@@ -1131,7 +1131,7 @@ export class RuleConstants {
         {
           id: 12,
           name: 'sw_allEpisodesSeenBy',
-          humanName: '[list] Users that saw all available episodes',
+          humanName: '[list] Users that watched every episode',
           mediaType: MediaType.SHOW,
           type: RuleType.TEXT_LIST, // return usernames []
           showType: ['show', 'season'],
@@ -1178,7 +1178,7 @@ export class RuleConstants {
         {
           id: 18,
           name: 'sw_watchers',
-          humanName: '[list] Users that watch the show/season/episode',
+          humanName: '[list] Users that watched at least one episode',
           mediaType: MediaType.SHOW,
           type: RuleType.TEXT_LIST, // return usernames []
           showType: ['show', 'season', 'episode'],

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
@@ -272,6 +272,12 @@ export class JellyfinGetterService {
           return favoritedByUserIds.map((id) => userMap.get(id) || id);
         }
 
+        // At season/show level this returns the UNION of users that watched
+        // any descendant episode — not the intersection. A user who watched
+        // 3/6 episodes is included. This is the documented behaviour and is
+        // covered by the #2559 regression test in
+        // jellyfin-getter.service.spec.ts. Use `sw_allEpisodesSeenBy` when
+        // you need "watched every episode" semantics instead.
         case 'sw_watchers': {
           return await this.getSwWatchers(metadata.id, metadata.type);
         }

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -320,6 +320,11 @@ export class PlexGetterService {
 
           return [];
         }
+        // At season/show level this returns the UNION of users that watched
+        // any descendant episode — not the intersection. Plex's per-show
+        // watch history aggregates child views, so any account that watched
+        // at least one episode appears here. Use `sw_allEpisodesSeenBy` when
+        // you need "watched every episode" semantics instead.
         case 'sw_watchers': {
           const plexUsers = await this.plexApi.getCorrectedUsers(false);
 

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
@@ -51,6 +51,12 @@ export class TautulliGetterService {
         collection.tautulliWatchedPercentOverride;
 
       switch (prop.name) {
+        // At season/show level `sw_watchers` returns the UNION of users that
+        // watched any descendant episode — not the intersection. Tautulli's
+        // history aggregates child views via grandparent_rating_key /
+        // parent_rating_key, so any account that watched at least one
+        // episode appears here. Use `sw_allEpisodesSeenBy` when you need
+        // "watched every episode" semantics instead.
         case 'seenBy':
         case 'sw_watchers': {
           const history = await this.getHistoryForMetadata(metadata);

--- a/apps/server/src/modules/rules/tasks/rule-executor-job-manager.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor-job-manager.service.spec.ts
@@ -1,5 +1,10 @@
+import { MaintainerrEvent } from '@maintainerr/contracts';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { createMockLogger } from '../../../../test/utils/data';
-import { ExecutionLockService } from '../../tasks/execution-lock.service';
+import {
+  ExecutionLockService,
+  RULES_COLLECTIONS_EXECUTION_LOCK_KEY,
+} from '../../tasks/execution-lock.service';
 import { RuleExecutorJobManagerService } from './rule-executor-job-manager.service';
 import { RuleExecutionResult } from './rule-executor.service';
 
@@ -359,5 +364,44 @@ describe('RuleExecutorJobManagerService', () => {
     await flushMicrotasks();
 
     expect(executeMock).toHaveBeenCalledWith(42, expect.any(AbortSignal));
+  });
+
+  // Regression for #2799: a synchronous status-event listener that throws
+  // must NOT prevent the rules-collections lock from being released. If the
+  // lock leaks here, manual Trigger Now stays broken until container restart.
+  it('releases the rules-collections lock when a status-event listener throws', async () => {
+    const executeMock: ExecuteMock = jest
+      .fn()
+      .mockResolvedValue({ status: 'success' });
+
+    const ruleExecutorService = { executeForRuleGroups: executeMock };
+    const realLock = new ExecutionLockService();
+    const realEmitter = new EventEmitter2();
+
+    realEmitter.on(MaintainerrEvent.RuleHandlerQueue_StatusUpdated, () => {
+      throw new Error('listener boom');
+    });
+
+    const service = new RuleExecutorJobManagerService(
+      ruleExecutorService as any,
+      realLock,
+      { verifyConnection: jest.fn().mockResolvedValue({}) } as any,
+      realEmitter,
+      logger as any,
+    );
+
+    service.enqueue({ ruleGroupId: 99 });
+
+    await flushMicrotasks();
+    await waitForNextTick();
+    await flushMicrotasks();
+    await waitForNextTick();
+
+    expect(executeMock).toHaveBeenCalledWith(99, expect.any(AbortSignal));
+    expect(service.isProcessing()).toBe(false);
+
+    const release = realLock.tryAcquire(RULES_COLLECTIONS_EXECUTION_LOCK_KEY);
+    expect(release).not.toBeNull();
+    release?.();
   });
 });

--- a/apps/server/src/modules/rules/tasks/rule-executor-job-manager.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor-job-manager.service.ts
@@ -45,10 +45,19 @@ export class RuleExecutorJobManagerService implements OnApplicationShutdown {
   }
 
   private emitStatusUpdate() {
-    this.eventEmitter.emit(
-      MaintainerrEvent.RuleHandlerQueue_StatusUpdated,
-      new RuleHandlerQueueStatusUpdatedEventDto(this.getStatus()),
-    );
+    // Defense-in-depth for #2799: a thrown synchronous listener must never
+    // bubble out of here. The executor holds the rules-collections lock by
+    // the time it emits, and a propagating throw could skip the release()
+    // call and leak the lock until restart.
+    try {
+      this.eventEmitter.emit(
+        MaintainerrEvent.RuleHandlerQueue_StatusUpdated,
+        new RuleHandlerQueueStatusUpdatedEventDto(this.getStatus()),
+      );
+    } catch (error) {
+      this.logger.debug('Failed to emit rule handler queue status update');
+      this.logger.debug(error);
+    }
   }
 
   private getPendingRuleGroupIds(): number[] {
@@ -216,20 +225,28 @@ export class RuleExecutorJobManagerService implements OnApplicationShutdown {
       const release = await this.executionLock.acquire(
         RULES_COLLECTIONS_EXECUTION_LOCK_KEY,
       );
-      this.executingRuleGroupId = request.ruleGroupId;
-      this.emitStatusUpdate();
 
+      // Everything between acquire and release lives inside this try so
+      // release() always runs — including if `emitStatusUpdate` synchronously
+      // throws (e.g. an event listener throws). Without this, a thrown
+      // listener would leak the lock entry forever and every future
+      // `tryAcquire` would return null until restart (#2799).
       try {
-        const result = await this.ruleExecutorService.executeForRuleGroups(
-          request.ruleGroupId,
-          this.abortController.signal,
-        );
-        this.handleQueueLevelFailure(result);
-      } catch (error) {
-        this.logger.error(
-          `An error occurred while executing job for rule group ${request.ruleGroupId}`,
-          error,
-        );
+        this.executingRuleGroupId = request.ruleGroupId;
+        this.emitStatusUpdate();
+
+        try {
+          const result = await this.ruleExecutorService.executeForRuleGroups(
+            request.ruleGroupId,
+            this.abortController.signal,
+          );
+          this.handleQueueLevelFailure(result);
+        } catch (error) {
+          this.logger.error(
+            `An error occurred while executing job for rule group ${request.ruleGroupId}`,
+            error,
+          );
+        }
       } finally {
         release();
         this.executingRuleGroupId = null;

--- a/apps/server/src/modules/tasks/execution-lock.service.spec.ts
+++ b/apps/server/src/modules/tasks/execution-lock.service.spec.ts
@@ -65,6 +65,15 @@ describe('ExecutionLockService', () => {
     release?.();
   });
 
+  it('allows tryAcquire after a previous acquire was released', async () => {
+    const release = await service.acquire('shared');
+    release();
+
+    const next = service.tryAcquire('shared');
+    expect(next).not.toBeNull();
+    next?.();
+  });
+
   it('does not block subsequent acquires after release', async () => {
     const release = await service.acquire('shared');
     release();

--- a/apps/server/src/modules/tasks/execution-lock.service.ts
+++ b/apps/server/src/modules/tasks/execution-lock.service.ts
@@ -35,21 +35,27 @@ export class ExecutionLockService {
   }
 
   public async acquire(key: string): Promise<() => void> {
-    const prior = this.locks.get(key) ?? Promise.resolve();
+    const prior = this.locks.get(key);
 
     let release!: () => void;
     const current = new Promise<void>((resolve) => {
       release = resolve;
     });
 
-    // Chain so future acquirers wait for this one to release
-    this.locks.set(
-      key,
-      prior.then(() => current),
-    );
+    // Store `current` directly so the release callback below can recognise
+    // its own entry by reference and delete it on release. Storing the
+    // chained promise (prior.then(() => current)) instead would leak the
+    // entry forever — `tryAcquire` checks `locks.has(key)` and would never
+    // return non-null again, which is the root cause of #2799.
+    this.locks.set(key, current);
 
-    // Wait for earlier holder, then return releaser
-    await prior;
+    // Wait for the earlier holder to release before handing the caller the
+    // releaser. Each acquire only sees the single direct predecessor, but
+    // because every caller follows this same await-prior pattern, we still
+    // get a FIFO chain across an arbitrary number of waiters.
+    if (prior !== undefined) {
+      await prior;
+    }
 
     let released = false;
     return () => {


### PR DESCRIPTION
## Summary

- Fix `ExecutionLockService.acquire` map-cleanup so `tryAcquire` recovers after a release. Root cause of the sticky "Collection handling is already running" error.
- Restructure `rule-executor-job-manager.executeJob` and harden `emitStatusUpdate` so a thrown SSE listener can't leak the lock.
- Clarify `sw_watchers` / `sw_allEpisodesSeenBy` labels across Plex, Jellyfin, and Tautulli; add code comments pointing at the alternative property. No behaviour change for the watchers data.

Fixes #2798
Fixes #2799