### PR TITLE
feat(storage-metrics): add cumulative cleanup totals section

### DIFF
--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
@@ -158,8 +158,7 @@ describe('StorageMetricsService', () => {
         { getRawMany },
         {
           get(target, prop) {
-            if (prop in target)
-              return target[prop as keyof typeof target];
+            if (prop in target) return target[prop as keyof typeof target];
             return jest.fn().mockReturnValue(queryBuilder);
           },
         },

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
@@ -143,6 +143,42 @@ describe('StorageMetricsService', () => {
     });
   });
 
+  describe('buildCleanupTotals', () => {
+    it('keeps movie, show, season, and episode totals separate', async () => {
+      const getRawMany = jest.fn().mockResolvedValue([
+        { type: 'movie', handled: '3' },
+        { type: 'show', handled: '4' },
+        { type: 'season', handled: 5 },
+        { type: 'episode', handled: '6' },
+      ]);
+      // Self-chaining proxy: any query-builder method (select, addSelect,
+      // groupBy, where, orderBy, …) returns the same builder, so the test
+      // does not break when buildCleanupTotals adds more chained calls.
+      const queryBuilder: any = new Proxy(
+        { getRawMany },
+        {
+          get(target, prop) {
+            if (prop in target)
+              return target[prop as keyof typeof target];
+            return jest.fn().mockReturnValue(queryBuilder);
+          },
+        },
+      );
+
+      (service as any).collectionRepo = {
+        createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+      };
+
+      await expect((service as any).buildCleanupTotals()).resolves.toEqual({
+        itemsHandled: 18,
+        moviesHandled: 3,
+        showsHandled: 4,
+        seasonsHandled: 5,
+        episodesHandled: 6,
+      });
+    });
+  });
+
   describe('computeTotals', () => {
     type MountInput = Partial<StorageDiskspaceEntry> & {
       instanceType: 'radarr' | 'sonarr';

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
@@ -540,19 +540,36 @@ export class StorageMetricsService {
 
     let itemsHandled = 0;
     let moviesHandled = 0;
+    let showsHandled = 0;
+    let seasonsHandled = 0;
     let episodesHandled = 0;
 
     for (const row of rows) {
       const handled = this.toNumber(row.handled) ?? 0;
       itemsHandled += handled;
-      if (row.type === 'movie') {
-        moviesHandled += handled;
-      } else {
-        episodesHandled += handled;
+      switch (row.type) {
+        case 'movie':
+          moviesHandled += handled;
+          break;
+        case 'show':
+          showsHandled += handled;
+          break;
+        case 'season':
+          seasonsHandled += handled;
+          break;
+        case 'episode':
+          episodesHandled += handled;
+          break;
       }
     }
 
-    return { itemsHandled, moviesHandled, episodesHandled };
+    return {
+      itemsHandled,
+      moviesHandled,
+      showsHandled,
+      seasonsHandled,
+      episodesHandled,
+    };
   }
 
   private async buildCollectionSummary(): Promise<StorageCollectionSummary> {

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
@@ -3,6 +3,7 @@ import {
   MediaLibrary,
   MediaServerType,
   normalizeDiskPath,
+  StorageCleanupTotals,
   StorageCollectionSummary,
   StorageDiskspaceEntry,
   StorageInstanceStatus,
@@ -110,11 +111,13 @@ export class StorageMetricsService {
       hostByInstance,
     );
 
-    const [collectionSummary, topCollections, mediaServer] = await Promise.all([
-      this.buildCollectionSummary(),
-      this.buildTopCollections(),
-      this.buildMediaServerInfo(),
-    ]);
+    const [collectionSummary, topCollections, mediaServer, cleanupTotals] =
+      await Promise.all([
+        this.buildCollectionSummary(),
+        this.buildTopCollections(),
+        this.buildMediaServerInfo(),
+        this.buildCleanupTotals(),
+      ]);
 
     return {
       generatedAt: new Date().toISOString(),
@@ -124,6 +127,7 @@ export class StorageMetricsService {
       mediaServer,
       collectionSummary,
       topCollections,
+      cleanupTotals,
     };
   }
 
@@ -524,6 +528,31 @@ export class StorageMetricsService {
       libraries: libraryStats,
       totalItemCount,
     };
+  }
+
+  private async buildCleanupTotals(): Promise<StorageCleanupTotals> {
+    const rows = await this.collectionRepo
+      .createQueryBuilder('c')
+      .select('c.type', 'type')
+      .addSelect('COALESCE(SUM(c.handledMediaAmount), 0)', 'handled')
+      .groupBy('c.type')
+      .getRawMany<{ type: MediaItemType; handled: string | number }>();
+
+    let itemsHandled = 0;
+    let moviesHandled = 0;
+    let episodesHandled = 0;
+
+    for (const row of rows) {
+      const handled = this.toNumber(row.handled) ?? 0;
+      itemsHandled += handled;
+      if (row.type === 'movie') {
+        moviesHandled += handled;
+      } else {
+        episodesHandled += handled;
+      }
+    }
+
+    return { itemsHandled, moviesHandled, episodesHandled };
   }
 
   private async buildCollectionSummary(): Promise<StorageCollectionSummary> {

--- a/apps/ui/src/components/StorageMetrics/index.spec.tsx
+++ b/apps/ui/src/components/StorageMetrics/index.spec.tsx
@@ -70,6 +70,11 @@ describe('StorageMetrics', () => {
         isActive: true,
       },
     ],
+    cleanupTotals: {
+      itemsHandled: 0,
+      moviesHandled: 0,
+      episodesHandled: 0,
+    },
   }
 
   beforeEach(() => {

--- a/apps/ui/src/components/StorageMetrics/index.spec.tsx
+++ b/apps/ui/src/components/StorageMetrics/index.spec.tsx
@@ -1,6 +1,6 @@
 import type { StorageMetricsResponse } from '@maintainerr/contracts'
 import { MediaServerType } from '@maintainerr/contracts'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import GetApiHandler from '../../utils/ApiHandler'
@@ -19,8 +19,16 @@ vi.mock('../Common/LoadingSpinner', () => ({
 
 describe('StorageMetrics', () => {
   const getApiHandlerMock = vi.mocked(GetApiHandler)
+  let metricsResponse: StorageMetricsResponse
 
-  const metricsResponse: StorageMetricsResponse = {
+  const renderStorageMetrics = () =>
+    render(
+      <MemoryRouter>
+        <StorageMetrics />
+      </MemoryRouter>,
+    )
+
+  const createMetricsResponse = (): StorageMetricsResponse => ({
     generatedAt: '2026-04-17T00:00:00.000Z',
     totals: {
       freeSpace: 400,
@@ -73,11 +81,14 @@ describe('StorageMetrics', () => {
     cleanupTotals: {
       itemsHandled: 0,
       moviesHandled: 0,
+      showsHandled: 0,
+      seasonsHandled: 0,
       episodesHandled: 0,
     },
-  }
+  })
 
   beforeEach(() => {
+    metricsResponse = createMetricsResponse()
     getApiHandlerMock.mockReset()
     getApiHandlerMock.mockImplementation(async (path: string) => {
       if (path === '/storage-metrics') {
@@ -93,22 +104,65 @@ describe('StorageMetrics', () => {
   })
 
   it('uses router links for top collections and shows the library size caveat', async () => {
-    render(
-      <MemoryRouter>
-        <StorageMetrics />
-      </MemoryRouter>,
-    )
+    const { unmount } = renderStorageMetrics()
 
-    await waitFor(() => {
-      expect(screen.getByText('Soon Gone')).toBeTruthy()
-    })
+    try {
+      await waitFor(() => {
+        expect(screen.getByText('Soon Gone')).toBeTruthy()
+      })
 
-    expect(
-      screen.getByText('Soon Gone').closest('a')?.getAttribute('href'),
-    ).toBe('/collections/7')
-    const caveat =
-      'Sizes approximate on-disk bytes and may not fully reflect hardlinks, sparse files, or filesystem snapshots.'
+      expect(
+        screen.getByText('Soon Gone').closest('a')?.getAttribute('href'),
+      ).toBe('/collections/7')
+      const caveat =
+        'Sizes approximate on-disk bytes and may not fully reflect hardlinks, sparse files, or filesystem snapshots.'
 
-    expect(screen.getByText(caveat)).toBeTruthy()
+      expect(screen.getByText(caveat)).toBeTruthy()
+    } finally {
+      unmount()
+    }
+  })
+
+  it('renders cleanup totals with separate show, season, and episode cards', async () => {
+    metricsResponse.cleanupTotals = {
+      itemsHandled: 18,
+      moviesHandled: 3,
+      showsHandled: 4,
+      seasonsHandled: 5,
+      episodesHandled: 6,
+    }
+
+    const { unmount } = renderStorageMetrics()
+
+    try {
+      await waitFor(() => {
+        expect(screen.getByText('Shows handled')).toBeTruthy()
+      })
+
+      expect(screen.getByText('18')).toBeTruthy()
+
+      const moviesCard = screen.getByRole('region', { name: 'Movies handled' })
+      const showsCard = screen.getByRole('region', { name: 'Shows handled' })
+      const seasonsCard = screen.getByRole('region', {
+        name: 'Seasons handled',
+      })
+      const episodesCard = screen.getByRole('region', {
+        name: 'Episodes handled',
+      })
+
+      expect(within(moviesCard).getByText('3')).toBeTruthy()
+      expect(within(showsCard).getByText('4')).toBeTruthy()
+      expect(within(showsCard).getByText('From show collections')).toBeTruthy()
+      expect(within(seasonsCard).getByText('5')).toBeTruthy()
+      expect(
+        within(seasonsCard).getByText('From season collections'),
+      ).toBeTruthy()
+      expect(within(episodesCard).getByText('6')).toBeTruthy()
+      expect(
+        within(episodesCard).getByText('From episode collections'),
+      ).toBeTruthy()
+    } finally {
+      unmount()
+    }
   })
 })

--- a/apps/ui/src/components/StorageMetrics/index.tsx
+++ b/apps/ui/src/components/StorageMetrics/index.tsx
@@ -1,5 +1,6 @@
 import {
   ChartBarIcon,
+  CheckCircleIcon,
   CollectionIcon,
   DesktopComputerIcon,
   ExclamationCircleIcon,
@@ -136,7 +137,8 @@ const StorageMetrics: React.FC = () => {
   const hasInstances = metrics.instances.length > 0
   const hasAnyMounts = metrics.mounts.length > 0
   const hasCollectionData = metrics.collectionSummary.totalCollectionCount > 0
-  const { totals } = metrics
+  const { totals, cleanupTotals } = metrics
+  const hasCleanupActivity = cleanupTotals.itemsHandled > 0
   const hasAnyTotal = totals.totalSpace > 0
   const hasAnyFree = totals.freeSpace > 0 || totals.mountCount > 0
   const mountLabel = (count: number) =>
@@ -193,6 +195,39 @@ const StorageMetrics: React.FC = () => {
             icon={<CollectionIcon className="h-5 w-5" />}
           />
         </div>
+
+        <section className="mt-8">
+          <h2 className="sm-heading">Cleanup totals</h2>
+          <p className="description">
+            Cumulative count of media items Maintainerr has handled across all
+            collections. Counters increment each time a collection action
+            removes, unmonitors, or otherwise processes a media item.
+          </p>
+          <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <SummaryCard
+              title="Items handled"
+              value={cleanupTotals.itemsHandled.toLocaleString()}
+              subtitle={
+                hasCleanupActivity
+                  ? 'Total across all collections'
+                  : 'No items processed yet'
+              }
+              icon={<CheckCircleIcon className="h-5 w-5" />}
+            />
+            <SummaryCard
+              title="Movies handled"
+              value={cleanupTotals.moviesHandled.toLocaleString()}
+              subtitle="From movie collections"
+              icon={<FilmIcon className="h-5 w-5" />}
+            />
+            <SummaryCard
+              title="Episodes handled"
+              value={cleanupTotals.episodesHandled.toLocaleString()}
+              subtitle="From show, season, and episode collections"
+              icon={<DesktopComputerIcon className="h-5 w-5" />}
+            />
+          </div>
+        </section>
 
         <section className="mt-8">
           <h2 className="sm-heading">Potential reclaim by type</h2>

--- a/apps/ui/src/components/StorageMetrics/index.tsx
+++ b/apps/ui/src/components/StorageMetrics/index.tsx
@@ -6,6 +6,7 @@ import {
   ExclamationCircleIcon,
   FilmIcon,
   FolderIcon,
+  PlayIcon,
   ServerIcon,
 } from '@heroicons/react/solid'
 import type {
@@ -39,7 +40,11 @@ const SummaryCard: React.FC<SummaryCardProps> = ({
   subtitle,
   icon,
 }) => (
-  <div className="transparent-glass-bg flex flex-col rounded-lg border border-zinc-700 p-4 shadow">
+  <div
+    role="region"
+    aria-label={title}
+    className="transparent-glass-bg flex flex-col rounded-lg border border-zinc-700 p-4 shadow"
+  >
     <div className="flex items-center text-sm font-medium uppercase tracking-wide text-zinc-400">
       <span className="mr-2 text-maintainerr-500">{icon}</span>
       {title}
@@ -203,7 +208,7 @@ const StorageMetrics: React.FC = () => {
             collections. Counters increment each time a collection action
             removes, unmonitors, or otherwise processes a media item.
           </p>
-          <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
             <SummaryCard
               title="Items handled"
               value={cleanupTotals.itemsHandled.toLocaleString()}
@@ -221,10 +226,22 @@ const StorageMetrics: React.FC = () => {
               icon={<FilmIcon className="h-5 w-5" />}
             />
             <SummaryCard
+              title="Shows handled"
+              value={cleanupTotals.showsHandled.toLocaleString()}
+              subtitle="From show collections"
+              icon={<DesktopComputerIcon className="h-5 w-5" />}
+            />
+            <SummaryCard
+              title="Seasons handled"
+              value={cleanupTotals.seasonsHandled.toLocaleString()}
+              subtitle="From season collections"
+              icon={<CollectionIcon className="h-5 w-5" />}
+            />
+            <SummaryCard
               title="Episodes handled"
               value={cleanupTotals.episodesHandled.toLocaleString()}
-              subtitle="From show, season, and episode collections"
-              icon={<DesktopComputerIcon className="h-5 w-5" />}
+              subtitle="From episode collections"
+              icon={<PlayIcon className="h-5 w-5" />}
             />
           </div>
         </section>

--- a/packages/contracts/src/storage-metrics/index.ts
+++ b/packages/contracts/src/storage-metrics/index.ts
@@ -64,6 +64,8 @@ export interface StorageMediaServerLibrary {
 export interface StorageCleanupTotals {
   itemsHandled: number
   moviesHandled: number
+  showsHandled: number
+  seasonsHandled: number
   episodesHandled: number
 }
 

--- a/packages/contracts/src/storage-metrics/index.ts
+++ b/packages/contracts/src/storage-metrics/index.ts
@@ -61,6 +61,12 @@ export interface StorageMediaServerLibrary {
   sizeBytes: number | null
 }
 
+export interface StorageCleanupTotals {
+  itemsHandled: number
+  moviesHandled: number
+  episodesHandled: number
+}
+
 export interface StorageMediaServerInfo {
   configured: boolean
   serverType: MediaServerType | null
@@ -79,6 +85,7 @@ export interface StorageMetricsResponse {
   mediaServer: StorageMediaServerInfo
   collectionSummary: StorageCollectionSummary
   topCollections: StorageTopCollection[]
+  cleanupTotals: StorageCleanupTotals
 }
 
 export interface StorageLibrarySizesResponse {


### PR DESCRIPTION
Surfaces cumulative items handled, movies handled, and episodes handled on the Storage Metrics page so users can see what Maintainerr has processed across all collections over time. Aggregates the existing Collection.handledMediaAmount counter grouped by collection type — no schema change.

<img width="1646" height="228" alt="image" src="https://github.com/user-attachments/assets/66643ab2-126c-4751-8b16-2a47a6731040" />

Can be expanded to include Storage over time in the future.