### PR TITLE
fix: harden server logging against stdio EPIPE

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -8,6 +8,13 @@ import path from 'path';
 import { AppModule } from './app/app.module';
 import { dataDir } from './app/config/dataDir';
 import { MaintainerrLogger } from './modules/logging/logs.service';
+import { installStdioPipeGuards } from './modules/logging/winston/stdioPipeGuard';
+
+// Pre-bootstrap guard so the console.warn/console.error calls below — and any
+// other write before LogsModule loads — cannot crash the process on a broken
+// stdio pipe. The logging module re-installs these (idempotent) for
+// defence-in-depth.
+installStdioPipeGuards();
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -95,6 +102,21 @@ process
     // We do not exit the process here as the error is unlikely to be fatal.
   })
   .on('uncaughtException', (err) => {
+    const code =
+      err && typeof err === 'object'
+        ? (err as NodeJS.ErrnoException).code
+        : undefined;
+
+    // A broken stdout/stderr pipe (EPIPE/ERR_STREAM_DESTROYED) is an
+    // output-sink failure, not an application correctness failure. The
+    // logging module installs guards on process.stdout/stderr to swallow
+    // these; this is a silent fallback in case one slips through. We don't
+    // log here because writing to the same broken sink could re-trigger the
+    // crash we're avoiding.
+    if (code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED') {
+      return;
+    }
+
     new Logger('main').error(
       'The server has crashed because of an uncaughtException. This is likely a bug, please report this issue on GitHub.',
       err,

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -102,21 +102,6 @@ process
     // We do not exit the process here as the error is unlikely to be fatal.
   })
   .on('uncaughtException', (err) => {
-    const code =
-      err && typeof err === 'object'
-        ? (err as NodeJS.ErrnoException).code
-        : undefined;
-
-    // A broken stdout/stderr pipe (EPIPE/ERR_STREAM_DESTROYED) is an
-    // output-sink failure, not an application correctness failure. The
-    // logging module installs guards on process.stdout/stderr to swallow
-    // these; this is a silent fallback in case one slips through. We don't
-    // log here because writing to the same broken sink could re-trigger the
-    // crash we're avoiding.
-    if (code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED') {
-      return;
-    }
-
     new Logger('main').error(
       'The server has crashed because of an uncaughtException. This is likely a bug, please report this issue on GitHub.',
       err,

--- a/apps/server/src/modules/logging/logs.module.ts
+++ b/apps/server/src/modules/logging/logs.module.ts
@@ -16,6 +16,9 @@ import {
   MaintainerrLoggerFactory,
 } from './logs.service';
 import { EventEmitterTransport } from './winston/eventEmitterTransport';
+import { installStdioPipeGuards } from './winston/stdioPipeGuard';
+
+installStdioPipeGuards();
 
 const dataDir =
   process.env.NODE_ENV === 'production'

--- a/apps/server/src/modules/logging/winston/stdioPipeGuard.spec.ts
+++ b/apps/server/src/modules/logging/winston/stdioPipeGuard.spec.ts
@@ -72,9 +72,7 @@ describe('stdioPipeGuard', () => {
       const stream = makeStream();
       installStdioPipeGuard(stream);
 
-      expect(() => stream.emit('error', makeError('ENOSPC'))).toThrow(
-        /ENOSPC/,
-      );
+      expect(() => stream.emit('error', makeError('ENOSPC'))).toThrow(/ENOSPC/);
     });
 
     it('is idempotent: re-installing does not double-attach listeners', () => {

--- a/apps/server/src/modules/logging/winston/stdioPipeGuard.spec.ts
+++ b/apps/server/src/modules/logging/winston/stdioPipeGuard.spec.ts
@@ -1,0 +1,91 @@
+import { EventEmitter } from 'events';
+import {
+  installStdioPipeGuard,
+  StdioStream,
+  __testing,
+} from './stdioPipeGuard';
+
+const makeStream = (): StdioStream => {
+  const emitter = new EventEmitter() as unknown as StdioStream;
+  return emitter;
+};
+
+const makeError = (code: string): NodeJS.ErrnoException => {
+  const err = new Error(`write ${code}`) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+};
+
+describe('stdioPipeGuard', () => {
+  describe('isBrokenPipeError', () => {
+    it.each(['EPIPE', 'ERR_STREAM_DESTROYED'])(
+      'classifies %s as a broken pipe error',
+      (code) => {
+        expect(__testing.isBrokenPipeError(makeError(code))).toBe(true);
+      },
+    );
+
+    it.each([
+      ['ENOSPC', makeError('ENOSPC')],
+      ['no code', new Error('boom')],
+      ['null', null],
+      ['string', 'EPIPE'],
+    ])('rejects %s as a non-broken-pipe error', (_label, value) => {
+      expect(__testing.isBrokenPipeError(value)).toBe(false);
+    });
+  });
+
+  describe('installStdioPipeGuard', () => {
+    it('swallows EPIPE without invoking the unexpected-error handler', () => {
+      const stream = makeStream();
+      const onUnexpected = jest.fn();
+      installStdioPipeGuard(stream, onUnexpected);
+
+      expect(() => stream.emit('error', makeError('EPIPE'))).not.toThrow();
+      expect(onUnexpected).not.toHaveBeenCalled();
+    });
+
+    it('swallows ERR_STREAM_DESTROYED without invoking the handler', () => {
+      const stream = makeStream();
+      const onUnexpected = jest.fn();
+      installStdioPipeGuard(stream, onUnexpected);
+
+      expect(() =>
+        stream.emit('error', makeError('ERR_STREAM_DESTROYED')),
+      ).not.toThrow();
+      expect(onUnexpected).not.toHaveBeenCalled();
+    });
+
+    it('forwards non-broken-pipe errors to the handler', () => {
+      const stream = makeStream();
+      const onUnexpected = jest.fn();
+      installStdioPipeGuard(stream, onUnexpected);
+
+      const err = makeError('ENOSPC');
+      stream.emit('error', err);
+
+      expect(onUnexpected).toHaveBeenCalledTimes(1);
+      expect(onUnexpected).toHaveBeenCalledWith(err);
+    });
+
+    it('rethrows non-broken-pipe errors when no handler is provided', () => {
+      const stream = makeStream();
+      installStdioPipeGuard(stream);
+
+      expect(() => stream.emit('error', makeError('ENOSPC'))).toThrow(
+        /ENOSPC/,
+      );
+    });
+
+    it('is idempotent: re-installing does not double-attach listeners', () => {
+      const stream = makeStream();
+      const onUnexpected = jest.fn();
+      installStdioPipeGuard(stream, onUnexpected);
+      installStdioPipeGuard(stream, onUnexpected);
+
+      stream.emit('error', makeError('ENOSPC'));
+
+      expect(onUnexpected).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/server/src/modules/logging/winston/stdioPipeGuard.ts
+++ b/apps/server/src/modules/logging/winston/stdioPipeGuard.ts
@@ -1,0 +1,35 @@
+const BROKEN_PIPE_CODES = new Set(['EPIPE', 'ERR_STREAM_DESTROYED']);
+
+const isBrokenPipeError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return typeof code === 'string' && BROKEN_PIPE_CODES.has(code);
+};
+
+export type StdioStream = NodeJS.WriteStream & { __pipeGuarded?: boolean };
+
+export const installStdioPipeGuard = (
+  stream: StdioStream,
+  onUnexpectedError?: (error: Error) => void,
+): void => {
+  if (stream.__pipeGuarded) return;
+  stream.__pipeGuarded = true;
+
+  stream.on('error', (error: NodeJS.ErrnoException) => {
+    if (isBrokenPipeError(error)) return;
+    if (onUnexpectedError) {
+      onUnexpectedError(error);
+      return;
+    }
+    throw error;
+  });
+};
+
+export const installStdioPipeGuards = (
+  onUnexpectedError?: (error: Error) => void,
+): void => {
+  installStdioPipeGuard(process.stdout as StdioStream, onUnexpectedError);
+  installStdioPipeGuard(process.stderr as StdioStream, onUnexpectedError);
+};
+
+export const __testing = { isBrokenPipeError };


### PR DESCRIPTION
## Summary

Prevent broken `stdout`/`stderr` pipes from crashing the server during logging by installing stdio guards before bootstrap and covering the behavior with focused tests.

Related: #2807

## Validation

- `yarn workspace @maintainerr/server jest --runTestsByPath src/modules/logging/winston/stdioPipeGuard.spec.ts src/modules/events/events.controller.spec.ts src/modules/logging/logs.controller.spec.ts src/modules/overlays/overlay-processor.service.spec.ts`