### PR TITLE
fix(app): correct version comparison for multi-digit segments

### DIFF
--- a/apps/server/src/app/app.service.spec.ts
+++ b/apps/server/src/app/app.service.spec.ts
@@ -127,6 +127,32 @@ describe('AppService', () => {
     expect(githubApi.getLatestRelease).not.toHaveBeenCalled();
   });
 
+  it('detects updates across multi-digit version segments', async () => {
+    process.env.npm_package_version = '3.9.0';
+    process.env.VERSION_TAG = 'latest';
+    process.env.GIT_SHA = 'bd8a1e0123456789';
+    process.env.NODE_ENV = 'production';
+
+    githubApi.getLatestRelease.mockResolvedValue({ tag_name: 'v3.10.1' });
+
+    await expect(service.getAppVersionStatus()).resolves.toMatchObject({
+      updateAvailable: true,
+    });
+  });
+
+  it('does not flag an update when local is newer than remote', async () => {
+    process.env.npm_package_version = '3.10.0';
+    process.env.VERSION_TAG = 'latest';
+    process.env.GIT_SHA = 'bd8a1e0123456789';
+    process.env.NODE_ENV = 'production';
+
+    githubApi.getLatestRelease.mockResolvedValue({ tag_name: 'v3.9.5' });
+
+    await expect(service.getAppVersionStatus()).resolves.toMatchObject({
+      updateAvailable: false,
+    });
+  });
+
   it('keeps local development builds marked as local', async () => {
     process.env.npm_package_version = '3.3.0';
     process.env.VERSION_TAG = 'development';

--- a/apps/server/src/app/app.service.ts
+++ b/apps/server/src/app/app.service.ts
@@ -103,8 +103,9 @@ export class AppService {
   }
 
   private parseSemver(version: string): [number, number, number] {
-    const cleaned = version.replace(/^v/, '').split('-')[0];
-    const segments = cleaned.split('.').map((s) => Number.parseInt(s, 10));
+    const withoutPrefix = version.startsWith('v') ? version.slice(1) : version;
+    const core = withoutPrefix.split('-')[0];
+    const segments = core.split('.').map((s) => Number.parseInt(s, 10));
     return [
       Number.isFinite(segments[0]) ? segments[0] : 0,
       Number.isFinite(segments[1]) ? segments[1] : 0,

--- a/apps/server/src/app/app.service.ts
+++ b/apps/server/src/app/app.service.ts
@@ -67,15 +67,7 @@ export class AppService {
         'Maintainerr',
       );
       if (githubResp && githubResp.tag_name) {
-        const transformedLocalVersion = currentVersion
-          .replace('v', '')
-          .replace('.', '');
-
-        const transformedGithubVersion = githubResp.tag_name
-          .replace('v', '')
-          .replace('.', '');
-
-        return transformedGithubVersion > transformedLocalVersion;
+        return this.isRemoteVersionNewer(currentVersion, githubResp.tag_name);
       }
       this.logger.warn(`Couldn't fetch latest release version from GitHub`);
       return false;
@@ -97,5 +89,26 @@ export class AppService {
       }
     }
     return false;
+  }
+
+  private isRemoteVersionNewer(local: string, remote: string): boolean {
+    const localParts = this.parseSemver(local);
+    const remoteParts = this.parseSemver(remote);
+
+    for (let i = 0; i < 3; i++) {
+      if (remoteParts[i] > localParts[i]) return true;
+      if (remoteParts[i] < localParts[i]) return false;
+    }
+    return false;
+  }
+
+  private parseSemver(version: string): [number, number, number] {
+    const cleaned = version.replace(/^v/, '').split('-')[0];
+    const segments = cleaned.split('.').map((s) => Number.parseInt(s, 10));
+    return [
+      Number.isFinite(segments[0]) ? segments[0] : 0,
+      Number.isFinite(segments[1]) ? segments[1] : 0,
+      Number.isFinite(segments[2]) ? segments[2] : 0,
+    ];
   }
 }


### PR DESCRIPTION
## Summary

Sidebar update indicator stopped lighting up for users on `latest`/`stable` once v3.10 shipped.

`isUpdateAvailable` stripped only the first dot via `.replace('.', '')` and then did a lexicographic string compare:

- `3.9.0`  → `"39.0"`
- `3.10.1` → `"310.1"`
- `"310.1" > "39.0"` → `false` (char `'1' < '9'`)

So every release-channel install missed updates from 3.10 onward. Replaced with proper numeric semver compare (split on `.`, compare each segment as an integer). Added regression tests for `3.9.0 → 3.10.1` and the reverse direction.

Closes #2835