### PR TITLE
fix(storage-metrics): merge shared volumes across hosts when byte-exact

### DIFF
--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
@@ -478,7 +478,37 @@ describe('StorageMetricsService', () => {
       expect(totals.mountCount).toBe(2);
     });
 
-    it('does not merge identical capacities across different hosts', () => {
+    it('merges shared storage across different hosts when totalSpace and freeSpace match byte-for-byte', () => {
+      const totals = compute(
+        [
+          mount({
+            instanceType: 'radarr',
+            instanceId: 1,
+            path: '/data/media/movies',
+            freeSpace: 2761668689920,
+            totalSpace: 4000000000000,
+          }),
+          mount({
+            instanceType: 'sonarr',
+            instanceId: 1,
+            path: '/data/media/tv',
+            freeSpace: 2761668689920,
+            totalSpace: 4000000000000,
+          }),
+        ],
+        {
+          'radarr||1': ['/data/media/movies'],
+          'sonarr||1': ['/data/media/tv'],
+        },
+        { 'radarr||1': 'radarr-lxc.local', 'sonarr||1': 'sonarr-lxc.local' },
+      );
+
+      expect(totals.totalSpace).toBe(4000000000000);
+      expect(totals.freeSpace).toBe(2761668689920);
+      expect(totals.mountCount).toBe(1);
+    });
+
+    it('keeps same-capacity disks on different hosts separate when freeSpace differs', () => {
       const totals = compute(
         [
           mount({
@@ -492,7 +522,7 @@ describe('StorageMetricsService', () => {
             instanceType: 'sonarr',
             instanceId: 1,
             path: '/tv',
-            freeSpace: 180,
+            freeSpace: 181,
             totalSpace: 200,
           }),
         ],
@@ -502,6 +532,34 @@ describe('StorageMetricsService', () => {
 
       expect(totals.totalSpace).toBe(400);
       expect(totals.mountCount).toBe(2);
+    });
+
+    it('merges shared storage across hosts when a matching volume label confirms identity', () => {
+      const totals = compute(
+        [
+          mount({
+            instanceType: 'radarr',
+            instanceId: 1,
+            path: '/movies',
+            label: 'media-pool',
+            freeSpace: 500,
+            totalSpace: 1000,
+          }),
+          mount({
+            instanceType: 'sonarr',
+            instanceId: 1,
+            path: '/tv',
+            label: 'media-pool',
+            freeSpace: 480,
+            totalSpace: 1000,
+          }),
+        ],
+        { 'radarr||1': ['/movies'], 'sonarr||1': ['/tv'] },
+        { 'radarr||1': 'radarr.local', 'sonarr||1': 'sonarr.local' },
+      );
+
+      expect(totals.totalSpace).toBe(1000);
+      expect(totals.mountCount).toBe(1);
     });
 
     it('merges shared filesystems even when freeSpace drifts between back-to-back queries', () => {

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
@@ -314,9 +314,7 @@ export class StorageMetricsService {
       mountCount: merged.size,
       accurateMountCount,
       accurateTotalSpace:
-        merged.size > 0 &&
-        accurateMountCount === merged.size &&
-        totalSpace > 0,
+        merged.size > 0 && accurateMountCount === merged.size && totalSpace > 0,
     };
   }
 
@@ -346,9 +344,7 @@ export class StorageMetricsService {
     return result;
   }
 
-  private buildCrossHostSharedKey(
-    mount: StorageDiskspaceEntry,
-  ): string | null {
+  private buildCrossHostSharedKey(mount: StorageDiskspaceEntry): string | null {
     // Without an accurate totalSpace there is no reliable cross-host
     // signature, so leave inaccurate mounts on their per-host key.
     if (!mount.hasAccurateTotalSpace) return null;

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
@@ -282,6 +282,14 @@ export class StorageMetricsService {
       }
     }
 
+    // Coalesce mounts that survived the per-host dedupe but clearly point at
+    // the same shared volume from different hosts (e.g. Radarr/Sonarr running
+    // in separate LXC containers against the same NAS). A byte-exact match on
+    // totalSpace plus freeSpace — or a matching volume label plus byte-exact
+    // totalSpace — is implausible across truly unrelated filesystems, since
+    // any block-level write would diverge them.
+    const merged = this.mergeSharedMountsAcrossHosts(seen);
+
     // Sonarr's /diskspace excludes DriveType.Network, so NFS/CIFS mounts
     // commonly arrive via /rootfolder, which reports freeSpace but not
     // totalSpace. Sum freeSpace across every deduped mount so the Free card
@@ -291,7 +299,7 @@ export class StorageMetricsService {
     let totalSpace = 0;
     let accurateMountCount = 0;
 
-    for (const mount of seen.values()) {
+    for (const mount of merged.values()) {
       freeSpace += mount.freeSpace;
       if (mount.hasAccurateTotalSpace) {
         totalSpace += mount.totalSpace;
@@ -303,11 +311,53 @@ export class StorageMetricsService {
       freeSpace,
       totalSpace,
       usedSpace: Math.max(totalSpace - freeSpace, 0),
-      mountCount: seen.size,
+      mountCount: merged.size,
       accurateMountCount,
       accurateTotalSpace:
-        seen.size > 0 && accurateMountCount === seen.size && totalSpace > 0,
+        merged.size > 0 &&
+        accurateMountCount === merged.size &&
+        totalSpace > 0,
     };
+  }
+
+  /**
+   * Second-pass dedupe that merges mounts across hosts when their signature
+   * is tight enough to imply shared backend storage. Stricter than the
+   * per-host pass: cross-host requires byte-exact totalSpace+freeSpace (or
+   * label + byte-exact totalSpace), since unrelated filesystems can land in
+   * the same MiB-bucketed signature by coincidence but cannot match
+   * byte-for-byte once any IO has happened.
+   */
+  private mergeSharedMountsAcrossHosts(
+    seen: Map<string, StorageDiskspaceEntry>,
+  ): Map<string, StorageDiskspaceEntry> {
+    const result = new Map<string, StorageDiskspaceEntry>();
+    for (const [originalKey, mount] of seen) {
+      const sharedKey = this.buildCrossHostSharedKey(mount);
+      const key = sharedKey ?? originalKey;
+      const existing = result.get(key);
+      if (
+        !existing ||
+        (!existing.hasAccurateTotalSpace && mount.hasAccurateTotalSpace)
+      ) {
+        result.set(key, mount);
+      }
+    }
+    return result;
+  }
+
+  private buildCrossHostSharedKey(
+    mount: StorageDiskspaceEntry,
+  ): string | null {
+    // Without an accurate totalSpace there is no reliable cross-host
+    // signature, so leave inaccurate mounts on their per-host key.
+    if (!mount.hasAccurateTotalSpace) return null;
+
+    const label = mount.label?.trim().toLowerCase();
+    if (label) {
+      return `shared||label||${label}||${mount.totalSpace}`;
+    }
+    return `shared||cap||${mount.totalSpace}||${mount.freeSpace}`;
   }
 
   /**


### PR DESCRIPTION
Closes #2841.

Storage totals were doubled when Radarr and Sonarr ran in separate LXC containers against the same backend volume — different hostnames meant PR #2721's per-host dedupe could not collapse them.

Adds a second pass after the per-host dedupe that merges mounts across hosts only when the signature is implausibly tight for unrelated filesystems: byte-exact `totalSpace` + `freeSpace`, or matching volume label + byte-exact `totalSpace`. Any block-level write diverges unrelated hosts byte-for-byte, so the false-positive surface is narrow.

Per-host dedupe still uses the existing 1 MiB freeSpace bucket to absorb same-host poll drift between Arr clients.