### PR TITLE
feat(storage-metrics): split potential reclaim into movie/show/season/episode panels

### DIFF
--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
@@ -338,31 +338,37 @@ describe('StorageMetricsService', () => {
       expect(summary.reclaimableSizedCount).toBe(2);
     });
 
-    it('rolls season and episode collections into the show bucket so they are not silently dropped', async () => {
+    it('keeps movie, show, season, and episode collections in separate buckets', async () => {
       setup(
         [
-          { id: 1, isActive: true, deleteAfterDays: 30, type: 'season' },
-          { id: 2, isActive: true, deleteAfterDays: 30, type: 'episode' },
-          { id: 3, isActive: true, deleteAfterDays: 30, type: 'movie' },
+          { id: 1, isActive: true, deleteAfterDays: 30, type: 'movie' },
+          { id: 2, isActive: true, deleteAfterDays: 30, type: 'show' },
+          { id: 3, isActive: true, deleteAfterDays: 30, type: 'season' },
+          { id: 4, isActive: true, deleteAfterDays: 30, type: 'episode' },
         ],
         [
-          { collectionId: 1, mediaServerId: 's-1', sizeBytes: 200 },
-          { collectionId: 2, mediaServerId: 'e-1', sizeBytes: 50 },
-          { collectionId: 3, mediaServerId: 'm-1', sizeBytes: 100 },
+          { collectionId: 1, mediaServerId: 'm-1', sizeBytes: 100 },
+          { collectionId: 2, mediaServerId: 'sh-1', sizeBytes: 200 },
+          { collectionId: 3, mediaServerId: 'se-1', sizeBytes: 300 },
+          { collectionId: 4, mediaServerId: 'ep-1', sizeBytes: 50 },
         ],
       );
 
       const summary = await (service as any).buildCollectionSummary();
 
-      expect(summary.reclaimableCount).toBe(3);
-      expect(summary.activeSizeBytes).toBe(350);
+      expect(summary.reclaimableCount).toBe(4);
+      expect(summary.activeSizeBytes).toBe(650);
       expect(summary.movieSizeBytes).toBe(100);
-      expect(summary.showSizeBytes).toBe(250);
+      expect(summary.showSizeBytes).toBe(200);
+      expect(summary.seasonSizeBytes).toBe(300);
+      expect(summary.episodeSizeBytes).toBe(50);
       expect(summary.reclaimableMovieCount).toBe(1);
-      expect(summary.reclaimableShowCount).toBe(2);
+      expect(summary.reclaimableShowCount).toBe(1);
+      expect(summary.reclaimableSeasonCount).toBe(1);
+      expect(summary.reclaimableEpisodeCount).toBe(1);
     });
 
-    it('rolls season and episode collections into the show bucket in fallback mode', async () => {
+    it('keeps season and episode buckets separate in fallback mode', async () => {
       setup(
         [
           {
@@ -387,8 +393,11 @@ describe('StorageMetricsService', () => {
 
       expect(summary.reclaimableUsingFallback).toBe(true);
       expect(summary.movieSizeBytes).toBe(0);
-      expect(summary.showSizeBytes).toBe(500);
-      expect(summary.reclaimableShowCount).toBe(2);
+      expect(summary.showSizeBytes).toBe(0);
+      expect(summary.seasonSizeBytes).toBe(400);
+      expect(summary.episodeSizeBytes).toBe(100);
+      expect(summary.reclaimableSeasonCount).toBe(1);
+      expect(summary.reclaimableEpisodeCount).toBe(1);
     });
   });
 

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.spec.ts
@@ -148,7 +148,7 @@ describe('StorageMetricsService', () => {
       id: number;
       isActive: boolean;
       deleteAfterDays: number | null;
-      type: 'movie' | 'show';
+      type: 'movie' | 'show' | 'season' | 'episode';
     };
     type FakeMediaRow = {
       collectionId: number;
@@ -336,6 +336,59 @@ describe('StorageMetricsService', () => {
       expect(summary.movieSizeBytes).toBe(300);
       expect(summary.showSizeBytes).toBe(700);
       expect(summary.reclaimableSizedCount).toBe(2);
+    });
+
+    it('rolls season and episode collections into the show bucket so they are not silently dropped', async () => {
+      setup(
+        [
+          { id: 1, isActive: true, deleteAfterDays: 30, type: 'season' },
+          { id: 2, isActive: true, deleteAfterDays: 30, type: 'episode' },
+          { id: 3, isActive: true, deleteAfterDays: 30, type: 'movie' },
+        ],
+        [
+          { collectionId: 1, mediaServerId: 's-1', sizeBytes: 200 },
+          { collectionId: 2, mediaServerId: 'e-1', sizeBytes: 50 },
+          { collectionId: 3, mediaServerId: 'm-1', sizeBytes: 100 },
+        ],
+      );
+
+      const summary = await (service as any).buildCollectionSummary();
+
+      expect(summary.reclaimableCount).toBe(3);
+      expect(summary.activeSizeBytes).toBe(350);
+      expect(summary.movieSizeBytes).toBe(100);
+      expect(summary.showSizeBytes).toBe(250);
+      expect(summary.reclaimableMovieCount).toBe(1);
+      expect(summary.reclaimableShowCount).toBe(2);
+    });
+
+    it('rolls season and episode collections into the show bucket in fallback mode', async () => {
+      setup(
+        [
+          {
+            id: 1,
+            isActive: true,
+            deleteAfterDays: 30,
+            type: 'season',
+            totalSizeBytes: 400,
+          } as any,
+          {
+            id: 2,
+            isActive: true,
+            deleteAfterDays: 30,
+            type: 'episode',
+            totalSizeBytes: 100,
+          } as any,
+        ],
+        [],
+      );
+
+      const summary = await (service as any).buildCollectionSummary();
+
+      expect(summary.reclaimableUsingFallback).toBe(true);
+      expect(summary.movieSizeBytes).toBe(0);
+      expect(summary.showSizeBytes).toBe(500);
+      expect(summary.reclaimableShowCount).toBe(2);
     });
   });
 

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
@@ -600,6 +600,8 @@ export class StorageMetricsService {
     let inactiveCount = 0;
     let reclaimableMovieCount = 0;
     let reclaimableShowCount = 0;
+    let reclaimableSeasonCount = 0;
+    let reclaimableEpisodeCount = 0;
     const eligibleIds = new Set<number>();
 
     for (const collection of collections) {
@@ -619,11 +621,12 @@ export class StorageMetricsService {
         reclaimableCount += 1;
         if (collection.type === 'movie') {
           reclaimableMovieCount += 1;
-        } else {
-          // 'show', 'season', and 'episode' are all show-derived content;
-          // roll them into the same bucket so episode/season collections
-          // are not silently dropped from the per-type breakdown.
+        } else if (collection.type === 'show') {
           reclaimableShowCount += 1;
+        } else if (collection.type === 'season') {
+          reclaimableSeasonCount += 1;
+        } else if (collection.type === 'episode') {
+          reclaimableEpisodeCount += 1;
         }
       }
     }
@@ -631,6 +634,8 @@ export class StorageMetricsService {
     let activeSizeBytes = 0;
     let movieSizeBytes = 0;
     let showSizeBytes = 0;
+    let seasonSizeBytes = 0;
+    let episodeSizeBytes = 0;
     let reclaimableSizedCount = 0;
     let reclaimableUsingFallback = false;
 
@@ -666,8 +671,12 @@ export class StorageMetricsService {
         activeSizeBytes += size;
         if (row.type === 'movie') {
           movieSizeBytes += size;
-        } else {
+        } else if (row.type === 'show') {
           showSizeBytes += size;
+        } else if (row.type === 'season') {
+          seasonSizeBytes += size;
+        } else if (row.type === 'episode') {
+          episodeSizeBytes += size;
         }
       }
 
@@ -688,6 +697,8 @@ export class StorageMetricsService {
         activeSizeBytes = 0;
         movieSizeBytes = 0;
         showSizeBytes = 0;
+        seasonSizeBytes = 0;
+        episodeSizeBytes = 0;
         reclaimableSizedCount = 0;
 
         for (const collection of collections) {
@@ -698,8 +709,12 @@ export class StorageMetricsService {
           activeSizeBytes += total;
           if (collection.type === 'movie') {
             movieSizeBytes += total;
-          } else {
+          } else if (collection.type === 'show') {
             showSizeBytes += total;
+          } else if (collection.type === 'season') {
+            seasonSizeBytes += total;
+          } else if (collection.type === 'episode') {
+            episodeSizeBytes += total;
           }
           reclaimableSizedCount += 1;
         }
@@ -716,8 +731,12 @@ export class StorageMetricsService {
       totalCollectionCount: collections.length,
       movieSizeBytes,
       showSizeBytes,
+      seasonSizeBytes,
+      episodeSizeBytes,
       reclaimableMovieCount,
       reclaimableShowCount,
+      reclaimableSeasonCount,
+      reclaimableEpisodeCount,
       reclaimableUsingFallback,
     };
   }

--- a/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
+++ b/apps/server/src/modules/storage-metrics/storage-metrics.service.ts
@@ -619,7 +619,10 @@ export class StorageMetricsService {
         reclaimableCount += 1;
         if (collection.type === 'movie') {
           reclaimableMovieCount += 1;
-        } else if (collection.type === 'show') {
+        } else {
+          // 'show', 'season', and 'episode' are all show-derived content;
+          // roll them into the same bucket so episode/season collections
+          // are not silently dropped from the per-type breakdown.
           reclaimableShowCount += 1;
         }
       }
@@ -663,7 +666,7 @@ export class StorageMetricsService {
         activeSizeBytes += size;
         if (row.type === 'movie') {
           movieSizeBytes += size;
-        } else if (row.type === 'show') {
+        } else {
           showSizeBytes += size;
         }
       }
@@ -695,7 +698,7 @@ export class StorageMetricsService {
           activeSizeBytes += total;
           if (collection.type === 'movie') {
             movieSizeBytes += total;
-          } else if (collection.type === 'show') {
+          } else {
             showSizeBytes += total;
           }
           reclaimableSizedCount += 1;

--- a/apps/ui/src/components/StorageMetrics/index.spec.tsx
+++ b/apps/ui/src/components/StorageMetrics/index.spec.tsx
@@ -65,8 +65,12 @@ describe('StorageMetrics', () => {
       totalCollectionCount: 1,
       movieSizeBytes: 500,
       showSizeBytes: 0,
+      seasonSizeBytes: 0,
+      episodeSizeBytes: 0,
       reclaimableMovieCount: 1,
       reclaimableShowCount: 0,
+      reclaimableSeasonCount: 0,
+      reclaimableEpisodeCount: 0,
       reclaimableUsingFallback: false,
     },
     topCollections: [
@@ -201,6 +205,45 @@ describe('StorageMetrics', () => {
           'Based on cached collection totals while per-item sizes are still backfilling. Duplicates across collections are resolved after the next collection size refresh.',
         ),
       ).toBeTruthy()
+    } finally {
+      unmount()
+    }
+  })
+
+  it('renders potential reclaim with separate movie, show, season, and episode panels', async () => {
+    metricsResponse.collectionSummary = {
+      ...metricsResponse.collectionSummary,
+      reclaimableCount: 4,
+      reclaimableSizedCount: 4,
+      activeSizeBytes: 1000,
+      movieSizeBytes: 100,
+      showSizeBytes: 200,
+      seasonSizeBytes: 300,
+      episodeSizeBytes: 400,
+      reclaimableMovieCount: 1,
+      reclaimableShowCount: 1,
+      reclaimableSeasonCount: 1,
+      reclaimableEpisodeCount: 1,
+    }
+
+    const { unmount } = renderStorageMetrics()
+
+    try {
+      const heading = await screen.findByRole('heading', {
+        name: 'Potential reclaim by type',
+      })
+      const section = heading.closest('section')
+      expect(section).toBeTruthy()
+      const within_ = within(section as HTMLElement)
+
+      expect(within_.getByText('Movies')).toBeTruthy()
+      expect(within_.getByText('Shows')).toBeTruthy()
+      expect(within_.getByText('Seasons')).toBeTruthy()
+      expect(within_.getByText('Episodes')).toBeTruthy()
+      expect(within_.getByText('100 B')).toBeTruthy()
+      expect(within_.getByText('200 B')).toBeTruthy()
+      expect(within_.getByText('300 B')).toBeTruthy()
+      expect(within_.getByText('400 B')).toBeTruthy()
     } finally {
       unmount()
     }

--- a/apps/ui/src/components/StorageMetrics/index.tsx
+++ b/apps/ui/src/components/StorageMetrics/index.tsx
@@ -259,7 +259,7 @@ const StorageMetrics: React.FC = () => {
               ? 'Based on cached collection totals while per-item sizes are still backfilling. Duplicates across collections are resolved after the next collection size refresh.'
               : 'Based on cached collection sizes, deduplicated across collections. Run collection processing jobs to refresh size data.'}
           </p>
-          <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <div className="transparent-glass-bg rounded-lg border border-zinc-700 p-4">
               <div className="flex items-center justify-between text-sm text-zinc-300">
                 <span className="flex items-center gap-2">
@@ -292,6 +292,40 @@ const StorageMetrics: React.FC = () => {
               </div>
               <div className="mt-2 text-2xl font-semibold text-white">
                 {formatBytes(metrics.collectionSummary.showSizeBytes)}
+              </div>
+            </div>
+            <div className="transparent-glass-bg rounded-lg border border-zinc-700 p-4">
+              <div className="flex items-center justify-between text-sm text-zinc-300">
+                <span className="flex items-center gap-2">
+                  <CollectionIcon className="h-5 w-5 text-maintainerr-500" />
+                  Seasons
+                </span>
+                <span className="text-zinc-400">
+                  {metrics.collectionSummary.reclaimableSeasonCount} collection
+                  {metrics.collectionSummary.reclaimableSeasonCount === 1
+                    ? ''
+                    : 's'}
+                </span>
+              </div>
+              <div className="mt-2 text-2xl font-semibold text-white">
+                {formatBytes(metrics.collectionSummary.seasonSizeBytes)}
+              </div>
+            </div>
+            <div className="transparent-glass-bg rounded-lg border border-zinc-700 p-4">
+              <div className="flex items-center justify-between text-sm text-zinc-300">
+                <span className="flex items-center gap-2">
+                  <PlayIcon className="h-5 w-5 text-maintainerrdark-500" />
+                  Episodes
+                </span>
+                <span className="text-zinc-400">
+                  {metrics.collectionSummary.reclaimableEpisodeCount} collection
+                  {metrics.collectionSummary.reclaimableEpisodeCount === 1
+                    ? ''
+                    : 's'}
+                </span>
+              </div>
+              <div className="mt-2 text-2xl font-semibold text-white">
+                {formatBytes(metrics.collectionSummary.episodeSizeBytes)}
               </div>
             </div>
           </div>

--- a/packages/contracts/src/storage-metrics/index.ts
+++ b/packages/contracts/src/storage-metrics/index.ts
@@ -50,10 +50,18 @@ export interface StorageCollectionSummary {
   movieSizeBytes: number
   /** Show portion of `activeSizeBytes` (deduplicated). */
   showSizeBytes: number
+  /** Season portion of `activeSizeBytes` (deduplicated). */
+  seasonSizeBytes: number
+  /** Episode portion of `activeSizeBytes` (deduplicated). */
+  episodeSizeBytes: number
   /** Count of reclaimable movie collections. */
   reclaimableMovieCount: number
   /** Count of reclaimable show collections. */
   reclaimableShowCount: number
+  /** Count of reclaimable season collections. */
+  reclaimableSeasonCount: number
+  /** Count of reclaimable episode collections. */
+  reclaimableEpisodeCount: number
   /**
    * True when `activeSizeBytes` was computed from cached per-collection
    * totals because per-item sizes have not been backfilled for every


### PR DESCRIPTION
## Summary

The Storage Metrics page's *Potential reclaim by type* panel only had Movies and Shows buckets. Season and episode collections fell through both the count and bytes branches and were silently dropped, while the header card directly above counted them — so the same view could show `1 of 1 reclaimable collections sized — 232 GB` immediately above `Movies 0 B / 0 collections, Shows 0 B / 0 collections` for an episode-typed collection.

This adds Seasons and Episodes panels to mirror the Cleanup totals layout (which already breaks out all four types). Now the per-type breakdown matches the header total and matches the Cleanup totals icons + structure.

## Changes

- **Contract** (`StorageCollectionSummary`): adds `seasonSizeBytes`, `episodeSizeBytes`, `reclaimableSeasonCount`, `reclaimableEpisodeCount`.
- **Service** (`buildCollectionSummary`): splits the count loop, the per-item DB-grouped sum, and the fallback per-collection-total sum into four explicit type branches.
- **UI**: grid widens from `sm:grid-cols-2` to `sm:grid-cols-2 lg:grid-cols-4`; Seasons uses `CollectionIcon`, Episodes uses `PlayIcon` — matching the Cleanup totals row.
- **Tests**: 25 server tests pass (two updated for the four-bucket split, including a fallback-mode case); 4 UI tests pass (new regression test asserting all four panels render).

## Validation

End-to-end checked with the dev server + Playwright + a seeded SQLite DB:

1. **Per-item path**: seeded 4 collections (one of each type) with `collection_media.sizeBytes` populated. UI shows Movies 953.67 MB / Shows 1.86 GB / Seasons 2.79 GB / Episodes 476.84 MB; header total 6.05 GB matches the sum of the four buckets.
2. **Fallback path**: cleared `collection_media` rows so per-item sizes are missing; service falls back to `collection.totalSizeBytes`. All four panels still display correctly with the fallback subtitle copy active.
3. **User's original reproducer**: a single episode-typed collection with 232 GB. Header reads 232.00 GB / 1 of 1 sized; Movies/Shows/Seasons all show 0 B / 0 collections; **Episodes shows 232.00 GB / 1 collection** — bytes are no longer invisible.
4. **Cleanup totals bytes-reclaimed**: seeded `handledMediaAmount` and `handledMediaSizeBytes` per type — all five summary cards (Items / Movies / Shows / Seasons / Episodes) display correct counts and reclaimed bytes.