### PR TITLE
fix(collections): credit reclaimed bytes when sizeBytes is not yet cached

### DIFF
--- a/apps/server/src/modules/collections/collection-handler.spec.ts
+++ b/apps/server/src/modules/collections/collection-handler.spec.ts
@@ -447,6 +447,120 @@ describe('CollectionHandler', () => {
     expect(collectionsService.saveCollection).not.toHaveBeenCalled();
   });
 
+  it('credits cached sizeBytes to handledMediaSizeBytes for delete-style actions', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      type: 'episode',
+    });
+    const collectionMedia = createCollectionMedia(collection);
+    collectionMedia.sizeBytes = 1_500_000_000 as any;
+
+    mediaServer.getLibraries.mockResolvedValue(
+      createMediaLibraries({
+        id: collection.libraryId.toString(),
+        type: 'show',
+      }),
+    );
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(collectionsService.resolveItemSize).not.toHaveBeenCalled();
+    expect(collectionsService.saveCollection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        handledMediaAmount: 1,
+        handledMediaSizeBytes: 1_500_000_000,
+      }),
+    );
+  });
+
+  it('falls back to media-server lookup when sizeBytes is null on a delete-style action', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      type: 'episode',
+    });
+    const collectionMedia = createCollectionMedia(collection);
+    collectionMedia.sizeBytes = null as any;
+
+    mediaServer.getLibraries.mockResolvedValue(
+      createMediaLibraries({
+        id: collection.libraryId.toString(),
+        type: 'show',
+      }),
+    );
+    collectionsService.resolveItemSize.mockResolvedValue(2_000_000_000);
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(collectionsService.resolveItemSize).toHaveBeenCalledWith(
+      mediaServer,
+      collectionMedia.mediaServerId,
+    );
+    expect(
+      collectionsService.resolveItemSize.mock.invocationCallOrder[0],
+    ).toBeLessThan(mediaServer.deleteFromDisk.mock.invocationCallOrder[0]);
+    expect(collectionsService.saveCollection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        handledMediaAmount: 1,
+        handledMediaSizeBytes: 2_000_000_000,
+      }),
+    );
+  });
+
+  it('does not look up size for unmonitor actions', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR,
+      sonarrSettingsId: 1,
+      type: 'show',
+    });
+    const collectionMedia = createCollectionMedia(collection);
+    collectionMedia.sizeBytes = null as any;
+
+    mediaServer.getLibraries.mockResolvedValue(
+      createMediaLibraries({
+        id: collection.libraryId.toString(),
+        type: 'show',
+      }),
+    );
+    sonarrActionHandler.handleAction.mockResolvedValue(true);
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(collectionsService.resolveItemSize).not.toHaveBeenCalled();
+    expect(collectionsService.saveCollection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        handledMediaAmount: 1,
+        handledMediaSizeBytes: 0,
+      }),
+    );
+  });
+
+  it('skips byte credit when the lookup also fails to resolve a size', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      type: 'episode',
+    });
+    const collectionMedia = createCollectionMedia(collection);
+    collectionMedia.sizeBytes = null as any;
+
+    mediaServer.getLibraries.mockResolvedValue(
+      createMediaLibraries({
+        id: collection.libraryId.toString(),
+        type: 'show',
+      }),
+    );
+    collectionsService.resolveItemSize.mockResolvedValue(null);
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(collectionsService.resolveItemSize).toHaveBeenCalled();
+    expect(collectionsService.saveCollection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        handledMediaAmount: 1,
+        handledMediaSizeBytes: 0,
+      }),
+    );
+  });
+
   it('should not call SeerrApiService if Seerr is not configured', async () => {
     const collection = createCollection({
       arrAction: ServarrAction.DELETE,

--- a/apps/server/src/modules/collections/collection-handler.ts
+++ b/apps/server/src/modules/collections/collection-handler.ts
@@ -50,6 +50,27 @@ export class CollectionHandler {
       (e) => e.id === collection.libraryId.toString(),
     );
 
+    // Resolve the on-disk size before running the action. The size cache is
+    // populated lazily by the collection size sync; if the handler runs
+    // against a freshly-added item before the next sync, `media.sizeBytes`
+    // is null and the post-action increment below would silently drop the
+    // bytes. After a delete-style action the file is gone and the media
+    // server's metadata loses the size, so this lookup has to happen first.
+    const freesDisk =
+      collection.arrAction !== ServarrAction.UNMONITOR &&
+      collection.arrAction !== ServarrAction.UNMONITOR_SHOW_IF_EMPTY &&
+      collection.arrAction !== ServarrAction.CHANGE_QUALITY_PROFILE;
+    let resolvedSizeBytes: number | null =
+      media.sizeBytes != null && Number(media.sizeBytes) > 0
+        ? Number(media.sizeBytes)
+        : null;
+    if (freesDisk && resolvedSizeBytes === null) {
+      resolvedSizeBytes = await this.collectionService.resolveItemSize(
+        mediaServer,
+        media.mediaServerId,
+      );
+    }
+
     let actionHandled = false;
 
     if (library?.type === 'movie' && collection.radarrSettingsId) {
@@ -161,15 +182,12 @@ export class CollectionHandler {
 
     collection.handledMediaAmount++;
 
-    // Only credit bytes when the action actually frees disk space.
-    // Unmonitor / quality-change actions leave files on disk.
-    const freesDisk =
-      collection.arrAction !== ServarrAction.UNMONITOR &&
-      collection.arrAction !== ServarrAction.UNMONITOR_SHOW_IF_EMPTY &&
-      collection.arrAction !== ServarrAction.CHANGE_QUALITY_PROFILE;
-    if (freesDisk && media.sizeBytes != null && media.sizeBytes > 0) {
+    // Credit bytes for delete-style actions only; unmonitor / quality-change
+    // leave files on disk. `resolvedSizeBytes` was captured before the action
+    // ran so it survives the file being gone afterwards.
+    if (freesDisk && resolvedSizeBytes != null && resolvedSizeBytes > 0) {
       collection.handledMediaSizeBytes =
-        Number(collection.handledMediaSizeBytes ?? 0) + Number(media.sizeBytes);
+        Number(collection.handledMediaSizeBytes ?? 0) + resolvedSizeBytes;
     }
 
     await this.collectionService.CollectionLogRecordForChild(

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -3058,7 +3058,10 @@ export class CollectionsService {
       const directSize = this.sumMediaSourceSizes(metadata);
       if (directSize > 0) return directSize;
       if (metadata.type === 'show' || metadata.type === 'season') {
-        const childSize = await this.getChildrenTotalSize(mediaServer, metadata);
+        const childSize = await this.getChildrenTotalSize(
+          mediaServer,
+          metadata,
+        );
         if (childSize > 0) return childSize;
       }
       return null;

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -3010,27 +3010,10 @@ export class CollectionsService {
       let hasAnySize = false;
 
       for (const media of collectionMedia) {
-        let itemSize: number | null = null;
-        try {
-          const metadata = await mediaServer.getMetadata(media.mediaServerId);
-          if (metadata) {
-            const directSize = this.sumMediaSourceSizes(metadata);
-            if (directSize > 0) {
-              itemSize = directSize;
-            } else if (metadata.type === 'show' || metadata.type === 'season') {
-              const childSize = await this.getChildrenTotalSize(
-                mediaServer,
-                metadata,
-              );
-              if (childSize > 0) itemSize = childSize;
-            }
-          }
-        } catch (error) {
-          this.logger.debug(
-            `Failed to get size for media ${media.mediaServerId}`,
-          );
-          this.logger.debug(error);
-        }
+        const itemSize = await this.resolveItemSize(
+          mediaServer,
+          media.mediaServerId,
+        );
 
         if (itemSize != null && itemSize > 0) {
           totalBytes += itemSize;
@@ -3057,6 +3040,32 @@ export class CollectionsService {
         `Failed to update total size for collection ${collectionId}`,
       );
       this.logger.debug(error);
+    }
+  }
+
+  /**
+   * Resolve the on-disk size of a single media item via the media server,
+   * falling back to summing children for shows/seasons. Returns null when
+   * the lookup fails or the server reports no usable size.
+   */
+  async resolveItemSize(
+    mediaServer: IMediaServerService,
+    mediaServerId: string,
+  ): Promise<number | null> {
+    try {
+      const metadata = await mediaServer.getMetadata(mediaServerId);
+      if (!metadata) return null;
+      const directSize = this.sumMediaSourceSizes(metadata);
+      if (directSize > 0) return directSize;
+      if (metadata.type === 'show' || metadata.type === 'season') {
+        const childSize = await this.getChildrenTotalSize(mediaServer, metadata);
+        if (childSize > 0) return childSize;
+      }
+      return null;
+    } catch (error) {
+      this.logger.debug(`Failed to get size for media ${mediaServerId}`);
+      this.logger.debug(error);
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary

`CollectionHandler.handleMedia` reads `media.sizeBytes` directly off the `collection_media` row and only increments `handledMediaSizeBytes` when it's non-null. Per-item sizes are populated lazily by `CollectionsService.updateCollectionTotalSize`, so any item handled before its first successful size sync falls into a null window — the *arr action runs, the file is deleted, and the reclaimed bytes are silently dropped from the per-collection counter and from the *Cleanup totals* breakdown. Once the file is gone the size is unrecoverable.

Symptom in the wild (a sized 232 GB episodes collection with `arrAction = 0` / `DELETE`, 128 currently-sized items, but `handledMediaAmount = 2` / `handledMediaSizeBytes = 0` for two earlier handles): the two handled items got processed in the gap before the size cache was backfilled.

## Fix

Resolve the on-disk size **before** the action runs:

- Use `media.sizeBytes` directly when it's already populated.
- Otherwise call `CollectionsService.resolveItemSize(mediaServer, mediaServerId)` — a new public helper that wraps the same `getMetadata` → `sumMediaSourceSizes` → `getChildrenTotalSize` chain `updateCollectionTotalSize` already uses (refactored to share the helper, no behavior change there).
- Stash the resolved value, run the action, and use the stashed value for the increment. Doing it before the action matters because for delete-style actions the file is gone afterwards and Plex/Jellyfin metadata loses the size on the next library scan.

Unmonitor / quality-change actions still don't contribute, by design — the lookup is skipped entirely for them.

## Cost

At most one extra `getMetadata` call per handled item, only when `sizeBytes` is null. After the first sync runs the cache is populated and subsequent handles take the cached path.

## Tests

Four new unit tests on `CollectionHandler`:
- Cached `sizeBytes` is credited and `resolveItemSize` is not called.
- Null `sizeBytes` on a delete-style action triggers the lookup, the lookup result is credited, and it runs **before** the action.
- Unmonitor actions skip the lookup and credit zero.
- A failed lookup (returns null) leaves the counter at zero without throwing.

Full collections + storage-metrics suites pass: 129/129.