### PR TITLE
fix(collections): apply collection sort on save, harden Plex reorder

### DIFF
--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -272,6 +272,10 @@ export interface IMediaServerService {
    * (or no-op) before applying. Gated by MediaServerFeature.COLLECTION_SORT.
    * Throws if not supported. Caller is responsible for filtering out
    * smart collections (Plex rejects move on smart).
+   *
+   * Implementations should short-circuit when the current child order
+   * already matches `orderedItemIds`, and continue through the full list
+   * if individual moves fail (logging a summary at the end).
    */
   reorderCollectionItems(
     collectionId: string,

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -762,6 +762,11 @@ describe('PlexAdapterService', () => {
     });
 
     it('should set custom sort then move items into the requested order', async () => {
+      plexApi.getCollectionChildren.mockResolvedValue([
+        createPlexLibraryItem('movie', { ratingKey: 'c' }),
+        createPlexLibraryItem('movie', { ratingKey: 'b' }),
+        createPlexLibraryItem('movie', { ratingKey: 'a' }),
+      ]);
       plexApi.setCollectionCustomSort.mockResolvedValue(undefined);
       plexApi.moveCollectionItem.mockResolvedValue(undefined);
 
@@ -778,8 +783,51 @@ describe('PlexAdapterService', () => {
     it('should no-op when reordering an empty list', async () => {
       await service.reorderCollectionItems('col123', []);
 
+      expect(plexApi.getCollectionChildren).not.toHaveBeenCalled();
       expect(plexApi.setCollectionCustomSort).not.toHaveBeenCalled();
       expect(plexApi.moveCollectionItem).not.toHaveBeenCalled();
+    });
+
+    it('should short-circuit without writing when current order already matches', async () => {
+      plexApi.getCollectionChildren.mockResolvedValue([
+        createPlexLibraryItem('movie', { ratingKey: 'a' }),
+        createPlexLibraryItem('movie', { ratingKey: 'b' }),
+        createPlexLibraryItem('movie', { ratingKey: 'c' }),
+      ]);
+
+      await service.reorderCollectionItems('col123', ['a', 'b', 'c']);
+
+      expect(plexApi.setCollectionCustomSort).not.toHaveBeenCalled();
+      expect(plexApi.moveCollectionItem).not.toHaveBeenCalled();
+    });
+
+    it('should continue past per-item move failures and log a summary', async () => {
+      plexApi.getCollectionChildren.mockResolvedValue([
+        createPlexLibraryItem('movie', { ratingKey: 'c' }),
+        createPlexLibraryItem('movie', { ratingKey: 'b' }),
+        createPlexLibraryItem('movie', { ratingKey: 'a' }),
+      ]);
+      plexApi.setCollectionCustomSort.mockResolvedValue(undefined);
+      plexApi.moveCollectionItem.mockImplementation(
+        async (_collectionId, itemId) => {
+          if (itemId === 'b') {
+            throw new Error('plex move 409');
+          }
+        },
+      );
+
+      await expect(
+        service.reorderCollectionItems('col123', ['a', 'b', 'c']),
+      ).resolves.toBeUndefined();
+
+      expect(plexApi.moveCollectionItem.mock.calls).toEqual([
+        ['col123', 'a', undefined],
+        ['col123', 'b', 'a'],
+        ['col123', 'c', 'a'],
+      ]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('1 failed move(s)'),
+      );
     });
   });
 });

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -694,24 +694,44 @@ export class PlexAdapterService implements IMediaServerService {
     collectionId: string,
     orderedItemIds: string[],
   ): Promise<void> {
-    if (!orderedItemIds || orderedItemIds.length === 0) {
+    if (orderedItemIds.length === 0) {
       return;
     }
 
-    try {
-      await this.plexApi.setCollectionCustomSort(collectionId);
+    // Short-circuit when the collection is already in the requested order:
+    // skip both the prefs PUT and every move PUT.
+    const currentChildren =
+      await this.plexApi.getCollectionChildren(collectionId);
+    const currentOrder =
+      currentChildren?.map((child) => child.ratingKey?.toString() ?? '') ?? [];
+    if (
+      currentOrder.length === orderedItemIds.length &&
+      currentOrder.every((id, index) => id === orderedItemIds[index])
+    ) {
+      return;
+    }
 
-      let previousId: string | undefined = undefined;
-      for (const itemId of orderedItemIds) {
+    await this.plexApi.setCollectionCustomSort(collectionId);
+
+    // Continue past per-item failures so a single rejected move doesn't
+    // leave the rest of the collection partially sorted.
+    const failedItemIds: string[] = [];
+    let previousId: string | undefined = undefined;
+    for (const itemId of orderedItemIds) {
+      try {
         await this.plexApi.moveCollectionItem(collectionId, itemId, previousId);
         previousId = itemId;
+      } catch (error) {
+        failedItemIds.push(itemId);
+        this.logger.debug(error);
       }
-    } catch (error) {
-      this.logger.error(
-        `Failed to reorder items in collection ${collectionId}`,
+    }
+
+    if (failedItemIds.length > 0) {
+      this.logger.warn(
+        `Reorder of collection ${collectionId} completed with ${failedItemIds.length} failed move(s); ` +
+          `failed item ids: ${failedItemIds.join(', ')}`,
       );
-      this.logger.debug(error);
-      throw new Error(`Failed to reorder items in collection ${collectionId}`);
     }
   }
 

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -3,7 +3,6 @@ import {
   CollectionLogMeta,
   CollectionMediaSortField,
   compareMediaItemsBySort,
-  parseCollectionSortKey,
   ECollectionLogType,
   isMediaType,
   MaintainerrEvent,
@@ -15,6 +14,7 @@ import {
   MediaServerFeature,
   MediaServerType,
   MediaSortOrder,
+  parseCollectionSortKey,
 } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -758,16 +758,21 @@ export class CollectionsService {
       );
   }
 
-  private async applyCollectionSort(
-    collection: Collection,
-    mediaServer: IMediaServerService,
-  ): Promise<void> {
+  async applyCollectionSort(collection: Collection): Promise<void> {
     const sortKey = collection.mediaServerSort;
     const parsed = sortKey ? parseCollectionSortKey(sortKey) : undefined;
     if (!parsed) {
       this.logger.warn(
         `Ignoring invalid collection sort '${sortKey}' on collection ${collection.id}`,
       );
+      return;
+    }
+    if (!collection.mediaServerId) {
+      return;
+    }
+
+    const mediaServer = await this.getMediaServer();
+    if (!mediaServer.supportsFeature(MediaServerFeature.COLLECTION_SORT)) {
       return;
     }
 
@@ -2071,16 +2076,11 @@ export class CollectionsService {
           );
         }
 
-        // Push collection sort to the media server only when membership
-        // changed in this cycle — relative order is preserved on remove-only
-        // cycles, so re-sorting unchanged collections would just be churn.
-        if (
-          collection.mediaServerSort &&
-          newMedia.length > 0 &&
-          collection.mediaServerId &&
-          mediaServer.supportsFeature(MediaServerFeature.COLLECTION_SORT)
-        ) {
-          await this.applyCollectionSort(collection, mediaServer);
+        // Push collection sort to the media server when membership changed
+        // in this cycle. The adapter short-circuits if the order already
+        // matches, so this is cheap when nothing actually moved.
+        if (collection.mediaServerSort && newMedia.length > 0) {
+          await this.applyCollectionSort(collection);
         }
 
         if (isSharedManualCollection) {

--- a/apps/server/src/modules/collections/sort-utils.spec.ts
+++ b/apps/server/src/modules/collections/sort-utils.spec.ts
@@ -1,0 +1,99 @@
+import {
+  compareMediaItemsBySort,
+  type MediaItem,
+} from '@maintainerr/contracts';
+
+const item = (overrides: Partial<MediaItem>): MediaItem =>
+  ({
+    id: overrides.id ?? overrides.title ?? 'item',
+    title: overrides.title ?? 'item',
+    type: 'movie',
+    addedAt: new Date('2024-01-01'),
+    ...overrides,
+  }) as MediaItem;
+
+const sortBy = (
+  items: MediaItem[],
+  sort: Parameters<typeof compareMediaItemsBySort>[2],
+  order: Parameters<typeof compareMediaItemsBySort>[3] = 'asc',
+) =>
+  [...items]
+    .sort((leftItem, rightItem) =>
+      compareMediaItemsBySort(leftItem, rightItem, sort, order),
+    )
+    .map((mediaItem) => mediaItem.title);
+
+describe('compareMediaItemsBySort tiebreakers', () => {
+  it('breaks deleteSoonest ties alphabetically by title (timelordx scenario)', () => {
+    const day3 = new Date('2024-01-01');
+    const day5 = new Date('2024-01-03');
+    const items: MediaItem[] = [
+      item({ title: 'S', addedAt: day3 }),
+      item({ title: 'H', addedAt: day3 }),
+      item({ title: 'G', addedAt: day3 }),
+      item({ title: 'X', addedAt: day3 }),
+      item({ title: 'C', addedAt: day5 }),
+      item({ title: 'Z', addedAt: day5 }),
+      item({ title: 'A', addedAt: day5 }),
+    ];
+
+    expect(sortBy(items, 'deleteSoonest', 'asc')).toEqual([
+      'G',
+      'H',
+      'S',
+      'X',
+      'A',
+      'C',
+      'Z',
+    ]);
+  });
+
+  it('breaks airDate ties alphabetically by title regardless of direction', () => {
+    const sharedDate = new Date('2024-06-01');
+    const items: MediaItem[] = [
+      item({ title: 'C', originallyAvailableAt: sharedDate }),
+      item({ title: 'A', originallyAvailableAt: sharedDate }),
+      item({ title: 'B', originallyAvailableAt: sharedDate }),
+    ];
+
+    expect(sortBy(items, 'airDate', 'asc')).toEqual(['A', 'B', 'C']);
+    expect(sortBy(items, 'airDate', 'desc')).toEqual(['A', 'B', 'C']);
+  });
+
+  it('breaks rating and watchCount ties alphabetically by title', () => {
+    const ratings: MediaItem[] = [
+      item({
+        title: 'C',
+        ratings: [{ type: 'audience', value: 7, source: 'audience' }],
+      }),
+      item({
+        title: 'A',
+        ratings: [{ type: 'audience', value: 7, source: 'audience' }],
+      }),
+      item({
+        title: 'B',
+        ratings: [{ type: 'audience', value: 9, source: 'audience' }],
+      }),
+    ];
+    expect(sortBy(ratings, 'rating', 'desc')).toEqual(['B', 'A', 'C']);
+
+    const views: MediaItem[] = [
+      item({ title: 'C', viewCount: 0 }),
+      item({ title: 'A', viewCount: 0 }),
+      item({ title: 'B', viewCount: 0 }),
+    ];
+    expect(sortBy(views, 'watchCount', 'asc')).toEqual(['A', 'B', 'C']);
+  });
+
+  it('does not apply a title tiebreaker to status sorts (manual/excluded)', () => {
+    // Status sorts intentionally only partition — incoming order must be
+    // preserved within each partition for stable filter UX.
+    const items: MediaItem[] = [
+      item({ title: 'C', maintainerrIsManual: true }),
+      item({ title: 'A', maintainerrIsManual: true }),
+      item({ title: 'B', maintainerrIsManual: false }),
+    ];
+
+    expect(sortBy(items, 'manual', 'desc')).toEqual(['C', 'A', 'B']);
+  });
+});

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -532,16 +532,19 @@ export class RulesService {
         // If there's no existing collection (e.g., after rule migration), create a new one
         // Otherwise, update the existing collection
         let collectionId: number | undefined;
+        let savedCollection: Collection | undefined;
         if (group.collectionId) {
           const result = await this.collectionService.updateCollection({
             id: group.collectionId,
             ...collectionData,
           });
-          collectionId = result?.dbCollection?.id;
+          savedCollection = result?.dbCollection as Collection | undefined;
+          collectionId = savedCollection?.id;
         } else {
           const result =
             await this.collectionService.createCollection(collectionData);
-          collectionId = result?.dbCollection?.id;
+          savedCollection = result?.dbCollection as Collection | undefined;
+          collectionId = savedCollection?.id;
         }
 
         if (!collectionId) {
@@ -549,6 +552,15 @@ export class RulesService {
             false,
             'Failed to create/update collection',
           );
+        }
+
+        // Apply collection sort immediately when it is newly enabled or changed.
+        // The executor still reapplies on membership changes during normal cycles;
+        // this covers save-time sort changes without otherwise touching contents.
+        const previousSort = dbCollection?.mediaServerSort ?? null;
+        const newSort = collectionData.mediaServerSort ?? null;
+        if (newSort && previousSort !== newSort && savedCollection) {
+          await this.collectionService.applyCollectionSort(savedCollection);
         }
 
         // update or create group

--- a/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
@@ -257,4 +257,145 @@ describe('RulesService.updateRules', () => {
       message: 'Success',
     });
   });
+
+  const buildSortTransitionFixture = (options: {
+    previousSort: string | null;
+    nextSort: string | null;
+  }) => {
+    const dbCollection = {
+      id: 7,
+      libraryId: 'lib-1',
+      mediaServerId: 'plex-col-1',
+      manualCollection: false,
+      manualCollectionName: '',
+      mediaServerSort: options.previousSort,
+    } as any;
+
+    const freshCollection = {
+      ...dbCollection,
+      mediaServerSort: options.nextSort,
+    } as any;
+
+    const collectionService = {
+      getCollection: jest.fn().mockResolvedValue(dbCollection),
+      saveCollection: jest.fn().mockResolvedValue(undefined),
+      addLogRecord: jest.fn().mockResolvedValue(undefined),
+      updateCollection: jest.fn().mockResolvedValue({
+        dbCollection: freshCollection,
+      }),
+      applyCollectionSort: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const mediaServer = {
+      cleanupCollectionForLibrary: jest.fn().mockResolvedValue(undefined),
+      getLibraries: jest
+        .fn()
+        .mockResolvedValue([{ id: 'lib-1', title: 'Movies', type: 'movie' }]),
+    };
+
+    const service = createRulesService({
+      rulesRepository: { delete: jest.fn(), save: jest.fn() },
+      ruleGroupRepository: {
+        findOne: jest.fn().mockResolvedValue({
+          id: 5,
+          collectionId: dbCollection.id,
+          dataType: 'movie',
+        }),
+      },
+      collectionMediaRepository: { delete: jest.fn() },
+      exclusionRepo: { delete: jest.fn() },
+      collectionService,
+      mediaServerFactory: {
+        getService: jest.fn().mockReturnValue(mediaServer),
+      },
+    });
+
+    jest.spyOn(service as any, 'createOrUpdateGroup').mockResolvedValue(5);
+
+    return { service, collectionService, dbCollection, freshCollection };
+  };
+
+  it('applies the collection sort immediately when newly enabled on save', async () => {
+    const { service, collectionService, freshCollection } =
+      buildSortTransitionFixture({
+        previousSort: null,
+        nextSort: 'title.asc',
+      });
+
+    await service.updateRules({
+      id: 5,
+      libraryId: 'lib-1',
+      dataType: 'movie',
+      name: 'rg',
+      description: '',
+      rules: [],
+      useRules: false,
+      isActive: true,
+      collection: {
+        manualCollection: false,
+        manualCollectionName: '',
+        keepLogsForMonths: 1,
+        mediaServerSort: 'title.asc',
+      },
+      notifications: [],
+    } as any);
+
+    expect(collectionService.applyCollectionSort).toHaveBeenCalledWith(
+      freshCollection,
+    );
+  });
+
+  it('does not reapply sort on save when the sort value is cleared', async () => {
+    const { service, collectionService } = buildSortTransitionFixture({
+      previousSort: 'title.asc',
+      nextSort: null,
+    });
+
+    await service.updateRules({
+      id: 5,
+      libraryId: 'lib-1',
+      dataType: 'movie',
+      name: 'rg',
+      description: '',
+      rules: [],
+      useRules: false,
+      isActive: true,
+      collection: {
+        manualCollection: false,
+        manualCollectionName: '',
+        keepLogsForMonths: 1,
+        mediaServerSort: null,
+      },
+      notifications: [],
+    } as any);
+
+    expect(collectionService.applyCollectionSort).not.toHaveBeenCalled();
+  });
+
+  it('does not touch sort on save when the sort value is unchanged', async () => {
+    const { service, collectionService } = buildSortTransitionFixture({
+      previousSort: 'title.asc',
+      nextSort: 'title.asc',
+    });
+
+    await service.updateRules({
+      id: 5,
+      libraryId: 'lib-1',
+      dataType: 'movie',
+      name: 'rg',
+      description: '',
+      rules: [],
+      useRules: false,
+      isActive: true,
+      collection: {
+        manualCollection: false,
+        manualCollectionName: '',
+        keepLogsForMonths: 1,
+        mediaServerSort: 'title.asc',
+      },
+      notifications: [],
+    } as any);
+
+    expect(collectionService.applyCollectionSort).not.toHaveBeenCalled();
+  });
 });

--- a/packages/contracts/src/media-server/sort-utils.ts
+++ b/packages/contracts/src/media-server/sort-utils.ts
@@ -46,20 +46,30 @@ export const compareMediaItemsBySort = (
 ): number => {
   const direction = sortOrder === 'desc' ? -1 : 1
 
+  // Numeric/date sorts fall back to the existing 'title.asc' branch when the
+  // primary returns 0, so within-group ordering is stable A→Z regardless of
+  // direction. Status sorts (manual/excluded) intentionally skip the
+  // tiebreaker — see compareMaintainerrState above.
   switch (sort) {
     case 'title':
       return leftItem.title.localeCompare(rightItem.title) * direction
     case 'airDate':
       return (
         (getComparableAirDate(leftItem) - getComparableAirDate(rightItem)) *
-        direction
+          direction ||
+        compareMediaItemsBySort(leftItem, rightItem, 'title', 'asc')
       )
     case 'rating':
       return (
-        (getAudienceRating(leftItem) - getAudienceRating(rightItem)) * direction
+        (getAudienceRating(leftItem) - getAudienceRating(rightItem)) *
+          direction ||
+        compareMediaItemsBySort(leftItem, rightItem, 'title', 'asc')
       )
     case 'watchCount':
-      return (getWatchCount(leftItem) - getWatchCount(rightItem)) * direction
+      return (
+        (getWatchCount(leftItem) - getWatchCount(rightItem)) * direction ||
+        compareMediaItemsBySort(leftItem, rightItem, 'title', 'asc')
+      )
     case 'manual':
       return compareMaintainerrState(
         leftItem,
@@ -80,7 +90,8 @@ export const compareMediaItemsBySort = (
       return (
         (new Date(leftItem.addedAt).getTime() -
           new Date(rightItem.addedAt).getTime()) *
-        direction
+          direction ||
+        compareMediaItemsBySort(leftItem, rightItem, 'title', 'asc')
       )
     default:
       return 0


### PR DESCRIPTION
## Summary

Follow-up to #2856. Three fixes flagged in post-merge review plus one related improvement.

**Save-time apply (HIGH).** Picking or changing the collection sort in the rule form now takes effect at save time. Previously the executor only pushed the order on cycles where `newMedia.length > 0`, so the UI could show a configured sort that didn't exist on Plex until membership happened to change.

**Per-item resilience (MEDIUM).** Plex `reorderCollectionItems` no longer aborts the entire move loop on a single failed move. Each `moveCollectionItem` is wrapped individually; failures are accumulated and surfaced in a single summary warning at the end.

**No-op short-circuit (MEDIUM).** Plex adapter reads current child IDs first and returns early if they already match the requested order — zero PUTs in the matching case (was 1 prefs PUT + N move PUTs).

**Alphabetical tiebreaker for tied sorts.** When `airDate` / `rating` / `watchCount` / `deleteSoonest` returns 0, the comparator now falls through to its own `case 'title':` branch (A→Z, direction-agnostic). Reuses the existing title-sort logic via recursion — no new helper. Affects every consumer of `compareMediaItemsBySort`, so Maintainerr's UI display and the Plex collection-sort push now order tied items the same way. Addresses #2856 (comment).

Status sorts (`manual` / `excluded`) intentionally skip the tiebreaker — their existing comment documents that they only partition.

## Test plan

- [x] `yarn workspace @maintainerr/server test --runInBand` — 1160 tests pass (was 1151)
- [x] `yarn workspace @maintainerr/ui test --run` — 195 tests pass
- [x] `yarn lint` — 0 errors / 0 warnings
- [x] `yarn format:check` — clean
- [x] New `sort-utils.spec.ts` covers the comment scenario (`G,H,S,X,A,C,Z`) and asserts manual/excluded preserve partition
- [x] `plex-adapter.service.spec.ts` adds short-circuit and mid-loop-failure cases
- [x] `rules.service.updateRules.spec.ts` covers apply-on-enable and no-op-when-unchanged transitions