### PR TITLE
Add typed TanStack Query test helpers and migrate spec mocks

### DIFF
--- a/apps/ui/src/components/Calendar/index.spec.tsx
+++ b/apps/ui/src/components/Calendar/index.spec.tsx
@@ -8,6 +8,7 @@ import {
   useCalendarOverlayData,
   useCalendarSchedule,
 } from '../../api/calendar'
+import { buildQuerySuccessResult } from '../../test-utils/queryResults'
 import type { ICollection } from '../Collection'
 import Calendar from './index'
 
@@ -59,21 +60,16 @@ describe('Calendar', () => {
       },
     ]
 
-    useCalendarScheduleMock.mockReturnValue({
-      data: calendarDays,
-      isLoading: false,
-    } as ReturnType<typeof useCalendarSchedule>)
+    useCalendarScheduleMock.mockReturnValue(
+      buildQuerySuccessResult(calendarDays),
+    )
     const overlayCollections: ICollection[] = []
-    useCalendarOverlayDataMock.mockReturnValue({
-      data: overlayCollections,
-      isLoading: false,
-    } as unknown as ReturnType<typeof useCalendarOverlayData>)
+    useCalendarOverlayDataMock.mockReturnValue(
+      buildQuerySuccessResult(overlayCollections),
+    )
     useCalendarEntryDetailsMock.mockImplementation(
       (params: Parameters<typeof useCalendarEntryDetails>[0]) => {
-        return {
-          data: params ? detailItems : [],
-          isLoading: false,
-        } as ReturnType<typeof useCalendarEntryDetails>
+        return buildQuerySuccessResult(params ? detailItems : [])
       },
     )
   })

--- a/apps/ui/src/components/Collection/CollectionItem/index.spec.tsx
+++ b/apps/ui/src/components/Collection/CollectionItem/index.spec.tsx
@@ -1,3 +1,4 @@
+import type { MediaLibrary } from '@maintainerr/contracts'
 import {
   cleanup,
   fireEvent,
@@ -7,8 +8,12 @@ import {
 } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import GetApiHandler from '../../../utils/ApiHandler'
 import { useMediaServerLibraries } from '../../../api/media-server'
+import {
+  buildQueryErrorResult,
+  buildQuerySuccessResult,
+} from '../../../test-utils/queryResults'
+import GetApiHandler from '../../../utils/ApiHandler'
 import CollectionItem from './index'
 
 vi.mock('../../../api/media-server', () => ({
@@ -39,11 +44,11 @@ describe('CollectionItem', () => {
 
   beforeEach(() => {
     getApiHandlerMock.mockReset()
-    librariesHookMock.mockReturnValue({
-      data: [{ id: 'library-1', title: 'Movies', type: 'movie' }],
-      error: undefined,
-      isLoading: false,
-    } as unknown as ReturnType<typeof useMediaServerLibraries>)
+    const libraries: MediaLibrary[] = [
+      { id: 'library-1', title: 'Movies', type: 'movie' },
+    ]
+
+    librariesHookMock.mockReturnValue(buildQuerySuccessResult(libraries))
   })
 
   afterEach(() => {
@@ -148,12 +153,9 @@ describe('CollectionItem', () => {
   })
 
   it('shows "Unavailable" in warning style when libraries query errored and the id is unresolved', () => {
-    librariesHookMock.mockReturnValue({
-      data: undefined,
-      error: new Error('offline'),
-      isError: true,
-      isLoading: false,
-    } as unknown as ReturnType<typeof useMediaServerLibraries>)
+    librariesHookMock.mockReturnValue(
+      buildQueryErrorResult<MediaLibrary[]>(new Error('offline')),
+    )
 
     render(
       <CollectionItem

--- a/apps/ui/src/components/Collection/CollectionOverview/index.spec.tsx
+++ b/apps/ui/src/components/Collection/CollectionOverview/index.spec.tsx
@@ -1,7 +1,9 @@
+import type { MediaLibrary } from '@maintainerr/contracts'
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useMediaServerLibraries } from '../../../api/media-server'
 import { useTaskStatusContext } from '../../../contexts/taskstatus-context'
+import { buildQuerySuccessResult } from '../../../test-utils/queryResults'
 import CollectionOverview from './index'
 
 vi.mock('../../../api/media-server', () => ({
@@ -38,14 +40,12 @@ describe('CollectionOverview', () => {
   const taskStatusHookMock = vi.mocked(useTaskStatusContext)
 
   beforeEach(() => {
-    librariesHookMock.mockReturnValue({
-      data: [],
-      error: undefined,
-      isLoading: false,
-    } as unknown as ReturnType<typeof useMediaServerLibraries>)
+    librariesHookMock.mockReturnValue(
+      buildQuerySuccessResult<MediaLibrary[]>([]),
+    )
     taskStatusHookMock.mockReturnValue({
       collectionHandlerRunning: false,
-    } as unknown as ReturnType<typeof useTaskStatusContext>)
+    })
   })
 
   afterEach(() => {

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.spec.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.spec.tsx
@@ -2,6 +2,11 @@ import { ServarrAction } from '@maintainerr/contracts'
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useServarrSettings } from '../../../../../api/settings'
+import {
+  buildQueryLoadingResult,
+  buildQuerySuccessResult,
+} from '../../../../../test-utils/queryResults'
+import type { ISonarrSetting } from '../../../../Settings/Sonarr'
 import ArrAction from './index'
 
 vi.mock('../../../../../api/settings', () => ({
@@ -13,10 +18,9 @@ describe('ArrAction', () => {
 
   beforeEach(() => {
     useServarrSettingsMock.mockReset()
-    useServarrSettingsMock.mockReturnValue({
-      data: [],
-      isLoading: false,
-    } as unknown as ReturnType<typeof useServarrSettings>)
+    useServarrSettingsMock.mockReturnValue(
+      buildQuerySuccessResult<ISonarrSetting[]>([]),
+    )
   })
 
   afterEach(() => {
@@ -26,11 +30,9 @@ describe('ArrAction', () => {
   it('does not clear the saved server before Servarr settings finish loading', async () => {
     const onUpdate = vi.fn()
 
-    useServarrSettingsMock.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      isFetching: true,
-    } as unknown as ReturnType<typeof useServarrSettings>)
+    useServarrSettingsMock.mockReturnValue(
+      buildQueryLoadingResult<ISonarrSetting[]>(),
+    )
 
     render(
       <ArrAction
@@ -56,11 +58,9 @@ describe('ArrAction', () => {
   it('clears the saved server after settings load when it no longer exists', async () => {
     const onUpdate = vi.fn()
 
-    useServarrSettingsMock.mockReturnValue({
-      data: [],
-      isLoading: false,
-      isFetching: false,
-    } as unknown as ReturnType<typeof useServarrSettings>)
+    useServarrSettingsMock.mockReturnValue(
+      buildQuerySuccessResult<ISonarrSetting[]>([]),
+    )
 
     render(
       <ArrAction
@@ -112,11 +112,18 @@ describe('ArrAction', () => {
   })
 
   it('shows quality profile action after a Sonarr server is selected', async () => {
-    useServarrSettingsMock.mockReturnValue({
-      data: [{ id: 12, serverName: 'Primary Sonarr' }],
-      isLoading: false,
-      isFetching: false,
-    } as ReturnType<typeof useServarrSettings>)
+    const sonarrSettings: ISonarrSetting[] = [
+      {
+        id: 12,
+        serverName: 'Primary Sonarr',
+        url: 'http://sonarr.example',
+        apiKey: 'test-api-key',
+      },
+    ]
+
+    useServarrSettingsMock.mockReturnValue(
+      buildQuerySuccessResult(sonarrSettings),
+    )
 
     render(
       <ArrAction

--- a/apps/ui/src/hooks/useLibraryDisplay.spec.tsx
+++ b/apps/ui/src/hooks/useLibraryDisplay.spec.tsx
@@ -1,20 +1,30 @@
+import type { MediaLibrary } from '@maintainerr/contracts'
 import { cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useMediaServerLibraries } from '../api/media-server'
+import {
+  buildQueryErrorResult,
+  buildQuerySuccessResult,
+} from '../test-utils/queryResults'
 import { useLibraryDisplay } from './useLibraryDisplay'
 
 vi.mock('../api/media-server', () => ({
   useMediaServerLibraries: vi.fn(),
 }))
 
-const mockHook = (overrides: {
-  data?: { id: string; title: string; type: string }[]
-  isError?: boolean
-}) => {
-  vi.mocked(useMediaServerLibraries).mockReturnValue({
-    data: overrides.data,
-    isError: overrides.isError ?? false,
-  } as unknown as ReturnType<typeof useMediaServerLibraries>)
+const mockHook = (overrides: { data?: MediaLibrary[]; isError?: boolean }) => {
+  if (overrides.isError) {
+    vi.mocked(useMediaServerLibraries).mockReturnValue(
+      buildQueryErrorResult<MediaLibrary[]>(
+        new Error('Media server unavailable'),
+      ),
+    )
+    return
+  }
+
+  vi.mocked(useMediaServerLibraries).mockReturnValue(
+    buildQuerySuccessResult(overrides.data ?? []),
+  )
 }
 
 describe('useLibraryDisplay', () => {

--- a/apps/ui/src/pages/CollectionsListPage.spec.tsx
+++ b/apps/ui/src/pages/CollectionsListPage.spec.tsx
@@ -8,10 +8,12 @@ import {
 import { useQueryClient } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchCollections, useCollections } from '../api/collections'
+import type { ICollection } from '../components/Collection'
+import { createTestQueryClient } from '../test-utils/queryClient'
+import { buildQuerySuccessResult } from '../test-utils/queryResults'
 import CollectionsListPage from './CollectionsListPage'
 
 const navigate = vi.fn()
-const fetchQuery = vi.fn()
 
 vi.mock('@tanstack/react-query', async () => {
   const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
@@ -72,26 +74,34 @@ describe('CollectionsListPage', () => {
   const useCollectionsMock = vi.mocked(useCollections)
   const fetchCollectionsMock = vi.mocked(fetchCollections)
   const useQueryClientMock = vi.mocked(useQueryClient)
+  let queryClient: ReturnType<typeof createTestQueryClient>
 
   beforeEach(() => {
     cleanup()
     navigate.mockReset()
-    fetchQuery.mockReset()
     fetchCollectionsMock.mockReset()
     useCollectionsMock.mockReset()
-    useQueryClientMock.mockReturnValue({
-      fetchQuery,
-    } as unknown as ReturnType<typeof useQueryClient>)
+    queryClient = createTestQueryClient()
+    vi.spyOn(queryClient, 'fetchQuery')
+    useQueryClientMock.mockReturnValue(queryClient)
 
-    useCollectionsMock.mockReturnValue({
-      data: [
-        {
-          id: 1,
-          title: 'Action',
-        },
-      ],
-      isLoading: false,
-    } as ReturnType<typeof useCollections>)
+    const collection: ICollection = {
+      id: 1,
+      title: 'Action',
+      libraryId: 'library-1',
+      isActive: true,
+      type: 'movie',
+      arrAction: 0,
+      media: [],
+      manualCollection: false,
+      manualCollectionName: '',
+      addDate: new Date(),
+      handledMediaAmount: 0,
+      lastDurationInSeconds: 0,
+      keepLogsForMonths: 0,
+    }
+
+    useCollectionsMock.mockReturnValue(buildQuerySuccessResult([collection]))
   })
 
   afterEach(() => {
@@ -99,7 +109,9 @@ describe('CollectionsListPage', () => {
   })
 
   it('restores the previous library selection if a library switch request fails', async () => {
-    fetchQuery.mockRejectedValueOnce(new Error('request failed'))
+    vi.mocked(queryClient.fetchQuery).mockRejectedValueOnce(
+      new Error('request failed'),
+    )
 
     render(<CollectionsListPage />)
 

--- a/apps/ui/src/test-utils/README.md
+++ b/apps/ui/src/test-utils/README.md
@@ -1,0 +1,23 @@
+# UI Test Utilities
+
+Use the query-result builders in `queryResults.ts` when mocking TanStack Query
+hooks in specs. They provide complete React Query v5 result objects, so upstream
+contract changes fail in one helper instead of being hidden by partial
+`ReturnType<typeof useFoo>` casts.
+
+Prefer:
+
+```ts
+useFooMock.mockReturnValue(buildQuerySuccessResult(data))
+useFooMock.mockReturnValue(buildQueryLoadingResult())
+useFooMock.mockReturnValue(buildQueryErrorResult(new Error('offline')))
+```
+
+Avoid:
+
+```ts
+useFooMock.mockReturnValue({
+  data,
+  isLoading: false,
+} as unknown as ReturnType<typeof useFoo>)
+```

--- a/apps/ui/src/test-utils/queryClient.ts
+++ b/apps/ui/src/test-utils/queryClient.ts
@@ -1,0 +1,17 @@
+import { QueryClient, type QueryClientConfig } from '@tanstack/react-query'
+
+export const createTestQueryClient = (config?: QueryClientConfig) => {
+  return new QueryClient({
+    ...config,
+    defaultOptions: {
+      queries: {
+        retry: false,
+        ...config?.defaultOptions?.queries,
+      },
+      mutations: {
+        retry: false,
+        ...config?.defaultOptions?.mutations,
+      },
+    },
+  })
+}

--- a/apps/ui/src/test-utils/queryResults.ts
+++ b/apps/ui/src/test-utils/queryResults.ts
@@ -1,0 +1,140 @@
+import type {
+  QueryObserverLoadingErrorResult,
+  QueryObserverLoadingResult,
+  QueryObserverResult,
+  QueryObserverSuccessResult,
+  UseQueryResult,
+} from '@tanstack/react-query'
+
+type QueryResultRefetch<TData, TError> = UseQueryResult<
+  TData,
+  TError
+>['refetch']
+
+const createPendingPromise = <TData>() => {
+  return new Promise<TData>((resolve) => {
+    // Keep React Query's stable promise pending in tests that never read it.
+    void resolve
+  })
+}
+
+const createRefetch = <TData, TError>(): QueryResultRefetch<TData, TError> => {
+  return async (): Promise<QueryObserverResult<TData, TError>> =>
+    buildQueryLoadingResult<TData, TError>()
+}
+
+export const buildQuerySuccessResult = <TData, TError = Error>(
+  data: TData,
+  overrides: Partial<QueryObserverSuccessResult<TData, TError>> = {},
+): QueryObserverSuccessResult<TData, TError> => {
+  const result = {
+    data,
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    errorUpdateCount: 0,
+    isError: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isLoading: false,
+    isPending: false,
+    isLoadingError: false,
+    isInitialLoading: false,
+    isPaused: false,
+    isPlaceholderData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true,
+    isEnabled: true,
+    refetch: createRefetch<TData, TError>(),
+    status: 'success',
+    fetchStatus: 'idle',
+    promise: Promise.resolve(data),
+  } satisfies QueryObserverSuccessResult<TData, TError>
+
+  return {
+    ...result,
+    ...overrides,
+  }
+}
+
+export const buildQueryLoadingResult = <TData, TError = Error>(
+  overrides: Partial<QueryObserverLoadingResult<TData, TError>> = {},
+): QueryObserverLoadingResult<TData, TError> => {
+  const result = {
+    data: undefined,
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    errorUpdateCount: 0,
+    isError: false,
+    isFetched: false,
+    isFetchedAfterMount: false,
+    isFetching: true,
+    isLoading: true,
+    isPending: true,
+    isLoadingError: false,
+    isInitialLoading: true,
+    isPaused: false,
+    isPlaceholderData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: true,
+    isSuccess: false,
+    isEnabled: true,
+    refetch: createRefetch<TData, TError>(),
+    status: 'pending',
+    fetchStatus: 'fetching',
+    promise: createPendingPromise<TData>(),
+  } satisfies QueryObserverLoadingResult<TData, TError>
+
+  return {
+    ...result,
+    ...overrides,
+  }
+}
+
+export const buildQueryErrorResult = <TData, TError = Error>(
+  error: TError,
+  overrides: Partial<QueryObserverLoadingErrorResult<TData, TError>> = {},
+): QueryObserverLoadingErrorResult<TData, TError> => {
+  const result = {
+    data: undefined,
+    dataUpdatedAt: 0,
+    error,
+    errorUpdatedAt: 0,
+    failureCount: 1,
+    failureReason: error,
+    errorUpdateCount: 1,
+    isError: true,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isLoading: false,
+    isPending: false,
+    isLoadingError: true,
+    isInitialLoading: false,
+    isPaused: false,
+    isPlaceholderData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: true,
+    isSuccess: false,
+    isEnabled: true,
+    refetch: createRefetch<TData, TError>(),
+    status: 'error',
+    fetchStatus: 'idle',
+    promise: createPendingPromise<TData>(),
+  } satisfies QueryObserverLoadingErrorResult<TData, TError>
+
+  return {
+    ...result,
+    ...overrides,
+  }
+}

--- a/apps/ui/src/test-utils/queryResults.ts
+++ b/apps/ui/src/test-utils/queryResults.ts
@@ -5,18 +5,12 @@ import type {
   QueryObserverSuccessResult,
   UseQueryResult,
 } from '@tanstack/react-query'
+import { createDeferred } from './createDeferred'
 
 type QueryResultRefetch<TData, TError> = UseQueryResult<
   TData,
   TError
 >['refetch']
-
-const createPendingPromise = <TData>() => {
-  return new Promise<TData>((resolve) => {
-    // Keep React Query's stable promise pending in tests that never read it.
-    void resolve
-  })
-}
 
 const createRefetch = <TData, TError>(): QueryResultRefetch<TData, TError> => {
   return async (): Promise<QueryObserverResult<TData, TError>> =>
@@ -91,7 +85,7 @@ export const buildQueryLoadingResult = <TData, TError = Error>(
     refetch: createRefetch<TData, TError>(),
     status: 'pending',
     fetchStatus: 'fetching',
-    promise: createPendingPromise<TData>(),
+    promise: createDeferred<TData>().promise,
   } satisfies QueryObserverLoadingResult<TData, TError>
 
   return {
@@ -130,7 +124,7 @@ export const buildQueryErrorResult = <TData, TError = Error>(
     refetch: createRefetch<TData, TError>(),
     status: 'error',
     fetchStatus: 'idle',
-    promise: createPendingPromise<TData>(),
+    promise: createDeferred<TData>().promise,
   } satisfies QueryObserverLoadingErrorResult<TData, TError>
 
   return {


### PR DESCRIPTION
## Summary
- Add shared UI test helpers for TanStack Query results and a reusable test `QueryClient`.
- Replace partial-cast hook mocks in the affected UI specs with typed builders.
- Document the new testing pattern in `apps/ui/src/test-utils`.

## Testing
- `yarn format:check`
- `yarn lint`
- `yarn workspace @maintainerr/ui exec tsc --noEmit`
- `yarn workspace @maintainerr/ui test`
- `yarn build`