### PR TITLE
fix(rules): scope exclusion cascade by type, not entry point (#2858)

### DIFF
--- a/apps/server/src/modules/rules/helpers/exclusion-cascade.helper.spec.ts
+++ b/apps/server/src/modules/rules/helpers/exclusion-cascade.helper.spec.ts
@@ -1,0 +1,214 @@
+import {
+  buildExclusionCascadeSets,
+  isMediaItemExcluded,
+} from './exclusion-cascade.helper';
+
+const EPISODE_ID = 'ep-1';
+const SIBLING_EPISODE_ID = 'ep-2';
+const SEASON_ID = 'season-1';
+const SIBLING_SEASON_ID = 'season-2';
+const SHOW_ID = 'show-1';
+const OTHER_SHOW_ID = 'show-2';
+
+describe('exclusion-cascade.helper', () => {
+  describe('buildExclusionCascadeSets', () => {
+    it('routes exclusions into mediaServerId / show / season buckets by type', () => {
+      const sets = buildExclusionCascadeSets([
+        { mediaServerId: SHOW_ID, type: 'show' },
+        { mediaServerId: SEASON_ID, type: 'season' },
+        { mediaServerId: EPISODE_ID, type: 'episode' },
+        { mediaServerId: 'movie-1', type: 'movie' },
+      ] as Parameters<typeof buildExclusionCascadeSets>[0]);
+
+      expect(sets.excludedMediaServerIds).toEqual(
+        new Set([SHOW_ID, SEASON_ID, EPISODE_ID, 'movie-1']),
+      );
+      expect(sets.excludedShowIds).toEqual(new Set([SHOW_ID]));
+      expect(sets.excludedSeasonIds).toEqual(new Set([SEASON_ID]));
+      expect(sets.legacyParentIds.size).toBe(0);
+    });
+
+    it('ignores exclusions with no mediaServerId', () => {
+      const sets = buildExclusionCascadeSets([
+        { mediaServerId: undefined, type: 'show' },
+        { mediaServerId: '', type: 'season' },
+      ] as Parameters<typeof buildExclusionCascadeSets>[0]);
+
+      expect(sets.excludedMediaServerIds.size).toBe(0);
+      expect(sets.excludedShowIds.size).toBe(0);
+      expect(sets.excludedSeasonIds.size).toBe(0);
+      expect(sets.legacyParentIds.size).toBe(0);
+    });
+
+    it('falls back to parent-based cascade for legacy null-type rows', () => {
+      // Legacy rows produced before exclusion.type was introduced. The
+      // ExclusionTypeCorrectorService backfills these on startup, but the
+      // backfill is skipped if the media server is unreachable, so we keep
+      // the pre-#2858 (loose) cascade until the type lands.
+      const sets = buildExclusionCascadeSets([
+        { mediaServerId: SHOW_ID, parent: SHOW_ID, type: undefined },
+        {
+          mediaServerId: SEASON_ID,
+          parent: SHOW_ID,
+          type: null as unknown as undefined,
+        },
+      ] as Parameters<typeof buildExclusionCascadeSets>[0]);
+
+      expect(sets.excludedMediaServerIds).toEqual(
+        new Set([SHOW_ID, SEASON_ID]),
+      );
+      expect(sets.excludedShowIds.size).toBe(0);
+      expect(sets.excludedSeasonIds.size).toBe(0);
+      expect(sets.legacyParentIds).toEqual(new Set([SHOW_ID]));
+    });
+  });
+
+  describe('isMediaItemExcluded', () => {
+    it('returns false for sibling episodes when only one episode is excluded (issue #2858)', () => {
+      const sets = buildExclusionCascadeSets([
+        { mediaServerId: EPISODE_ID, type: 'episode' },
+      ] as Parameters<typeof buildExclusionCascadeSets>[0]);
+
+      expect(
+        isMediaItemExcluded(sets, {
+          id: EPISODE_ID,
+          parentId: SEASON_ID,
+          grandparentId: SHOW_ID,
+        }),
+      ).toBe(true);
+
+      expect(
+        isMediaItemExcluded(sets, {
+          id: SIBLING_EPISODE_ID,
+          parentId: SEASON_ID,
+          grandparentId: SHOW_ID,
+        }),
+      ).toBe(false);
+    });
+
+    it('cascades a season exclusion to its episodes only', () => {
+      const sets = buildExclusionCascadeSets([
+        { mediaServerId: SEASON_ID, type: 'season' },
+      ] as Parameters<typeof buildExclusionCascadeSets>[0]);
+
+      expect(
+        isMediaItemExcluded(sets, {
+          id: EPISODE_ID,
+          parentId: SEASON_ID,
+          grandparentId: SHOW_ID,
+        }),
+      ).toBe(true);
+
+      // Episode in a different season of the same show is not affected.
+      expect(
+        isMediaItemExcluded(sets, {
+          id: SIBLING_EPISODE_ID,
+          parentId: SIBLING_SEASON_ID,
+          grandparentId: SHOW_ID,
+        }),
+      ).toBe(false);
+    });
+
+    it('cascades a show exclusion to its seasons and episodes', () => {
+      const sets = buildExclusionCascadeSets([
+        { mediaServerId: SHOW_ID, type: 'show' },
+      ] as Parameters<typeof buildExclusionCascadeSets>[0]);
+
+      expect(
+        isMediaItemExcluded(sets, {
+          id: SEASON_ID,
+          parentId: SHOW_ID,
+        }),
+      ).toBe(true);
+
+      expect(
+        isMediaItemExcluded(sets, {
+          id: EPISODE_ID,
+          parentId: SEASON_ID,
+          grandparentId: SHOW_ID,
+        }),
+      ).toBe(true);
+
+      // Other show's content is unaffected.
+      expect(
+        isMediaItemExcluded(sets, {
+          id: 'season-other',
+          parentId: OTHER_SHOW_ID,
+        }),
+      ).toBe(false);
+    });
+
+    it('keeps cascading legacy null-type exclusions via the parent fallback', () => {
+      const sets = buildExclusionCascadeSets([
+        { mediaServerId: SHOW_ID, parent: SHOW_ID, type: undefined },
+      ] as Parameters<typeof buildExclusionCascadeSets>[0]);
+
+      expect(
+        isMediaItemExcluded(sets, {
+          id: SEASON_ID,
+          parentId: SHOW_ID,
+        }),
+      ).toBe(true);
+
+      expect(
+        isMediaItemExcluded(sets, {
+          id: EPISODE_ID,
+          parentId: SEASON_ID,
+          grandparentId: SHOW_ID,
+        }),
+      ).toBe(true);
+
+      expect(
+        isMediaItemExcluded(sets, {
+          id: 'season-other',
+          parentId: OTHER_SHOW_ID,
+        }),
+      ).toBe(false);
+    });
+
+    it('cascades a legacy null-type episode exclusion to siblings, but stops once its type is backfilled', () => {
+      // Trade-off documented in buildExclusionCascadeSets: legacy null-type
+      // rows fall back to the pre-#2858 (loose) parent cascade, so a legacy
+      // single-episode exclusion still over-skips its siblings. The bug-fix
+      // for #2858 only applies once ExclusionTypeCorrectorService has stamped
+      // the row with its real type.
+      const legacy = buildExclusionCascadeSets([
+        { mediaServerId: EPISODE_ID, parent: SHOW_ID, type: undefined },
+      ] as Parameters<typeof buildExclusionCascadeSets>[0]);
+
+      expect(
+        isMediaItemExcluded(legacy, {
+          id: SIBLING_EPISODE_ID,
+          parentId: SEASON_ID,
+          grandparentId: SHOW_ID,
+        }),
+      ).toBe(true);
+
+      const backfilled = buildExclusionCascadeSets([
+        { mediaServerId: EPISODE_ID, parent: SHOW_ID, type: 'episode' },
+      ] as Parameters<typeof buildExclusionCascadeSets>[0]);
+
+      expect(
+        isMediaItemExcluded(backfilled, {
+          id: SIBLING_EPISODE_ID,
+          parentId: SEASON_ID,
+          grandparentId: SHOW_ID,
+        }),
+      ).toBe(false);
+    });
+
+    it('coerces numeric ids to strings before set lookup', () => {
+      const sets = buildExclusionCascadeSets([
+        { mediaServerId: '42', type: 'show' },
+      ] as Parameters<typeof buildExclusionCascadeSets>[0]);
+
+      expect(
+        isMediaItemExcluded(sets, {
+          id: 99 as unknown as string,
+          parentId: 7 as unknown as string,
+          grandparentId: 42 as unknown as string,
+        }),
+      ).toBe(true);
+    });
+  });
+});

--- a/apps/server/src/modules/rules/helpers/exclusion-cascade.helper.ts
+++ b/apps/server/src/modules/rules/helpers/exclusion-cascade.helper.ts
@@ -1,0 +1,87 @@
+import { Exclusion } from '../entities/exclusion.entities';
+
+/**
+ * Pre-computed sets used to decide whether a media item is covered by any
+ * exclusion. Cascade is driven by `exclusion.type` and `exclusion.mediaServerId`
+ * — the `parent` field on Exclusion records the entry point of the original
+ * exclusion request (used by bulk find/delete) and must not be used as a
+ * cascade key for typed rows, or a single-episode exclusion would skip every
+ * other episode of the same show (issue #2858).
+ *
+ * `legacyParentIds` retains the pre-#2858 `parent`-based cascade for rows
+ * where `type` is still null/undefined. ExclusionTypeCorrectorService backfills
+ * types best-effort at startup, but it can be skipped when the media server
+ * is unreachable, so we keep the old (loose) cascade for legacy rows rather
+ * than silently dropping their descendants from exclusion until the next
+ * successful corrector run.
+ */
+export interface ExclusionCascadeSets {
+  excludedMediaServerIds: Set<string>;
+  excludedShowIds: Set<string>;
+  excludedSeasonIds: Set<string>;
+  legacyParentIds: Set<string>;
+}
+
+export function buildExclusionCascadeSets(
+  exclusions: Pick<Exclusion, 'mediaServerId' | 'type' | 'parent'>[],
+): ExclusionCascadeSets {
+  const excludedMediaServerIds = new Set<string>();
+  const excludedShowIds = new Set<string>();
+  const excludedSeasonIds = new Set<string>();
+  const legacyParentIds = new Set<string>();
+
+  for (const exclusion of exclusions) {
+    if (!exclusion.mediaServerId) continue;
+    excludedMediaServerIds.add(exclusion.mediaServerId);
+
+    if (exclusion.type === 'show') {
+      excludedShowIds.add(exclusion.mediaServerId);
+    } else if (exclusion.type === 'season') {
+      excludedSeasonIds.add(exclusion.mediaServerId);
+    } else if (exclusion.type == null && exclusion.parent) {
+      legacyParentIds.add(String(exclusion.parent));
+    }
+  }
+
+  return {
+    excludedMediaServerIds,
+    excludedShowIds,
+    excludedSeasonIds,
+    legacyParentIds,
+  };
+}
+
+export function isMediaItemExcluded(
+  cascade: ExclusionCascadeSets,
+  item: {
+    id: string | number;
+    parentId?: string | number;
+    grandparentId?: string | number;
+  },
+): boolean {
+  const id = item.id?.toString();
+  if (id && cascade.excludedMediaServerIds.has(id)) {
+    return true;
+  }
+
+  const parentId = item.parentId?.toString();
+  if (
+    parentId &&
+    (cascade.excludedSeasonIds.has(parentId) ||
+      cascade.excludedShowIds.has(parentId) ||
+      cascade.legacyParentIds.has(parentId))
+  ) {
+    return true;
+  }
+
+  const grandparentId = item.grandparentId?.toString();
+  if (
+    grandparentId &&
+    (cascade.excludedShowIds.has(grandparentId) ||
+      cascade.legacyParentIds.has(grandparentId))
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -1246,4 +1246,138 @@ describe('RuleExecutorService', () => {
       collectionService.removeFromCollectionWithResolvedLink,
     ).not.toHaveBeenCalled();
   });
+
+  // Issue #2858: Excluding a single episode previously cascaded to every
+  // sibling because Exclusion.parent (the entry-point of the exclusion
+  // request) was misused as a structural cascade key.
+  it('only filters the specifically excluded episode, leaving siblings of the same show eligible', async () => {
+    const { service, collectionService, rulesService } = createService(
+      MediaServerType.JELLYFIN,
+    );
+
+    collectionService.getCollectionMedia.mockResolvedValue([] as any);
+    rulesService.getExclusions.mockResolvedValue([
+      // parent=showId mirrors what setExclusion writes when the AddModal is
+      // opened from a show overview — the regression hinges on this shape.
+      { mediaServerId: 'ep-1', parent: 'show-1', type: 'episode' },
+    ] as any);
+
+    (service as any).startTime = new Date();
+    (service as any).statisticsData = [];
+    (service as any).resultData = [
+      { id: 'ep-1', parentId: 'season-1', grandparentId: 'show-1' },
+      { id: 'ep-2', parentId: 'season-1', grandparentId: 'show-1' },
+      { id: 'ep-3', parentId: 'season-2', grandparentId: 'show-1' },
+    ];
+
+    await (service as any).handleCollection({ id: 10, collectionId: 1 });
+
+    expect(collectionService.addToCollection).toHaveBeenCalledWith(
+      1,
+      expect.arrayContaining([
+        expect.objectContaining({ mediaServerId: 'ep-2' }),
+        expect.objectContaining({ mediaServerId: 'ep-3' }),
+      ]),
+    );
+    const addedIds = collectionService.addToCollection.mock.calls[0][1].map(
+      (m: { mediaServerId: string }) => m.mediaServerId,
+    );
+    expect(addedIds).not.toContain('ep-1');
+  });
+
+  it('cascades a season exclusion to its episodes only', async () => {
+    const { service, collectionService, rulesService } = createService(
+      MediaServerType.JELLYFIN,
+    );
+
+    collectionService.getCollectionMedia.mockResolvedValue([] as any);
+    rulesService.getExclusions.mockResolvedValue([
+      { mediaServerId: 'season-1', parent: 'show-1', type: 'season' },
+    ] as any);
+
+    (service as any).startTime = new Date();
+    (service as any).statisticsData = [];
+    (service as any).resultData = [
+      { id: 'ep-1', parentId: 'season-1', grandparentId: 'show-1' },
+      { id: 'ep-2', parentId: 'season-2', grandparentId: 'show-1' },
+    ];
+
+    await (service as any).handleCollection({ id: 10, collectionId: 1 });
+
+    const addedIds = collectionService.addToCollection.mock.calls[0][1].map(
+      (m: { mediaServerId: string }) => m.mediaServerId,
+    );
+    expect(addedIds).toEqual(['ep-2']);
+  });
+
+  it('cascades a show exclusion to its seasons and episodes', async () => {
+    const { service, collectionService, rulesService } = createService(
+      MediaServerType.JELLYFIN,
+    );
+
+    collectionService.getCollectionMedia.mockResolvedValue([] as any);
+    rulesService.getExclusions.mockResolvedValue([
+      { mediaServerId: 'show-1', parent: 'show-1', type: 'show' },
+    ] as any);
+
+    (service as any).startTime = new Date();
+    (service as any).statisticsData = [];
+    (service as any).resultData = [
+      { id: 'season-1', parentId: 'show-1' },
+      { id: 'ep-1', parentId: 'season-1', grandparentId: 'show-1' },
+      { id: 'season-other', parentId: 'show-2' },
+    ];
+
+    await (service as any).handleCollection({ id: 10, collectionId: 1 });
+
+    const addedIds = collectionService.addToCollection.mock.calls[0][1].map(
+      (m: { mediaServerId: string }) => m.mediaServerId,
+    );
+    expect(addedIds).toEqual(['season-other']);
+  });
+
+  it('does not skip sibling episodes when syncing manually added children after a single-episode exclusion (issue #2858)', async () => {
+    const { service, mediaServer, rulesService, collectionService } =
+      createService(MediaServerType.JELLYFIN);
+
+    mediaServer.getCollectionChildren.mockResolvedValue([
+      { id: 'ep-1', parentId: 'season-1', grandparentId: 'show-1' },
+      { id: 'ep-2', parentId: 'season-1', grandparentId: 'show-1' },
+    ]);
+    collectionService.getCollectionMedia.mockResolvedValue([]);
+    rulesService.getExclusions.mockResolvedValue([
+      { mediaServerId: 'ep-1', parent: 'show-1', type: 'episode' },
+    ] as any);
+
+    await (
+      service as unknown as {
+        syncManualMediaServerToCollectionDB: (
+          ruleGroup: { id: number; collectionId: number },
+          collectionSyncChanges: {
+            addedMediaServerIds: Set<string>;
+            removedMediaServerIds: Set<string>;
+          },
+        ) => Promise<void>;
+      }
+    ).syncManualMediaServerToCollectionDB(
+      { id: 10, collectionId: 1 },
+      {
+        addedMediaServerIds: new Set(),
+        removedMediaServerIds: new Set(),
+      },
+    );
+
+    expect(
+      collectionService.syncMediaServerChildrenToCollection,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, mediaServerId: 'coll-1' }),
+      [
+        {
+          mediaServerId: 'ep-2',
+          reason: { type: 'media_added_manually' },
+        },
+      ],
+      'local',
+    );
+  });
 });

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -30,6 +30,10 @@ import { SettingsService } from '../../settings/settings.service';
 import { RuleConstants } from '../constants/rules.constants';
 import { RulesDto } from '../dtos/rules.dto';
 import { RuleGroup } from '../entities/rule-group.entities';
+import {
+  buildExclusionCascadeSets,
+  isMediaItemExcluded,
+} from '../helpers/exclusion-cascade.helper';
 import { RuleComparatorServiceFactory } from '../helpers/rule.comparator.service';
 import { RulesService } from '../rules.service';
 import { RuleExecutorProgressService } from './rule-executor-progress.service';
@@ -398,12 +402,7 @@ export class RuleExecutorService {
                   Boolean(mediaServerId),
                 ),
             );
-            const excludedMediaServerIds = new Set<string>(
-              exclusions.map((e) => e.mediaServerId),
-            );
-            const excludedParentIds = new Set<string>(
-              exclusions.filter((e) => e.parent).map((e) => String(e.parent)),
-            );
+            const exclusionCascade = buildExclusionCascadeSets(exclusions);
             const missingManualChildren: CollectionMediaChange[] = [];
 
             for (const child of children) {
@@ -420,13 +419,7 @@ export class RuleExecutorService {
                 }
 
                 // Skip items that are excluded
-                if (
-                  excludedMediaServerIds.has(childId) ||
-                  (child.parentId &&
-                    excludedParentIds.has(child.parentId.toString())) ||
-                  (child.grandparentId &&
-                    excludedParentIds.has(child.grandparentId.toString()))
-                ) {
+                if (isMediaItemExcluded(exclusionCascade, child)) {
                   continue;
                 }
 
@@ -612,14 +605,7 @@ export class RuleExecutorService {
       );
 
       const exclusions = await this.rulesService.getExclusions(rulegroup?.id);
-
-      // Build sets of excluded IDs - both direct mediaServerId and parent IDs
-      const excludedMediaServerIds = new Set<string>(
-        exclusions.map((e) => e.mediaServerId),
-      );
-      const excludedParentIds = new Set<string>(
-        exclusions.filter((e) => e.parent).map((e) => String(e.parent)),
-      );
+      const exclusionCascade = buildExclusionCascadeSets(exclusions);
 
       const statsByMediaServerId = new Map<string, IComparisonStatistics>();
       for (const stat of this.statisticsData ?? []) {
@@ -629,24 +615,14 @@ export class RuleExecutorService {
         }
       }
 
-      // filter exclusions out of results & get correct media item ID
-      // Check both direct exclusion and parent exclusion (e.g., show excluded -> all seasons excluded)
+      // Filter exclusions out of results. Cascade is keyed off the show/season
+      // exclusion's own mediaServerId (via type), so a single-episode exclusion
+      // only skips that episode — not its siblings (issue #2858).
       const desiredMediaServerIds = new Set<string>();
 
       for (const item of this.resultData ?? []) {
-        const mediaServerId = item.id;
-        const isDirectlyExcluded = excludedMediaServerIds.has(mediaServerId);
-        const isParentExcluded =
-          item.parentId && excludedParentIds.has(item.parentId);
-        const isGrandparentExcluded =
-          item.grandparentId && excludedParentIds.has(item.grandparentId);
-
-        if (
-          !isDirectlyExcluded &&
-          !isParentExcluded &&
-          !isGrandparentExcluded
-        ) {
-          desiredMediaServerIds.add(mediaServerId);
+        if (!isMediaItemExcluded(exclusionCascade, item)) {
+          desiredMediaServerIds.add(item.id);
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes #2858. Excluding a single episode skipped every other episode of the same show.

The cascade filter in `handleCollection` and `syncManualMediaServerToCollectionDB` keyed off `Exclusion.parent`, but `parent` is the entry point of the exclusion request — `setExclusion` writes `parent: data.mediaId`, and from the AddModal opened on a show overview that's always the show id, regardless of whether the user is excluding the show, a season, or one episode. So a single-episode exclusion landed with `parent=showId`, and any other episode of that show matched via `grandparentId`.

Cascade is now driven by `Exclusion.type` + `Exclusion.mediaServerId` via a small helper (`buildExclusionCascadeSets` / `isMediaItemExcluded`). A `type='show'` row cascades to its seasons and episodes; a `type='season'` row cascades to its episodes; episode/movie rows do not cascade. Legacy null-type rows fall back to the pre-existing `parent`-based cascade so we don't regress users whose `ExclusionTypeCorrectorService` backfill hasn't yet completed.

Both `handleCollection` and `syncManualMediaServerToCollectionDB` now go through the helper, removing two copies of the same buggy filter.