### PR TITLE
fix(collections): sort by addDate and group episodes by show

### DIFF
--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -1220,21 +1220,16 @@ describe('CollectionsService', () => {
     });
   });
 
-  it('orders deleteSoonest paging by collection_media.addDate so the UI matches the media-server push', async () => {
-    // Regression for #2867: the API response and applyCollectionSort must
-    // agree, otherwise the user sees one order in Maintainerr and another
-    // in the media-server collection. MediaItem.addedAt is held identical
-    // across all rows here so any path that falls back to it would tie
-    // and the result order would depend on Map iteration.
+  it('paginates deleteSoonest at the SQL level by collection_media.addDate', async () => {
+    // `deleteSoonest` is equivalent to ordering by `collection_media.addDate`
+    // because `deleteAfterDays` is constant across a collection. SQL does the
+    // pagination so we don't have to hydrate every row in the collection
+    // before slicing — critical for collections with hundreds of items where
+    // hydrating all rows would block the UI for minutes.
     const collection = createCollection({
       id: 9,
       mediaServerId: 'remote-collection',
       type: 'movie',
-    });
-    const libraryAddDate = new Date('2024-06-01T00:00:00Z');
-    const leavesLatest = createCollectionMedia(collection, {
-      mediaServerId: 'leaves-latest',
-      addDate: new Date('2024-02-01T10:00:00Z'),
     });
     const leavesSoonest = createCollectionMedia(collection, {
       mediaServerId: 'leaves-soonest',
@@ -1244,49 +1239,24 @@ describe('CollectionsService', () => {
       mediaServerId: 'leaves-middle',
       addDate: new Date('2024-01-15T10:00:00Z'),
     });
-    const entities = [leavesLatest, leavesSoonest, leavesMiddle];
-    const metadataByMediaServerId = new Map([
-      [
-        'leaves-latest',
-        createMediaItem({
-          id: 'leaves-latest',
-          title: 'Latest',
-          addedAt: libraryAddDate,
-        }),
-      ],
-      [
-        'leaves-soonest',
-        createMediaItem({
-          id: 'leaves-soonest',
-          title: 'Soonest',
-          addedAt: libraryAddDate,
-        }),
-      ],
-      [
-        'leaves-middle',
-        createMediaItem({
-          id: 'leaves-middle',
-          title: 'Middle',
-          addedAt: libraryAddDate,
-        }),
-      ],
-    ]);
+    const sqlPagedEntities = [leavesSoonest, leavesMiddle];
     const queryBuilder = {
       where: jest.fn().mockReturnThis(),
-      getCount: jest.fn().mockResolvedValue(entities.length),
+      getCount: jest.fn().mockResolvedValue(3),
       clone: jest.fn(),
     };
     const cloneBuilder = {
       orderBy: jest.fn().mockReturnThis(),
       addOrderBy: jest.fn().mockReturnThis(),
-      getRawAndEntities: jest.fn().mockResolvedValue({ entities }),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getRawAndEntities: jest
+        .fn()
+        .mockResolvedValue({ entities: sqlPagedEntities }),
     };
     queryBuilder.clone.mockReturnValue(cloneBuilder);
     collectionMediaRepo.createQueryBuilder.mockReturnValue(queryBuilder as any);
 
-    jest
-      .spyOn(service as any, 'getCollectionMediaMetadata')
-      .mockResolvedValue(metadataByMediaServerId);
     const hydrateSpy = jest
       .spyOn(service as any, 'hydrateCollectionMediaWithMetadata')
       .mockImplementation(async (page) => page as any);
@@ -1294,12 +1264,60 @@ describe('CollectionsService', () => {
     await service.getCollectionMediaWithServerDataAndPaging(collection.id, {
       sort: 'deleteSoonest',
       sortOrder: 'asc',
+      offset: 0,
+      size: 2,
     });
 
-    expect(hydrateSpy).toHaveBeenCalledWith(
-      [leavesSoonest, leavesMiddle, leavesLatest],
-      mediaServer,
-      metadataByMediaServerId,
+    expect(cloneBuilder.orderBy).toHaveBeenCalledWith(
+      'collection_media.addDate',
+      'ASC',
+    );
+    expect(cloneBuilder.addOrderBy).toHaveBeenCalledWith(
+      'collection_media.id',
+      'ASC',
+    );
+    expect(cloneBuilder.skip).toHaveBeenCalledWith(0);
+    expect(cloneBuilder.take).toHaveBeenCalledWith(2);
+    expect(hydrateSpy).toHaveBeenCalledWith(sqlPagedEntities, mediaServer);
+  });
+
+  it('paginates deleteSoonest desc by ordering addDate DESC', async () => {
+    const collection = createCollection({
+      id: 11,
+      mediaServerId: 'remote-collection',
+      type: 'movie',
+    });
+    const queryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      getCount: jest.fn().mockResolvedValue(0),
+      clone: jest.fn(),
+    };
+    const cloneBuilder = {
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getRawAndEntities: jest.fn().mockResolvedValue({ entities: [] }),
+    };
+    queryBuilder.clone.mockReturnValue(cloneBuilder);
+    collectionMediaRepo.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+    jest
+      .spyOn(service as any, 'hydrateCollectionMediaWithMetadata')
+      .mockResolvedValue([]);
+
+    await service.getCollectionMediaWithServerDataAndPaging(collection.id, {
+      sort: 'deleteSoonest',
+      sortOrder: 'desc',
+    });
+
+    expect(cloneBuilder.orderBy).toHaveBeenCalledWith(
+      'collection_media.addDate',
+      'DESC',
+    );
+    expect(cloneBuilder.addOrderBy).toHaveBeenCalledWith(
+      'collection_media.id',
+      'DESC',
     );
   });
 

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -1,4 +1,4 @@
-import { MediaServerType } from '@maintainerr/contracts';
+import { MediaServerFeature, MediaServerType } from '@maintainerr/contracts';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Mocked, TestBed } from '@suites/unit';
 import { DataSource, Repository } from 'typeorm';
@@ -1220,6 +1220,89 @@ describe('CollectionsService', () => {
     });
   });
 
+  it('orders deleteSoonest paging by collection_media.addDate so the UI matches the media-server push', async () => {
+    // Regression for #2867: the API response and applyCollectionSort must
+    // agree, otherwise the user sees one order in Maintainerr and another
+    // in the media-server collection. MediaItem.addedAt is held identical
+    // across all rows here so any path that falls back to it would tie
+    // and the result order would depend on Map iteration.
+    const collection = createCollection({
+      id: 9,
+      mediaServerId: 'remote-collection',
+      type: 'movie',
+    });
+    const libraryAddDate = new Date('2024-06-01T00:00:00Z');
+    const leavesLatest = createCollectionMedia(collection, {
+      mediaServerId: 'leaves-latest',
+      addDate: new Date('2024-02-01T10:00:00Z'),
+    });
+    const leavesSoonest = createCollectionMedia(collection, {
+      mediaServerId: 'leaves-soonest',
+      addDate: new Date('2024-01-01T10:00:00Z'),
+    });
+    const leavesMiddle = createCollectionMedia(collection, {
+      mediaServerId: 'leaves-middle',
+      addDate: new Date('2024-01-15T10:00:00Z'),
+    });
+    const entities = [leavesLatest, leavesSoonest, leavesMiddle];
+    const metadataByMediaServerId = new Map([
+      [
+        'leaves-latest',
+        createMediaItem({
+          id: 'leaves-latest',
+          title: 'Latest',
+          addedAt: libraryAddDate,
+        }),
+      ],
+      [
+        'leaves-soonest',
+        createMediaItem({
+          id: 'leaves-soonest',
+          title: 'Soonest',
+          addedAt: libraryAddDate,
+        }),
+      ],
+      [
+        'leaves-middle',
+        createMediaItem({
+          id: 'leaves-middle',
+          title: 'Middle',
+          addedAt: libraryAddDate,
+        }),
+      ],
+    ]);
+    const queryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      getCount: jest.fn().mockResolvedValue(entities.length),
+      clone: jest.fn(),
+    };
+    const cloneBuilder = {
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      getRawAndEntities: jest.fn().mockResolvedValue({ entities }),
+    };
+    queryBuilder.clone.mockReturnValue(cloneBuilder);
+    collectionMediaRepo.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+    jest
+      .spyOn(service as any, 'getCollectionMediaMetadata')
+      .mockResolvedValue(metadataByMediaServerId);
+    const hydrateSpy = jest
+      .spyOn(service as any, 'hydrateCollectionMediaWithMetadata')
+      .mockImplementation(async (page) => page as any);
+
+    await service.getCollectionMediaWithServerDataAndPaging(collection.id, {
+      sort: 'deleteSoonest',
+      sortOrder: 'asc',
+    });
+
+    expect(hydrateSpy).toHaveBeenCalledWith(
+      [leavesSoonest, leavesMiddle, leavesLatest],
+      mediaServer,
+      metadataByMediaServerId,
+    );
+  });
+
   it('uses the sortable entity count for sorted collection media totals', async () => {
     const collection = createCollection({
       id: 8,
@@ -1664,5 +1747,68 @@ describe('CollectionsService', () => {
     expect(mediaServer.getMetadata).toHaveBeenCalledWith('movie-1');
     expect(result).toHaveLength(1);
     expect(result[0].mediaData?.title).toBe('Fallback Movie');
+  });
+
+  it('reorders Plex collection items by collection_media.addDate, not media-server addedAt', async () => {
+    // Regression for #2867: applyCollectionSort previously sorted by
+    // MediaItem.addedAt (when the file was added to the Plex library).
+    // The user-visible "Leaving in X days" overlay is driven by
+    // collection_media.addDate, so the Plex order must follow that.
+    const collection = createCollection({
+      id: 99,
+      mediaServerId: 'remote-99',
+      mediaServerSort: 'deleteSoonest.asc',
+      type: 'movie',
+    });
+
+    const libraryAddDate = new Date('2024-06-01T00:00:00Z');
+    const rows = [
+      createCollectionMedia(collection, {
+        mediaServerId: 'leaves-latest',
+        addDate: new Date('2024-02-01T10:00:00Z'),
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'leaves-soonest',
+        addDate: new Date('2024-01-01T10:00:00Z'),
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'leaves-middle',
+        addDate: new Date('2024-01-15T10:00:00Z'),
+      }),
+    ];
+
+    collectionMediaRepo.find.mockResolvedValue(rows);
+
+    mediaServer.supportsFeature.mockImplementation(
+      (feature) => feature === MediaServerFeature.COLLECTION_SORT,
+    );
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-99',
+      title: 'Test',
+      smart: false,
+      childCount: rows.length,
+    } as any);
+
+    // Hand back metadata where every item has the same library addedAt —
+    // if the comparator falls through to MediaItem.addedAt (the bug) the
+    // ordering becomes whatever Map iteration gives us; the assertion
+    // below would fail.
+    mediaServer.getMetadata.mockImplementation(async (id: string) =>
+      createMediaItem({
+        id,
+        title: id,
+        type: 'movie',
+        addedAt: libraryAddDate,
+      }),
+    );
+
+    mediaServer.reorderCollectionItems = jest.fn().mockResolvedValue(undefined);
+
+    await service.applyCollectionSort(collection as Collection);
+
+    expect(mediaServer.reorderCollectionItems).toHaveBeenCalledWith(
+      'remote-99',
+      ['leaves-soonest', 'leaves-middle', 'leaves-latest'],
+    );
   });
 });

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -916,12 +916,29 @@ export class CollectionsService {
 
       const itemCount = await queryBuilder.getCount();
 
-      if (!sort) {
-        // Default load (no explicit sort): SQL-paginate by recently-added.
+      if (!sort || sort === 'deleteSoonest') {
+        // SQL-paginate by `collection_media.addDate`. `deleteSoonest` is
+        // equivalent to `addDate` ordering because `deleteAfterDays` is
+        // constant for every item in a collection — so the only sort key
+        // that actually matters lives on the `collection_media` row and the
+        // database can paginate it directly without hydrating MediaItem
+        // metadata for every row in the collection. This keeps page loads
+        // fast on collections with hundreds of items.
+        //
+        // Trade-off: `applyCollectionSort` (the media-server push) still
+        // applies the day-bucketed title tiebreaker via `compareMediaItemsBySort`,
+        // so the polished alphabetical-within-day order is what users see
+        // when browsing the actual Plex/Jellyfin collection. The Maintainerr
+        // UI page may show same-day items in a slightly different order
+        // (by `addDate, id` instead of by title) — acceptable because the
+        // primary sort key is correct and Maintainerr's DB remains the
+        // source of truth driving the next push.
+        const direction =
+          sort === 'deleteSoonest' && sortOrder === 'asc' ? 'ASC' : 'DESC';
         const { entities } = await queryBuilder
           .clone()
-          .orderBy('collection_media.addDate', 'DESC')
-          .addOrderBy('collection_media.id', 'DESC')
+          .orderBy('collection_media.addDate', direction)
+          .addOrderBy('collection_media.id', direction)
           .skip(offset)
           .take(size)
           .getRawAndEntities();
@@ -935,11 +952,11 @@ export class CollectionsService {
         };
       }
 
-      // Explicit sort — including deleteSoonest — goes through hydrate-
-      // then-sort so the response matches what applyCollectionSort pushes
-      // to the media server (day-bucketed addDate with show-aware
-      // tiebreakers). The `deleteSoonest` SQL fast-path was dropped to keep
-      // the two paths consistent; fix it together if perf becomes an issue.
+      // Explicit sort on a MediaItem-side key (airDate / rating / watchCount /
+      // title) — the sort value isn't on `collection_media`, so we have to
+      // hydrate the whole collection before paginating. Acceptable because
+      // these sorts are rarely used compared to `deleteSoonest` and the
+      // default load.
       const { entities } = await queryBuilder
         .clone()
         .orderBy('collection_media.addDate', 'DESC')

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -3,6 +3,7 @@ import {
   CollectionLogMeta,
   CollectionMediaSortField,
   compareMediaItemsBySort,
+  type CompareMediaItemsOptions,
   ECollectionLogType,
   isMediaType,
   MaintainerrEvent,
@@ -758,6 +759,25 @@ export class CollectionsService {
       );
   }
 
+  /**
+   * Builds the comparator options that route `deleteSoonest` to each row's
+   * `collection_media.addDate` (when Maintainerr started the deletion timer)
+   * instead of `MediaItem.addedAt` (when the file landed in the underlying
+   * media-server library). Sorting must follow the user-visible
+   * "Leaving in X days" overlay so what Maintainerr UI shows matches what is
+   * pushed to the media server collection.
+   */
+  private buildCollectionMediaCompareOptions(
+    rows: ReadonlyArray<{ mediaServerId: string; addDate: Date | string }>,
+  ): CompareMediaItemsOptions {
+    const addDateByMediaItemId = new Map<string, Date | string>(
+      rows.map((row) => [row.mediaServerId, row.addDate]),
+    );
+    return {
+      deleteSoonestDate: (item) => addDateByMediaItemId.get(item.id),
+    };
+  }
+
   async applyCollectionSort(collection: Collection): Promise<void> {
     const sortKey = collection.mediaServerSort;
     const parsed = sortKey ? parseCollectionSortKey(sortKey) : undefined;
@@ -801,12 +821,15 @@ export class CollectionsService {
         return;
       }
 
+      const compareOptions = this.buildCollectionMediaCompareOptions(sortable);
+
       sortable.sort((a, b) =>
         compareMediaItemsBySort(
           a.mediaData,
           b.mediaData,
           parsed.sort,
           parsed.order,
+          compareOptions,
         ),
       );
 
@@ -880,15 +903,12 @@ export class CollectionsService {
 
       const itemCount = await queryBuilder.getCount();
 
-      if (!sort || sort === 'deleteSoonest') {
-        // deleteSoonest is equivalent to addDate ordering because
-        // deleteAfterDays is constant for every item in a collection.
-        const direction =
-          sort === 'deleteSoonest' && sortOrder === 'asc' ? 'ASC' : 'DESC';
+      if (!sort) {
+        // Default load (no explicit sort): SQL-paginate by recently-added.
         const { entities } = await queryBuilder
           .clone()
-          .orderBy('collection_media.addDate', direction)
-          .addOrderBy('collection_media.id', direction)
+          .orderBy('collection_media.addDate', 'DESC')
+          .addOrderBy('collection_media.id', 'DESC')
           .skip(offset)
           .take(size)
           .getRawAndEntities();
@@ -902,15 +922,17 @@ export class CollectionsService {
         };
       }
 
+      // Explicit sort — including deleteSoonest — goes through hydrate-
+      // then-sort so the response matches what applyCollectionSort pushes
+      // to the media server (day-bucketed addDate with show-aware
+      // tiebreakers). The `deleteSoonest` SQL fast-path was dropped to keep
+      // the two paths consistent; fix it together if perf becomes an issue.
       const { entities } = await queryBuilder
         .clone()
         .orderBy('collection_media.addDate', 'DESC')
         .addOrderBy('collection_media.id', 'DESC')
         .getRawAndEntities();
 
-      // Metadata-backed sorts currently hydrate every matching row before
-      // pagination because these sort keys are not persisted locally.
-      // Replace this with cached DB-backed fields when available.
       this.logger.debug(
         `Collection ${id} sort ${sort} is hydrating ${itemCount} items before pagination`,
       );
@@ -924,6 +946,9 @@ export class CollectionsService {
         metadataByMediaServerId.has(entity.mediaServerId),
       );
 
+      const compareOptions =
+        this.buildCollectionMediaCompareOptions(sortableEntities);
+
       const sortedPageEntities = sortableEntities
         .sort((leftItem, rightItem) =>
           compareMediaItemsBySort(
@@ -931,6 +956,7 @@ export class CollectionsService {
             metadataByMediaServerId.get(rightItem.mediaServerId)!,
             sort,
             sortOrder,
+            compareOptions,
           ),
         )
         .slice(offset, offset + size);

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -766,16 +766,26 @@ export class CollectionsService {
    * media-server library). Sorting must follow the user-visible
    * "Leaving in X days" overlay so what Maintainerr UI shows matches what is
    * pushed to the media server collection.
+   *
+   * `deleteSoonestReferenceTime` anchors the comparator's day buckets to the
+   * same `daysLeft` rollover the overlay shows, so two items with the same
+   * countdown tie even when their `addDate`s straddle UTC midnight.
    */
   private buildCollectionMediaCompareOptions(
     rows: ReadonlyArray<{ mediaServerId: string; addDate: Date | string }>,
+    deleteAfterDays: number | null | undefined,
   ): CompareMediaItemsOptions {
     const addDateByMediaItemId = new Map<string, Date | string>(
       rows.map((row) => [row.mediaServerId, row.addDate]),
     );
-    return {
+    const options: CompareMediaItemsOptions = {
       deleteSoonestDate: (item) => addDateByMediaItemId.get(item.id),
     };
+    if (deleteAfterDays != null) {
+      options.deleteSoonestReferenceTime =
+        Date.now() - deleteAfterDays * 86400000;
+    }
+    return options;
   }
 
   async applyCollectionSort(collection: Collection): Promise<void> {
@@ -821,7 +831,10 @@ export class CollectionsService {
         return;
       }
 
-      const compareOptions = this.buildCollectionMediaCompareOptions(sortable);
+      const compareOptions = this.buildCollectionMediaCompareOptions(
+        sortable,
+        collection.deleteAfterDays,
+      );
 
       sortable.sort((a, b) =>
         compareMediaItemsBySort(
@@ -946,8 +959,11 @@ export class CollectionsService {
         metadataByMediaServerId.has(entity.mediaServerId),
       );
 
-      const compareOptions =
-        this.buildCollectionMediaCompareOptions(sortableEntities);
+      const collectionRecord = await this.getCollection(id);
+      const compareOptions = this.buildCollectionMediaCompareOptions(
+        sortableEntities,
+        collectionRecord?.deleteAfterDays,
+      );
 
       const sortedPageEntities = sortableEntities
         .sort((leftItem, rightItem) =>

--- a/apps/server/src/modules/collections/sort-utils.spec.ts
+++ b/apps/server/src/modules/collections/sort-utils.spec.ts
@@ -1,5 +1,6 @@
 import {
   compareMediaItemsBySort,
+  type CompareMediaItemsOptions,
   type MediaItem,
 } from '@maintainerr/contracts';
 
@@ -16,10 +17,11 @@ const sortBy = (
   items: MediaItem[],
   sort: Parameters<typeof compareMediaItemsBySort>[2],
   order: Parameters<typeof compareMediaItemsBySort>[3] = 'asc',
+  options?: CompareMediaItemsOptions,
 ) =>
   [...items]
     .sort((leftItem, rightItem) =>
-      compareMediaItemsBySort(leftItem, rightItem, sort, order),
+      compareMediaItemsBySort(leftItem, rightItem, sort, order, options),
     )
     .map((mediaItem) => mediaItem.title);
 
@@ -95,5 +97,176 @@ describe('compareMediaItemsBySort tiebreakers', () => {
     ];
 
     expect(sortBy(items, 'manual', 'desc')).toEqual(['C', 'A', 'B']);
+  });
+});
+
+describe('compareMediaItemsBySort show-aware title ordering', () => {
+  it('groups episodes from the same show together when sorting by title', () => {
+    // Pre-fix the title sort would interleave episodes by episode title
+    // (Aurora, Borealis, Comet, Drift) and split episodes from the same
+    // show. Show-aware ordering keeps a show's episodes contiguous.
+    const items: MediaItem[] = [
+      item({
+        id: 'ep1',
+        title: 'Comet',
+        type: 'episode',
+        grandparentTitle: 'Show Beta',
+      }),
+      item({
+        id: 'ep2',
+        title: 'Aurora',
+        type: 'episode',
+        grandparentTitle: 'Show Alpha',
+      }),
+      item({
+        id: 'ep3',
+        title: 'Drift',
+        type: 'episode',
+        grandparentTitle: 'Show Beta',
+      }),
+      item({
+        id: 'ep4',
+        title: 'Borealis',
+        type: 'episode',
+        grandparentTitle: 'Show Alpha',
+      }),
+    ];
+
+    expect(sortBy(items, 'title', 'asc')).toEqual([
+      'Aurora',
+      'Borealis',
+      'Comet',
+      'Drift',
+    ]);
+  });
+
+  it('reverses both show and episode order when sorting title desc', () => {
+    const items: MediaItem[] = [
+      item({
+        id: 'ep1',
+        title: 'Comet',
+        type: 'episode',
+        grandparentTitle: 'Show Beta',
+      }),
+      item({
+        id: 'ep2',
+        title: 'Aurora',
+        type: 'episode',
+        grandparentTitle: 'Show Alpha',
+      }),
+      item({
+        id: 'ep3',
+        title: 'Drift',
+        type: 'episode',
+        grandparentTitle: 'Show Beta',
+      }),
+      item({
+        id: 'ep4',
+        title: 'Borealis',
+        type: 'episode',
+        grandparentTitle: 'Show Alpha',
+      }),
+    ];
+
+    expect(sortBy(items, 'title', 'desc')).toEqual([
+      'Drift',
+      'Comet',
+      'Borealis',
+      'Aurora',
+    ]);
+  });
+
+  it('leaves movie title ordering unchanged (no parent/grandparent titles)', () => {
+    const items: MediaItem[] = [
+      item({ title: 'Charlie', type: 'movie' }),
+      item({ title: 'Alpha', type: 'movie' }),
+      item({ title: 'Bravo', type: 'movie' }),
+    ];
+
+    expect(sortBy(items, 'title', 'asc')).toEqual([
+      'Alpha',
+      'Bravo',
+      'Charlie',
+    ]);
+  });
+});
+
+describe('compareMediaItemsBySort deleteSoonest day bucketing', () => {
+  it('treats items added in the same UTC day as ties so the title tiebreaker fires', () => {
+    // Same calendar day, hours apart. Pre-fix this would sort strictly by
+    // millisecond timestamp and the title tiebreaker would never fire.
+    const items: MediaItem[] = [
+      item({ title: 'C', addedAt: new Date('2024-01-01T01:00:00Z') }),
+      item({ title: 'A', addedAt: new Date('2024-01-01T15:00:00Z') }),
+      item({ title: 'B', addedAt: new Date('2024-01-01T08:00:00Z') }),
+    ];
+
+    expect(sortBy(items, 'deleteSoonest', 'asc')).toEqual(['A', 'B', 'C']);
+    expect(sortBy(items, 'deleteSoonest', 'desc')).toEqual(['A', 'B', 'C']);
+  });
+
+  it('still orders separate days by date', () => {
+    const items: MediaItem[] = [
+      item({ title: 'Day3-A', addedAt: new Date('2024-01-03T22:00:00Z') }),
+      item({ title: 'Day1-Z', addedAt: new Date('2024-01-01T02:00:00Z') }),
+      item({ title: 'Day2-M', addedAt: new Date('2024-01-02T10:00:00Z') }),
+    ];
+
+    expect(sortBy(items, 'deleteSoonest', 'asc')).toEqual([
+      'Day1-Z',
+      'Day2-M',
+      'Day3-A',
+    ]);
+  });
+});
+
+describe('compareMediaItemsBySort deleteSoonest date override', () => {
+  it('uses options.deleteSoonestDate over MediaItem.addedAt when provided', () => {
+    // Models the collection-media case: MediaItem.addedAt is the library
+    // add date (irrelevant to deletion timing), the override carries
+    // collection_media.addDate (drives the visible "Leaving in X days").
+    const libraryAddDate = new Date('2024-06-01T00:00:00Z');
+    const collectionDates = new Map<string, Date>([
+      ['leaves-soonest', new Date('2024-01-01T00:00:00Z')],
+      ['leaves-middle', new Date('2024-01-15T00:00:00Z')],
+      ['leaves-latest', new Date('2024-02-01T00:00:00Z')],
+    ]);
+
+    const items: MediaItem[] = [
+      item({
+        id: 'leaves-latest',
+        title: 'Leaves last',
+        addedAt: libraryAddDate,
+      }),
+      item({
+        id: 'leaves-soonest',
+        title: 'Leaves first',
+        addedAt: libraryAddDate,
+      }),
+      item({
+        id: 'leaves-middle',
+        title: 'Leaves second',
+        addedAt: libraryAddDate,
+      }),
+    ];
+
+    expect(
+      sortBy(items, 'deleteSoonest', 'asc', {
+        deleteSoonestDate: (mediaItem) => collectionDates.get(mediaItem.id),
+      }),
+    ).toEqual(['Leaves first', 'Leaves second', 'Leaves last']);
+  });
+
+  it('falls back to MediaItem.addedAt when the override returns undefined', () => {
+    const items: MediaItem[] = [
+      item({ id: 'a', title: 'A', addedAt: new Date('2024-01-02T00:00:00Z') }),
+      item({ id: 'b', title: 'B', addedAt: new Date('2024-01-01T00:00:00Z') }),
+    ];
+
+    expect(
+      sortBy(items, 'deleteSoonest', 'asc', {
+        deleteSoonestDate: () => undefined,
+      }),
+    ).toEqual(['B', 'A']);
   });
 });

--- a/apps/server/src/modules/collections/sort-utils.spec.ts
+++ b/apps/server/src/modules/collections/sort-utils.spec.ts
@@ -270,3 +270,89 @@ describe('compareMediaItemsBySort deleteSoonest date override', () => {
     ).toEqual(['B', 'A']);
   });
 });
+
+describe('compareMediaItemsBySort missing values', () => {
+  // Missing-to-end is direction-independent: items without a value cannot be
+  // meaningfully placed on a numeric axis, so they always trail real values.
+  // Pre-fix they coerced to 0 and silently sorted to the front in 'asc' mode
+  // (e.g. an item with no air date appeared before one from 1995).
+  it('sorts items without an air date to the end regardless of direction', () => {
+    const items: MediaItem[] = [
+      item({ title: 'No date 1', originallyAvailableAt: undefined }),
+      item({ title: 'New', originallyAvailableAt: new Date('2024-06-01') }),
+      item({ title: 'No date 2', originallyAvailableAt: undefined }),
+      item({ title: 'Old', originallyAvailableAt: new Date('1995-06-01') }),
+    ];
+
+    expect(sortBy(items, 'airDate', 'asc')).toEqual([
+      'Old',
+      'New',
+      'No date 1',
+      'No date 2',
+    ]);
+    expect(sortBy(items, 'airDate', 'desc')).toEqual([
+      'New',
+      'Old',
+      'No date 1',
+      'No date 2',
+    ]);
+  });
+
+  it('sorts items without a rating to the end regardless of direction', () => {
+    const items: MediaItem[] = [
+      item({ title: 'Unrated', ratings: undefined }),
+      item({
+        title: 'Mid',
+        ratings: [{ type: 'audience', value: 5, source: 'tmdb' }],
+      }),
+      item({
+        title: 'High',
+        ratings: [{ type: 'audience', value: 9, source: 'tmdb' }],
+      }),
+    ];
+
+    expect(sortBy(items, 'rating', 'desc')).toEqual(['High', 'Mid', 'Unrated']);
+    expect(sortBy(items, 'rating', 'asc')).toEqual(['Mid', 'High', 'Unrated']);
+  });
+
+  it('treats viewCount === 0 as a real value, only undefined trails to the end', () => {
+    // Distinguishes "watched zero times" (a real data point) from
+    // "watch count not reported" — pre-fix both collapsed to 0.
+    const items: MediaItem[] = [
+      item({ title: 'Unknown', viewCount: undefined }),
+      item({ title: 'Watched', viewCount: 3 }),
+      item({ title: 'Never', viewCount: 0 }),
+    ];
+
+    expect(sortBy(items, 'watchCount', 'asc')).toEqual([
+      'Never',
+      'Watched',
+      'Unknown',
+    ]);
+  });
+
+  it('sorts items without a delete-soonest date to the end', () => {
+    const items: MediaItem[] = [
+      item({ id: 'has-date', title: 'Has date' }),
+      item({ id: 'no-date', title: 'No date' }),
+    ];
+
+    expect(
+      sortBy(items, 'deleteSoonest', 'asc', {
+        deleteSoonestDate: (mediaItem) =>
+          mediaItem.id === 'has-date' ? new Date('2024-01-01') : undefined,
+      }),
+    ).toEqual(['Has date', 'No date']);
+  });
+
+  it('falls back to title order when both items are missing the value', () => {
+    const items: MediaItem[] = [
+      item({ title: 'C', originallyAvailableAt: undefined }),
+      item({ title: 'A', originallyAvailableAt: undefined }),
+      item({ title: 'B', originallyAvailableAt: undefined }),
+    ];
+
+    expect(sortBy(items, 'airDate', 'asc')).toEqual(['A', 'B', 'C']);
+    expect(sortBy(items, 'airDate', 'desc')).toEqual(['A', 'B', 'C']);
+  });
+});

--- a/apps/server/src/modules/collections/sort-utils.spec.ts
+++ b/apps/server/src/modules/collections/sort-utils.spec.ts
@@ -101,10 +101,28 @@ describe('compareMediaItemsBySort tiebreakers', () => {
 });
 
 describe('compareMediaItemsBySort show-aware title ordering', () => {
+  // Helper: capture both the show title and the episode title so the
+  // assertion would fail under a plain episode-title-only comparator. The
+  // earlier version of this test used data (Aurora/Borealis/Comet/Drift)
+  // that happened to alphabetize correctly under either comparator.
+  const sortByShowAndEpisode = (
+    items: MediaItem[],
+    order: 'asc' | 'desc' = 'asc',
+  ): Array<[string, string]> =>
+    [...items]
+      .sort((leftItem, rightItem) =>
+        compareMediaItemsBySort(leftItem, rightItem, 'title', order),
+      )
+      .map((mediaItem) => [
+        mediaItem.grandparentTitle ?? mediaItem.parentTitle ?? '',
+        mediaItem.title,
+      ]);
+
   it('groups episodes from the same show together when sorting by title', () => {
-    // Pre-fix the title sort would interleave episodes by episode title
-    // (Aurora, Borealis, Comet, Drift) and split episodes from the same
-    // show. Show-aware ordering keeps a show's episodes contiguous.
+    // Episode titles are deliberately interleaved across shows so that an
+    // episode-title-only sort would yield Aurora, Bravo, Comet, Delta —
+    // which interleaves Show Alpha and Show Beta episodes. The show-aware
+    // comparator must instead group all of Show Alpha first.
     const items: MediaItem[] = [
       item({
         id: 'ep1',
@@ -114,29 +132,29 @@ describe('compareMediaItemsBySort show-aware title ordering', () => {
       }),
       item({
         id: 'ep2',
-        title: 'Aurora',
+        title: 'Bravo',
         type: 'episode',
         grandparentTitle: 'Show Alpha',
       }),
       item({
         id: 'ep3',
-        title: 'Drift',
+        title: 'Aurora',
         type: 'episode',
         grandparentTitle: 'Show Beta',
       }),
       item({
         id: 'ep4',
-        title: 'Borealis',
+        title: 'Delta',
         type: 'episode',
         grandparentTitle: 'Show Alpha',
       }),
     ];
 
-    expect(sortBy(items, 'title', 'asc')).toEqual([
-      'Aurora',
-      'Borealis',
-      'Comet',
-      'Drift',
+    expect(sortByShowAndEpisode(items, 'asc')).toEqual([
+      ['Show Alpha', 'Bravo'],
+      ['Show Alpha', 'Delta'],
+      ['Show Beta', 'Aurora'],
+      ['Show Beta', 'Comet'],
     ]);
   });
 
@@ -150,29 +168,29 @@ describe('compareMediaItemsBySort show-aware title ordering', () => {
       }),
       item({
         id: 'ep2',
-        title: 'Aurora',
+        title: 'Bravo',
         type: 'episode',
         grandparentTitle: 'Show Alpha',
       }),
       item({
         id: 'ep3',
-        title: 'Drift',
+        title: 'Aurora',
         type: 'episode',
         grandparentTitle: 'Show Beta',
       }),
       item({
         id: 'ep4',
-        title: 'Borealis',
+        title: 'Delta',
         type: 'episode',
         grandparentTitle: 'Show Alpha',
       }),
     ];
 
-    expect(sortBy(items, 'title', 'desc')).toEqual([
-      'Drift',
-      'Comet',
-      'Borealis',
-      'Aurora',
+    expect(sortByShowAndEpisode(items, 'desc')).toEqual([
+      ['Show Beta', 'Comet'],
+      ['Show Beta', 'Aurora'],
+      ['Show Alpha', 'Delta'],
+      ['Show Alpha', 'Bravo'],
     ]);
   });
 
@@ -268,6 +286,95 @@ describe('compareMediaItemsBySort deleteSoonest date override', () => {
         deleteSoonestDate: () => undefined,
       }),
     ).toEqual(['B', 'A']);
+  });
+});
+
+describe('compareMediaItemsBySort deleteSoonest reference-time bucketing', () => {
+  // Without a referenceTime, items bucket by UTC midnight: items added at
+  // 23:00 today and 01:00 tomorrow show the same overlay countdown but sort
+  // apart. With referenceTime = now - deleteAfterDays * dayMs, buckets
+  // align with the user-visible `daysLeft` rollover so they tie correctly.
+  const dayMs = 86400000;
+
+  it('ties items that share the same daysLeft despite straddling UTC midnight', () => {
+    const now = new Date('2024-01-02T12:00:00Z').getTime();
+    const deleteAfterDays = 3;
+    // Both items show "Leaves in 3 days" against `now`:
+    //   ceil((addDate + 3*day - now) / dayMs) === 3
+    const items: MediaItem[] = [
+      item({
+        id: 'late',
+        title: 'C',
+        addedAt: new Date('2024-01-01T23:00:00Z'),
+      }),
+      item({
+        id: 'early',
+        title: 'A',
+        addedAt: new Date('2024-01-02T01:00:00Z'),
+      }),
+      item({
+        id: 'mid',
+        title: 'B',
+        addedAt: new Date('2024-01-02T08:00:00Z'),
+      }),
+    ];
+
+    expect(
+      sortBy(items, 'deleteSoonest', 'asc', {
+        deleteSoonestReferenceTime: now - deleteAfterDays * dayMs,
+      }),
+    ).toEqual(['A', 'B', 'C']);
+  });
+
+  it('still keeps items in different daysLeft buckets ordered by date', () => {
+    const now = new Date('2024-01-02T12:00:00Z').getTime();
+    const deleteAfterDays = 3;
+    const items: MediaItem[] = [
+      item({
+        id: 'far',
+        title: 'Leaves day 5',
+        addedAt: new Date('2024-01-04T01:00:00Z'),
+      }),
+      item({
+        id: 'near',
+        title: 'Leaves day 2',
+        addedAt: new Date('2024-01-01T01:00:00Z'),
+      }),
+      item({
+        id: 'mid',
+        title: 'Leaves day 4',
+        addedAt: new Date('2024-01-03T01:00:00Z'),
+      }),
+    ];
+
+    expect(
+      sortBy(items, 'deleteSoonest', 'asc', {
+        deleteSoonestReferenceTime: now - deleteAfterDays * dayMs,
+      }),
+    ).toEqual(['Leaves day 2', 'Leaves day 4', 'Leaves day 5']);
+  });
+
+  it('accepts a Date for deleteSoonestReferenceTime (interchangeable with number)', () => {
+    const now = new Date('2024-01-02T12:00:00Z').getTime();
+    const deleteAfterDays = 3;
+    const items: MediaItem[] = [
+      item({
+        id: 'late',
+        title: 'C',
+        addedAt: new Date('2024-01-01T23:00:00Z'),
+      }),
+      item({
+        id: 'early',
+        title: 'A',
+        addedAt: new Date('2024-01-02T01:00:00Z'),
+      }),
+    ];
+
+    expect(
+      sortBy(items, 'deleteSoonest', 'asc', {
+        deleteSoonestReferenceTime: new Date(now - deleteAfterDays * dayMs),
+      }),
+    ).toEqual(['A', 'C']);
   });
 });
 

--- a/apps/server/tsconfig.build.json
+++ b/apps/server/tsconfig.build.json
@@ -1,7 +1,13 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // Pin the incremental build info next to the emitted output. Without
+    // this, nest-cli's type-check pass writes a duplicate
+    // tsconfig.build.tsbuildinfo at the package root because TS computes
+    // the default location from the caller's resolved outDir, which differs
+    // between the type-check invocation and the emit invocation.
+    "tsBuildInfoFile": "./dist/tsconfig.build.tsbuildinfo"
   },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "**/__mocks__/*"]
 }

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -23,11 +23,7 @@
     /* Additional */
     "allowJs": true,
     "esModuleInterop": true,
-    "preserveWatchOutput": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "preserveWatchOutput": true
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/packages/contracts/src/media-server/sort-utils.ts
+++ b/packages/contracts/src/media-server/sort-utils.ts
@@ -24,6 +24,47 @@ const getWatchCount = (item: MediaItem): number => {
   return item.viewCount ?? 0
 }
 
+export interface CompareMediaItemsOptions {
+  /**
+   * Override the timestamp used for the `deleteSoonest` sort. Collection
+   * callers pass `collection_media.addDate` (when Maintainerr started the
+   * deletion timer) so ordering reflects the user-visible "Leaving in X
+   * days" overlay rather than `MediaItem.addedAt` (when the file was added
+   * to the underlying media-server library).
+   */
+  deleteSoonestDate?: (item: MediaItem) => Date | string | undefined | null
+}
+
+const getDeleteSoonestDayBucket = (
+  item: MediaItem,
+  override: CompareMediaItemsOptions['deleteSoonestDate'],
+): number => {
+  const value = override?.(item) ?? item.addedAt
+  const ms = value ? new Date(value).getTime() : 0
+  // Bucket by UTC day so items added in the same rule run tie and reach the
+  // title tiebreaker. Items split across the UTC midnight boundary land in
+  // adjacent buckets — acceptable because the user-visible "Leaving in X
+  // days" label can also flip across that boundary.
+  return Math.floor(ms / 86_400_000)
+}
+
+// Title comparison that groups episodes and seasons under their show. Movies
+// and shows have no parent/grandparent title, so this reduces to a plain
+// title compare for those types.
+const compareByDisplayHierarchy = (
+  leftItem: MediaItem,
+  rightItem: MediaItem,
+): number => {
+  const leftPrimary =
+    leftItem.grandparentTitle ?? leftItem.parentTitle ?? leftItem.title
+  const rightPrimary =
+    rightItem.grandparentTitle ?? rightItem.parentTitle ?? rightItem.title
+  return (
+    leftPrimary.localeCompare(rightPrimary) ||
+    leftItem.title.localeCompare(rightItem.title)
+  )
+}
+
 const compareMaintainerrState = (
   leftItem: MediaItem,
   rightItem: MediaItem,
@@ -43,6 +84,7 @@ export const compareMediaItemsBySort = (
   rightItem: MediaItem,
   sort?: CollectionMediaSortField,
   sortOrder: MediaSortOrder = 'asc',
+  options?: CompareMediaItemsOptions,
 ): number => {
   const direction = sortOrder === 'desc' ? -1 : 1
 
@@ -52,7 +94,9 @@ export const compareMediaItemsBySort = (
   // tiebreaker — see compareMaintainerrState above.
   switch (sort) {
     case 'title':
-      return leftItem.title.localeCompare(rightItem.title) * direction
+      // Show-aware so episodes/seasons group under their show. The
+      // direction multiplier still applies, so 'desc' reverses both tiers.
+      return compareByDisplayHierarchy(leftItem, rightItem) * direction
     case 'airDate':
       return (
         (getComparableAirDate(leftItem) - getComparableAirDate(rightItem)) *
@@ -84,15 +128,20 @@ export const compareMediaItemsBySort = (
         sortOrder,
         (item) => item.maintainerrExclusionId != null,
       )
-    case 'deleteSoonest':
-      // deleteSoonest is equivalent to addDate sorting because
-      // deleteAfterDays is constant per collection.
+    case 'deleteSoonest': {
+      const leftBucket = getDeleteSoonestDayBucket(
+        leftItem,
+        options?.deleteSoonestDate,
+      )
+      const rightBucket = getDeleteSoonestDayBucket(
+        rightItem,
+        options?.deleteSoonestDate,
+      )
       return (
-        (new Date(leftItem.addedAt).getTime() -
-          new Date(rightItem.addedAt).getTime()) *
-          direction ||
+        (leftBucket - rightBucket) * direction ||
         compareMediaItemsBySort(leftItem, rightItem, 'title', 'asc')
       )
+    }
     default:
       return 0
   }

--- a/packages/contracts/src/media-server/sort-utils.ts
+++ b/packages/contracts/src/media-server/sort-utils.ts
@@ -10,19 +10,22 @@ import type { MediaItem } from './types'
 
 const defaultMediaLibrarySort: MediaLibrarySortKey = 'title.asc'
 
-export const getAudienceRating = (item: MediaItem): number => {
-  return item.ratings?.find((rating) => rating.type === 'audience')?.value ?? 0
+const toDayBucket = (
+  value: Date | string | number | null | undefined,
+): number | undefined => {
+  if (value == null) return undefined
+  const ms = value instanceof Date ? value.getTime() : new Date(value).getTime()
+  return Number.isNaN(ms) ? undefined : Math.floor(ms / 86400000)
 }
 
-const getComparableAirDate = (item: MediaItem): number => {
-  return item.originallyAvailableAt
-    ? new Date(item.originallyAvailableAt).getTime()
-    : 0
+export const getAudienceRating = (item: MediaItem): number | undefined => {
+  return item.ratings?.find((rating) => rating.type === 'audience')?.value
 }
 
-const getWatchCount = (item: MediaItem): number => {
-  return item.viewCount ?? 0
-}
+const getAirDateBucket = (item: MediaItem): number | undefined =>
+  toDayBucket(item.originallyAvailableAt)
+
+const getWatchCount = (item: MediaItem): number | undefined => item.viewCount
 
 export interface CompareMediaItemsOptions {
   /**
@@ -38,14 +41,12 @@ export interface CompareMediaItemsOptions {
 const getDeleteSoonestDayBucket = (
   item: MediaItem,
   override: CompareMediaItemsOptions['deleteSoonestDate'],
-): number => {
-  const value = override?.(item) ?? item.addedAt
-  const ms = value ? new Date(value).getTime() : 0
+): number | undefined => {
   // Bucket by UTC day so items added in the same rule run tie and reach the
   // title tiebreaker. Items split across the UTC midnight boundary land in
   // adjacent buckets — acceptable because the user-visible "Leaving in X
   // days" label can also flip across that boundary.
-  return Math.floor(ms / 86_400_000)
+  return toDayBucket(override?.(item) ?? item.addedAt)
 }
 
 // Title comparison that groups episodes and seasons under their show. Movies
@@ -62,6 +63,29 @@ const compareByDisplayHierarchy = (
   return (
     leftPrimary.localeCompare(rightPrimary) ||
     leftItem.title.localeCompare(rightItem.title)
+  )
+}
+
+// Numeric sort with two invariants: (1) items missing the value sort to the
+// end regardless of direction — sorting "oldest air date first" must not put
+// an item with no air date ahead of one from 1995; and (2) within-group ties
+// fall back to the show-aware title order so the listing stays stable A→Z.
+const compareNumericWithTitleFallback = (
+  leftItem: MediaItem,
+  rightItem: MediaItem,
+  getValue: (item: MediaItem) => number | undefined,
+  direction: 1 | -1,
+): number => {
+  const leftValue = getValue(leftItem)
+  const rightValue = getValue(rightItem)
+  if (leftValue === undefined && rightValue === undefined) {
+    return compareByDisplayHierarchy(leftItem, rightItem)
+  }
+  if (leftValue === undefined) return 1
+  if (rightValue === undefined) return -1
+  return (
+    (leftValue - rightValue) * direction ||
+    compareByDisplayHierarchy(leftItem, rightItem)
   )
 }
 
@@ -86,33 +110,33 @@ export const compareMediaItemsBySort = (
   sortOrder: MediaSortOrder = 'asc',
   options?: CompareMediaItemsOptions,
 ): number => {
-  const direction = sortOrder === 'desc' ? -1 : 1
+  const direction: 1 | -1 = sortOrder === 'desc' ? -1 : 1
 
-  // Numeric/date sorts fall back to the existing 'title.asc' branch when the
-  // primary returns 0, so within-group ordering is stable A→Z regardless of
-  // direction. Status sorts (manual/excluded) intentionally skip the
-  // tiebreaker — see compareMaintainerrState above.
   switch (sort) {
     case 'title':
       // Show-aware so episodes/seasons group under their show. The
       // direction multiplier still applies, so 'desc' reverses both tiers.
       return compareByDisplayHierarchy(leftItem, rightItem) * direction
     case 'airDate':
-      return (
-        (getComparableAirDate(leftItem) - getComparableAirDate(rightItem)) *
-          direction ||
-        compareMediaItemsBySort(leftItem, rightItem, 'title', 'asc')
+      return compareNumericWithTitleFallback(
+        leftItem,
+        rightItem,
+        getAirDateBucket,
+        direction,
       )
     case 'rating':
-      return (
-        (getAudienceRating(leftItem) - getAudienceRating(rightItem)) *
-          direction ||
-        compareMediaItemsBySort(leftItem, rightItem, 'title', 'asc')
+      return compareNumericWithTitleFallback(
+        leftItem,
+        rightItem,
+        getAudienceRating,
+        direction,
       )
     case 'watchCount':
-      return (
-        (getWatchCount(leftItem) - getWatchCount(rightItem)) * direction ||
-        compareMediaItemsBySort(leftItem, rightItem, 'title', 'asc')
+      return compareNumericWithTitleFallback(
+        leftItem,
+        rightItem,
+        getWatchCount,
+        direction,
       )
     case 'manual':
       return compareMaintainerrState(
@@ -128,20 +152,13 @@ export const compareMediaItemsBySort = (
         sortOrder,
         (item) => item.maintainerrExclusionId != null,
       )
-    case 'deleteSoonest': {
-      const leftBucket = getDeleteSoonestDayBucket(
+    case 'deleteSoonest':
+      return compareNumericWithTitleFallback(
         leftItem,
-        options?.deleteSoonestDate,
-      )
-      const rightBucket = getDeleteSoonestDayBucket(
         rightItem,
-        options?.deleteSoonestDate,
+        (item) => getDeleteSoonestDayBucket(item, options?.deleteSoonestDate),
+        direction,
       )
-      return (
-        (leftBucket - rightBucket) * direction ||
-        compareMediaItemsBySort(leftItem, rightItem, 'title', 'asc')
-      )
-    }
     default:
       return 0
   }

--- a/packages/contracts/src/media-server/sort-utils.ts
+++ b/packages/contracts/src/media-server/sort-utils.ts
@@ -36,17 +36,40 @@ export interface CompareMediaItemsOptions {
    * to the underlying media-server library).
    */
   deleteSoonestDate?: (item: MediaItem) => Date | string | undefined | null
+  /**
+   * Anchor for `daysLeft` bucketing — pass `now - deleteAfterDays * dayMs`.
+   * When set, items with the same overlay countdown tie even if they
+   * straddle UTC midnight (e.g. addedAt 23:00 vs. 01:00 the next day with
+   * the same "Leaves in 3 days" label). When omitted, items bucket by UTC
+   * calendar day, which is acceptable for callers without a per-collection
+   * `deleteAfterDays` (e.g. defensive paths in the comparator spec).
+   */
+  deleteSoonestReferenceTime?: Date | number
+}
+
+const toReferenceMs = (
+  value: CompareMediaItemsOptions['deleteSoonestReferenceTime'],
+): number | undefined => {
+  if (value == null) return undefined
+  return value instanceof Date ? value.getTime() : value
 }
 
 const getDeleteSoonestDayBucket = (
   item: MediaItem,
-  override: CompareMediaItemsOptions['deleteSoonestDate'],
+  options: CompareMediaItemsOptions | undefined,
 ): number | undefined => {
-  // Bucket by UTC day so items added in the same rule run tie and reach the
-  // title tiebreaker. Items split across the UTC midnight boundary land in
-  // adjacent buckets — acceptable because the user-visible "Leaving in X
-  // days" label can also flip across that boundary.
-  return toDayBucket(override?.(item) ?? item.addedAt)
+  const value = options?.deleteSoonestDate?.(item) ?? item.addedAt
+  const referenceMs = toReferenceMs(options?.deleteSoonestReferenceTime)
+  if (referenceMs === undefined) {
+    // No collection context — bucket by UTC midnight.
+    return toDayBucket(value)
+  }
+  const ms = value instanceof Date ? value.getTime() : new Date(value).getTime()
+  if (Number.isNaN(ms)) return undefined
+  // daysLeft = ceil((addDate + N*day - now) / dayMs) = ceil((addDate - R) / dayMs).
+  // Two items tie iff they share the same daysLeft window, which keeps the
+  // sort aligned with the visible countdown across UTC midnight.
+  return Math.ceil((ms - referenceMs) / 86400000)
 }
 
 // Title comparison that groups episodes and seasons under their show. Movies
@@ -156,7 +179,7 @@ export const compareMediaItemsBySort = (
       return compareNumericWithTitleFallback(
         leftItem,
         rightItem,
-        (item) => getDeleteSoonestDayBucket(item, options?.deleteSoonestDate),
+        (item) => getDeleteSoonestDayBucket(item, options),
         direction,
       )
     default:


### PR DESCRIPTION
Reported in Discord on `main`: with "Delete Soonest" / "Delete Latest" the Plex collection order is wrong, the alphabetical tiebreaker never fires, and TV episodes are interleaved by episode title instead of grouped by show.

**Maintainerr's DB is the source of truth for ordering.** `applyCollectionSort` pushes Maintainerr's order to the media server; the UI reads from the same DB. Both must agree on the primary sort key (`collection_media.addDate`).

## Key changes

- **`deleteSoonest` reads `collection_media.addDate`** via a `deleteSoonestDate` callback on the comparator options, replacing the previous `MediaItem.addedAt` (which is the unrelated library-add date).
- **Day buckets align with the visible "Leaving in X days" countdown.** New `deleteSoonestReferenceTime` option (`now − deleteAfterDays × dayMs`) makes `ceil((addDate − reference) / dayMs)` the bucket key, so two items with the same overlay countdown tie even if their `addDate`s straddle UTC midnight. Within a tied bucket the show-aware title order is the tiebreaker. Used by `applyCollectionSort`.
- **`deleteSoonest` UI paging stays SQL-paginated** — orders by `collection_media.addDate` directly at the DB level instead of hydrating every row in the collection. Restored after the initial PR removed it; hydrate-then-sort on a 127-item Jellyfin collection blocked the UI page for minutes. Trade-off: same-day items on the UI page may show in a slightly different within-bucket order than the polished Plex/Jellyfin collection (which has the title tiebreak applied by `applyCollectionSort`). Primary sort key matches; both views agree on which items leave first.
- **Title sort groups episodes under their show** via `grandparentTitle ?? parentTitle ?? title`, then `title`. Movies are unaffected. Shared with the library Overview comparator, so general library title sorts also group episodes under their show — matches Plex's own behavior.

## Comparator hardening (same surface)

- Items missing the sort value (no air date / no rating / no view count / no add date) now sort to the end regardless of asc/desc. Previously they coerced to `0` and silently sorted to the front in `asc` mode.
- `airDate`, `rating`, `watchCount`, and `deleteSoonest` collapse onto one `compareNumericWithTitleFallback` helper.
- `airDate` now day-buckets like `deleteSoonest`.

## Other

- Pinned `tsBuildInfoFile` in `apps/server/tsconfig.build.json` so nest-cli's type-check pass stops emitting a stray `tsconfig.build.tsbuildinfo` at the package root.
- Removed unused `baseUrl` + `@/*` paths from `apps/ui/tsconfig.json` (cleared a TS 6 deprecation in the IDE).

## Caveat

Existing collections won't visually re-sort in Plex until membership changes — `applyCollectionSort` only re-runs when `newMedia.length > 0`. Editing a rule (touch + save) triggers it. Worth a release-notes line.

## Test plan

- [ ] On a movie collection with `deleteSoonest.asc`, items leaving today appear before items leaving in 7+ days, and the page loads in under a second on a collection with 100+ items
- [ ] In the actual Plex/Jellyfin collection, items added at 23:00 vs. 01:00 the next morning showing the same overlay countdown sort alphabetically together
- [ ] Episode collection sorted by Title A–Z keeps episodes from the same show contiguous
- [ ] Items with no `addDate` / no air date / no rating sort to the **end** in both `asc` and `desc`
- [ ] `apps/server/tsconfig.build.tsbuildinfo` does NOT exist after `yarn workspace @maintainerr/server build` (only `apps/server/dist/tsconfig.build.tsbuildinfo`)
- [ ] `yarn lint`, `yarn test`, `yarn build`, `yarn dev` all clean