### PR TITLE
fix(rules,jellyfin): close collection add/remove loop (#2554, #1446)

### DIFF
--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -519,6 +519,73 @@ describe('JellyfinAdapterService', () => {
     });
   });
 
+  // Jellyfin libraries with "Group films into collections" hide BoxSet members
+  // unless the query opts out. Locks every library-scoped getItems call to the
+  // shared default so a Maintainerr-managed BoxSet does not flip movies in and
+  // out of library listings between rule runs (#2554).
+  describe('library queries opt out of BoxSet collapsing', () => {
+    beforeEach(async () => {
+      settingsService.getSettings.mockResolvedValue({
+        ...mockSettings,
+        jellyfin_user_id: 'user-1',
+      } as unknown as Awaited<ReturnType<SettingsService['getSettings']>>);
+      await service.initialize();
+      jellyfinApiMocks.getItems.mockResolvedValue({
+        data: { Items: [], TotalRecordCount: 0 },
+      });
+    });
+
+    const expectCollapseFalse = () =>
+      expect(jellyfinApiMocks.getItems).toHaveBeenCalledWith(
+        expect.objectContaining({ collapseBoxSetItems: false }),
+      );
+
+    it('getLibraryContents passes collapseBoxSetItems: false', async () => {
+      await service.getLibraryContents('library-1', { offset: 0, limit: 30 });
+      expectCollapseFalse();
+    });
+
+    it('getLibraryContentCount passes collapseBoxSetItems: false', async () => {
+      await service.getLibraryContentCount('library-1', 'movie');
+      expectCollapseFalse();
+    });
+
+    it('searchLibraryContents passes collapseBoxSetItems: false', async () => {
+      await service.searchLibraryContents('library-1', 'query', 'movie');
+      expectCollapseFalse();
+    });
+
+    it('getRecentlyAdded passes collapseBoxSetItems: false', async () => {
+      await service.getRecentlyAdded('library-1', { limit: 10 });
+      expectCollapseFalse();
+    });
+
+    it('searchContent passes collapseBoxSetItems: false', async () => {
+      await service.searchContent('query');
+      expectCollapseFalse();
+    });
+
+    it('findRandomItem passes collapseBoxSetItems: false', async () => {
+      await service.findRandomItem(['library-1'], ['Movie' as any]);
+      expectCollapseFalse();
+    });
+
+    it('computeLibraryStorageSizes passes collapseBoxSetItems: false', async () => {
+      jellyfinApiMocks.getMediaFolders.mockResolvedValueOnce({
+        data: {
+          Items: [
+            { Id: 'library-1', Name: 'Movies', CollectionType: 'movies' },
+          ],
+        },
+      });
+      jellyfinApiMocks.getItems.mockResolvedValueOnce({
+        data: { Items: [], TotalRecordCount: 0 },
+      });
+      await service.computeLibraryStorageSizes();
+      expectCollapseFalse();
+    });
+  });
+
   describe('getLibraries', () => {
     beforeEach(async () => {
       settingsService.getSettings.mockResolvedValue(

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -65,6 +65,7 @@ import {
   JELLYFIN_CACHE_TTL,
   JELLYFIN_CLIENT_INFO,
   JELLYFIN_DEVICE_INFO,
+  JELLYFIN_LIBRARY_QUERY_DEFAULTS,
   JELLYFIN_LIBRARY_RETRY_DELAY_MS,
   JELLYFIN_RETRYABLE_LIBRARY_ERROR_CODES,
   JELLYFIN_RETRYABLE_LIBRARY_STATUS_CODES,
@@ -414,6 +415,7 @@ export class JellyfinAdapterService implements IMediaServerService {
       // recursive getItems call spans the selected parent or the whole server.
       const parentId = sectionIds?.[0];
       const response = await getItemsApi(this.api).getItems({
+        ...JELLYFIN_LIBRARY_QUERY_DEFAULTS,
         userId,
         parentId,
         includeItemTypes: kinds,
@@ -686,6 +688,7 @@ export class JellyfinAdapterService implements IMediaServerService {
       let page: Awaited<ReturnType<ReturnType<typeof getItemsApi>['getItems']>>;
       try {
         page = await getItemsApi(this.api!).getItems({
+          ...JELLYFIN_LIBRARY_QUERY_DEFAULTS,
           userId,
           parentId: library.id,
           recursive: true,
@@ -749,6 +752,7 @@ export class JellyfinAdapterService implements IMediaServerService {
         `get Jellyfin library contents for ${libraryId}`,
         async () =>
           await getItemsApi(this.api!).getItems({
+            ...JELLYFIN_LIBRARY_QUERY_DEFAULTS,
             userId,
             parentId: libraryId,
             recursive: true,
@@ -792,6 +796,7 @@ export class JellyfinAdapterService implements IMediaServerService {
     try {
       const userId = await this.getUserId();
       const response = await getItemsApi(this.api).getItems({
+        ...JELLYFIN_LIBRARY_QUERY_DEFAULTS,
         userId,
         parentId: libraryId,
         recursive: true,
@@ -818,6 +823,7 @@ export class JellyfinAdapterService implements IMediaServerService {
     try {
       const userId = await this.getUserId();
       const response = await getItemsApi(this.api).getItems({
+        ...JELLYFIN_LIBRARY_QUERY_DEFAULTS,
         userId,
         parentId: libraryId,
         recursive: true,
@@ -970,6 +976,7 @@ export class JellyfinAdapterService implements IMediaServerService {
     try {
       const userId = await this.getUserId();
       const response = await getItemsApi(this.api).getItems({
+        ...JELLYFIN_LIBRARY_QUERY_DEFAULTS,
         userId,
         parentId: libraryId,
         recursive: true,
@@ -1000,6 +1007,7 @@ export class JellyfinAdapterService implements IMediaServerService {
     try {
       const userId = await this.getUserId();
       const response = await getItemsApi(this.api).getItems({
+        ...JELLYFIN_LIBRARY_QUERY_DEFAULTS,
         userId,
         recursive: true,
         searchTerm: query,

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin.constants.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin.constants.ts
@@ -17,6 +17,20 @@ export const JELLYFIN_BATCH_SIZE = {
   MAX_PAGE_SIZE: 500,
 } as const;
 
+/**
+ * Default query options for every library-scoped getItems() call — i.e.
+ * any call whose parentId is a library (or no parentId for a global recursive
+ * search) and that expects to surface real media items.
+ *
+ * collapseBoxSetItems: false always includes BoxSet members. Jellyfin libraries
+ * with "Group films into collections" hide them by default, which caused an
+ * add/remove loop on Maintainerr-managed BoxSets and silently under-counted
+ * library size/recent items (#2554).
+ */
+export const JELLYFIN_LIBRARY_QUERY_DEFAULTS = {
+  collapseBoxSetItems: false,
+} as const;
+
 export const JELLYFIN_LIBRARY_RETRY_DELAY_MS = 300;
 
 export const JELLYFIN_RETRYABLE_LIBRARY_ERROR_CODES = new Set([

--- a/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -21,6 +21,12 @@ import { ValueGetterService } from '../getter/getter.service';
 interface IComparatorReturnValue {
   stats: IComparisonStatistics[];
   data: MediaItem[];
+  // Items whose evaluation hit a getter that returned `undefined` — the
+  // documented "transport failure" signal (see plex/seerr-getter outer
+  // catches). Distinct from `null` (definitive absence). The executor
+  // uses this set to defer rule-driven removal so a brief external-API
+  // blip does not break the deleteAfterDays countdown (#1446).
+  transientFailureMediaIds: Set<string>;
 }
 
 @Injectable()
@@ -53,6 +59,7 @@ export class RuleComparatorService {
   private workerIds: Set<string>;
   private resultIds: Set<string>;
   private statsById: Map<string, IComparisonStatistics>;
+  private transientFailureIds: Set<string>;
 
   private static readonly UNARY_RULE_ACTIONS = new Set<RulePossibility>([
     RulePossibility.EXISTS,
@@ -86,6 +93,7 @@ export class RuleComparatorService {
       this.workerIds = new Set<string>();
       this.resultIds = new Set<string>();
       this.statsById = new Map<string, IComparisonStatistics>();
+      this.transientFailureIds = new Set<string>();
 
       // run rules
       let currentSection = 0;
@@ -141,7 +149,11 @@ export class RuleComparatorService {
       this.updateStatisticResults();
 
       // return comparatorReturnValue
-      return { stats: this.statistics, data: this.resultData };
+      return {
+        stats: this.statistics,
+        data: this.resultData,
+        transientFailureMediaIds: this.transientFailureIds,
+      };
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {
         throw error;
@@ -221,9 +233,23 @@ export class RuleComparatorService {
         this.abortSignal?.throwIfAborted();
       }
 
+      // Distinguish transient transport failure (`=== undefined`, returned by
+      // the outer catch in plex/seerr-getter) from definitive absence (`null`,
+      // e.g. lastViewedAt for a never-watched item). The executor uses
+      // `transientFailureIds` to defer rule-driven removal on transient
+      // failures; the comparator also skips unary EXISTS/NOT_EXISTS on a
+      // transient `undefined` so it never resolves to `!hasExistsValue(undefined)
+      // === true` and spuriously **adds** the item (#1446).
+      const firstValTransient = firstVal === undefined;
+      const secondValTransient =
+        rule.lastVal != null && secondVal === undefined;
+      if (firstValTransient || secondValTransient) {
+        this.transientFailureIds.add(mediaId);
+      }
+
       const reasons = this.buildMissingReasons(rule, firstVal, secondVal);
       const shouldCompare = this.isUnaryRuleAction(rule.action)
-        ? true
+        ? !firstValTransient
         : firstVal != null && (secondVal != null || rule.lastVal != null);
 
       if (shouldCompare) {

--- a/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -21,11 +21,6 @@ import { ValueGetterService } from '../getter/getter.service';
 interface IComparatorReturnValue {
   stats: IComparisonStatistics[];
   data: MediaItem[];
-  // Items whose evaluation hit a getter that returned `undefined` — the
-  // documented "transport failure" signal (see plex/seerr-getter outer
-  // catches). Distinct from `null` (definitive absence). The executor
-  // uses this set to defer rule-driven removal so a brief external-API
-  // blip does not break the deleteAfterDays countdown (#1446).
   transientFailureMediaIds: Set<string>;
 }
 
@@ -233,13 +228,6 @@ export class RuleComparatorService {
         this.abortSignal?.throwIfAborted();
       }
 
-      // Distinguish transient transport failure (`=== undefined`, returned by
-      // the outer catch in plex/seerr-getter) from definitive absence (`null`,
-      // e.g. lastViewedAt for a never-watched item). The executor uses
-      // `transientFailureIds` to defer rule-driven removal on transient
-      // failures; the comparator also skips unary EXISTS/NOT_EXISTS on a
-      // transient `undefined` so it never resolves to `!hasExistsValue(undefined)
-      // === true` and spuriously **adds** the item (#1446).
       const firstValTransient = firstVal === undefined;
       const secondValTransient =
         rule.lastVal != null && secondVal === undefined;
@@ -248,6 +236,11 @@ export class RuleComparatorService {
       }
 
       const reasons = this.buildMissingReasons(rule, firstVal, secondVal);
+      // `undefined` from a getter is the documented transport-failure signal
+      // (outer catch in plex/seerr-getter); `null` is definitive absence.
+      // Skip unary EXISTS/NOT_EXISTS on transient `undefined` so it never
+      // resolves to `!hasExistsValue(undefined) === true` and spuriously
+      // adds the item (#1446).
       const shouldCompare = this.isUnaryRuleAction(rule.action)
         ? !firstValTransient
         : firstVal != null && (secondVal != null || rule.lastVal != null);

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -98,9 +98,11 @@ describe('RuleExecutorService', () => {
 
     const comparatorFactory = {
       create: jest.fn().mockReturnValue({
-        executeRulesWithData: jest
-          .fn()
-          .mockResolvedValue({ stats: [], data: [] }),
+        executeRulesWithData: jest.fn().mockResolvedValue({
+          stats: [],
+          data: [],
+          transientFailureMediaIds: new Set<string>(),
+        }),
       }),
     } as unknown as jest.Mocked<RuleComparatorServiceFactory>;
 
@@ -1378,6 +1380,178 @@ describe('RuleExecutorService', () => {
         },
       ],
       'local',
+    );
+  });
+
+  // Defer rule-driven removal when the comparator flagged a transient getter
+  // failure for the item. Without this, a brief external-API blip restarts the
+  // deleteAfterDays countdown on every affected item (#1446).
+  it('preserves items dropped from resultData due to transient getter failure', async () => {
+    const { service, collectionService, logger } = createService(
+      MediaServerType.PLEX,
+    );
+
+    const collection = {
+      id: 1,
+      title: 'Flap test',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+      deleteAfterDays: 10,
+    };
+
+    collectionService.getCollection.mockResolvedValue(collection as any);
+    collectionService.getCollectionMedia.mockResolvedValue([
+      { mediaServerId: 'm-transient' },
+    ] as any);
+
+    (service as any).startTime = new Date();
+    (service as any).resultData = [];
+    (service as any).statisticsData = [];
+    (service as any).transientFailureMediaIds = new Set<string>([
+      'm-transient',
+    ]);
+
+    await (service as any).handleCollection({ id: 10, collectionId: 1 });
+
+    expect(collectionService.removeFromCollection).not.toHaveBeenCalled();
+    expect(
+      collectionService.removeFromCollectionWithResolvedLink,
+    ).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Preserved 1 media item in 'Flap test' because rule data was unfetchable",
+      ),
+    );
+  });
+
+  it('still removes items that dropped out for non-transient reasons', async () => {
+    const { service, collectionService } = createService(MediaServerType.PLEX);
+
+    const collection = {
+      id: 1,
+      title: 'Flap test',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+      deleteAfterDays: 10,
+    };
+
+    collectionService.getCollection.mockResolvedValue(collection as any);
+    collectionService.getCollectionMedia.mockResolvedValue([
+      { mediaServerId: 'm-stopped-matching' },
+    ] as any);
+
+    (service as any).startTime = new Date();
+    (service as any).resultData = [];
+    (service as any).statisticsData = [];
+    // Empty transient set: item dropped out because it stopped matching, not
+    // because a getter failed. Removal must still proceed.
+    (service as any).transientFailureMediaIds = new Set<string>();
+
+    await (service as any).handleCollection({ id: 10, collectionId: 1 });
+
+    // collMediaData.length > 0, so removal goes through the resolved-link
+    // variant — mirror the executor's branch in the assertion.
+    expect(
+      collectionService.removeFromCollectionWithResolvedLink,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1 }),
+      [
+        {
+          mediaServerId: 'm-stopped-matching',
+          reason: {
+            type: 'media_removed_by_rule',
+            data: undefined,
+          },
+        },
+      ],
+      'rule',
+    );
+  });
+
+  // The executor processes media in 50-item chunks via `getMediaData`; the
+  // comparator returns a transient set per chunk. Without union accumulation,
+  // the removal gate would only see the last chunk's ids and silently drop
+  // preservation for items earlier in the library.
+  it('accumulates transientFailureMediaIds across executor chunks', async () => {
+    const {
+      service,
+      rulesService,
+      mediaServer,
+      collectionService,
+      eventEmitter,
+    } = createService(MediaServerType.PLEX);
+
+    const ruleGroup = {
+      id: 10,
+      name: 'Two-chunk run',
+      isActive: true,
+      libraryId: 'library-1',
+      useRules: true,
+      rules: [],
+      collectionId: 1,
+      collection: { title: 'Two-chunk run' },
+    };
+
+    rulesService.getRuleGroup.mockResolvedValue(ruleGroup as any);
+    rulesService.getRuleGroupById.mockResolvedValue(ruleGroup as any);
+
+    collectionService.getCollection.mockResolvedValue({
+      id: 1,
+      title: 'Two-chunk run',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+      deleteAfterDays: 10,
+    } as any);
+    collectionService.getCollectionMedia.mockResolvedValue([
+      { mediaServerId: 'A' },
+      { mediaServerId: 'B' },
+    ] as any);
+    // Server's collection still contains A and B so the manual-removal sync
+    // path (which compares DB membership to server-side collection children)
+    // is a no-op for this test. We are only exercising the rule-driven gate.
+    mediaServer.getCollectionChildren.mockResolvedValue([
+      { id: 'A' },
+      { id: 'B' },
+    ] as any);
+
+    // Two non-empty chunks so the executor loops twice.
+    mediaServer.getLibraryContents
+      .mockResolvedValueOnce({
+        items: Array.from({ length: 50 }, (_, i) => ({ id: `chunk1-${i}` })),
+        totalSize: 60,
+      } as any)
+      .mockResolvedValueOnce({
+        items: Array.from({ length: 10 }, (_, i) => ({ id: `chunk2-${i}` })),
+        totalSize: 60,
+      } as any);
+    mediaServer.getLibraryContentCount.mockResolvedValue(60);
+
+    // Each chunk reports a different transient id. Without accumulation, only
+    // B (the last chunk) would be preserved and A would be removed.
+    const comparator = (service as any).comparatorFactory.create();
+    comparator.executeRulesWithData
+      .mockResolvedValueOnce({
+        stats: [],
+        data: [],
+        transientFailureMediaIds: new Set<string>(['A']),
+      })
+      .mockResolvedValueOnce({
+        stats: [],
+        data: [],
+        transientFailureMediaIds: new Set<string>(['B']),
+      });
+
+    await service.executeForRuleGroups(10, new AbortController().signal);
+
+    // Neither A nor B should be removed — both were flagged transient across
+    // the two chunks.
+    expect(collectionService.removeFromCollection).not.toHaveBeenCalled();
+    expect(
+      collectionService.removeFromCollectionWithResolvedLink,
+    ).not.toHaveBeenCalled();
+    expect(eventEmitter.emit).not.toHaveBeenCalledWith(
+      MaintainerrEvent.CollectionMedia_Removed,
+      expect.anything(),
     );
   });
 });

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -1383,9 +1383,6 @@ describe('RuleExecutorService', () => {
     );
   });
 
-  // Defer rule-driven removal when the comparator flagged a transient getter
-  // failure for the item. Without this, a brief external-API blip restarts the
-  // deleteAfterDays countdown on every affected item (#1446).
   it('preserves items dropped from resultData due to transient getter failure', async () => {
     const { service, collectionService, logger } = createService(
       MediaServerType.PLEX,
@@ -1417,9 +1414,9 @@ describe('RuleExecutorService', () => {
     expect(
       collectionService.removeFromCollectionWithResolvedLink,
     ).not.toHaveBeenCalled();
-    expect(logger.log).toHaveBeenCalledWith(
+    expect(logger.debug).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Preserved 1 media item in 'Flap test' because rule data was unfetchable",
+        "Skipped rule-driven removal for 1 media item in 'Flap test'",
       ),
     );
   });
@@ -1443,14 +1440,10 @@ describe('RuleExecutorService', () => {
     (service as any).startTime = new Date();
     (service as any).resultData = [];
     (service as any).statisticsData = [];
-    // Empty transient set: item dropped out because it stopped matching, not
-    // because a getter failed. Removal must still proceed.
     (service as any).transientFailureMediaIds = new Set<string>();
 
     await (service as any).handleCollection({ id: 10, collectionId: 1 });
 
-    // collMediaData.length > 0, so removal goes through the resolved-link
-    // variant — mirror the executor's branch in the assertion.
     expect(
       collectionService.removeFromCollectionWithResolvedLink,
     ).toHaveBeenCalledWith(
@@ -1468,11 +1461,7 @@ describe('RuleExecutorService', () => {
     );
   });
 
-  // The executor processes media in 50-item chunks via `getMediaData`; the
-  // comparator returns a transient set per chunk. Without union accumulation,
-  // the removal gate would only see the last chunk's ids and silently drop
-  // preservation for items earlier in the library.
-  it('accumulates transientFailureMediaIds across executor chunks', async () => {
+  it('accumulates transient failures across executor chunks before removal', async () => {
     const {
       service,
       rulesService,
@@ -1506,15 +1495,10 @@ describe('RuleExecutorService', () => {
       { mediaServerId: 'A' },
       { mediaServerId: 'B' },
     ] as any);
-    // Server's collection still contains A and B so the manual-removal sync
-    // path (which compares DB membership to server-side collection children)
-    // is a no-op for this test. We are only exercising the rule-driven gate.
     mediaServer.getCollectionChildren.mockResolvedValue([
       { id: 'A' },
       { id: 'B' },
     ] as any);
-
-    // Two non-empty chunks so the executor loops twice.
     mediaServer.getLibraryContents
       .mockResolvedValueOnce({
         items: Array.from({ length: 50 }, (_, i) => ({ id: `chunk1-${i}` })),
@@ -1526,8 +1510,6 @@ describe('RuleExecutorService', () => {
       } as any);
     mediaServer.getLibraryContentCount.mockResolvedValue(60);
 
-    // Each chunk reports a different transient id. Without accumulation, only
-    // B (the last chunk) would be preserved and A would be removed.
     const comparator = (service as any).comparatorFactory.create();
     comparator.executeRulesWithData
       .mockResolvedValueOnce({
@@ -1543,8 +1525,6 @@ describe('RuleExecutorService', () => {
 
     await service.executeForRuleGroups(10, new AbortController().signal);
 
-    // Neither A nor B should be removed — both were flagged transient across
-    // the two chunks.
     expect(collectionService.removeFromCollection).not.toHaveBeenCalled();
     expect(
       collectionService.removeFromCollectionWithResolvedLink,

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -92,15 +92,7 @@ export class RuleExecutorService {
   workerData: MediaItem[];
   resultData: MediaItem[];
   statisticsData: IComparisonStatistics[];
-  // Union of media ids whose evaluation hit a getter that returned
-  // `undefined` (transient transport failure) on any chunk in this run.
-  // Used as the gate on rule-driven removal so a brief blip on an
-  // external API (Plex watch history, plex.tv users, Seerr, etc.) does
-  // not silently restart the deleteAfterDays countdown (#1446). Default
-  // to an empty set so direct calls into handleCollection() (in tests
-  // and any future call paths that bypass executeForRuleGroups) never
-  // dereference undefined.
-  transientFailureMediaIds: Set<string> = new Set();
+  transientFailureMediaIds: Set<string> = new Set<string>();
   Data: MediaItem[];
   startTime: Date;
 
@@ -270,9 +262,6 @@ export class RuleExecutorService {
           if (ruleResult) {
             this.statisticsData.push(...ruleResult.stats);
             this.resultData.push(...ruleResult.data);
-            // The comparator returns transient ids per chunk. Union them so the
-            // removal gate in handleCollection() sees every item that had a
-            // transient failure anywhere in the run — not just the last chunk.
             for (const id of ruleResult.transientFailureMediaIds) {
               this.transientFailureMediaIds.add(id);
             }
@@ -736,33 +725,28 @@ export class RuleExecutorService {
           }),
         );
 
-        // Defer rule-driven removal when the only reason an item dropped out
-        // of `desiredMediaServerIds` is a transient getter failure (the
-        // documented `=== undefined` outer-catch return from plex/seerr-getter).
-        // Without this, a brief external-API blip restarts the deleteAfterDays
-        // countdown on every affected item and the destructive Servarr action
-        // never fires (#1446). The signal is strict-undefined only; legitimate
-        // `null` (never-watched, never-released, no Seerr request) still
-        // removes normally.
         const mediaToRemove: string[] = [];
-        let preservedDueToTransientFailureCount = 0;
+        let preservedTransientRemovalCount = 0;
         for (const mediaServerId of currentMediaServerIds) {
-          if (desiredMediaServerIds.has(mediaServerId)) continue;
+          if (desiredMediaServerIds.has(mediaServerId)) {
+            continue;
+          }
           if (this.transientFailureMediaIds.has(mediaServerId)) {
-            preservedDueToTransientFailureCount++;
+            preservedTransientRemovalCount++;
             continue;
           }
           mediaToRemove.push(mediaServerId);
         }
-        if (preservedDueToTransientFailureCount > 0) {
-          this.logger.log(
-            `Preserved ${preservedDueToTransientFailureCount} media item${
-              preservedDueToTransientFailureCount === 1 ? '' : 's'
+
+        if (preservedTransientRemovalCount > 0) {
+          this.logger.debug(
+            `Skipped rule-driven removal for ${preservedTransientRemovalCount} media item${
+              preservedTransientRemovalCount === 1 ? '' : 's'
             } in '${
               collection.manualCollection
                 ? collection.manualCollectionName
                 : collection.title
-            }' because rule data was unfetchable this run; will retry next pass.`,
+            }' because rule data was transiently unavailable this run; will retry next pass.`,
           );
         }
 

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -92,6 +92,15 @@ export class RuleExecutorService {
   workerData: MediaItem[];
   resultData: MediaItem[];
   statisticsData: IComparisonStatistics[];
+  // Union of media ids whose evaluation hit a getter that returned
+  // `undefined` (transient transport failure) on any chunk in this run.
+  // Used as the gate on rule-driven removal so a brief blip on an
+  // external API (Plex watch history, plex.tv users, Seerr, etc.) does
+  // not silently restart the deleteAfterDays countdown (#1446). Default
+  // to an empty set so direct calls into handleCollection() (in tests
+  // and any future call paths that bypass executeForRuleGroups) never
+  // dereference undefined.
+  transientFailureMediaIds: Set<string> = new Set();
   Data: MediaItem[];
   startTime: Date;
 
@@ -237,6 +246,7 @@ export class RuleExecutorService {
         this.workerData = [];
         this.resultData = [];
         this.statisticsData = [];
+        this.transientFailureMediaIds = new Set<string>();
         this.mediaData = { page: 0, finished: false, data: [] };
 
         this.mediaDataType = ruleGroup.dataType || undefined;
@@ -260,6 +270,12 @@ export class RuleExecutorService {
           if (ruleResult) {
             this.statisticsData.push(...ruleResult.stats);
             this.resultData.push(...ruleResult.data);
+            // The comparator returns transient ids per chunk. Union them so the
+            // removal gate in handleCollection() sees every item that had a
+            // transient failure anywhere in the run — not just the last chunk.
+            for (const id of ruleResult.transientFailureMediaIds) {
+              this.transientFailureMediaIds.add(id);
+            }
           }
         }
 
@@ -720,11 +736,34 @@ export class RuleExecutorService {
           }),
         );
 
+        // Defer rule-driven removal when the only reason an item dropped out
+        // of `desiredMediaServerIds` is a transient getter failure (the
+        // documented `=== undefined` outer-catch return from plex/seerr-getter).
+        // Without this, a brief external-API blip restarts the deleteAfterDays
+        // countdown on every affected item and the destructive Servarr action
+        // never fires (#1446). The signal is strict-undefined only; legitimate
+        // `null` (never-watched, never-released, no Seerr request) still
+        // removes normally.
         const mediaToRemove: string[] = [];
+        let preservedDueToTransientFailureCount = 0;
         for (const mediaServerId of currentMediaServerIds) {
-          if (!desiredMediaServerIds.has(mediaServerId)) {
-            mediaToRemove.push(mediaServerId);
+          if (desiredMediaServerIds.has(mediaServerId)) continue;
+          if (this.transientFailureMediaIds.has(mediaServerId)) {
+            preservedDueToTransientFailureCount++;
+            continue;
           }
+          mediaToRemove.push(mediaServerId);
+        }
+        if (preservedDueToTransientFailureCount > 0) {
+          this.logger.log(
+            `Preserved ${preservedDueToTransientFailureCount} media item${
+              preservedDueToTransientFailureCount === 1 ? '' : 's'
+            } in '${
+              collection.manualCollection
+                ? collection.manualCollectionName
+                : collection.title
+            }' because rule data was unfetchable this run; will retry next pass.`,
+          );
         }
 
         const dataToRemove: CollectionMediaChange[] = this.prepareDataAmendment(

--- a/apps/server/src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts
+++ b/apps/server/src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts
@@ -424,13 +424,58 @@ describe('RuleComparatorService.executeRulesWithData', () => {
     });
   });
 
-  // Strict-undefined transient-failure tracking (#1446). The getter contract is
-  // `null` = definitive absence, `undefined` = outer-catch transport failure.
-  // The set must reflect that distinction precisely so the executor can defer
-  // rule-driven removal on transient failures without sticking items that are
-  // legitimately empty (e.g. never-watched).
+  // Unary EXISTS/NOT_EXISTS must distinguish the getter's `null` (definitive
+  // absence — e.g. lastViewedAt for a never-watched item) from `undefined`
+  // (outer-catch transport failure in plex/seerr-getter). Without the
+  // tightened shouldCompare, `!hasExistsValue(undefined) === true` would
+  // spuriously add items on every transient API blip (#1446).
+  describe('unary EXISTS contract on null vs undefined', () => {
+    it('keeps NOT_EXISTS matching when firstVal is null (definitive absence)', async () => {
+      // Locks the existing semantic against the new shouldCompare branch.
+      const mediaItem = createSingleMedia();
+      const rules = [
+        createStoredRule(1, {
+          operator: null,
+          action: RulePossibility.NOT_EXISTS,
+          firstVal: [Application.PLEX, 6],
+          section: 0,
+        }),
+      ];
+
+      mockGetterSequence(null);
+
+      const result = await ruleComparatorService.executeRulesWithData(
+        createRulesDto({ dataType: 'movie', rules }),
+        [mediaItem],
+      );
+
+      expect(result.data).toHaveLength(1);
+    });
+
+    it('skips unary NOT_EXISTS on transient undefined so the item is not spuriously added', async () => {
+      const mediaItem = createSingleMedia();
+      const rules = [
+        createStoredRule(1, {
+          operator: null,
+          action: RulePossibility.NOT_EXISTS,
+          firstVal: [Application.PLEX, 6],
+          section: 0,
+        }),
+      ];
+
+      mockGetterSequence(undefined);
+
+      const result = await ruleComparatorService.executeRulesWithData(
+        createRulesDto({ dataType: 'movie', rules }),
+        [mediaItem],
+      );
+
+      expect(result.data).toEqual([]);
+    });
+  });
+
   describe('transientFailureMediaIds', () => {
-    it('adds the media id when firstVal is undefined (transient transport failure)', async () => {
+    it('tracks firstVal undefined as a transient failure', async () => {
       const mediaItem = createSingleMedia();
       const rules = [
         createStoredRule(1, {
@@ -450,11 +495,9 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       );
 
       expect(result.transientFailureMediaIds.has('media-1')).toBe(true);
-      // Skip branch dropped the item from worker; it must not appear in data.
-      expect(result.data).toEqual([]);
     });
 
-    it('does not add the media id when firstVal is null (definitive absence)', async () => {
+    it('does not track firstVal null as a transient failure', async () => {
       const mediaItem = createSingleMedia();
       const rules = [
         createStoredRule(1, {
@@ -476,7 +519,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       expect(result.transientFailureMediaIds.has('media-1')).toBe(false);
     });
 
-    it('adds the media id when secondVal is undefined and rule.lastVal is set', async () => {
+    it('tracks secondVal undefined when rule.lastVal is used', async () => {
       const mediaItem = createSingleMedia();
       const rules = [
         createStoredRule(1, {
@@ -498,11 +541,8 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       expect(result.transientFailureMediaIds.has('media-1')).toBe(true);
     });
 
-    it('does not add the media id when secondVal comes from customVal (no lastVal)', async () => {
+    it('does not track customVal comparisons as second-value transients', async () => {
       const mediaItem = createSingleMedia();
-      // customVal path: getSecondValue never returns undefined regardless of
-      // getter behavior — the guard is `rule.lastVal != null`. Use a real
-      // first value so the comparison reaches the shouldCompare branch.
       const rules = [
         createStoredRule(1, {
           operator: null,
@@ -521,58 +561,6 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       );
 
       expect(result.transientFailureMediaIds.has('media-1')).toBe(false);
-    });
-
-    it('keeps NOT_EXISTS matching on null and does not flag the id as transient', async () => {
-      // Legitimate absence (`null`, e.g. lastViewedAt for a never-watched
-      // item) must keep producing NOT_EXISTS = true and must NOT trip the
-      // transient guard — otherwise items that legitimately stopped matching
-      // would be preserved forever. Locks the existing semantic against
-      // regression alongside the spec at line ~233.
-      const mediaItem = createSingleMedia();
-      const rules = [
-        createStoredRule(1, {
-          operator: null,
-          action: RulePossibility.NOT_EXISTS,
-          firstVal: [Application.PLEX, 6],
-          section: 0,
-        }),
-      ];
-
-      mockGetterSequence(null);
-
-      const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
-        [mediaItem],
-      );
-
-      expect(result.data).toHaveLength(1);
-      expect(result.transientFailureMediaIds.has('media-1')).toBe(false);
-    });
-
-    it('skips unary NOT_EXISTS on transient undefined and tracks the media id', async () => {
-      // Before fix 2, !hasExistsValue(undefined) === true would spuriously add
-      // the item. The tightened shouldCompare skips the unary branch on
-      // transient undefined: item is not in `data`, id is in the transient set.
-      const mediaItem = createSingleMedia();
-      const rules = [
-        createStoredRule(1, {
-          operator: null,
-          action: RulePossibility.NOT_EXISTS,
-          firstVal: [Application.PLEX, 6],
-          section: 0,
-        }),
-      ];
-
-      mockGetterSequence(undefined);
-
-      const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
-        [mediaItem],
-      );
-
-      expect(result.data).toEqual([]);
-      expect(result.transientFailureMediaIds.has('media-1')).toBe(true);
     });
   });
 });

--- a/apps/server/src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts
+++ b/apps/server/src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts
@@ -423,4 +423,156 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       result: true,
     });
   });
+
+  // Strict-undefined transient-failure tracking (#1446). The getter contract is
+  // `null` = definitive absence, `undefined` = outer-catch transport failure.
+  // The set must reflect that distinction precisely so the executor can defer
+  // rule-driven removal on transient failures without sticking items that are
+  // legitimately empty (e.g. never-watched).
+  describe('transientFailureMediaIds', () => {
+    it('adds the media id when firstVal is undefined (transient transport failure)', async () => {
+      const mediaItem = createSingleMedia();
+      const rules = [
+        createStoredRule(1, {
+          operator: null,
+          action: RulePossibility.SMALLER,
+          firstVal: [Application.PLEX, 31],
+          customVal: { ruleTypeId: +RuleType.NUMBER, value: '6' },
+          section: 0,
+        }),
+      ];
+
+      mockGetterSequence(undefined);
+
+      const result = await ruleComparatorService.executeRulesWithData(
+        createRulesDto({ dataType: 'movie', rules }),
+        [mediaItem],
+      );
+
+      expect(result.transientFailureMediaIds.has('media-1')).toBe(true);
+      // Skip branch dropped the item from worker; it must not appear in data.
+      expect(result.data).toEqual([]);
+    });
+
+    it('does not add the media id when firstVal is null (definitive absence)', async () => {
+      const mediaItem = createSingleMedia();
+      const rules = [
+        createStoredRule(1, {
+          operator: null,
+          action: RulePossibility.SMALLER,
+          firstVal: [Application.PLEX, 31],
+          customVal: { ruleTypeId: +RuleType.NUMBER, value: '6' },
+          section: 0,
+        }),
+      ];
+
+      mockGetterSequence(null);
+
+      const result = await ruleComparatorService.executeRulesWithData(
+        createRulesDto({ dataType: 'movie', rules }),
+        [mediaItem],
+      );
+
+      expect(result.transientFailureMediaIds.has('media-1')).toBe(false);
+    });
+
+    it('adds the media id when secondVal is undefined and rule.lastVal is set', async () => {
+      const mediaItem = createSingleMedia();
+      const rules = [
+        createStoredRule(1, {
+          operator: null,
+          action: RulePossibility.BIGGER,
+          firstVal: [Application.PLEX, 5],
+          lastVal: [Application.PLEX, 6],
+          section: 0,
+        }),
+      ];
+
+      mockGetterSequence(10, undefined);
+
+      const result = await ruleComparatorService.executeRulesWithData(
+        createRulesDto({ dataType: 'movie', rules }),
+        [mediaItem],
+      );
+
+      expect(result.transientFailureMediaIds.has('media-1')).toBe(true);
+    });
+
+    it('does not add the media id when secondVal comes from customVal (no lastVal)', async () => {
+      const mediaItem = createSingleMedia();
+      // customVal path: getSecondValue never returns undefined regardless of
+      // getter behavior — the guard is `rule.lastVal != null`. Use a real
+      // first value so the comparison reaches the shouldCompare branch.
+      const rules = [
+        createStoredRule(1, {
+          operator: null,
+          action: RulePossibility.SMALLER,
+          firstVal: [Application.PLEX, 31],
+          customVal: { ruleTypeId: +RuleType.NUMBER, value: '6' },
+          section: 0,
+        }),
+      ];
+
+      mockGetterSequence(5);
+
+      const result = await ruleComparatorService.executeRulesWithData(
+        createRulesDto({ dataType: 'movie', rules }),
+        [mediaItem],
+      );
+
+      expect(result.transientFailureMediaIds.has('media-1')).toBe(false);
+    });
+
+    it('keeps NOT_EXISTS matching on null and does not flag the id as transient', async () => {
+      // Legitimate absence (`null`, e.g. lastViewedAt for a never-watched
+      // item) must keep producing NOT_EXISTS = true and must NOT trip the
+      // transient guard — otherwise items that legitimately stopped matching
+      // would be preserved forever. Locks the existing semantic against
+      // regression alongside the spec at line ~233.
+      const mediaItem = createSingleMedia();
+      const rules = [
+        createStoredRule(1, {
+          operator: null,
+          action: RulePossibility.NOT_EXISTS,
+          firstVal: [Application.PLEX, 6],
+          section: 0,
+        }),
+      ];
+
+      mockGetterSequence(null);
+
+      const result = await ruleComparatorService.executeRulesWithData(
+        createRulesDto({ dataType: 'movie', rules }),
+        [mediaItem],
+      );
+
+      expect(result.data).toHaveLength(1);
+      expect(result.transientFailureMediaIds.has('media-1')).toBe(false);
+    });
+
+    it('skips unary NOT_EXISTS on transient undefined and tracks the media id', async () => {
+      // Before fix 2, !hasExistsValue(undefined) === true would spuriously add
+      // the item. The tightened shouldCompare skips the unary branch on
+      // transient undefined: item is not in `data`, id is in the transient set.
+      const mediaItem = createSingleMedia();
+      const rules = [
+        createStoredRule(1, {
+          operator: null,
+          action: RulePossibility.NOT_EXISTS,
+          firstVal: [Application.PLEX, 6],
+          section: 0,
+        }),
+      ];
+
+      mockGetterSequence(undefined);
+
+      const result = await ruleComparatorService.executeRulesWithData(
+        createRulesDto({ dataType: 'movie', rules }),
+        [mediaItem],
+      );
+
+      expect(result.data).toEqual([]);
+      expect(result.transientFailureMediaIds.has('media-1')).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Closes #2554: Jellyfin libraries with *Group films into collections* hide BoxSet members from default library listings. A shared `JELLYFIN_LIBRARY_QUERY_DEFAULTS = { collapseBoxSetItems: false }` constant is spread into the seven library-scoped `getItems()` calls so Maintainerr-managed BoxSets stop flipping movies in and out of rule results.
- Closes #1446 with the smallest real fix: the getter contract is still `null` = definitive absence vs `undefined` = transient transport failure, so the comparator now tracks only strict-`=== undefined` failures per media item, the executor unions those ids across chunks, and the remove path skips only those items for that run. This prevents transient API blips from restarting the `deleteAfterDays` countdown without adding persisted state, UI, or contract changes.
- Keeps the unary correctness fix: `EXISTS` / `NOT_EXISTS` skip transient `undefined` so `!hasExistsValue(undefined) === true` no longer spuriously adds items, while legitimate `null` semantics remain unchanged.
- Adds only a debug-level breadcrumb when a rule-driven removal is skipped due to transiently unavailable rule data. No new normal-log noise.

## Scope

- No contracts-package change
- No new event, service, migration, or persisted state
- No UI/log metadata change
- `firstValueReason` / `secondValueReason` semantics unchanged

## Validation

- `yarn workspace @maintainerr/server exec jest src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts --runInBand`
- `yarn workspace @maintainerr/server exec jest src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts src/modules/rules/tasks/rule-executor.service.spec.ts --runInBand`
