### PR TITLE
fix(ui): clarify custom-collection terminology and warn on disable

### DIFF
--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -1818,6 +1818,35 @@ describe('JellyfinAdapterService', () => {
           'jellyfin:collections:children:collection-1',
         );
       });
+
+      it('swallows deleteCollection failure when the collection is already gone (Jellyfin auto-delete race)', async () => {
+        jellyfinApiMocks.deleteItem.mockRejectedValueOnce(
+          createResponseError(500),
+        );
+        jellyfinApiMocks.getItem.mockRejectedValueOnce(
+          createResponseError(404),
+        );
+
+        await expect(
+          service.deleteCollection('collection-1'),
+        ).resolves.toBeUndefined();
+
+        expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
+          'jellyfin:collections:children:collection-1',
+        );
+      });
+
+      it('rethrows deleteCollection failure when the collection still exists', async () => {
+        const serverError = createResponseError(500);
+        jellyfinApiMocks.deleteItem.mockRejectedValueOnce(serverError);
+        jellyfinApiMocks.getItem.mockResolvedValueOnce({
+          data: { Id: 'collection-1', Name: 'Still here' },
+        });
+
+        await expect(service.deleteCollection('collection-1')).rejects.toBe(
+          serverError,
+        );
+      });
     });
   });
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -1431,14 +1431,22 @@ export class JellyfinAdapterService implements IMediaServerService {
 
     try {
       await getLibraryApi(this.api).deleteItem({ itemId: collectionId });
-      // libraryId not known here; clear all per-library entries.
-      this.invalidateCollectionsCache();
-      this.invalidateCollectionChildrenCache(collectionId);
     } catch (error) {
-      this.logger.error(`Failed to delete collection ${collectionId}`);
-      this.logger.debug(error);
-      throw error;
+      // Jellyfin auto-deletes empty BoxSets — this races with our explicit
+      // delete and 404/500s once the item is gone. Re-check and swallow if so.
+      if (await this.getCollection(collectionId).then(Boolean)) {
+        this.logger.error(`Failed to delete collection ${collectionId}`);
+        this.logger.debug(error);
+        // Throw before the cache invalidation below — the collection still
+        // exists, so cached entries are still valid.
+        throw error;
+      }
+      this.logger.debug(`Jellyfin collection ${collectionId} already gone`);
     }
+
+    // libraryId not known here; clear all per-library entries.
+    this.invalidateCollectionsCache();
+    this.invalidateCollectionChildrenCache(collectionId);
   }
 
   async getCollectionChildren(collectionId: string): Promise<MediaItem[]> {

--- a/apps/ui/src/components/Collection/CollectionItem/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionItem/index.tsx
@@ -133,7 +133,7 @@ const CollectionItem = (props: ICollectionItem) => {
         <div className="overflow-hidden overflow-ellipsis whitespace-nowrap text-base font-bold text-white sm:text-lg">
           <div>
             {props.collection.manualCollection
-              ? `${props.collection.manualCollectionName} (manual)`
+              ? `${props.collection.manualCollectionName} (custom)`
               : props.collection.title}
           </div>
         </div>

--- a/apps/ui/src/components/Collection/CollectionOverview/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionOverview/index.tsx
@@ -39,6 +39,7 @@ const CollectionOverview = (props: ICollectionOverview) => {
             text="Handle Collections"
             executing={collectionHandlerRunning}
             disabled={collectionHandlerRunning}
+            title="Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
           />
         }
         controls={

--- a/apps/ui/src/components/Common/ExecuteButton/index.tsx
+++ b/apps/ui/src/components/Common/ExecuteButton/index.tsx
@@ -6,6 +6,7 @@ interface IExecuteButton {
   onClick: () => void
   executing?: boolean
   disabled?: boolean
+  title?: string
 }
 
 const ExecuteButton = (props: IExecuteButton) => {
@@ -14,6 +15,7 @@ const ExecuteButton = (props: IExecuteButton) => {
       className="edit-button m-auto flex h-9 rounded text-zinc-200 shadow-md"
       onClick={props.onClick}
       disabled={props.disabled}
+      title={props.title}
     >
       {props.executing ? (
         <SmallLoadingSpinner className="m-auto ml-2 h-5" />

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -1822,24 +1822,16 @@ const AddModal = (props: AddModal) => {
       </div>
       {pendingDisableSubmit && (
         <Modal
-          title="Disable this rule group?"
+          title="Disabling this rule group"
           size="md"
           backgroundClickable={false}
-          onCancel={() => setPendingDisableSubmit(null)}
-          cancelText="Cancel"
-          footerActions={
-            <Button
-              buttonType="warning"
-              className="ml-3"
-              onClick={() => {
-                const data = pendingDisableSubmit
-                setPendingDisableSubmit(null)
-                void performSubmit(data)
-              }}
-            >
-              Disable anyway
-            </Button>
-          }
+          cancelText="Got it"
+          cancelButtonType="primary"
+          onCancel={() => {
+            const data = pendingDisableSubmit
+            setPendingDisableSubmit(null)
+            void performSubmit(data)
+          }}
         >
           <p>
             Disabling won&apos;t remove items already tracked by this rule

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -1825,13 +1825,21 @@ const AddModal = (props: AddModal) => {
           title="Disabling this rule group"
           size="md"
           backgroundClickable={false}
-          cancelText="Got it"
-          cancelButtonType="primary"
-          onCancel={() => {
-            const data = pendingDisableSubmit
-            setPendingDisableSubmit(null)
-            void performSubmit(data)
-          }}
+          onCancel={() => setPendingDisableSubmit(null)}
+          cancelText="Cancel"
+          footerActions={
+            <Button
+              buttonType="primary"
+              className="ml-3"
+              onClick={() => {
+                const data = pendingDisableSubmit
+                setPendingDisableSubmit(null)
+                void performSubmit(data)
+              }}
+            >
+              Got it
+            </Button>
+          }
         >
           <p>
             Disabling won&apos;t remove items already tracked by this rule

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -42,6 +42,7 @@ import Button from '../../../Common/Button'
 import CommunityRuleModal from '../../../Common/CommunityRuleModal'
 import LazyModalBoundary from '../../../Common/LazyModalBoundary'
 import LoadingSpinner from '../../../Common/LoadingSpinner'
+import Modal from '../../../Common/Modal'
 import { getCollectionMediaSortConfig } from '../../../Common/MediaLibrarySortControl'
 import SaveButton from '../../../Common/SaveButton'
 import { Input } from '../../../Forms/Input'
@@ -503,6 +504,8 @@ const AddModal = (props: AddModal) => {
     [],
   )
   const [overlayTemplatesLoaded, setOverlayTemplatesLoaded] = useState(false)
+  const [pendingDisableSubmit, setPendingDisableSubmit] =
+    useState<RuleGroupFormOutput | null>(null)
 
   const overlayTemplateMode =
     selectedType === 'episode' ? 'titlecard' : 'poster'
@@ -750,6 +753,24 @@ const AddModal = (props: AddModal) => {
 
     setFormIncomplete(false)
 
+    // Disabling an active rule group freezes its tracked items rather than
+    // clearing them — confirm so users don't expect the linked collection to
+    // drain on its own.
+    const isDisablingActiveGroup =
+      props.editData &&
+      !props.isCloneMode &&
+      props.editData.isActive &&
+      !data.active
+
+    if (isDisablingActiveGroup) {
+      setPendingDisableSubmit(data)
+      return
+    }
+
+    await performSubmit(data)
+  }
+
+  const performSubmit = async (data: RuleGroupFormOutput) => {
     const creationObj: RuleGroupCreatePayload = {
       name: data.name,
       description: data.description ?? '',
@@ -1799,6 +1820,38 @@ const AddModal = (props: AddModal) => {
           </div>
         </form>
       </div>
+      {pendingDisableSubmit && (
+        <Modal
+          title="Disable this rule group?"
+          size="md"
+          backgroundClickable={false}
+          onCancel={() => setPendingDisableSubmit(null)}
+          cancelText="Cancel"
+          footerActions={
+            <Button
+              buttonType="warning"
+              className="ml-3"
+              onClick={() => {
+                const data = pendingDisableSubmit
+                setPendingDisableSubmit(null)
+                void performSubmit(data)
+              }}
+            >
+              Disable anyway
+            </Button>
+          }
+        >
+          <p>
+            Disabling won&apos;t remove items already tracked by this rule
+            group. The linked collection will keep them until this rule group is
+            re-enabled or deleted.
+          </p>
+          <p className="mt-2">
+            To clear them first, edit the rule&apos;s criteria so it matches
+            nothing, run the rule, and then disable it.
+          </p>
+        </Modal>
+      )}
     </>
   )
 }


### PR DESCRIPTION
Improves the UX gaps surfaced in #2878.

- Renames the collection card tag from `(manual)` to `(custom)` to match the "Custom collection" wording used in rule group settings. The `(manual)` log tag in `CollectionLogsTable` is unchanged — it still refers to genuine `media_added_manually` / `media_removed_manually` events.
- Adds a tooltip to "Handle Collections" clarifying that it executes the configured action and does not remove items from collections.
- Adds a confirmation modal when disabling a previously-active rule group, explaining that tracked items remain until the group is re-enabled or deleted, and how to clear them first.

Refs #2878