### PR TITLE
fix(plex): improve error message when library section ID is invalid

### DIFF
--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -375,6 +375,114 @@ describe('PlexApiService.getMetadata', () => {
   });
 });
 
+describe('PlexApiService.getCollections (invalid section vs auth)', () => {
+  let service: PlexApiService;
+  let settingsService: PlexApiSettingsStub;
+  let logger: Mocked<MaintainerrLogger>;
+  let loggerFactory: Mocked<MaintainerrLoggerFactory>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(PlexApiService).compile();
+
+    service = unit;
+    settingsService = unitRef.get(
+      SettingsService,
+    ) as unknown as PlexApiSettingsStub;
+    logger = unitRef.get(MaintainerrLogger);
+    loggerFactory = unitRef.get(MaintainerrLoggerFactory);
+
+    settingsService.plex_hostname = 'plex.local';
+    settingsService.plex_port = 32400;
+    settingsService.plex_ssl = 0;
+    settingsService.plex_auth_token = 'token';
+    loggerFactory.createLogger.mockReturnValue({
+      setContext: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as any);
+  });
+
+  it('warns about a stale section when Plex returns 200 with no MediaContainer', async () => {
+    (service as any).plexClient = {
+      queryAll: jest.fn().mockResolvedValue({}),
+    };
+
+    await expect(service.getCollections('42')).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Plex library section '42' returned no data"),
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('warns about a stale section on a 404 response', async () => {
+    const wrapped = new Error(
+      'GET /library/sections/42/collections failed: not found',
+      { cause: { response: { status: 404 } } as any },
+    );
+    (service as any).plexClient = {
+      queryAll: jest.fn().mockRejectedValue(wrapped),
+    };
+
+    await expect(service.getCollections('42')).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Plex library section '42' returned no data"),
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('emits the generic communication-failure error on a 401 auth failure', async () => {
+    const wrapped = new Error(
+      'GET /library/sections/42/collections failed: Plex Server denied request',
+      { cause: { response: { status: 401 } } as any },
+    );
+    (service as any).plexClient = {
+      queryAll: jest.fn().mockRejectedValue(wrapped),
+    };
+
+    await expect(service.getCollections('42')).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Plex api communication failure.. Is the application running?',
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('emits the generic communication-failure error on a 403 permission failure', async () => {
+    const wrapped = new Error(
+      'GET /library/sections/42/collections failed: managed user permissions',
+      { cause: { response: { status: 403 } } as any },
+    );
+    (service as any).plexClient = {
+      queryAll: jest.fn().mockRejectedValue(wrapped),
+    };
+
+    await expect(service.getCollections('42')).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Plex api communication failure.. Is the application running?',
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('emits the generic communication-failure error on a non-HTTP transport failure', async () => {
+    const wrapped = new Error('connect ECONNREFUSED');
+    (service as any).plexClient = {
+      queryAll: jest.fn().mockRejectedValue(wrapped),
+    };
+
+    await expect(service.getCollections('42')).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Plex api communication failure.. Is the application running?',
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});
+
 describe('PlexApiService.initialize', () => {
   let service: PlexApiService;
   let settingsService: PlexApiSettingsStub;

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -498,12 +498,14 @@ export class PlexApiService {
         },
       });
 
+      if (!response?.MediaContainer) {
+        this.logLibrarySectionError(id);
+        return undefined;
+      }
+
       return response.MediaContainer.totalSize;
     } catch (error) {
-      this.logger.error(
-        'Plex api communication failure.. Is the application running?',
-      );
-      this.logger.debug(error);
+      this.logLibrarySectionError(id, error);
       return undefined;
     }
   }
@@ -532,15 +534,17 @@ export class PlexApiService {
         useCache,
       );
 
+      if (!response?.MediaContainer) {
+        this.logLibrarySectionError(id);
+        return undefined;
+      }
+
       return {
         totalSize: response.MediaContainer.totalSize,
         items: (response.MediaContainer.Metadata as PlexLibraryItem[]) ?? [],
       };
     } catch (error) {
-      this.logger.error(
-        'Plex api communication failure.. Is the application running?',
-      );
-      this.logger.debug(error);
+      this.logLibrarySectionError(id, error);
       return undefined;
     }
   }
@@ -557,12 +561,14 @@ export class PlexApiService {
         useCache,
       );
 
+      if (!response?.MediaContainer) {
+        this.logLibrarySectionError(id);
+        return undefined;
+      }
+
       return (response.MediaContainer.Metadata as PlexLibraryItem[]) ?? [];
     } catch (error) {
-      this.logger.error(
-        'Plex api communication failure.. Is the application running?',
-      );
-      this.logger.debug(error);
+      this.logLibrarySectionError(id, error);
       return undefined;
     }
   }
@@ -583,12 +589,14 @@ export class PlexApiService {
         uri: `/library/sections/${id}/all?${params.toString()}`,
       });
 
+      if (!response?.MediaContainer) {
+        this.logLibrarySectionError(id);
+        return undefined;
+      }
+
       return response.MediaContainer.Metadata as PlexLibraryItem[];
     } catch (error) {
-      this.logger.error(
-        'Plex api communication failure.. Is the application running?',
-      );
-      this.logger.debug(error);
+      this.logLibrarySectionError(id, error);
       return undefined;
     }
   }
@@ -717,12 +725,15 @@ export class PlexApiService {
           options.addedAt / 1000,
         )}`,
       });
+
+      if (!response?.MediaContainer) {
+        this.logLibrarySectionError(id);
+        return undefined;
+      }
+
       return response.MediaContainer.Metadata as PlexLibraryItem[];
     } catch (error) {
-      this.logger.error(
-        'Plex api communication failure.. Is the application running?',
-      );
-      this.logger.debug(error);
+      this.logLibrarySectionError(id, error);
       return undefined;
     }
   }
@@ -754,15 +765,15 @@ export class PlexApiService {
       const response = await this.plexClient.queryAll<PlexLibraryResponse>({
         uri: `/library/sections/${libraryId}/collections?${subType ? `subtype=${subType}` : ''}`,
       });
-      const collection: PlexCollection[] = response.MediaContainer
-        .Metadata as PlexCollection[];
 
-      return collection;
+      if (!response?.MediaContainer) {
+        this.logLibrarySectionError(libraryId);
+        return undefined;
+      }
+
+      return response.MediaContainer.Metadata as PlexCollection[];
     } catch (error) {
-      this.logger.error(
-        'Plex api communication failure.. Is the application running?',
-      );
-      this.logger.debug(error);
+      this.logLibrarySectionError(libraryId, error);
       return undefined;
     }
   }
@@ -879,10 +890,7 @@ export class PlexApiService {
       }
       return collection;
     } catch (error) {
-      this.logger.error(
-        'Plex api communication failure.. Is the application running?',
-      );
-      this.logger.debug(error);
+      this.logLibrarySectionError(params.libraryId, error);
       return undefined;
     }
   }
@@ -907,10 +915,7 @@ export class PlexApiService {
       await this.plexClient.putQuery({ uri });
       return await this.getCollection(+body.collectionId);
     } catch (error) {
-      this.logger.error(
-        'Plex api communication failure.. Is the application running?',
-      );
-      this.logger.debug(error);
+      this.logLibrarySectionError(body.libraryId, error);
       return undefined;
     }
   }
@@ -1107,6 +1112,32 @@ export class PlexApiService {
         'Plex api communication failure.. Is the application running?',
       ),
     };
+  }
+
+  private logLibrarySectionError(id: string | number, error?: unknown): void {
+    // Only 404 indicates a missing/renamed section. 401 and 403 share the
+    // same wrapper in lib/plexApi.ts but mean auth/permission failures, so
+    // those must fall through to the generic communication-failure log.
+    const status =
+      error instanceof Error
+        ? (error.cause as { response?: { status?: number } } | undefined)
+            ?.response?.status
+        : undefined;
+    const isInvalidSection = error === undefined || status === 404;
+
+    if (isInvalidSection) {
+      this.logger.warn(
+        `Plex library section '${id}' returned no data. The library may have been removed or its ID changed in Plex. Update any rules or collections that reference this library.`,
+      );
+    } else {
+      this.logger.error(
+        'Plex api communication failure.. Is the application running?',
+      );
+    }
+
+    if (error !== undefined) {
+      this.logger.debug(error);
+    }
   }
 
   private stringifyResponseBody(body: unknown): string | undefined {


### PR DESCRIPTION
Fixes #1302.

## Problem

When a Plex library is removed and re-added it receives a new section ID. Rules and collections still reference the old ID, so Plex returns either HTTP 404 or HTTP 200 with a missing `MediaContainer`. Both cases previously logged the misleading:

```
[WARN] [PlexApiService] Plex api communication failure.. Is the application running?
```

That points users at connectivity instead of the actual cause: a stale library section ID.

## Fix

- Null-guard on `MediaContainer` and 404-aware catch routing for every section-scoped endpoint that takes a user-supplied library ID: `getLibraryContentCount`, `getLibraryContents`, `getLibraryLeaves`, `searchLibraryContents`, `getRecentlyAdded`, `getCollections` (the path hit by collection-aware rule evaluation), and the section-scoped writes `createCollection` / `updateCollection`.
- Single `logLibrarySectionError(id, error?)` helper. Detection reads `error.cause.response.status` (typed) and matches only on `status === 404`. 401 and 403 share the same wrapper in `lib/plexApi.ts` but mean auth/permission failures, so they fall through to the generic communication-failure log.
- Spec coverage for `getCollections`: empty `MediaContainer`, 404, 401, 403, and a non-HTTP transport failure.

**Before:**
```
[WARN] [PlexApiService] Plex api communication failure.. Is the application running?
[DEBUG] [PlexApiService] Cannot read properties of undefined (reading 'MediaContainer')
```

**After (404 or empty body):**
```
[WARN] [PlexApiService] Plex library section '16' returned no data. The library may have been removed or its ID changed in Plex. Update any rules or collections that reference this library.
```