### PR TITLE
fix(sonarr): don't require never-downloaded seasons to be unmonitored before show cleanup

### DIFF
--- a/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -495,6 +495,61 @@ describe('SonarrActionHandler', () => {
     );
   });
 
+  // Regression for issues #2757 / #2891. Sonarr carries every TVDB season on
+  // the series, including ones the user never downloaded; those stay
+  // monitored forever. The no-Seerr fallback must not require every season to
+  // be unmonitored — an ended show with zero episode files is deletable even
+  // when later (never-downloaded) seasons are still monitored.
+  it('should delete ended show with no episode files when Seerr is not configured even if later seasons remain monitored', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE_SHOW_IF_EMPTY,
+      sonarrSettingsId: 1,
+      type: 'season',
+    });
+    const collectionMedia = createCollectionMediaWithMetadata(collection, {
+      tmdbId: 1,
+    });
+
+    mockMediaServerMetadata(collectionMedia.mediaData);
+    seerrApi.isConfigured.mockReturnValue(false);
+
+    const series = createSonarrSeries({
+      id: 42,
+      status: 'ended',
+      seasons: [
+        { seasonNumber: 0, monitored: true },
+        { seasonNumber: 1, monitored: false },
+        { seasonNumber: 2, monitored: false },
+        { seasonNumber: 3, monitored: false },
+        { seasonNumber: 4, monitored: false },
+        { seasonNumber: 5, monitored: true },
+        { seasonNumber: 6, monitored: true },
+      ],
+      statistics: {
+        seasonCount: 6,
+        episodeFileCount: 0,
+        episodeCount: 100,
+        totalEpisodeCount: 100,
+        sizeOnDisk: 0,
+        percentOfEpisodes: 0,
+      },
+    });
+
+    const mockedSonarrApi = mockSonarrApi(servarrService, logger);
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mockedSonarrApi.deleteShow).toHaveBeenCalledWith(
+      series.id,
+      true,
+      collection.listExclusions,
+    );
+  });
+
   it.each([
     ServarrAction.DELETE_SHOW_IF_EMPTY,
     ServarrAction.UNMONITOR_SHOW_IF_EMPTY,

--- a/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -742,6 +742,48 @@ describe('SonarrActionHandler', () => {
     expect(mockedSonarrApi.updateSeries).not.toHaveBeenCalled();
   });
 
+  // season.statistics is optional in Sonarr's response. A monitored season
+  // with no statistics has an unknown file count — it must be treated as
+  // still having content, never assumed empty.
+  it('should not unmonitor show when a monitored season has no statistics', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR_SHOW_IF_EMPTY,
+      sonarrSettingsId: 1,
+      type: 'season',
+    });
+    const collectionMedia = createCollectionMediaWithMetadata(collection, {
+      tmdbId: 1,
+    });
+
+    mockMediaServerMetadata(collectionMedia.mediaData);
+
+    const series = createSonarrSeries({
+      id: 42,
+      monitored: true,
+      status: 'ended',
+      seasons: [
+        { seasonNumber: 0, monitored: false, statistics: emptySeasonStats() },
+        {
+          seasonNumber: 1,
+          monitored: false,
+          statistics: emptySeasonStats({ episodeFileCount: 20 }),
+        },
+        // monitored, statistics omitted -> file count unknown
+        { seasonNumber: 2, monitored: true },
+      ],
+    });
+
+    const mockedSonarrApi = mockSonarrApi(servarrService, logger);
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mockedSonarrApi.updateSeries).not.toHaveBeenCalled();
+  });
+
   it('should unmonitor and delete episode when type EPISODES and action DELETE', async () => {
     const collection = createCollection({
       arrAction: ServarrAction.DELETE,

--- a/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -76,6 +76,17 @@ describe('SonarrActionHandler', () => {
     mediaServer.getMetadata.mockResolvedValue(mediaData);
   };
 
+  // Per-season Sonarr statistics; defaults to an empty (never-downloaded)
+  // season, override episodeFileCount for seasons that hold files.
+  const emptySeasonStats = (overrides: { episodeFileCount?: number } = {}) => ({
+    episodeFileCount: 0,
+    episodeCount: 0,
+    totalEpisodeCount: 0,
+    sizeOnDisk: 0,
+    percentOfEpisodes: 0,
+    ...overrides,
+  });
+
   it.each([
     { type: 'season', title: 'SEASONS' },
     {
@@ -630,6 +641,105 @@ describe('SonarrActionHandler', () => {
         monitored: false,
       }),
     );
+  });
+
+  // Regression for issues #2757 / #2891 on the unmonitor-show path. Sonarr
+  // carries every TVDB season on the series; seasons the user never
+  // downloaded stay monitored with zero files. They must not count as
+  // "monitored content" or a finished show could never be unmonitored.
+  it('should unmonitor ended show even if never-downloaded seasons remain monitored', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR_SHOW_IF_EMPTY,
+      sonarrSettingsId: 1,
+      type: 'season',
+    });
+    const collectionMedia = createCollectionMediaWithMetadata(collection, {
+      tmdbId: 1,
+    });
+
+    mockMediaServerMetadata(collectionMedia.mediaData);
+
+    const series = createSonarrSeries({
+      id: 42,
+      monitored: true,
+      status: 'ended',
+      seasons: [
+        // specials + never-downloaded later seasons: monitored, zero files
+        { seasonNumber: 0, monitored: true, statistics: emptySeasonStats() },
+        // processed seasons: unmonitored, files kept by the UNMONITOR action
+        {
+          seasonNumber: 1,
+          monitored: false,
+          statistics: emptySeasonStats({ episodeFileCount: 20 }),
+        },
+        {
+          seasonNumber: 2,
+          monitored: false,
+          statistics: emptySeasonStats({ episodeFileCount: 22 }),
+        },
+        { seasonNumber: 3, monitored: true, statistics: emptySeasonStats() },
+        { seasonNumber: 4, monitored: true, statistics: emptySeasonStats() },
+      ],
+    });
+
+    const mockedSonarrApi = mockSonarrApi(servarrService, logger);
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mockedSonarrApi.updateSeries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: series.id,
+        monitored: false,
+      }),
+    );
+  });
+
+  // A season that is still monitored AND holds files means the user is not
+  // done with the show — it must not be unmonitored.
+  it('should not unmonitor show when a monitored season still has files', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR_SHOW_IF_EMPTY,
+      sonarrSettingsId: 1,
+      type: 'season',
+    });
+    const collectionMedia = createCollectionMediaWithMetadata(collection, {
+      tmdbId: 1,
+    });
+
+    mockMediaServerMetadata(collectionMedia.mediaData);
+
+    const series = createSonarrSeries({
+      id: 42,
+      monitored: true,
+      status: 'ended',
+      seasons: [
+        { seasonNumber: 0, monitored: false, statistics: emptySeasonStats() },
+        {
+          seasonNumber: 1,
+          monitored: false,
+          statistics: emptySeasonStats({ episodeFileCount: 20 }),
+        },
+        {
+          seasonNumber: 2,
+          monitored: true,
+          statistics: emptySeasonStats({ episodeFileCount: 22 }),
+        },
+      ],
+    });
+
+    const mockedSonarrApi = mockSonarrApi(servarrService, logger);
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mockedSonarrApi.updateSeries).not.toHaveBeenCalled();
   });
 
   it('should unmonitor and delete episode when type EPISODES and action DELETE', async () => {

--- a/apps/server/src/modules/actions/sonarr-action-handler.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.ts
@@ -522,7 +522,7 @@ export class SonarrActionHandler {
     series.monitored = false;
     await sonarrApiClient.updateSeries(series);
     this.logger.log(
-      `[Sonarr] Show '${series.title}' is ended with no monitored seasons - unmonitored show`,
+      `[Sonarr] Show '${series.title}' is ended with no monitored seasons holding files - unmonitored show`,
     );
   }
 
@@ -558,9 +558,14 @@ export class SonarrActionHandler {
     // monitored on the series object indefinitely (Sonarr carries every TVDB
     // season) and have zero files — they must not count as monitored content,
     // or a genuinely finished show could never be unmonitored (#2757 / #2891).
+    //
+    // A monitored season is only treated as empty when Sonarr *explicitly*
+    // reports zero files. season.statistics is optional; if it's absent the
+    // file count is unknown, so the season is treated as still having content
+    // (conservative — never unmonitor a show on an assumption).
     return series.seasons.every(
       (season) =>
-        !season.monitored || (season.statistics?.episodeFileCount ?? 0) === 0,
+        !season.monitored || season.statistics?.episodeFileCount === 0,
     );
   }
 }

--- a/apps/server/src/modules/actions/sonarr-action-handler.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.ts
@@ -479,16 +479,23 @@ export class SonarrActionHandler {
       return;
     }
 
-    if (!this.isShowEmptyAndEnded(series, 'monitored')) {
+    // No-Seerr fallback. The file gate above already proved the show has no
+    // episode files; `ended` confirms no further episodes are coming. We do
+    // NOT additionally require every season to be unmonitored: Sonarr carries
+    // every TVDB season on the series, including ones the user never
+    // downloaded, and those stay monitored forever — which would block
+    // deletion of a genuinely empty, ended show indefinitely (issue #2757 /
+    // #2891: e.g. a show where the user only ever had seasons 1-4).
+    if (series.status !== 'ended') {
       this.logger.debug(
-        `[Sonarr] Show '${series.title}' is not ended with all seasons unmonitored (status=${series.status}) - skipping show deletion`,
+        `[Sonarr] Show '${series.title}' has no episode files but is not ended (status=${series.status}) - skipping show deletion`,
       );
       return;
     }
 
     await sonarrApiClient.deleteShow(series.id, true, listExclusions);
     this.logger.log(
-      `[Sonarr] Show '${series.title}' is ended with no files or monitored seasons remaining - deleted from Sonarr`,
+      `[Sonarr] Show '${series.title}' is ended with no episode files remaining - deleted from Sonarr`,
     );
   }
 

--- a/apps/server/src/modules/actions/sonarr-action-handler.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.ts
@@ -514,7 +514,7 @@ export class SonarrActionHandler {
 
     if (!this.isShowEmptyAndEnded(series, 'monitored')) {
       this.logger.debug(
-        `[Sonarr] Show '${series.title}' is not ended with all seasons unmonitored (status=${series.status}) - skipping show unmonitor`,
+        `[Sonarr] Show '${series.title}' is not ended or still has monitored seasons with files (status=${series.status}) - skipping show unmonitor`,
       );
       return;
     }
@@ -553,6 +553,14 @@ export class SonarrActionHandler {
       return (series.statistics?.episodeFileCount ?? 0) === 0;
     }
 
-    return series.seasons.every((season) => !season.monitored);
+    // 'monitored': the show counts as empty once no season is still both
+    // monitored AND holding files. Seasons the user never downloaded stay
+    // monitored on the series object indefinitely (Sonarr carries every TVDB
+    // season) and have zero files — they must not count as monitored content,
+    // or a genuinely finished show could never be unmonitored (#2757 / #2891).
+    return series.seasons.every(
+      (season) =>
+        !season.monitored || (season.statistics?.episodeFileCount ?? 0) === 0,
+    );
   }
 }

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
@@ -33,17 +33,19 @@ describe('RadarrApi', () => {
       year: 2024,
     });
 
-    jest.spyOn(api, 'get').mockImplementation(async (endpoint) => {
-      if (endpoint === 'movie/5') {
-        return movie;
-      }
+    jest
+      .spyOn(api, 'getWithoutCache')
+      .mockImplementation(async (endpoint) => {
+        if (endpoint === 'movie/5') {
+          return movie;
+        }
 
-      if (endpoint === 'moviefile?movieId=5') {
-        return [createRadarrMovieFile()];
-      }
+        if (endpoint === 'moviefile?movieId=5') {
+          return [createRadarrMovieFile()];
+        }
 
-      return undefined;
-    });
+        return undefined;
+      });
 
     jest.spyOn(api as any, 'runPut').mockResolvedValue(true);
     jest.spyOn(api as any, 'runDelete').mockResolvedValue(true);
@@ -60,6 +62,44 @@ describe('RadarrApi', () => {
       tmdbId: movie.tmdbId,
       movieTitle: movie.title,
       movieYear: movie.year,
+    });
+  });
+
+  describe('cache coherency', () => {
+    it('getMovieByTmdbId reads uncached so post-mutation state is never stale', async () => {
+      const movie = createRadarrMovie({ id: 5, tmdbId: 123 });
+      const getSpy = jest
+        .spyOn(api, 'get')
+        .mockResolvedValue(undefined as never);
+      const getWithoutCacheSpy = jest
+        .spyOn(api, 'getWithoutCache')
+        .mockResolvedValue([movie]);
+
+      await api.getMovieByTmdbId(123);
+
+      expect(getWithoutCacheSpy).toHaveBeenCalledWith('/movie?tmdbId=123');
+      expect(getSpy).not.toHaveBeenCalled();
+    });
+
+    it('updateMovie reads the movie uncached before its read-modify-write', async () => {
+      const movie = createRadarrMovie({ id: 5, tmdbId: 123, monitored: true });
+      const getSpy = jest
+        .spyOn(api, 'get')
+        .mockResolvedValue(undefined as never);
+      jest.spyOn(api, 'getWithoutCache').mockResolvedValue(movie);
+      const runPutSpy = jest
+        .spyOn(api as any, 'runPut')
+        .mockResolvedValue(true);
+
+      await expect(
+        api.updateMovie(5, { monitored: false }),
+      ).resolves.toBe(true);
+
+      expect(getSpy).not.toHaveBeenCalled();
+      expect(runPutSpy).toHaveBeenCalledWith(
+        'movie/5',
+        JSON.stringify({ ...movie, monitored: false }),
+      );
     });
   });
 });

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
@@ -33,19 +33,17 @@ describe('RadarrApi', () => {
       year: 2024,
     });
 
-    jest
-      .spyOn(api, 'getWithoutCache')
-      .mockImplementation(async (endpoint) => {
-        if (endpoint === 'movie/5') {
-          return movie;
-        }
+    jest.spyOn(api, 'getWithoutCache').mockImplementation(async (endpoint) => {
+      if (endpoint === 'movie/5') {
+        return movie;
+      }
 
-        if (endpoint === 'moviefile?movieId=5') {
-          return [createRadarrMovieFile()];
-        }
+      if (endpoint === 'moviefile?movieId=5') {
+        return [createRadarrMovieFile()];
+      }
 
-        return undefined;
-      });
+      return undefined;
+    });
 
     jest.spyOn(api as any, 'runPut').mockResolvedValue(true);
     jest.spyOn(api as any, 'runDelete').mockResolvedValue(true);
@@ -91,9 +89,9 @@ describe('RadarrApi', () => {
         .spyOn(api as any, 'runPut')
         .mockResolvedValue(true);
 
-      await expect(
-        api.updateMovie(5, { monitored: false }),
-      ).resolves.toBe(true);
+      await expect(api.updateMovie(5, { monitored: false })).resolves.toBe(
+        true,
+      );
 
       expect(getSpy).not.toHaveBeenCalled();
       expect(runPutSpy).toHaveBeenCalledWith(

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
@@ -46,9 +46,14 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
     }
   };
 
+  // Intentionally uncached: this drives rule evaluation and resolves the
+  // movie that actions then mutate — both need Radarr's current truth, not a
+  // snapshot that can be up to DEFAULT_TTL stale.
   public async getMovieByTmdbId(id: number): Promise<RadarrMovie> {
     try {
-      const response = await this.get<RadarrMovie[]>(`/movie?tmdbId=${id}`);
+      const response = await this.getWithoutCache<RadarrMovie[]>(
+        `/movie?tmdbId=${id}`,
+      );
 
       if (!response[0]) {
         this.logger.warn(`Could not find Movie with TMDb id ${id} in Radarr`);
@@ -100,7 +105,9 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
     },
   ): Promise<boolean> {
     try {
-      const movieData: RadarrMovie = await this.get(`movie/${movieId}`);
+      const movieData: RadarrMovie = await this.getWithoutCache(
+        `movie/${movieId}`,
+      );
 
       if (!movieData) {
         return false;
@@ -117,7 +124,7 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
       }
 
       if (options?.deleteFiles) {
-        const movieFiles: RadarrMovieFile[] = await this.get(
+        const movieFiles: RadarrMovieFile[] = await this.getWithoutCache(
           `moviefile?movieId=${movieId}`,
         );
         for (const movieFile of movieFiles ?? []) {

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
@@ -181,6 +181,23 @@ describe('SonarrApi', () => {
     expect(runDeleteSpy).toHaveBeenCalledWith('episodefile/700');
   });
 
+  describe('cache coherency (issue #2757 / #2891)', () => {
+    it('getSeriesByTvdbId reads uncached so post-mutation state is never stale', async () => {
+      const series = createSonarrSeries({ id: 1, tvdbId: 555 });
+      const getSpy = jest
+        .spyOn(sonarrApi as any, 'get')
+        .mockResolvedValue([series]);
+      const getWithoutCacheSpy = jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue([series]);
+
+      await sonarrApi.getSeriesByTvdbId(555);
+
+      expect(getWithoutCacheSpy).toHaveBeenCalledWith('/series?tvdbId=555');
+      expect(getSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('runPut / runDelete failure contract', () => {
     it('should return false when PUT returns undefined (API failure)', async () => {
       jest.spyOn(sonarrApi as any, 'put').mockResolvedValue(undefined);

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
@@ -105,9 +105,15 @@ export class SonarrApi extends ServarrApi<{
     }
   }
 
+  // Intentionally uncached: this endpoint is read straight after mutations
+  // (unmonitor + file deletes) by the empty-show cleanup, and also drives
+  // rule evaluation — both need Sonarr's current truth, not a snapshot that
+  // can be up to DEFAULT_TTL stale (see issue #2757 / #2891).
   public async getSeriesByTvdbId(id: number): Promise<SonarrSeries> {
     try {
-      const response = await this.get<SonarrSeries[]>(`/series?tvdbId=${id}`);
+      const response = await this.getWithoutCache<SonarrSeries[]>(
+        `/series?tvdbId=${id}`,
+      );
 
       if (!response?.[0]) {
         this.logger.warn(`Could not retrieve show by tvdb ID ${id}`);


### PR DESCRIPTION
## Summary

Closes #2891 (and re-closes #2757). The "Unmonitor and delete season + delete show if empty" action deleted a season's files but never deleted the now-empty show. Two distinct bugs were stacked on top of each other.

## Root cause: stale cache (the reason nothing earlier worked)

`ExternalApiService.get()` caches responses for 20 minutes. `getSeriesByTvdbId` went through that cache. The empty-show cleanup's "refetch" — which runs immediately after the unmonitor + episode-file deletes — was a **cache hit**, so it evaluated the *pre-mutation* snapshot and concluded the show still had content.

Confirmed from daviddanko's Sonarr debug log: after the deletes, **no HTTP `GET /series?tvdbId=` was issued at all** — the refetch never hit Sonarr. Every gate-logic change before this was being fed stale input, which is why "reverted to basics" still failed.

Fix: `getSeriesByTvdbId` / `getMovieByTmdbId` now read via `getWithoutCache`. These endpoints are read straight after mutations and also drive rule evaluation — both need current truth. `updateMovie`'s internal read-modify-write read is uncached too, so it can't PUT a stale movie object back to Radarr.

## Secondary fix: the `allSeasonsUnmonitored` gate

Even with a fresh refetch, the no-Seerr fallback required *every* season to be unmonitored. Sonarr carries every TVDB season on the series — including ones the user never downloaded — and those stay monitored forever, permanently blocking deletion of a genuinely empty, ended show (e.g. a library with only seasons 1–4 of a 10-season show).

Fix: the no-Seerr fallback now requires `series.status === 'ended'` and no longer requires all seasons unmonitored. The `episodeFileCount === 0` file gate and the Seerr-authority path are unchanged. `isShowEmpty`'s `'monitored'` mode now also treats a monitored-but-fileless season as empty, and missing season statistics are treated as unknown rather than empty.

## Commits

- `5760c484` — don't require all seasons unmonitored to delete an empty ended show
- `620292f9` — apply the same fix to the unmonitor-show check
- `841c4adf` — treat missing season statistics as unknown, not empty
- `252ad047` — read series/movie lookups uncached so the post-mutation refetch is fresh

## Note

`getSeriesByTvdbId` / `getMovieByTmdbId` are also called by the rule getters (once per media item per rule evaluation), so they no longer benefit from the 20-minute cache there. For local *arr APIs this is negligible per-call, and rule evaluation arguably *should* run on current data anyway — but it's a deliberate trade of some read-amplification for guaranteed freshness.