### PR TITLE
fix(plex): extract logInvalidLibrarySection and fix Octokit type cast

### DIFF
--- a/apps/server/src/modules/api/github-api/github-api.service.ts
+++ b/apps/server/src/modules/api/github-api/github-api.service.ts
@@ -36,7 +36,9 @@ export class GitHubApiService {
     this.loadPersistedCache();
 
     // Create Octokit instance with throttling plugin
-    const OctokitWithPlugins = Octokit.plugin(throttling);
+    const OctokitWithPlugins = Octokit.plugin(
+      throttling as Parameters<typeof Octokit.plugin>[0],
+    );
 
     const octokitOptions: ConstructorParameters<typeof OctokitWithPlugins>[0] =
       {

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -499,7 +499,7 @@ export class PlexApiService {
       });
 
       if (!response?.MediaContainer) {
-        this.logLibrarySectionError(id);
+        this.logInvalidLibrarySection(id);
         return undefined;
       }
 
@@ -535,7 +535,7 @@ export class PlexApiService {
       );
 
       if (!response?.MediaContainer) {
-        this.logLibrarySectionError(id);
+        this.logInvalidLibrarySection(id);
         return undefined;
       }
 
@@ -562,7 +562,7 @@ export class PlexApiService {
       );
 
       if (!response?.MediaContainer) {
-        this.logLibrarySectionError(id);
+        this.logInvalidLibrarySection(id);
         return undefined;
       }
 
@@ -590,7 +590,7 @@ export class PlexApiService {
       });
 
       if (!response?.MediaContainer) {
-        this.logLibrarySectionError(id);
+        this.logInvalidLibrarySection(id);
         return undefined;
       }
 
@@ -727,7 +727,7 @@ export class PlexApiService {
       });
 
       if (!response?.MediaContainer) {
-        this.logLibrarySectionError(id);
+        this.logInvalidLibrarySection(id);
         return undefined;
       }
 
@@ -767,7 +767,7 @@ export class PlexApiService {
       });
 
       if (!response?.MediaContainer) {
-        this.logLibrarySectionError(libraryId);
+        this.logInvalidLibrarySection(libraryId);
         return undefined;
       }
 
@@ -1114,30 +1114,27 @@ export class PlexApiService {
     };
   }
 
-  private logLibrarySectionError(id: string | number, error?: unknown): void {
-    // Only 404 indicates a missing/renamed section. 401 and 403 share the
-    // same wrapper in lib/plexApi.ts but mean auth/permission failures, so
-    // those must fall through to the generic communication-failure log.
+  private logInvalidLibrarySection(id: string | number): void {
+    this.logger.warn(
+      `Plex library section '${id}' returned no data. The library may have been removed or its ID changed in Plex. Update any rules or collections that reference this library.`,
+    );
+  }
+
+  private logLibrarySectionError(id: string | number, error: unknown): void {
     const status =
       error instanceof Error
         ? (error.cause as { response?: { status?: number } } | undefined)
             ?.response?.status
         : undefined;
-    const isInvalidSection = error === undefined || status === 404;
 
-    if (isInvalidSection) {
-      this.logger.warn(
-        `Plex library section '${id}' returned no data. The library may have been removed or its ID changed in Plex. Update any rules or collections that reference this library.`,
-      );
+    if (status === 404) {
+      this.logInvalidLibrarySection(id);
     } else {
       this.logger.error(
         'Plex api communication failure.. Is the application running?',
       );
     }
-
-    if (error !== undefined) {
-      this.logger.debug(error);
-    }
+    this.logger.debug(error);
   }
 
   private stringifyResponseBody(body: unknown): string | undefined {


### PR DESCRIPTION
### Description & Design

**What problem this change solves:**

Two related issues in `plex-api.service.ts` and `github-api.service.ts`:

1. **`logLibrarySectionError` was called with one argument in six places** — the no-error path (when `response?.MediaContainer` is missing) — despite the method accepting `error?: unknown`. This relied on an implicit `error === undefined` branch to treat the missing-section case. The intent was unclear and the method signature was misleading.

2. **TypeScript type error in `github-api.service.ts`**: `Octokit.plugin(throttling)` produces a TS2345 error due to a type incompatibility between the `octokit` package's bundled `@octokit/core` and the standalone `@octokit/core` that `@octokit/plugin-throttling` depends on (`retryCount` property missing in one variant).

**Why this approach was chosen:**

- Extract `logInvalidLibrarySection(id)` as a dedicated private method for the "section returned no data" case. The six call sites that detected a missing `MediaContainer` now call it directly, making their intent explicit.
- Make `logLibrarySectionError(id, error)` require `error: unknown` — it now only handles thrown exceptions, with 404 delegating to `logInvalidLibrarySection`.
- Cast `throttling` to `Parameters<typeof Octokit.plugin>[0]` to silence the type incompatibility without changing runtime behaviour.

**How the solution works:**

- No behaviour change — the warn message and routing logic are identical.
- The refactor makes the two cases (no-response vs. thrown error) structurally distinct and easier to follow.

**Trade-offs / limitations:**

- The Octokit cast is a workaround for a package dependency conflict; the proper fix would be aligning `octokit` and `@octokit/plugin-throttling` to share the same `@octokit/core`.

### Related issue

Follows up on #2883 (which introduced `logLibrarySectionError` with structured 404 detection).

### AI-Assisted Development

This PR was developed with Claude Code assistance. I reviewed all changes for correctness, verified the test suite passes, and confirmed the behaviour is identical to the previous implementation.

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I understand the code I am submitting and can explain how it works
- [x] I have performed a self-review of my code
- [x] I have linted and formatted my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

### How to test

1. Run `yarn check-types` — should complete without errors
2. Run `yarn workspace @maintainerr/server jest --testRegex="plex-api.service.spec|github-api.service.spec"` — all 38 tests pass
3. Configure a Plex library section with an invalid/removed ID and verify the warn log appears correctly