### PR TITLE
refactor(rules): extract resolveArrTagNames helper for ARR tag resolution

### DIFF
--- a/apps/server/src/modules/api/servarr-api/common/servarr-api.service.ts
+++ b/apps/server/src/modules/api/servarr-api/common/servarr-api.service.ts
@@ -169,7 +169,7 @@ export abstract class ServarrApi<QueueItemAppendT> extends ExternalApiService {
     }
   };
 
-  public getTags = async (): Promise<Tag[]> => {
+  public getTags = async (): Promise<Tag[] | undefined> => {
     try {
       const response = await this.axios.get<Tag[]>(`/tag`);
 
@@ -177,7 +177,7 @@ export abstract class ServarrApi<QueueItemAppendT> extends ExternalApiService {
     } catch (error) {
       this.logger.warn('Failed to retrieve tags');
       this.logger.debug(error);
-      return [];
+      return undefined;
     }
   };
 

--- a/apps/server/src/modules/rules/getter/radarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.ts
@@ -16,6 +16,7 @@ import {
 import { RuleDto } from '../dtos/rule.dto';
 import { RulesDto } from '../dtos/rules.dto';
 import { evaluateArrDiskspaceGiB } from '../helpers/diskspace.utils';
+import { resolveArrTagNames } from '../helpers/arr-tags.utils';
 
 @Injectable()
 export class RadarrGetterService {
@@ -130,10 +131,7 @@ export class RadarrGetterService {
             return movieResponse.monitored ? 1 : 0;
           }
           case 'tags': {
-            const movieTags = movieResponse.tags;
-            return (await radarrApiClient.getTags())
-              ?.filter((el) => movieTags.includes(el.id))
-              .map((el) => el.label);
+            return resolveArrTagNames(movieResponse.tags, radarrApiClient);
           }
           case 'profile': {
             const movieProfile = movieResponse.qualityProfileId;

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -26,6 +26,7 @@ import {
 import { RuleDto } from '../dtos/rule.dto';
 import { RulesDto } from '../dtos/rules.dto';
 import { evaluateArrDiskspaceGiB } from '../helpers/diskspace.utils';
+import { resolveArrTagNames } from '../helpers/arr-tags.utils';
 
 @Injectable()
 export class SonarrGetterService {
@@ -264,10 +265,7 @@ export class SonarrGetterService {
           return episode?.episodeNumber != null ? episode.episodeNumber : null;
         }
         case 'tags': {
-          const tagIds = showResponse.tags;
-          return (await sonarrApiClient.getTags())
-            ?.filter((el) => tagIds.includes(el.id))
-            .map((el) => el.label);
+          return resolveArrTagNames(showResponse.tags, sonarrApiClient);
         }
         case 'qualityProfileId': {
           const episodeFile = await getEpisodeFile();

--- a/apps/server/src/modules/rules/helpers/arr-tags.utils.spec.ts
+++ b/apps/server/src/modules/rules/helpers/arr-tags.utils.spec.ts
@@ -1,0 +1,53 @@
+import { resolveArrTagNames } from './arr-tags.utils';
+
+const makeTags = (entries: [number, string][]) =>
+  entries.map(([id, label]) => ({ id, label }));
+
+describe('resolveArrTagNames', () => {
+  it('returns matching label strings for given IDs', async () => {
+    const client = {
+      getTags: jest.fn().mockResolvedValue(
+        makeTags([
+          [1, 'action'],
+          [2, 'comedy'],
+          [3, 'drama'],
+        ]),
+      ),
+    };
+    await expect(resolveArrTagNames([1, 3], client)).resolves.toEqual([
+      'action',
+      'drama',
+    ]);
+  });
+
+  it('returns empty array when no IDs match', async () => {
+    const client = {
+      getTags: jest.fn().mockResolvedValue(makeTags([[1, 'action']])),
+    };
+    await expect(resolveArrTagNames([99], client)).resolves.toEqual([]);
+  });
+
+  it('returns empty array when tagIds is empty', async () => {
+    const client = {
+      getTags: jest.fn().mockResolvedValue(makeTags([[1, 'action']])),
+    };
+    await expect(resolveArrTagNames([], client)).resolves.toEqual([]);
+  });
+
+  it('returns undefined when getTags returns undefined (API failure)', async () => {
+    const client = { getTags: jest.fn().mockResolvedValue(undefined) };
+    await expect(resolveArrTagNames([1], client)).resolves.toBeUndefined();
+  });
+
+  it('behaves identically for Radarr-style and Sonarr-style tag payloads', async () => {
+    const tags = makeTags([
+      [10, 'hd'],
+      [20, '4k'],
+    ]);
+    const radarrClient = { getTags: jest.fn().mockResolvedValue(tags) };
+    const sonarrClient = { getTags: jest.fn().mockResolvedValue(tags) };
+    const radarrResult = await resolveArrTagNames([10, 20], radarrClient);
+    const sonarrResult = await resolveArrTagNames([10, 20], sonarrClient);
+    expect(radarrResult).toEqual(sonarrResult);
+  });
+});

--- a/apps/server/src/modules/rules/helpers/arr-tags.utils.ts
+++ b/apps/server/src/modules/rules/helpers/arr-tags.utils.ts
@@ -1,0 +1,18 @@
+import { Tag } from '../../api/servarr-api/interfaces/servarr.interface';
+
+interface ArrTagClient {
+  getTags(): Promise<Tag[] | undefined>;
+}
+
+/**
+ * Resolves tag IDs to their human-readable label strings using an ARR API client.
+ * Shared between Radarr and Sonarr getters — semantics are identical in both.
+ * Returns undefined when getTags() fails (signals transient failure to the comparator).
+ */
+export async function resolveArrTagNames(
+  tagIds: number[],
+  client: ArrTagClient,
+): Promise<string[] | undefined> {
+  const allTags = await client.getTags();
+  return allTags?.filter((t) => tagIds.includes(t.id)).map((t) => t.label);
+}


### PR DESCRIPTION
## Summary

- Extracts a shared `resolveArrTagNames(tagIds, client)` utility from the duplicated inline tag-resolution chains in `RadarrGetterService` and `SonarrGetterService`
- Changes `ServarrApi.getTags()` return type from `Tag[]` to `Tag[] | undefined` on failure — callers can now distinguish a transient API error from a server with no tags configured (previously both returned `[]`)
- Adds a 5-test unit spec covering: matching labels, no match, empty IDs, API failure (`undefined`), and Radarr/Sonarr consistency

## Test plan

- [ ] `yarn workspace @maintainerr/server jest --testPathPatterns="arr-tags"` — 5 tests pass
- [ ] `yarn test` — full suite passes with no regressions
- [ ] Prettier check passes (`yarn workspace @maintainerr/server prettier --check .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)