### PR TITLE
fix(streamystats): don't send stored Jellyfin API key on connection test

### DIFF
--- a/apps/server/src/modules/api/streamystats-api/helpers/streamystats-api.helper.ts
+++ b/apps/server/src/modules/api/streamystats-api/helpers/streamystats-api.helper.ts
@@ -4,14 +4,12 @@ import cacheManager from '../../lib/cache';
 
 export class StreamystatsApi extends ExternalApiService {
   constructor(
-    { url, apiKey }: { url: string; apiKey: string },
+    { url, apiKey }: { url: string; apiKey?: string },
     protected readonly logger: MaintainerrLogger,
   ) {
     logger.setContext(StreamystatsApi.name);
     super(url, {}, logger, {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
       nodeCache: cacheManager.getCache('streamystats').data,
     });
   }

--- a/apps/server/src/modules/api/streamystats-api/streamystats-api.service.spec.ts
+++ b/apps/server/src/modules/api/streamystats-api/streamystats-api.service.spec.ts
@@ -1,5 +1,6 @@
 import { Mocked, TestBed } from '@suites/unit';
 import { SettingsService } from '../../settings/settings.service';
+import { StreamystatsApi } from './helpers/streamystats-api.helper';
 import { StreamystatsApiService } from './streamystats-api.service';
 
 const apiMock = {
@@ -274,6 +275,30 @@ describe('StreamystatsApiService', () => {
       });
 
       expect(result.status).toBe('NOK');
+    });
+
+    it('supports being called without an apiKey (no Authorization header)', async () => {
+      const StreamystatsApiMock = StreamystatsApi as unknown as jest.Mock;
+      StreamystatsApiMock.mockClear();
+      apiMock.getRawWithoutCache.mockResolvedValue({
+        data: {
+          currentVersion: '2.18.0',
+          latestVersion: '2.18.0',
+          hasUpdate: false,
+          buildTime: 0,
+        },
+      });
+
+      const result = await service.testConnection({
+        url: 'http://streamystats',
+      });
+
+      expect(result.status).toBe('OK');
+      // The helper is constructed with url only — no apiKey leaks to a
+      // user-supplied URL via /api/settings/test/streamystats.
+      const callArgs = StreamystatsApiMock.mock.calls.at(-1)?.[0];
+      expect(callArgs?.url).toBe('http://streamystats');
+      expect(callArgs?.apiKey).toBeUndefined();
     });
   });
 });

--- a/apps/server/src/modules/settings/settings.service.ts
+++ b/apps/server/src/modules/settings/settings.service.ts
@@ -1380,9 +1380,12 @@ export class SettingsService implements SettingDto {
     setting?: StreamystatsSetting,
   ): Promise<BasicResponseDto> {
     if (setting) {
+      // testConnection only hits Streamystats's unauthenticated /api/version
+      // endpoint, so we deliberately do not send the stored Jellyfin API key
+      // here. This avoids handing the stored credential to a URL the caller
+      // just supplied via the test endpoint.
       return await this.streamystats.testConnection({
         url: setting.url,
-        apiKey: this.jellyfin_api_key,
       });
     }
 


### PR DESCRIPTION
## Summary

`POST /api/settings/test/streamystats` previously passed the stored `jellyfin_api_key` as `Authorization: Bearer …` against the **caller-supplied** URL. The endpoint only hits Streamystats's `/api/version` route, which is unauthenticated upstream — so the Bearer was functionally a no-op while still shipping a live credential to whatever URL a caller put in the request body.

This was flagged as a LOW defense-in-depth finding during the Streamystats integration security review. No HIGH/MEDIUM impact in the documented threat model (the unmasked `jellyfin_api_key` is already readable via `GET /api/settings/jellyfin` for anyone reaching the API), but no reason to keep the extra exfil path either.

## Changes

- `StreamystatsApi` helper: `apiKey` is now optional. `Authorization` is only set when an `apiKey` is provided.
- `SettingsService.testStreamystats`: drops the stored `jellyfin_api_key` from the user-supplied test path. Operational calls (`getItemDetails`) keep using `this.api` constructed in `init()` with the stored key — unchanged.
- Regression test pins the no-Authorization shape on the test path.

## Verification

- `yarn lint`: clean
- `yarn test`: 1333 server + 52 UI test files (206 tests) pass
- New focused test asserts `StreamystatsApi` is constructed without `apiKey` on the test path