### PR TITLE
fix(overlays): keep ellipse anchored on drag and resize

### DIFF
--- a/apps/ui/src/components/OverlayEditor/OverlayCanvas.tsx
+++ b/apps/ui/src/components/OverlayEditor/OverlayCanvas.tsx
@@ -226,10 +226,18 @@ export function OverlayCanvas({
   const handleDragEnd = useCallback(
     (el: OverlayElement, e: Konva.KonvaEventObject<DragEvent>) => {
       const node = e.target
+      let targetX = node.x()
+      let targetY = node.y()
+
+      if (el.shapeType === 'ellipse') {
+        targetX -= node.width() / 2
+        targetY -= node.height() / 2
+      }
+
       onUpdate({
         ...el,
-        x: Math.round(node.x() / scale),
-        y: Math.round(node.y() / scale),
+        x: Math.round(targetX / scale),
+        y: Math.round(targetY / scale),
       })
     },
     [onUpdate, scale],
@@ -245,12 +253,29 @@ export function OverlayCanvas({
       node.scaleX(1)
       node.scaleY(1)
 
+      const finalW = Math.max(
+        1,
+        Math.round((node.width() * scaleXNode) / scale),
+      )
+      const finalH = Math.max(
+        1,
+        Math.round((node.height() * scaleYNode) / scale),
+      )
+
+      let targetX = node.x()
+      let targetY = node.y()
+
+      if (el.shapeType === 'ellipse') {
+        targetX -= (node.width() * scaleXNode) / 2
+        targetY -= (node.height() * scaleYNode) / 2
+      }
+
       onUpdate({
         ...el,
-        x: Math.round(node.x() / scale),
-        y: Math.round(node.y() / scale),
-        width: Math.max(1, Math.round((node.width() * scaleXNode) / scale)),
-        height: Math.max(1, Math.round((node.height() * scaleYNode) / scale)),
+        x: Math.round(targetX / scale),
+        y: Math.round(targetY / scale),
+        width: finalW,
+        height: finalH,
         rotation: Math.round(node.rotation()),
       })
     },


### PR DESCRIPTION
Konva renders ellipses by their center, but the drag/transform handlers stored that center as the top-left `x/y`, so ellipses jumped by half their size on every drag and resize. Convert center→top-left for ellipses in `handleDragEnd` and `handleTransformEnd`.

Fixes #2938.