### PR TITLE
fix(ui): sync settings forms via react-hook-form values to stop render loop

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -112,7 +112,8 @@
       ]
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!(@octokit|octokit|bottleneck|@jellyfin/sdk)/)"
+      "node_modules/(?!(@octokit|octokit|bottleneck|@jellyfin/sdk)/)",
+      "/packages/contracts/dist/"
     ],
     "collectCoverageFrom": [
       "**/*.ts"

--- a/apps/ui/src/components/Settings/Emby/index.tsx
+++ b/apps/ui/src/components/Settings/Emby/index.tsx
@@ -4,7 +4,7 @@ import {
   embySettingSchema,
   maskSecret,
 } from '@maintainerr/contracts'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Controller, useForm, useWatch } from 'react-hook-form'
 import { z } from 'zod'
 import { useSettingsOutletContext } from '..'
@@ -59,6 +59,17 @@ const EmbySettings = () => {
   const { data: embyData } = useEmbySettings({ enabled: !!settings })
   const isEmbyLoading = settings != null && embyData == null
 
+  // Sync the form to the loaded settings once they arrive. react-hook-form's
+  // `values` option deep-compares, so an unstable reference with equal contents
+  // won't re-trigger a reset (no effect, no render loop).
+  const formValues = embyData
+    ? {
+        emby_url: embyData.emby_url ?? '',
+        emby_api_key: embyData.emby_api_key ?? '',
+        emby_user_id: embyData.emby_user_id ?? '',
+      }
+    : undefined
+
   const { mutateAsync: testEmby, isPending: isTestPending } = useTestEmby()
   const { mutateAsync: saveSettings, isPending: isSavePending } =
     useSaveEmbySettings()
@@ -81,20 +92,11 @@ const EmbySettings = () => {
       emby_api_key: '',
       emby_user_id: '',
     },
+    values: formValues,
   })
 
   const embyUrl = useWatch({ control, name: 'emby_url' })
   const embyApiKey = useWatch({ control, name: 'emby_api_key' })
-
-  useEffect(() => {
-    if (embyData) {
-      reset({
-        emby_url: embyData.emby_url ?? '',
-        emby_api_key: embyData.emby_api_key ?? '',
-        emby_user_id: embyData.emby_user_id ?? '',
-      })
-    }
-  }, [embyData, reset])
 
   const isGoingToRemoveSettings = embyUrl === '' && embyApiKey === ''
   const enteredSettingsHaveBeenTested =

--- a/apps/ui/src/components/Settings/Jellyfin/index.tsx
+++ b/apps/ui/src/components/Settings/Jellyfin/index.tsx
@@ -4,7 +4,7 @@ import {
   jellyfinSettingSchema,
   maskSecret,
 } from '@maintainerr/contracts'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Controller, useForm, useWatch } from 'react-hook-form'
 import { z } from 'zod'
 import { useSettingsOutletContext } from '..'
@@ -60,6 +60,17 @@ const JellyfinSettings = () => {
   })
   const isJellyfinLoading = settings != null && jellyfinData == null
 
+  // Sync the form to the loaded settings once they arrive. react-hook-form's
+  // `values` option deep-compares, so an unstable reference with equal contents
+  // won't re-trigger a reset (no effect, no render loop).
+  const formValues = jellyfinData
+    ? {
+        jellyfin_url: jellyfinData.jellyfin_url ?? '',
+        jellyfin_api_key: jellyfinData.jellyfin_api_key ?? '',
+        jellyfin_user_id: jellyfinData.jellyfin_user_id ?? '',
+      }
+    : undefined
+
   const { mutateAsync: testJellyfin, isPending: isTestPending } =
     useTestJellyfin()
   const { mutateAsync: saveSettings, isPending: isSavePending } =
@@ -83,21 +94,11 @@ const JellyfinSettings = () => {
       jellyfin_api_key: '',
       jellyfin_user_id: '',
     },
+    values: formValues,
   })
 
   const jellyfinUrl = useWatch({ control, name: 'jellyfin_url' })
   const jellyfinApiKey = useWatch({ control, name: 'jellyfin_api_key' })
-
-  // Initialize form when jellyfin settings load (from dedicated endpoint with real values)
-  useEffect(() => {
-    if (jellyfinData) {
-      reset({
-        jellyfin_url: jellyfinData.jellyfin_url ?? '',
-        jellyfin_api_key: jellyfinData.jellyfin_api_key ?? '',
-        jellyfin_user_id: jellyfinData.jellyfin_user_id ?? '',
-      })
-    }
-  }, [jellyfinData, reset])
 
   const isGoingToRemoveSettings = jellyfinUrl === '' && jellyfinApiKey === ''
   const enteredSettingsHaveBeenTested =

--- a/apps/ui/src/components/Settings/Servarr/ServarrSettingsModal.tsx
+++ b/apps/ui/src/components/Settings/Servarr/ServarrSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import {
   getApiErrorMessage,
@@ -184,9 +184,12 @@ const ServarrSettingsModal = <TSetting extends ServarrSettingShape>({
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<TestStatus>()
 
-  const { register, handleSubmit, control, getValues, reset } =
+  const { register, handleSubmit, control, getValues } =
     useForm<ServarrFormState>({
       defaultValues: initialState,
+      // `values` keeps the form synced to the loaded setting via deep compare;
+      // no effect needed and no render loop on an unstable reference.
+      values: initialState,
     })
 
   const serverName = useWatch({ control, name: 'serverName' }) ?? ''
@@ -213,10 +216,6 @@ const ServarrSettingsModal = <TSetting extends ServarrSettingShape>({
     testedConnectionStateKey === settingsKey
       ? testedConnectionState
       : savedConnectionState
-
-  useEffect(() => {
-    reset(initialState)
-  }, [initialState, reset, settings])
 
   const isClearingExistingSetting =
     settings?.id != null && isEmptyServarrState(currentState)


### PR DESCRIPTION
The Emby, Jellyfin and Servarr settings forms reset from loaded settings inside a `useEffect` keyed on the query result. When that data reference is unstable, the effect re-fires every render and loops until the vitest worker exhausts memory and is SIGTERM'd — the failure in the test job. Replaced with react-hook-form's `values` option, which deep-compares and removes the effect.

Also stops ts-jest from re-transforming the prebuilt `@maintainerr/contracts` dist output, removing the compiler warning flood on server test runs.

The remaining "worker failed to exit gracefully" warning is left intentionally and tracked in #2946.