### PR TITLE
refactor(server): remove module forwardRefs left by the settings split

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby.module.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby.module.ts
@@ -1,9 +1,7 @@
-import { forwardRef, Module } from '@nestjs/common';
-import { SettingsModule } from '../../../settings/settings.module';
+import { Module } from '@nestjs/common';
 import { EmbyAdapterService } from './emby-adapter.service';
 
 @Module({
-  imports: [forwardRef(() => SettingsModule)],
   providers: [EmbyAdapterService],
   exports: [EmbyAdapterService],
 })

--- a/apps/server/src/modules/api/media-server/guards/media-server-setup.guard.spec.ts
+++ b/apps/server/src/modules/api/media-server/guards/media-server-setup.guard.spec.ts
@@ -1,11 +1,11 @@
 import { MaintainerrLogger } from '../../../logging/logs.service';
-import { SettingsOperationsService } from '../../../settings/settings-operations.service';
+import { SettingsDataService } from '../../../settings/settings-data.service';
 import { MediaServerSetupGuard } from './media-server-setup.guard';
 
 describe('MediaServerSetupGuard', () => {
-  const settingsOperationsService = {
+  const settingsDataService = {
     testSetup: jest.fn(),
-  } as unknown as jest.Mocked<SettingsOperationsService>;
+  } as unknown as jest.Mocked<SettingsDataService>;
 
   const logger = {
     setContext: jest.fn(),
@@ -17,11 +17,11 @@ describe('MediaServerSetupGuard', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    guard = new MediaServerSetupGuard(settingsOperationsService, logger);
+    guard = new MediaServerSetupGuard(settingsDataService, logger);
   });
 
   it('returns false and logs when media server setup test throws', async () => {
-    settingsOperationsService.testSetup.mockRejectedValue(
+    settingsDataService.testSetup.mockRejectedValue(
       new Error('connection failed'),
     );
 

--- a/apps/server/src/modules/api/media-server/guards/media-server-setup.guard.ts
+++ b/apps/server/src/modules/api/media-server/guards/media-server-setup.guard.ts
@@ -1,6 +1,6 @@
 import { CanActivate, Injectable } from '@nestjs/common';
 import { MaintainerrLogger } from '../../../logging/logs.service';
-import { SettingsOperationsService } from '../../../settings/settings-operations.service';
+import { SettingsDataService } from '../../../settings/settings-data.service';
 
 /**
  * Guard that checks if a media server (Plex or Jellyfin) is configured.
@@ -13,7 +13,7 @@ import { SettingsOperationsService } from '../../../settings/settings-operations
 @Injectable()
 export class MediaServerSetupGuard implements CanActivate {
   constructor(
-    private readonly settingsOperationsService: SettingsOperationsService,
+    private readonly settingsDataService: SettingsDataService,
     private readonly logger: MaintainerrLogger,
   ) {
     this.logger.setContext(MediaServerSetupGuard.name);
@@ -21,7 +21,7 @@ export class MediaServerSetupGuard implements CanActivate {
 
   async canActivate(): Promise<boolean> {
     try {
-      return await this.settingsOperationsService.testSetup();
+      return await this.settingsDataService.testSetup();
     } catch (error) {
       this.logger.error('Media server setup check failed');
       this.logger.debug(error);

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin.module.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin.module.ts
@@ -1,5 +1,4 @@
-import { forwardRef, Module } from '@nestjs/common';
-import { SettingsModule } from '../../../settings/settings.module';
+import { Module } from '@nestjs/common';
 import { JellyfinAdapterService } from './jellyfin-adapter.service';
 
 /**
@@ -20,7 +19,6 @@ import { JellyfinAdapterService } from './jellyfin-adapter.service';
  * ```
  */
 @Module({
-  imports: [forwardRef(() => SettingsModule)],
   providers: [JellyfinAdapterService],
   exports: [JellyfinAdapterService],
 })

--- a/apps/server/src/modules/api/media-server/media-server-switch-state.service.ts
+++ b/apps/server/src/modules/api/media-server/media-server-switch-state.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Holds the "a media server switch is in progress" flag.
+ *
+ * Extracted so the read side (MediaServerFactory, which rejects requests during
+ * the switch window) and the write side (MediaServerSwitchService, which owns
+ * the switch flow) can share the flag without depending on each other. That
+ * removes the only remaining MediaServerFactory <-> MediaServerSwitchService
+ * circular dependency. This holder deliberately injects nothing.
+ */
+@Injectable()
+export class MediaServerSwitchState {
+  private switching = false;
+
+  isSwitching(): boolean {
+    return this.switching;
+  }
+
+  setSwitching(switching: boolean): void {
+    this.switching = switching;
+  }
+}

--- a/apps/server/src/modules/api/media-server/media-server.factory.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-server.factory.spec.ts
@@ -2,10 +2,10 @@ import { MediaServerType } from '@maintainerr/contracts';
 import { ServiceUnavailableException } from '@nestjs/common';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { Settings } from '../../settings/entities/settings.entities';
-import { MediaServerSwitchService } from '../../settings/media-server-switch.service';
 import { SettingsDataService } from '../../settings/settings-data.service';
 import { EmbyAdapterService } from './emby/emby-adapter.service';
 import { JellyfinAdapterService } from './jellyfin/jellyfin-adapter.service';
+import { MediaServerSwitchState } from './media-server-switch-state.service';
 import { MediaServerFactory } from './media-server.factory';
 import { PlexAdapterService } from './plex/plex-adapter.service';
 
@@ -21,9 +21,9 @@ describe('MediaServerFactory', () => {
     getSettings: jest.fn(),
   } as unknown as jest.Mocked<SettingsDataService>;
 
-  const mediaServerSwitchService = {
+  const mediaServerSwitchState = {
     isSwitching: jest.fn(),
-  } as unknown as jest.Mocked<MediaServerSwitchService>;
+  } as unknown as jest.Mocked<MediaServerSwitchState>;
 
   const plexAdapter = {
     isSetup: jest.fn(),
@@ -64,21 +64,21 @@ describe('MediaServerFactory', () => {
     jest.clearAllMocks();
     factory = new MediaServerFactory(
       settingsDataService,
-      mediaServerSwitchService,
+      mediaServerSwitchState,
       plexAdapter,
       jellyfinAdapter,
       embyAdapter,
       logger,
     );
 
-    mediaServerSwitchService.isSwitching.mockReturnValue(false);
+    mediaServerSwitchState.isSwitching.mockReturnValue(false);
     plexAdapter.isSetup.mockReturnValue(true);
     jellyfinAdapter.isSetup.mockReturnValue(true);
     embyAdapter.isSetup.mockReturnValue(true);
   });
 
   it('throws ServiceUnavailableException while switch is in progress', async () => {
-    mediaServerSwitchService.isSwitching.mockReturnValue(true);
+    mediaServerSwitchState.isSwitching.mockReturnValue(true);
 
     await expect(factory.getService()).rejects.toBeInstanceOf(
       ServiceUnavailableException,

--- a/apps/server/src/modules/api/media-server/media-server.factory.ts
+++ b/apps/server/src/modules/api/media-server/media-server.factory.ts
@@ -1,17 +1,11 @@
 import { MediaServerType } from '@maintainerr/contracts';
-import {
-  forwardRef,
-  Inject,
-  Injectable,
-  ServiceUnavailableException,
-} from '@nestjs/common';
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { Settings } from '../../settings/entities/settings.entities';
-import { MediaServerSwitchService } from '../../settings/media-server-switch.service';
-import type { MediaServerSwitchService as MediaServerSwitchServiceType } from '../../settings/media-server-switch.service';
 import { SettingsDataService } from '../../settings/settings-data.service';
 import { EmbyAdapterService } from './emby/emby-adapter.service';
 import { JellyfinAdapterService } from './jellyfin/jellyfin-adapter.service';
+import { MediaServerSwitchState } from './media-server-switch-state.service';
 import { IMediaServerService } from './media-server.interface';
 import { PlexAdapterService } from './plex/plex-adapter.service';
 
@@ -35,8 +29,7 @@ function isSettings(obj: unknown): obj is Settings {
 export class MediaServerFactory {
   constructor(
     private readonly settingsDataService: SettingsDataService,
-    @Inject(forwardRef(() => MediaServerSwitchService))
-    private readonly mediaServerSwitchService: MediaServerSwitchServiceType,
+    private readonly mediaServerSwitchState: MediaServerSwitchState,
     private readonly plexAdapter: PlexAdapterService,
     private readonly jellyfinAdapter: JellyfinAdapterService,
     private readonly embyAdapter: EmbyAdapterService,
@@ -72,7 +65,7 @@ export class MediaServerFactory {
    * This method reads from settings on each call to support runtime configuration changes.
    */
   async getService(): Promise<IMediaServerService> {
-    if (this.mediaServerSwitchService.isSwitching()) {
+    if (this.mediaServerSwitchState.isSwitching()) {
       throw new ServiceUnavailableException(
         'Media server switch is in progress. Please try again shortly.',
       );

--- a/apps/server/src/modules/api/media-server/media-server.module.ts
+++ b/apps/server/src/modules/api/media-server/media-server.module.ts
@@ -1,9 +1,8 @@
-import { forwardRef, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CollectionMedia } from '../../collections/entities/collection_media.entities';
 import { RuleGroup } from '../../rules/entities/rule-group.entities';
 import { Exclusion } from '../../rules/entities/exclusion.entities';
-import { SettingsModule } from '../../settings/settings.module';
 import { PlexApiModule } from '../plex-api/plex-api.module';
 import { EmbyAdapterService } from './emby/emby-adapter.service';
 import { EmbyModule } from './emby/emby.module';
@@ -11,6 +10,7 @@ import { MediaServerSetupGuard } from './guards/media-server-setup.guard';
 import { JellyfinAdapterService } from './jellyfin/jellyfin-adapter.service';
 import { JellyfinModule } from './jellyfin/jellyfin.module';
 import { MediaItemEnrichmentService } from './media-item-enrichment.service';
+import { MediaServerSwitchState } from './media-server-switch-state.service';
 import { MediaServerController } from './media-server.controller';
 import { MediaServerFactory } from './media-server.factory';
 import { PlexAdapterService } from './plex/plex-adapter.service';
@@ -39,7 +39,6 @@ import { PlexAdapterService } from './plex/plex-adapter.service';
   imports: [
     TypeOrmModule.forFeature([Exclusion, CollectionMedia, RuleGroup]),
     PlexApiModule,
-    forwardRef(() => SettingsModule),
     JellyfinModule,
     EmbyModule,
   ],
@@ -49,6 +48,7 @@ import { PlexAdapterService } from './plex/plex-adapter.service';
     JellyfinAdapterService,
     EmbyAdapterService,
     MediaServerFactory,
+    MediaServerSwitchState,
     MediaServerSetupGuard,
     MediaItemEnrichmentService,
   ],
@@ -64,6 +64,7 @@ import { PlexAdapterService } from './plex/plex-adapter.service';
     // EmbyAdapterService is exported for EmbyGetterService (mirrors Jellyfin pattern).
     EmbyAdapterService,
     MediaServerFactory,
+    MediaServerSwitchState,
     MediaServerSetupGuard,
   ],
 })

--- a/apps/server/src/modules/api/plex-api/plex-api.module.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.module.ts
@@ -1,14 +1,14 @@
-import { forwardRef, Module } from '@nestjs/common';
-import { SettingsModule } from '../../../modules/settings/settings.module';
+import { Module } from '@nestjs/common';
 import { PlexApiService } from './plex-api.service';
 
 /**
  * PlexApiModule
  *
  * Provides the PlexApiService for internal use by other modules.
+ * Reads settings via the @Global SettingsDataService, so it does not import
+ * SettingsModule.
  */
 @Module({
-  imports: [forwardRef(() => SettingsModule)],
   controllers: [],
   providers: [PlexApiService],
   exports: [PlexApiService],

--- a/apps/server/src/modules/api/tmdb-api/tmdb.module.ts
+++ b/apps/server/src/modules/api/tmdb-api/tmdb.module.ts
@@ -1,10 +1,9 @@
-import { Module, forwardRef } from '@nestjs/common';
-import { SettingsModule } from '../../settings/settings.module';
+import { Module } from '@nestjs/common';
 import { ExternalApiModule } from '../external-api/external-api.module';
 import { TmdbApiService } from './tmdb.service';
 
 @Module({
-  imports: [ExternalApiModule, forwardRef(() => SettingsModule)],
+  imports: [ExternalApiModule],
   providers: [TmdbApiService],
   exports: [TmdbApiService],
 })

--- a/apps/server/src/modules/api/tvdb-api/tvdb.module.ts
+++ b/apps/server/src/modules/api/tvdb-api/tvdb.module.ts
@@ -1,10 +1,9 @@
-import { Module, forwardRef } from '@nestjs/common';
-import { SettingsModule } from '../../settings/settings.module';
+import { Module } from '@nestjs/common';
 import { ExternalApiModule } from '../external-api/external-api.module';
 import { TvdbApiService } from './tvdb.service';
 
 @Module({
-  imports: [ExternalApiModule, forwardRef(() => SettingsModule)],
+  imports: [ExternalApiModule],
   providers: [TvdbApiService],
   exports: [TvdbApiService],
 })

--- a/apps/server/src/modules/settings/media-server-switch.service.spec.ts
+++ b/apps/server/src/modules/settings/media-server-switch.service.spec.ts
@@ -7,6 +7,7 @@ import { dataDir as configDataDir } from '../../app/config/dataDir';
 import { Collection } from '../collections/entities/collection.entities';
 import { CollectionLog } from '../collections/entities/collection_log.entities';
 import { CollectionMedia } from '../collections/entities/collection_media.entities';
+import { MediaServerSwitchState } from '../api/media-server/media-server-switch-state.service';
 import { MaintainerrLogger } from '../logging/logs.service';
 import { Exclusion } from '../rules/entities/exclusion.entities';
 import { MediaServerSwitchService } from './media-server-switch.service';
@@ -49,6 +50,16 @@ describe('MediaServerSwitchService', () => {
     jest
       .spyOn(mediaServerFactory, 'uninitializeServer')
       .mockImplementation(() => undefined);
+
+    // Back the switch-state holder with real state so the concurrency guard
+    // (executeSwitch rejecting a second switch while one is in progress) works.
+    const switchState = unitRef.get(MediaServerSwitchState);
+    let switching = false;
+    switchState.isSwitching.mockImplementation(() => switching);
+    switchState.setSwitching.mockImplementation((value: boolean) => {
+      switching = value;
+    });
+
     unitRef.get(MaintainerrLogger);
   });
 

--- a/apps/server/src/modules/settings/media-server-switch.service.ts
+++ b/apps/server/src/modules/settings/media-server-switch.service.ts
@@ -4,19 +4,14 @@ import {
   SwitchMediaServerRequest,
   SwitchMediaServerResponse,
 } from '@maintainerr/contracts';
-import {
-  ConflictException,
-  forwardRef,
-  Inject,
-  Injectable,
-} from '@nestjs/common';
+import { ConflictException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as fs from 'fs';
 import * as path from 'path';
 import { DataSource, QueryRunner, Repository } from 'typeorm';
 import { dataDir as configDataDir } from '../../app/config/dataDir';
+import { MediaServerSwitchState } from '../api/media-server/media-server-switch-state.service';
 import { MediaServerFactory } from '../api/media-server/media-server.factory';
-import type { MediaServerFactory as MediaServerFactoryType } from '../api/media-server/media-server.factory';
 import { Collection } from '../collections/entities/collection.entities';
 import { CollectionLog } from '../collections/entities/collection_log.entities';
 import { CollectionMedia } from '../collections/entities/collection_media.entities';
@@ -46,20 +41,10 @@ const COLLECTION_POSTER_EXTENSION = '.jpg';
  */
 @Injectable()
 export class MediaServerSwitchService {
-  private switching = false;
-
-  /**
-   * Whether a media server switch is currently in progress.
-   * Used by MediaServerFactory to reject requests during the switch window.
-   */
-  public isSwitching(): boolean {
-    return this.switching;
-  }
-
   constructor(
     private readonly settingsDataService: SettingsDataService,
-    @Inject(forwardRef(() => MediaServerFactory))
-    private readonly mediaServerFactory: MediaServerFactoryType,
+    private readonly mediaServerFactory: MediaServerFactory,
+    private readonly mediaServerSwitchState: MediaServerSwitchState,
     @InjectRepository(Collection)
     private readonly collectionRepo: Repository<Collection>,
     @InjectRepository(CollectionMedia)
@@ -122,17 +107,17 @@ export class MediaServerSwitchService {
   async executeSwitch(
     request: SwitchMediaServerRequest,
   ): Promise<SwitchMediaServerResponse> {
-    if (this.switching) {
+    if (this.mediaServerSwitchState.isSwitching()) {
       throw new ConflictException(
         'A media server switch is already in progress',
       );
     }
-    this.switching = true;
+    this.mediaServerSwitchState.setSwitching(true);
 
     try {
       return await this.executeSwitchInternal(request);
     } finally {
-      this.switching = false;
+      this.mediaServerSwitchState.setSwitching(false);
     }
   }
 

--- a/apps/server/src/modules/settings/settings-data.service.ts
+++ b/apps/server/src/modules/settings/settings-data.service.ts
@@ -343,6 +343,46 @@ export class SettingsDataService implements SettingDto {
     return (this.media_server_type as MediaServerType) || null;
   }
 
+  // Test if all required media server settings are set.
+  public async testSetup(): Promise<boolean> {
+    try {
+      // If no media server type is selected, setup is not complete
+      if (!this.media_server_type) {
+        return false;
+      }
+
+      // Check based on configured media server type
+      if (this.media_server_type === MediaServerType.JELLYFIN) {
+        // Jellyfin requires URL and API key (user ID is optional, can be auto-detected later)
+        if (this.jellyfin_url && this.jellyfin_api_key) {
+          return true;
+        }
+      } else if (this.media_server_type === MediaServerType.EMBY) {
+        // Emby requires URL and API key (user ID is optional, can be auto-detected later)
+        if (this.emby_url && this.emby_api_key) {
+          return true;
+        }
+      } else if (this.media_server_type === MediaServerType.PLEX) {
+        // Plex requires hostname, name, port, and auth token
+        if (
+          this.plex_hostname &&
+          this.plex_name &&
+          this.plex_port &&
+          this.plex_auth_token
+        ) {
+          return true;
+        }
+      }
+      return false;
+    } catch (error) {
+      this.logger.debug(
+        'Failed to determine whether the application setup is complete',
+        error,
+      );
+      return false;
+    }
+  }
+
   /**
    * Get count of Radarr settings (for switch preview)
    */

--- a/apps/server/src/modules/settings/settings-operations.service.ts
+++ b/apps/server/src/modules/settings/settings-operations.service.ts
@@ -1357,54 +1357,7 @@ export class SettingsOperationsService {
 
   // Test if all required settings are set.
   public async testSetup(): Promise<boolean> {
-    try {
-      // If no media server type is selected, setup is not complete
-      if (!this.settingsDataService.media_server_type) {
-        return false;
-      }
-
-      // Check based on configured media server type
-      if (
-        this.settingsDataService.media_server_type === MediaServerType.JELLYFIN
-      ) {
-        // Jellyfin requires URL and API key (user ID is optional, can be auto-detected later)
-        if (
-          this.settingsDataService.jellyfin_url &&
-          this.settingsDataService.jellyfin_api_key
-        ) {
-          return true;
-        }
-      } else if (
-        this.settingsDataService.media_server_type === MediaServerType.EMBY
-      ) {
-        // Emby requires URL and API key (user ID is optional, can be auto-detected later)
-        if (
-          this.settingsDataService.emby_url &&
-          this.settingsDataService.emby_api_key
-        ) {
-          return true;
-        }
-      } else if (
-        this.settingsDataService.media_server_type === MediaServerType.PLEX
-      ) {
-        // Plex requires hostname, name, port, and auth token
-        if (
-          this.settingsDataService.plex_hostname &&
-          this.settingsDataService.plex_name &&
-          this.settingsDataService.plex_port &&
-          this.settingsDataService.plex_auth_token
-        ) {
-          return true;
-        }
-      }
-      return false;
-    } catch (error) {
-      this.logger.debug(
-        'Failed to determine whether the application setup is complete',
-        error,
-      );
-      return false;
-    }
+    return this.settingsDataService.testSetup();
   }
 
   public async getPlexServers() {

--- a/apps/server/src/modules/settings/settings.module.ts
+++ b/apps/server/src/modules/settings/settings.module.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Global, Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { InternalApiModule } from '../api/internal-api/internal-api.module';
 import { MediaServerModule } from '../api/media-server/media-server.module';
@@ -29,15 +29,15 @@ import { SettingsDataService } from './settings-data.service';
 @Global()
 @Module({
   imports: [
-    forwardRef(() => PlexApiModule),
-    forwardRef(() => MediaServerModule),
-    forwardRef(() => ServarrApiModule),
-    forwardRef(() => SeerrApiModule),
-    forwardRef(() => TautulliApiModule),
-    forwardRef(() => StreamystatsApiModule),
-    forwardRef(() => TmdbApiModule),
-    forwardRef(() => TvdbApiModule),
-    forwardRef(() => InternalApiModule),
+    PlexApiModule,
+    MediaServerModule,
+    ServarrApiModule,
+    SeerrApiModule,
+    TautulliApiModule,
+    StreamystatsApiModule,
+    TmdbApiModule,
+    TvdbApiModule,
+    InternalApiModule,
     TypeOrmModule.forFeature([
       Settings,
       RadarrSettings,


### PR DESCRIPTION
Follow-up to #2955. That PR split the `SettingsService` god-object and made `SettingsModule` a `@Global` provider of `SettingsDataService`, but left the module-level `forwardRef` wiring (and the one constructor cycle it called *irreducible*) in place. With the settings cycles gone, those workarounds are now removable.

## What this does
- **Vestigial drops** — the Plex, TMDB, TVDB, Jellyfin and Emby modules each only read settings via the `@Global` `SettingsDataService`, so their `forwardRef(() => SettingsModule)` import is dropped entirely.
- **SettingsModule** — its nine `forwardRef(() => XApiModule)` imports become plain imports, now that no API module imports `SettingsModule` back.
- **The last service cycle** — `MediaServerFactory ↔ MediaServerSwitchService` is broken by extracting the in-progress flag into a zero-dependency `MediaServerSwitchState` holder: the factory *reads* it, the switch service *writes* it, neither depends on the other.
- **The guard** — the data-only `testSetup()` moves onto `SettingsDataService` (kept as a delegating wrapper on `SettingsOperationsService`), so `MediaServerSetupGuard` reads it from the `@Global` service and `MediaServerModule` drops its `SettingsModule` import.

## Result
| | before | after |
|---|---|---|
| module `forwardRef` imports | 16 | **2** |
| `forwardRef` constructor injections | 2 | **0** |
| `@swc/jest` type-only aliases | 2 | **0** |

The only remaining `forwardRef`s are the genuine, pre-existing `CollectionsModule ↔ RulesModule` domain cycle (`RulesService` injects `CollectionsService`; `CollectionsController` reads the rule executor's processing state), untouched here and a clean candidate for the same flag-extraction pattern in a follow-up.

## Behaviour
Unchanged. The switch/conflict semantics, the public `testSetup` API, and the media-server setup guard all behave as before — only their wiring moved.

## Validation
build (tsc) ✓ · 75 suites / 1336 tests ✓ · lint ✓ · prettier ✓ · full Nest DI context boots with the rewired providers (no circular dependency) ✓.