### PR TITLE
chore: pre-approve project MCP servers (github, playwright)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "attribution": {
     "commit": ""
   },
+  "enabledMcpjsonServers": ["github", "playwright"],
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
Project-scoped .mcp.json servers require per-project approval before Claude Code loads them; without it the playwright server silently never attaches and its browser tools are unavailable. Add enabledMcpjsonServers so both configured servers auto-connect on session start.

