### PR TITLE
perf: cache hygiene for external API and metadata responses

### DIFF
--- a/apps/server/src/modules/api/external-api/external-api.service.spec.ts
+++ b/apps/server/src/modules/api/external-api/external-api.service.spec.ts
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios';
+import NodeCache from 'node-cache';
 import { ExternalApiService } from './external-api.service';
 
 describe('ExternalApiService', () => {
@@ -62,5 +63,70 @@ describe('ExternalApiService', () => {
     expect(logger.debug).toHaveBeenCalledWith(
       'GET https://example.test/items/123 failed (code=ETIMEDOUT)',
     );
+  });
+
+  describe('caching guard (isCacheable)', () => {
+    const createServiceWithCache = () => {
+      const logger = createLogger();
+      const cache = new NodeCache({ stdTTL: 300 });
+      const service = new ExternalApiService(
+        'https://example.test',
+        {},
+        logger as any,
+        { nodeCache: cache },
+      );
+      return { service, cache };
+    };
+
+    it('does not cache Buffer responses — second call hits the network again', async () => {
+      const { service } = createServiceWithCache();
+      const validObject = { data: 'ok' };
+
+      const getFn = jest
+        .fn()
+        .mockResolvedValueOnce({ data: Buffer.from('binary') })
+        .mockResolvedValueOnce({ data: validObject });
+
+      (service as any).axios = { get: getFn };
+
+      await service.get('/binary');
+      await service.get('/binary');
+
+      // Buffer was not cached, so two network calls were made
+      expect(getFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not cache null responses — second call hits the network again', async () => {
+      const { service } = createServiceWithCache();
+      const validObject = { items: [] };
+
+      const getFn = jest
+        .fn()
+        .mockResolvedValueOnce({ data: null })
+        .mockResolvedValueOnce({ data: validObject });
+
+      (service as any).axios = { get: getFn };
+
+      await service.get('/nullable');
+      await service.get('/nullable');
+
+      expect(getFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches valid object responses — second call does not hit the network', async () => {
+      const { service } = createServiceWithCache();
+      const validObject = { items: [1, 2, 3] };
+
+      const getFn = jest.fn().mockResolvedValueOnce({ data: validObject });
+
+      (service as any).axios = { get: getFn };
+
+      const first = await service.get('/data');
+      const second = await service.get('/data');
+
+      expect(getFn).toHaveBeenCalledTimes(1);
+      expect(first).toEqual(validObject);
+      expect(second).toEqual(validObject);
+    });
   });
 });

--- a/apps/server/src/modules/api/external-api/external-api.service.ts
+++ b/apps/server/src/modules/api/external-api/external-api.service.ts
@@ -57,7 +57,7 @@ export class ExternalApiService {
       }
       const response = await this.axios.get<T>(endpoint, config);
 
-      if (this.cache) {
+      if (this.cache && this.isCacheable(response.data)) {
         this.cache.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
       }
 
@@ -146,7 +146,9 @@ export class ExternalApiService {
           Date.now() - DEFAULT_ROLLING_BUFFER
         ) {
           void this.axios.get<T>(endpoint, config).then((response) => {
-            this.cache?.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
+            if (this.isCacheable(response.data)) {
+              this.cache?.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
+            }
           });
         }
         return cachedItem;
@@ -154,7 +156,7 @@ export class ExternalApiService {
 
       const response = await this.axios.get<T>(endpoint, config);
 
-      if (this.cache) {
+      if (this.cache && this.isCacheable(response.data)) {
         this.cache.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
       }
 
@@ -188,7 +190,9 @@ export class ExternalApiService {
           this.axios
             .post<T>(endpoint, data, config)
             .then((response) => {
-              this.cache?.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
+              if (this.isCacheable(response.data)) {
+                this.cache?.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
+              }
             })
             .catch((error: AxiosError) => {
               if (error.response?.status === 429) {
@@ -220,15 +224,19 @@ export class ExternalApiService {
           return undefined;
         });
 
-      if (this.cache) {
+      if (this.cache && this.isCacheable(response?.data)) {
         this.cache.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
       }
 
-      return response.data;
+      return response?.data;
     } catch (error: any) {
       this.logger.warn(this.formatRequestFailure('POST', url, error));
       return undefined;
     }
+  }
+
+  private isCacheable(data: unknown): boolean {
+    return data != null && typeof data === 'object' && !Buffer.isBuffer(data);
   }
 
   private logRequestFailure(

--- a/apps/server/src/modules/api/lib/cache.ts
+++ b/apps/server/src/modules/api/lib/cache.ts
@@ -21,6 +21,9 @@ const DEFAULT_CHECK_PERIOD = 120; // 2 min
 type CacheOptions = {
   stdTtl?: number;
   checkPeriod?: number;
+  // If true, this cache is NOT flushed by flushAll(). Use for external metadata
+  // caches (e.g. TMDB, TVDB) whose data doesn't change between rule group runs.
+  persistent?: boolean;
 };
 
 export class Cache {
@@ -28,6 +31,7 @@ export class Cache {
   public data: NodeCache;
   public name: string;
   public type?: CacheType;
+  public persistent: boolean;
 
   constructor(
     id: string,
@@ -38,6 +42,7 @@ export class Cache {
     this.id = id;
     this.name = name;
     this.type = type;
+    this.persistent = options.persistent ?? false;
     this.data = new NodeCache({
       stdTTL: options.stdTtl ?? DEFAULT_TTL,
       checkperiod: options.checkPeriod ?? DEFAULT_CHECK_PERIOD,
@@ -58,10 +63,12 @@ class CacheManager {
     tmdb: new Cache('tmdb', 'The Movie Database API', 'tmdb', {
       stdTtl: 21600, // 6 hours
       checkPeriod: 60 * 30,
+      persistent: true,
     }),
     tvdb: new Cache('tvdb', 'TheTVDB API', 'tvdb', {
       stdTtl: 21600, // 6 hours
       checkPeriod: 60 * 30,
+      persistent: true,
     }),
     plexguid: new Cache('plexguid', 'Plex GUID', 'plexguid'),
     plextv: new Cache('plextv', 'Plex.tv', 'plextv'),
@@ -110,7 +117,9 @@ class CacheManager {
 
   public flushAll(): void {
     for (const [, value] of Object.entries(this.getAllCaches())) {
-      value.flush();
+      if (!value.persistent) {
+        value.flush();
+      }
     }
   }
 }

--- a/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.ts
+++ b/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.ts
@@ -57,7 +57,7 @@ export class TmdbMetadataProvider implements IMetadataProvider {
     type: 'movie' | 'tv',
   ): Promise<MetadataDetails | undefined> {
     const record = await this.getRecord(tmdbId, type);
-    if (!record) {
+    if (!record || typeof record !== 'object') {
       return undefined;
     }
 


### PR DESCRIPTION
Reduced to the cache-hygiene fixes after review — the original Radarr/Sonarr bulk-fetch, Plex watch-history prefetch, Plex collection/watchlist caching, and broad cache persistence were dropped (see review thread for the reasoning).

## Changes

- **ExternalApiService**: skip caching `Buffer` / `null` / non-object responses, so binary blobs and empty bodies can't poison the shared NodeCaches. Applied to every cache write (GET, both rolling refreshes, and the cached POST).
- **cache**: mark only the `tmdb`/`tvdb` caches `persistent` so the per-run `flushAll()` no longer evicts immutable external metadata (6h TTL) every rule run. The metadata-settings refresh still flushes them directly, so manual refreshes are unaffected.
- **metadata providers**: ignore non-object records — `tmdb` uses the `in` operator, which throws on a non-object response; `tvdb` guarded for symmetry.

## Follow-up (out of scope)

A leaf-only (movie/episode) watch-history bulk prefetch could still be worthwhile; it was dropped here because Plex has no documented way to roll a bulk `/status/sessions/history/all` sweep up to show/season level. Tracked for a separate PR.
