### PR TITLE
feat(ui): adopt Tailwind v4.x features

### DIFF
--- a/apps/ui/src/components/Collection/CollectionDetail/CollectionInfo/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/CollectionInfo/index.tsx
@@ -131,9 +131,12 @@ const CollectionInfo = (props: ICollectionInfo) => {
                       value={currentFilter}
                       join="right"
                     >
-                      <option key={`filter-option-all`} value={-1}>
-                        -
-                      </option>
+                      <option
+                        key={`filter-option-all`}
+                        value={-1}
+                        aria-label="No filter"
+                      />
+
                       {Object.values(ECollectionLogType)
                         .filter((value) => typeof value === 'number')
                         .map((value, index) => {

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
@@ -642,7 +642,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
             </div>
           </div>
           <div className="p-4">
-            <div className="flex items-center justify-between border-b pb-4">
+            <div className="flex items-center justify-between border-b border-zinc-700 pb-4">
               <div>
                 <h2 className="text-xl font-semibold text-gray-100">
                   {title}

--- a/apps/ui/src/components/Common/MediaCard/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/index.tsx
@@ -192,11 +192,13 @@ const MediaCard: React.FC<IMediaCard> = ({
                 <div className="flex h-full w-full items-end">
                   <div className={`w-full px-2 pb-1 text-zinc-200`}>
                     {displayYear && (
-                      <div className="text-sm font-medium">{displayYear}</div>
+                      <div className="text-sm font-medium text-shadow-sm">
+                        {displayYear}
+                      </div>
                     )}
 
                     <h1
-                      className="w-full text-sm leading-tight font-bold whitespace-normal"
+                      className="w-full text-sm leading-tight font-bold whitespace-normal text-shadow-sm"
                       style={{
                         WebkitLineClamp: 3,
                         display: '-webkit-box',
@@ -209,7 +211,7 @@ const MediaCard: React.FC<IMediaCard> = ({
                     </h1>
                     {mediaType == 'episode' && (
                       <div
-                        className="text-xs whitespace-normal"
+                        className="text-xs whitespace-normal text-shadow-sm"
                         style={{
                           WebkitLineClamp: 5,
                           display: '-webkit-box',

--- a/apps/ui/src/components/Common/SearchBar/index.tsx
+++ b/apps/ui/src/components/Common/SearchBar/index.tsx
@@ -43,7 +43,7 @@ const SearchBar = (props: ISearchBar) => {
         onChange={(e) => inputHandler(e)}
         placeholder={placeholder ? placeholder : 'Search'}
         value={displayedValue}
-        className="block w-full rounded-full border border-zinc-600 bg-zinc-900/80 py-2 pl-10 text-white placeholder-zinc-300 hover:border-zinc-500 focus:border-zinc-500 focus:bg-zinc-900 focus:placeholder-zinc-400 focus:ring-0 focus:outline-hidden sm:text-base"
+        className="pl-10"
       />
     </div>
   )

--- a/apps/ui/src/components/Forms/Input.tsx
+++ b/apps/ui/src/components/Forms/Input.tsx
@@ -6,8 +6,9 @@ import {
   InputHTMLAttributes,
 } from 'react'
 
+// Field base styling lives in the global `input/select/textarea` rule in
+// globals.css (single source of truth). Only deltas live here.
 const inputClassNames = {
-  base: 'block w-full min-w-0 flex-1 rounded-md border border-zinc-500 bg-zinc-700 text-white shadow-xs transition duration-150 ease-in-out focus:border-maintainerr-600 focus:outline-hidden focus:ring-0 disabled:opacity-50 sm:text-sm sm:leading-5',
   leadingAdornment:
     'inline-flex cursor-default items-center rounded-l-md border border-r-0 border-zinc-500 bg-zinc-700 px-3 text-sm text-zinc-100 transition duration-150 ease-in-out group-focus-within:border-maintainerr-600',
   joinedLeft: 'rounded-l-only rounded-r-none border-r-0',
@@ -49,7 +50,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         ref={ref}
         id={props.id || props.name}
         className={clsx(
-          inputClassNames.base,
           join === 'left' && inputClassNames.joinedLeft,
           join === 'right' && inputClassNames.joinedRight,
           !props.disabled &&

--- a/apps/ui/src/components/Forms/Select.tsx
+++ b/apps/ui/src/components/Forms/Select.tsx
@@ -2,10 +2,13 @@ import { ChevronDownIcon } from '@heroicons/react/solid'
 import clsx from 'clsx'
 import { ReactNode, SelectHTMLAttributes, forwardRef } from 'react'
 
+// Field base styling lives in the global `input/select/textarea` rule in
+// globals.css (single source of truth). Only select-specific deltas live here
+// (hide the native arrow for the custom chevron, left-align, horizontal pad).
 const selectClassNames = {
-  base: 'block h-10 w-full min-w-0 flex-1 appearance-none rounded-md border border-zinc-600 bg-zinc-600 px-3 text-left text-white shadow-none transition duration-150 ease-in-out focus:border-maintainerr-600 focus:outline-hidden focus:ring-0 disabled:opacity-50 sm:text-sm sm:leading-5',
+  base: 'appearance-none px-3 text-left',
   leadingAdornment:
-    'inline-flex cursor-default items-center rounded-l-md border border-r-0 border-zinc-600 bg-zinc-600 px-3 text-sm text-zinc-100 transition duration-150 ease-in-out group-focus-within:border-maintainerr-600',
+    'inline-flex cursor-default items-center rounded-l-md border border-r-0 border-zinc-500 bg-zinc-700 px-3 text-sm text-zinc-100 transition duration-150 ease-in-out group-focus-within:border-maintainerr-600',
   joinedLeft: 'rounded-l-only rounded-r-none border-r-0',
   joinedRight: 'rounded-r-only border-l-0',
 } as const

--- a/apps/ui/src/components/OverlayEditor/PropertiesPanel.tsx
+++ b/apps/ui/src/components/OverlayEditor/PropertiesPanel.tsx
@@ -150,7 +150,7 @@ function TextProperties({
     <>
       <FieldGroup label="Text">
         <textarea
-          className="block field-sizing-content w-full min-w-0 flex-1 rounded-md border border-zinc-500 bg-zinc-700 px-3 py-1.5 text-sm text-white shadow-xs transition duration-150 ease-in-out focus:border-maintainerr-600 focus:ring-0 focus:outline-hidden disabled:opacity-50"
+          className="block field-sizing-content min-h-14 w-full min-w-0 flex-1 rounded-md border border-zinc-500 bg-zinc-700 px-3 py-1.5 text-sm text-white shadow-xs transition duration-150 ease-in-out focus:border-maintainerr-600 focus:ring-0 focus:outline-hidden disabled:opacity-50"
           rows={2}
           value={el.text}
           onChange={(e) => update('text', e.target.value)}

--- a/apps/ui/src/components/OverlayEditor/PropertiesPanel.tsx
+++ b/apps/ui/src/components/OverlayEditor/PropertiesPanel.tsx
@@ -150,7 +150,7 @@ function TextProperties({
     <>
       <FieldGroup label="Text">
         <textarea
-          className="block w-full min-w-0 flex-1 rounded-md border border-zinc-500 bg-zinc-700 px-3 py-1.5 text-sm text-white shadow-xs transition duration-150 ease-in-out focus:border-maintainerr-600 focus:ring-0 focus:outline-hidden disabled:opacity-50"
+          className="block field-sizing-content w-full min-w-0 flex-1 rounded-md border border-zinc-500 bg-zinc-700 px-3 py-1.5 text-sm text-white shadow-xs transition duration-150 ease-in-out focus:border-maintainerr-600 focus:ring-0 focus:outline-hidden disabled:opacity-50"
           rows={2}
           value={el.text}
           onChange={(e) => update('text', e.target.value)}

--- a/apps/ui/src/components/Overview/Content/index.tsx
+++ b/apps/ui/src/components/Overview/Content/index.tsx
@@ -125,83 +125,88 @@ const OverviewContent = (props: IOverviewContent) => {
           <LoadingSpinner />
         </div>
       ) : hasData ? (
-        <ul
-          className="cards-vertical"
-          aria-busy={loading || Boolean(extrasLoading)}
-        >
-          {data.map((el) => (
-            <li key={el.id}>
-              <MediaCard
-                id={el.id}
-                libraryId={props.libraryId}
-                type={el.type}
-                summary={
-                  el.type === 'movie' || el.type === 'show'
-                    ? el.summary
-                    : el.type === 'season'
-                      ? el.title
-                      : el.type === 'episode'
-                        ? 'Episode ' + el.index + ' - ' + el.title
-                        : ''
-                }
-                year={
-                  el.type === 'episode'
-                    ? el.parentTitle
-                    : getParentYear(el)
-                      ? getParentYear(el)?.toString()
-                      : el.year?.toString()
-                }
-                mediaType={el.type}
-                title={
-                  el.grandparentTitle
-                    ? el.grandparentTitle
-                    : el.parentTitle
+        // @container lets the grid size its columns to this wrapper's width
+        // (not the viewport), so it lays out correctly inside narrow contexts
+        // like the collection-detail exclusions slideover.
+        <div className="@container">
+          <ul
+            className="cards-vertical"
+            aria-busy={loading || Boolean(extrasLoading)}
+          >
+            {data.map((el) => (
+              <li key={el.id}>
+                <MediaCard
+                  id={el.id}
+                  libraryId={props.libraryId}
+                  type={el.type}
+                  summary={
+                    el.type === 'movie' || el.type === 'show'
+                      ? el.summary
+                      : el.type === 'season'
+                        ? el.title
+                        : el.type === 'episode'
+                          ? 'Episode ' + el.index + ' - ' + el.title
+                          : ''
+                  }
+                  year={
+                    el.type === 'episode'
                       ? el.parentTitle
-                      : el.title
-                }
-                exclusionId={
-                  el.maintainerrExclusionId
-                    ? el.maintainerrExclusionId
-                    : undefined
-                }
-                providerIds={extractProviderIds(el)}
-                collectionPage={
-                  props.collectionPage ? props.collectionPage : false
-                }
-                exclusionType={el.maintainerrExclusionType}
-                onRemove={props.onRemove}
-                collectionId={props.collectionId}
-                collection={
-                  props.collection ??
-                  props.collectionInfo?.find(
-                    (colEl) => colEl.mediaServerId === el.id,
-                  )?.collection
-                }
-                isManual={
-                  el.maintainerrIsManual ? el.maintainerrIsManual : false
-                }
-                {...(props.collectionInfo
-                  ? {
-                      daysLeft: getDaysLeft(el.id),
-                      collectionId: props.collectionInfo.find(
-                        (colEl) => colEl.mediaServerId === el.id,
-                      )?.collectionId,
-                    }
-                  : undefined)}
-              />
-            </li>
-          ))}
-          {showAppendLoading ? (
-            <li
-              className="flex min-h-10 items-center justify-center"
-              style={{ overflowAnchor: 'none' }}
-            >
-              <div role="status" aria-label="Loading more items">
-                <SmallLoadingSpinner className="h-10 w-10" />
-              </div>
-            </li>
-          ) : null}
-        </ul>
+                      : getParentYear(el)
+                        ? getParentYear(el)?.toString()
+                        : el.year?.toString()
+                  }
+                  mediaType={el.type}
+                  title={
+                    el.grandparentTitle
+                      ? el.grandparentTitle
+                      : el.parentTitle
+                        ? el.parentTitle
+                        : el.title
+                  }
+                  exclusionId={
+                    el.maintainerrExclusionId
+                      ? el.maintainerrExclusionId
+                      : undefined
+                  }
+                  providerIds={extractProviderIds(el)}
+                  collectionPage={
+                    props.collectionPage ? props.collectionPage : false
+                  }
+                  exclusionType={el.maintainerrExclusionType}
+                  onRemove={props.onRemove}
+                  collectionId={props.collectionId}
+                  collection={
+                    props.collection ??
+                    props.collectionInfo?.find(
+                      (colEl) => colEl.mediaServerId === el.id,
+                    )?.collection
+                  }
+                  isManual={
+                    el.maintainerrIsManual ? el.maintainerrIsManual : false
+                  }
+                  {...(props.collectionInfo
+                    ? {
+                        daysLeft: getDaysLeft(el.id),
+                        collectionId: props.collectionInfo.find(
+                          (colEl) => colEl.mediaServerId === el.id,
+                        )?.collectionId,
+                      }
+                    : undefined)}
+                />
+              </li>
+            ))}
+            {showAppendLoading ? (
+              <li
+                className="flex min-h-10 items-center justify-center"
+                style={{ overflowAnchor: 'none' }}
+              >
+                <div role="status" aria-label="Loading more items">
+                  <SmallLoadingSpinner className="h-10 w-10" />
+                </div>
+              </li>
+            ) : null}
+          </ul>
+        </div>
       ) : (
         <div className="flex min-h-80 items-center justify-center rounded-xl border border-dashed border-zinc-700 bg-zinc-900/30 p-6 text-sm text-zinc-400">
           No items found.

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -902,7 +902,7 @@ const AddModal = (props: AddModal) => {
                 General
               </h2>
               <div className="flex w-full flex-col rounded-lg bg-zinc-800 px-3 py-1">
-                <div className="space-y-2 md:p-4">
+                <div className="md:p-4">
                   <div className="form-row items-center">
                     <label htmlFor="name" className="text-label">
                       Name *
@@ -931,7 +931,7 @@ const AddModal = (props: AddModal) => {
                       <div className="form-input-field">
                         <textarea
                           id="description"
-                          className="field-sizing-content"
+                          className="field-sizing-content min-h-30"
                           rows={5}
                           {...register('description')}
                         ></textarea>

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -931,6 +931,7 @@ const AddModal = (props: AddModal) => {
                       <div className="form-input-field">
                         <textarea
                           id="description"
+                          className="field-sizing-content"
                           rows={5}
                           {...register('description')}
                         ></textarea>

--- a/apps/ui/styles/globals.css
+++ b/apps/ui/styles/globals.css
@@ -104,22 +104,6 @@
   transition-property: width;
 }
 
-/*
-  Tailwind CSS v4 changed the default border color to `currentColor`.
-  Preserve the v3 default so existing bordered elements look unchanged.
-  To drop this shim, add an explicit border-color utility wherever a border
-  relies on the old gray-200 default.
-*/
-@layer base {
-  *,
-  ::after,
-  ::before,
-  ::backdrop,
-  ::file-selector-button {
-    border-color: var(--color-gray-200, currentcolor);
-  }
-}
-
 :root {
   --toastify-color-success: var(--color-success);
   --toastify-color-error: var(--color-error);
@@ -143,6 +127,12 @@
 
 @layer base {
   html {
+    /*
+      The app is dark-only. `color-scheme: dark` tells the browser to render
+      native controls (date pickers, <select> dropdowns, scrollbars, autofill,
+      spin buttons) with their dark UA styling instead of the light default.
+    */
+    color-scheme: dark;
     min-height: calc(100% + env(safe-area-inset-top));
     padding: env(safe-area-inset-top) env(safe-area-inset-right)
       env(safe-area-inset-bottom) env(safe-area-inset-left);
@@ -317,7 +307,9 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  @media (min-width: 440px) {
+  /* Sizes to the nearest `@container` ancestor (see Overview/Content), so the
+     grid reflows by its own width rather than the viewport's. */
+  @container (min-width: 440px) {
     ul.cards-vertical {
       grid-template-columns: repeat(auto-fill, minmax(9.375rem, 1fr));
     }

--- a/apps/ui/styles/globals.css
+++ b/apps/ui/styles/globals.css
@@ -543,13 +543,21 @@
     @apply h-6 w-6 rounded-md border-zinc-600 text-maintainerr-600 transition duration-150 ease-in-out hover:border-zinc-500 focus:border-zinc-500 focus:ring-0 focus:ring-offset-0 focus:outline-hidden;
   }
 
+  /*
+    Single source of truth for form field styling. Applies to every native
+    field element (raw or rendered by Forms/Input, Forms/Select, etc.), so
+    changing it here restyles all inputs, selects, and textareas at once. The
+    components only add element-specific deltas (select chevron, adornments,
+    error states) on top — they must not re-declare this base.
+  */
   input[type='text'],
   input[type='password'],
   input[type='number'],
   input[type='date'],
+  input[type='search'],
   select,
   textarea {
-    @apply block w-full min-w-0 flex-1 rounded-md border border-zinc-500 bg-zinc-700 text-white transition duration-150 ease-in-out sm:text-sm sm:leading-5;
+    @apply block w-full min-w-0 flex-1 rounded-md border border-zinc-500 bg-zinc-700 text-white shadow-xs transition duration-150 ease-in-out focus:border-maintainerr-600 focus:ring-0 focus:outline-hidden disabled:opacity-50 sm:text-sm sm:leading-5;
   }
 
   input.rounded-l-only,


### PR DESCRIPTION
Follow-up to the Tailwind v4 migration (#2969), implementing the opportunities tracked in #2970.

- **`color-scheme: dark`** on `html` — native controls (`<select>` dropdowns/arrows, date pickers, scrollbars, autofill) now render dark instead of light.
- **Container query** for the media-card grid — `ul.cards-vertical` now sizes its columns to its `@container` wrapper rather than the viewport, so it reflows correctly inside narrow contexts (e.g. the collection-detail exclusions slideover).
- **`field-sizing-content`** on the rule Description and overlay Text textareas — they auto-grow with content, no JS.
- **`text-shadow`** on the poster-overlaid title/year/summary text for legibility over artwork.
- **Removed the v3→v4 border-color compat shim.** Audited every bordered element; only one relied on the old `gray-200` default (a divider in the media modal) — made explicit with the app's standard `border-zinc-700`.

Closes #2970