### PR TITLE
feat(rules): add Plex "Amount of episodes marked as watched" rule

### DIFF
--- a/apps/server/src/modules/rules/constants/rules.constants.ts
+++ b/apps/server/src/modules/rules/constants/rules.constants.ts
@@ -259,6 +259,14 @@ export class RuleConstants {
           showType: ['show', 'season'],
         },
         {
+          id: 45,
+          name: 'sw_markedWatchedEpisodes',
+          humanName: 'Amount of episodes marked as watched',
+          mediaType: MediaType.SHOW,
+          type: RuleType.NUMBER,
+          showType: ['show', 'season'],
+        },
+        {
           id: 16,
           name: 'sw_lastEpisodeAddedAt',
           humanName: 'Last episode added at',

--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -77,6 +77,32 @@ describe('PlexGetterService', () => {
     });
   });
 
+  describe('sw_markedWatchedEpisodes (id 45)', () => {
+    const MARKED_WATCHED_PROP_ID = 45;
+
+    it('returns Plex viewedLeafCount (watched state, including manual marks)', async () => {
+      const libItem = createMediaItem({ id: PLEX_ITEM_ID, type: 'show' });
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({ type: 'show', leafCount: 22, viewedLeafCount: 22 }),
+      );
+
+      const result = await service.get(MARKED_WATCHED_PROP_ID, libItem);
+
+      expect(result).toBe(22);
+    });
+
+    it('returns 0 when no episodes are marked as watched', async () => {
+      const libItem = createMediaItem({ id: PLEX_ITEM_ID, type: 'show' });
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({ type: 'show', leafCount: 10, viewedLeafCount: 0 }),
+      );
+
+      const result = await service.get(MARKED_WATCHED_PROP_ID, libItem);
+
+      expect(result).toBe(0);
+    });
+  });
+
   it('requests external media metadata for IMDb ratings', async () => {
     const mediaItem = createMediaItem({ id: PLEX_ITEM_ID });
 

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -388,6 +388,13 @@ export class PlexGetterService {
           }
           return viewCount;
         }
+        case 'sw_markedWatchedEpisodes': {
+          // Uses Plex's watched STATE (viewedLeafCount) instead of play history.
+          // Unlike sw_viewedEpisodes (which counts episodes with a play-history
+          // entry), this also counts episodes manually marked as watched: Plex
+          // updates viewedLeafCount for manual marks but records no play history.
+          return metadata.viewedLeafCount ? +metadata.viewedLeafCount : 0;
+        }
         case 'sw_amountOfViews': {
           let viewCount = 0;
 


### PR DESCRIPTION
### Description & Design

Currently, there is no way to create a rule that counts all shows with a "watched" state in Plex. The two available options:
 1. Users who have watched all episodes
 2. No of watched episodes

Both require a legitimate watch history, whereas a user can mark an episode/season/show as watched, which cannot be caught by any existing rule. 

This change just adds a new rule property (sw_markedWatchedEpisodes) backed by Plex's viewedLeafCount (watched state) instead of play history. It's worth noting that all the data is already retrieved, and an equivalent option already exists for movies, this just ports it across to TV Shows.

### Related issue

None that I could find

### AI-Assisted Development

Solution implemented via Claude, verified and tested by hand.

### Checklist

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [X] I understand the code I am submitting and can explain how it works
- [X] I have performed a self-review of my code
- [X] I have linted and formatted my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

### How to test

Please describe the steps to test your changes, including any setup required.

1. Find an unwatched episode of a show in Plex & mark it as watched
2. Set up the following rules
<img width="1114" height="582" alt="Screenshot 2026-05-24 at 9 06 44 pm" src="https://github.com/user-attachments/assets/87886e17-af68-4530-89f1-9f9b0e16f746" />
<img width="1110" height="562" alt="Screenshot 2026-05-24 at 9 06 37 pm" src="https://github.com/user-attachments/assets/12aa2862-bdac-41bf-ac32-da3b4deaba62" />
 3. Note that the show appears in the new collection but not the existing one
