### PR TITLE
fix(rules): robust community/YAML rule import across media servers

### DIFF
--- a/apps/server/src/modules/rules/constants/constants.service.ts
+++ b/apps/server/src/modules/rules/constants/constants.service.ts
@@ -64,16 +64,25 @@ export class RuleConstanstService {
     return this.ruleConstants;
   }
 
-  public getValueIdentifier(location: [number, number]) {
+  /**
+   * Build the `App.property` identifier for a rule value, or return null when
+   * the application/property no longer exists in the constants (e.g. a rule
+   * authored on an older version referencing a since-removed property). Callers
+   * must skip such values rather than emit `App.undefined`, which produces YAML
+   * that cannot be decoded again.
+   */
+  public getValueIdentifier(location: [number, number]): string | null {
     const application = this.ruleConstants.applications.find(
       (el) => el.id === location[0],
-    )?.name;
+    );
 
-    const rule = this.ruleConstants.applications
-      .find((el) => el.id === location[0])
-      ?.props.find((el) => el.id === location[1])?.name;
+    const rule = application?.props.find((el) => el.id === location[1]);
 
-    return application + '.' + rule;
+    if (!application || !rule) {
+      return null;
+    }
+
+    return application.name + '.' + rule.name;
   }
 
   public getValueHumanName(location: [number, number]) {
@@ -103,17 +112,28 @@ export class RuleConstanstService {
     return buildDynamicNullReason(prop, application?.name);
   }
 
-  public getValueFromIdentifier(identifier: string): [number, number] {
+  /**
+   * Resolve an `App.property` identifier back to its `[appId, propId]` pair, or
+   * return null when either part is unknown. Callers must skip the rule rather
+   * than crash the whole import, so a single stale identifier (e.g. from an
+   * older export) doesn't reject an otherwise-valid YAML document.
+   */
+  public getValueFromIdentifier(identifier: string): [number, number] | null {
     const application = identifier.split('.')[0];
     const rule = identifier.split('.')[1];
 
     const applicationConstant = this.ruleConstants.applications.find(
-      (el) => el.name.toLowerCase() === application.toLowerCase(),
+      (el) => el.name.toLowerCase() === application?.toLowerCase(),
     );
 
-    const ruleConstant = applicationConstant.props.find(
-      (el) => el.name.toLowerCase() === rule.toLowerCase(),
+    const ruleConstant = applicationConstant?.props.find(
+      (el) => el.name.toLowerCase() === rule?.toLowerCase(),
     );
+
+    if (!applicationConstant || !ruleConstant) {
+      return null;
+    }
+
     return [applicationConstant.id, ruleConstant.id];
   }
 

--- a/apps/server/src/modules/rules/helpers/section-operators.ts
+++ b/apps/server/src/modules/rules/helpers/section-operators.ts
@@ -1,0 +1,40 @@
+import { RuleOperators } from '../constants/rules.constants';
+import { RuleDto } from '../dtos/rule.dto';
+
+/**
+ * Re-assert each section's combine operator onto its first surviving rule.
+ *
+ * When rules are dropped on import (an unresolved YAML identifier, or a property
+ * with no equivalent on the configured media server), a section's original first
+ * rule may be gone. Without this the next surviving rule keeps its within-section
+ * operator and silently becomes the section boundary, flipping the section
+ * AND<->OR. Shared by the YAML decode and the cross-server migration import paths.
+ *
+ * @param rules surviving rules in section/order; mutated in place.
+ * @param sectionCombineOp section -> the operator of that section's ORIGINAL
+ *   first rule, captured before any rules were dropped.
+ */
+export function reassertSectionBoundaryOperators(
+  rules: RuleDto[],
+  sectionCombineOp: Map<number, RuleDto['operator']>,
+): void {
+  const seenSections = new Set<number>();
+
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i];
+    if (seenSections.has(rule.section)) continue;
+    seenSections.add(rule.section);
+
+    // The first rule of the whole group is always null. Every other section's
+    // first surviving rule keeps that section's original combine operator,
+    // defaulting to AND when it was unset (the section-combine default).
+    const desired =
+      i === 0
+        ? null
+        : (sectionCombineOp.get(rule.section) ?? RuleOperators.AND);
+
+    if (rule.operator !== desired) {
+      rules[i] = { ...rule, operator: desired };
+    }
+  }
+}

--- a/apps/server/src/modules/rules/helpers/yaml.service.spec.ts
+++ b/apps/server/src/modules/rules/helpers/yaml.service.spec.ts
@@ -108,4 +108,94 @@ describe('RuleYamlService', () => {
       RuleOperators.AND,
     ]);
   });
+
+  it('skips a rule with an unresolved property on export instead of emitting App.undefined', () => {
+    // Second rule references a property that no longer resolves.
+    ruleConstants.getValueIdentifier.mockImplementation(
+      (loc: [number, number]) => (loc[1] === 99 ? null : 'Plex.viewCount'),
+    );
+
+    const result = service.encode(
+      [
+        {
+          operator: null,
+          action: RulePossibility.EQUALS,
+          firstVal: [0, 5],
+          section: 0,
+        },
+        {
+          operator: RuleOperators.OR,
+          action: RulePossibility.BIGGER,
+          firstVal: [0, 99],
+          section: 0,
+        },
+      ],
+      'movie',
+    );
+
+    expect(result.code).toBe(1);
+    expect(result.skipped).toBe(1); // surfaced to the user on export
+    const yaml = result.result as string;
+    expect(yaml).not.toContain('undefined'); // no `App.undefined`
+    const parsed = YAML.parse(yaml);
+    expect(parsed.rules[0]['0']).toHaveLength(1); // unresolved rule omitted
+  });
+
+  it('skips a rule with an unresolved identifier on import instead of failing the whole document', () => {
+    // First rule resolves, second does not.
+    ruleConstants.getValueFromIdentifier.mockImplementation(
+      (identifier: string) =>
+        identifier.includes('gone') ? null : ([0, 5] as [number, number]),
+    );
+
+    const yaml = YAML.stringify({
+      mediaType: 'MOVIES',
+      rules: [
+        {
+          0: [
+            { firstValue: 'Plex.viewCount', action: 'EQUALS' },
+            { operator: 'OR', firstValue: 'Plex.gone', action: 'BIGGER' },
+          ],
+        },
+      ],
+    });
+
+    const decoded = service.decode(yaml, 'movie');
+
+    expect(decoded.code).toBe(1); // not a whole-document failure
+    expect(decoded.skipped).toBe(1); // surfaced (top-level) to the user on import
+    const parsed = JSON.parse(decoded.result as string);
+    expect(parsed.rules).toHaveLength(1); // the unresolved rule was skipped
+    expect(parsed.rules[0].firstVal).toEqual([0, 5]);
+  });
+
+  it('gives the section-boundary AND default to the first surviving rule when an earlier one is skipped', () => {
+    ruleConstants.getValueFromIdentifier.mockImplementation(
+      (identifier: string) =>
+        identifier.includes('gone') ? null : ([0, 5] as [number, number]),
+    );
+
+    const yaml = YAML.stringify({
+      mediaType: 'MOVIES',
+      rules: [
+        { 0: [{ firstValue: 'Plex.viewCount', action: 'EQUALS' }] },
+        {
+          1: [
+            // First rule of section 1 is unresolved -> skipped. The next rule
+            // (no explicit operator) is now the section boundary and must
+            // default to AND, not OR.
+            { firstValue: 'Plex.gone', action: 'BIGGER' },
+            { firstValue: 'Plex.viewCount', action: 'BIGGER' },
+          ],
+        },
+      ],
+    });
+
+    const decoded = service.decode(yaml, 'movie');
+    const rules: RuleDto[] = JSON.parse(decoded.result as string).rules;
+
+    expect(rules.map((r) => r.section)).toEqual([0, 1]);
+    expect(rules[0].operator).toBeNull(); // first rule of the group
+    expect(rules[1].operator).toBe(RuleOperators.AND); // section boundary, not OR
+  });
 });

--- a/apps/server/src/modules/rules/helpers/yaml.service.ts
+++ b/apps/server/src/modules/rules/helpers/yaml.service.ts
@@ -13,6 +13,7 @@ import {
 import { RuleOperators, RulePossibility } from '../constants/rules.constants';
 import { RuleDto } from '../dtos/rule.dto';
 import { ReturnStatus } from '../rules.service';
+import { reassertSectionBoundaryOperators } from './section-operators';
 
 interface IRuleYamlParent {
   mediaType: string;
@@ -45,6 +46,7 @@ export class RuleYamlService {
     try {
       let workingSection = { id: 0, rules: [] };
       const sections: ISectionYaml[] = [];
+      let skipped = 0;
 
       for (const rule of rules) {
         if (rule.section !== workingSection.id) {
@@ -55,6 +57,26 @@ export class RuleYamlService {
           workingSection = { id: rule.section, rules: [] };
         }
 
+        const firstValue = this.ruleConstanstService.getValueIdentifier(
+          rule.firstVal,
+        );
+        const lastValue = rule.lastVal
+          ? this.ruleConstanstService.getValueIdentifier(rule.lastVal)
+          : undefined;
+
+        // Skip an unresolved property rather than emit `App.undefined`, which
+        // produces YAML that cannot be decoded again. The section boundary was
+        // already advanced, so section keys stay aligned with the kept rules.
+        if (firstValue == null || (rule.lastVal != null && lastValue == null)) {
+          skipped += 1;
+          this.logger.warn(
+            `Skipping rule on YAML export: unresolved property identifier ` +
+              `(firstVal=${JSON.stringify(rule.firstVal)}` +
+              `${rule.lastVal != null ? `, lastVal=${JSON.stringify(rule.lastVal)}` : ''})`,
+          );
+          continue;
+        }
+
         // transform rule and add to workingSection
         workingSection.rules.push({
           // Use a null check, not a truthy check: the AND operator is 0, which
@@ -63,15 +85,11 @@ export class RuleYamlService {
           ...(rule.operator != null
             ? { operator: RuleOperators[+rule.operator] }
             : {}),
-          firstValue: this.ruleConstanstService.getValueIdentifier(
-            rule.firstVal,
-          ),
+          firstValue,
           action: RulePossibility[+rule.action],
-          ...(rule.lastVal
+          ...(lastValue != null
             ? {
-                lastValue: this.ruleConstanstService.getValueIdentifier(
-                  rule.lastVal,
-                ),
+                lastValue,
               }
             : {}),
           ...(rule.customVal
@@ -107,6 +125,7 @@ export class RuleYamlService {
         code: 1,
         result: yaml,
         message: 'success',
+        skipped,
       };
     } catch (error) {
       this.logger.warn('Yaml export failed');
@@ -122,6 +141,7 @@ export class RuleYamlService {
     try {
       const decoded: IRuleYamlParent = YAML.parse(yaml);
       const rules: RuleDto[] = [];
+      let skipped = 0;
       let idRef = 0;
 
       // Convert YAML uppercase string to MediaItemType
@@ -146,26 +166,55 @@ export class RuleYamlService {
         };
       }
 
+      // Capture each section's original combine operator (its first YAML rule's
+      // operator) before any rule is skipped, so a dropped boundary doesn't let
+      // the next rule's within-section operator silently become the boundary.
+      const sectionCombineOp = new Map<number, RuleDto['operator']>();
+      decoded.rules.forEach((section, sectionIndex) => {
+        const firstRule = section[sectionIndex]?.[0];
+        sectionCombineOp.set(
+          sectionIndex,
+          firstRule?.operator
+            ? +RuleOperators[firstRule.operator.toUpperCase()]
+            : null,
+        );
+      });
+
       for (const section of decoded.rules) {
-        for (const [ruleIndex, rule] of section[idRef].entries()) {
+        for (const rule of section[idRef]) {
+          const firstVal = this.ruleConstanstService.getValueFromIdentifier(
+            rule.firstValue.toLowerCase(),
+          );
+          const lastVal = rule.lastValue
+            ? this.ruleConstanstService.getValueFromIdentifier(
+                rule.lastValue.toLowerCase(),
+              )
+            : undefined;
+
+          // Skip an unresolved rule rather than reject the whole document.
+          if (firstVal == null || (rule.lastValue && lastVal == null)) {
+            skipped += 1;
+            this.logger.warn(
+              `Skipping rule on YAML import: unresolved identifier ` +
+                `'${rule.firstValue}'${rule.lastValue ? `/'${rule.lastValue}'` : ''}`,
+            );
+            continue;
+          }
+
           rules.push({
+            // Within-section default is OR; section boundaries are re-asserted
+            // from the captured combine operators after the loop.
             operator: rule.operator
               ? +RuleOperators[rule.operator.toUpperCase()]
               : rules.length === 0
                 ? null
-                : ruleIndex === 0
-                  ? RuleOperators.AND
-                  : RuleOperators.OR,
+                : RuleOperators.OR,
             action: +RulePossibility[rule.action.toUpperCase()],
             section: idRef,
-            firstVal: this.ruleConstanstService.getValueFromIdentifier(
-              rule.firstValue.toLowerCase(),
-            ),
-            ...(rule.lastValue
+            firstVal,
+            ...(lastVal != null
               ? {
-                  lastVal: this.ruleConstanstService.getValueFromIdentifier(
-                    rule.lastValue.toLowerCase(),
-                  ),
+                  lastVal,
                 }
               : {}),
             ...(rule.customValue
@@ -186,15 +235,15 @@ export class RuleYamlService {
         idRef++;
       }
 
-      const returnObj: { mediaType: MediaItemType; rules: RuleDto[] } = {
-        mediaType: yamlMediaType,
-        rules: rules,
-      };
+      // Carry each section's original combine operator onto its first surviving
+      // rule so a dropped boundary can't flip the section AND<->OR.
+      reassertSectionBoundaryOperators(rules, sectionCombineOp);
 
       return {
         code: 1,
-        result: JSON.stringify(returnObj),
+        result: JSON.stringify({ mediaType: yamlMediaType, rules }),
         message: 'success',
+        skipped,
       };
     } catch (error) {
       this.logger.warn('Yaml import failed. Is the yaml valid?');

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -46,6 +46,7 @@ export interface ReturnStatus {
   code: 0 | 1;
   result?: string;
   message?: string;
+  skipped?: number;
 }
 
 @Injectable()
@@ -916,8 +917,18 @@ export class RulesService {
   private validateRule(rule: RuleDto): ReturnStatus {
     try {
       const val1: Property = this.ruleConstants.applications
-        .find((el) => el.id === rule.firstVal[0])
-        .props.find((el) => el.id === rule.firstVal[1]);
+        .find((el) => el.id === rule.firstVal?.[0])
+        ?.props.find((el) => el.id === rule.firstVal?.[1]);
+      // Guard against a first value whose application/property no longer exists
+      // (e.g. an imported rule referencing an unconfigured service). Returning a
+      // clean status beats throwing a TypeError that surfaces as a generic
+      // "Unexpected error occurred".
+      if (!val1) {
+        return this.createReturnStatus(
+          false,
+          'First value is not available for this server',
+        );
+      }
       if (
         [RulePossibility.EXISTS, RulePossibility.NOT_EXISTS].includes(
           +rule.action,
@@ -931,7 +942,13 @@ export class RulesService {
       if (rule.lastVal) {
         const val2: Property = this.ruleConstants.applications
           .find((el) => el.id === rule.lastVal[0])
-          .props.find((el) => el.id === rule.lastVal[1]);
+          ?.props.find((el) => el.id === rule.lastVal[1]);
+        if (!val2) {
+          return this.createReturnStatus(
+            false,
+            'Second value is not available for this server',
+          );
+        }
         if (
           val1.type === val2.type ||
           ([RuleType.TEXT_LIST, RuleType.TEXT].includes(val1.type) &&
@@ -1156,11 +1173,19 @@ export class RulesService {
             .loadMany(),
         );
 
-      // Associate new notifications to the RuleGroup
-      await connection
-        .relation(RuleGroup, 'notifications')
-        .of(id)
-        .add(notifications?.map((notification) => notification.id));
+      // Associate new notifications to the RuleGroup. Guard against an
+      // empty/omitted list: `.add(undefined)` (when `notifications` is omitted
+      // by an API/import client) inserts a join row with a null notificationId
+      // and fails the whole rule-group create.
+      const notificationIds = notifications?.map(
+        (notification) => notification.id,
+      );
+      if (notificationIds?.length) {
+        await connection
+          .relation(RuleGroup, 'notifications')
+          .of(id)
+          .add(notificationIds);
+      }
 
       return id;
     } catch (error) {
@@ -1318,11 +1343,17 @@ export class RulesService {
     // Migrate decoded rules to the configured media server
     if (result.code === 1 && result.result) {
       const parsed = JSON.parse(result.result);
+      const beforeMigrate = parsed.rules.length;
       const migrationResult = await this.migrateRules(parsed.rules);
       if (migrationResult.code === 1 && migrationResult.result) {
         parsed.rules = JSON.parse(migrationResult.result);
-        result.result = JSON.stringify(parsed);
       }
+      // Combine rules dropped by decode (unresolved identifier) and by
+      // migration (no equivalent on the target server) into the single
+      // top-level skipped count so the UI reads it the same way as export.
+      result.skipped =
+        (result.skipped ?? 0) + (beforeMigrate - parsed.rules.length);
+      result.result = JSON.stringify(parsed);
     }
 
     return result;

--- a/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
@@ -183,6 +183,41 @@ describe('RulesService.updateRules', () => {
     });
   });
 
+  it('returns a clean status (not a crash) when a rule references a property not on this server', async () => {
+    const ruleGroupRepository = {
+      findOne: jest.fn().mockResolvedValue(null),
+    };
+
+    const service = createRulesService({ ruleGroupRepository });
+
+    const result = await service.updateRules({
+      id: 999,
+      libraryId: '1',
+      dataType: 'movie',
+      name: 'Test',
+      description: '',
+      rules: [
+        {
+          operator: null,
+          action: RulePossibility.EQUALS,
+          // Application/property that does not exist (e.g. an imported rule for
+          // an unconfigured service). Previously threw a TypeError that surfaced
+          // as a generic "Unexpected error occurred".
+          firstVal: [999, 999],
+          customVal: { ruleTypeId: 0, value: '1' },
+          section: 0,
+        },
+      ],
+    } as any);
+
+    expect(ruleGroupRepository.findOne).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      code: 0,
+      result: 'First value is not available for this server',
+      message: 'First value is not available for this server',
+    });
+  });
+
   it('cleans up the previous library when a rule moves libraries', async () => {
     const rulesRepository = {
       delete: jest.fn().mockResolvedValue(undefined),

--- a/apps/server/src/modules/settings/rule-migration.service.spec.ts
+++ b/apps/server/src/modules/settings/rule-migration.service.spec.ts
@@ -359,6 +359,135 @@ describe('RuleMigrationService', () => {
       expect(result.migratedRules).toBe(1);
       expect(result.rules[0].firstVal?.[0]).toBe(6); // 6 = JELLYFIN
     });
+
+    it('migrates a media-server firstVal while leaving a foreign-app lastVal untouched (mixed-app rule)', () => {
+      // The common real-world shape: compare a media-server property against a
+      // value sourced from another app (here a Seerr value in lastVal). The
+      // firstVal must migrate; the Seerr lastVal must be left alone.
+      const rules: RuleDto[] = [
+        {
+          operator: null,
+          action: RulePossibility.BIGGER,
+          firstVal: [Application.PLEX, 0], // addDate - compatible
+          lastVal: [Application.SEERR, 0], // Seerr - media-server independent
+          section: 0,
+        },
+      ];
+
+      const result = service.migrateImportedRuleDtos(
+        rules,
+        MediaServerType.JELLYFIN,
+      );
+
+      expect(result.migratedRules).toBe(1);
+      expect(result.skippedRules).toBe(0);
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].firstVal).toEqual([Application.JELLYFIN, 0]);
+      expect(result.rules[0].lastVal).toEqual([Application.SEERR, 0]); // untouched
+    });
+
+    it('migrates a media-server lastVal when firstVal belongs to another app', () => {
+      const rules: RuleDto[] = [
+        {
+          operator: null,
+          action: RulePossibility.BIGGER,
+          firstVal: [Application.SEERR, 0], // foreign - untouched
+          lastVal: [Application.PLEX, 0], // addDate - must migrate
+          section: 0,
+        },
+      ];
+
+      const result = service.migrateImportedRuleDtos(
+        rules,
+        MediaServerType.JELLYFIN,
+      );
+
+      expect(result.migratedRules).toBe(1);
+      expect(result.rules[0].firstVal).toEqual([Application.SEERR, 0]);
+      expect(result.rules[0].lastVal).toEqual([Application.JELLYFIN, 0]);
+    });
+
+    it('drops a rule whose media-server property has no target equivalent', () => {
+      const rules: RuleDto[] = [
+        {
+          operator: null,
+          action: RulePossibility.EQUALS,
+          firstVal: [Application.PLEX, 30], // watchlist_isWatchlisted - Plex only
+          customVal: { ruleTypeId: 3, value: '1' },
+          section: 0,
+        },
+      ];
+
+      const result = service.migrateImportedRuleDtos(
+        rules,
+        MediaServerType.JELLYFIN,
+      );
+
+      expect(result.skippedRules).toBe(1);
+      expect(result.migratedRules).toBe(0);
+      expect(result.rules).toHaveLength(0);
+    });
+
+    it('leaves non-media-server rules (Radarr/Sonarr/Seerr) unchanged', () => {
+      const rules: RuleDto[] = [
+        {
+          operator: null,
+          action: RulePossibility.BIGGER,
+          firstVal: [Application.RADARR, 0],
+          customVal: { ruleTypeId: 1, value: '30' },
+          section: 0,
+        },
+      ];
+
+      const result = service.migrateImportedRuleDtos(
+        rules,
+        MediaServerType.JELLYFIN,
+      );
+
+      expect(result.migratedRules).toBe(0);
+      expect(result.skippedRules).toBe(0);
+      expect(result.rules[0].firstVal).toEqual([Application.RADARR, 0]);
+    });
+
+    it("keeps a section's combine operator when its first rule is dropped as incompatible", () => {
+      // section 1's boundary rule uses a Jellyfin-only property (favoritedBy,
+      // id 39) that has no Plex equivalent, so it is dropped. Its AND must be
+      // inherited by the next surviving rule instead of that rule's own OR
+      // silently becoming the new section boundary (AND -> OR flip).
+      const rules: RuleDto[] = [
+        {
+          operator: null,
+          action: RulePossibility.BIGGER,
+          firstVal: [Application.JELLYFIN, 0], // addDate - compatible, first of group
+          section: 0,
+        },
+        {
+          operator: RuleOperators.AND,
+          action: RulePossibility.EQUALS,
+          firstVal: [Application.JELLYFIN, 39], // favoritedBy - Jellyfin only -> dropped
+          section: 1,
+        },
+        {
+          operator: RuleOperators.OR,
+          action: RulePossibility.BIGGER,
+          firstVal: [Application.JELLYFIN, 0], // within-section rule -> becomes section 1's survivor
+          section: 1,
+        },
+      ];
+
+      const result = service.migrateImportedRuleDtos(
+        rules,
+        MediaServerType.PLEX,
+      );
+
+      expect(result.skippedRules).toBe(1);
+      const sectionOne = result.rules.filter((r) => r.section === 1);
+      expect(sectionOne).toHaveLength(1);
+      // Inherits the dropped boundary's AND — does NOT keep its own OR.
+      expect(sectionOne[0].operator).toBe(RuleOperators.AND);
+      // Group's first rule still null.
+      expect(result.rules[0].operator).toBeNull();
+    });
   });
 
   describe('rating property migration', () => {

--- a/apps/server/src/modules/settings/rule-migration.service.ts
+++ b/apps/server/src/modules/settings/rule-migration.service.ts
@@ -10,11 +10,33 @@ import { EntityManager, Repository } from 'typeorm';
 import { MaintainerrLogger } from '../logging/logs.service';
 import { Application, RuleConstants } from '../rules/constants/rules.constants';
 import { RuleDto } from '../rules/dtos/rule.dto';
+import { reassertSectionBoundaryOperators } from '../rules/helpers/section-operators';
 import { RuleGroup } from '../rules/entities/rule-group.entities';
 import { Rules } from '../rules/entities/rules.entities';
 
 /** Singleton instance – avoids re-creating the constant data on every call. */
 const RULE_CONSTANTS = new RuleConstants();
+
+/**
+ * Single source of truth mapping each supported media server to its rule
+ * `Application` id. The `Record<MediaServerType, …>` type is exhaustive — adding
+ * a new media server to `MediaServerType` is a compile error until it is mapped
+ * here, which keeps the migrator in step with the supported-server list.
+ */
+const MEDIA_SERVER_TYPE_TO_APP: Record<MediaServerType, Application> = {
+  [MediaServerType.PLEX]: Application.PLEX,
+  [MediaServerType.JELLYFIN]: Application.JELLYFIN,
+  [MediaServerType.EMBY]: Application.EMBY,
+};
+
+/**
+ * Apps that represent the media server itself and therefore differ between
+ * servers. Only these are remapped during migration; every other app (Radarr,
+ * Sonarr, Seerr, Tautulli) is media-server independent and left exactly as-is.
+ */
+const MEDIA_SERVER_APPS = new Set<Application>(
+  Object.values(MEDIA_SERVER_TYPE_TO_APP),
+);
 
 /**
  * Outcome of checking whether a single rule can be migrated.
@@ -324,9 +346,15 @@ export class RuleMigrationService {
    * This is intended for imports (e.g. community/YAML) and does not touch the DB.
    *
    * Behavior:
-   * - Auto-detects source app per rule (Plex/Jellyfin only)
-   * - Rewrites firstVal/lastVal app ID to the target app
-   * - Skips rules that use properties not available on the target server
+   * - Migrates `firstVal` and `lastVal` INDEPENDENTLY, each by its own app. A
+   *   rule may compare a media-server property (e.g. last-viewed date) against a
+   *   value sourced from another app (e.g. a Seerr request date in `lastVal`);
+   *   only the media-server field is remapped, the other is left untouched.
+   * - Radarr/Sonarr/Seerr/Tautulli fields are media-server independent and are
+   *   never rewritten.
+   * - A rule is dropped only when one of its media-server properties has no
+   *   equivalent on the target server (e.g. Plex watchlist → Jellyfin). This is
+   *   expected and logged at debug, not as a warning.
    */
   migrateImportedRuleDtos(
     rules: RuleDto[],
@@ -338,62 +366,100 @@ export class RuleMigrationService {
 
     const targetApp = this.getApplicationId(toServer);
 
+    // Capture each section's combine operator (the operator on its first rule)
+    // BEFORE any drops. A section's first rule carries the section-combine
+    // operator; if it is later dropped as incompatible, the next surviving rule
+    // must inherit this value, otherwise its within-section operator would
+    // silently become the section boundary and flip the section AND<->OR.
+    const sectionCombineOp = new Map<number, RuleDto['operator']>();
+    for (const rule of rules) {
+      if (!sectionCombineOp.has(rule.section)) {
+        sectionCombineOp.set(rule.section, rule.operator ?? null);
+      }
+    }
+
     // Cache compatibility per source app – avoids recomputing for every rule.
     const compatCache = new Map<Application, PropertyCompatibility>();
-
-    let migratedRules = 0;
-    let skippedRules = 0;
-
-    const migrated = rules.map((rule) => {
-      const sourceApp = this.detectRuleSourceApp(rule);
-
-      // Only migrate if rule clearly belongs to Plex/Jellyfin and is not already on target.
-      if (sourceApp === undefined || sourceApp === targetApp) {
-        return rule;
-      }
-
+    const getCompat = (sourceApp: Application): PropertyCompatibility => {
       if (!compatCache.has(sourceApp)) {
         compatCache.set(
           sourceApp,
           computePropertyCompatibility(sourceApp, targetApp),
         );
       }
-      const compat = compatCache.get(sourceApp)!;
+      return compatCache.get(sourceApp)!;
+    };
 
-      const analysis = this.analyzeRuleDto(rule, sourceApp, compat);
-      if (!analysis.canMigrate) {
+    let migratedRules = 0;
+    let skippedRules = 0;
+    const result: RuleDto[] = [];
+
+    for (const rule of rules) {
+      let changed = false;
+      let incompatibleProperty: string | undefined;
+
+      const migrateField = (
+        val?: [number, number],
+      ): [number, number] | undefined => {
+        if (!val) return val;
+        const [app, propId] = val;
+        // Only media-server apps differ between servers; leave everything else.
+        if (!MEDIA_SERVER_APPS.has(app) || app === targetApp) return val;
+
+        const compat = getCompat(app);
+        if (compat.incompatible.has(propId)) {
+          incompatibleProperty = getPropertyName(app, propId);
+          return val;
+        }
+        changed = true;
+        return [targetApp, compat.remapping.get(propId) ?? propId];
+      };
+
+      const newFirst = migrateField(rule.firstVal as [number, number]);
+      const newLast = migrateField(rule.lastVal as [number, number]);
+
+      if (incompatibleProperty !== undefined) {
         skippedRules += 1;
         this.logger.warn(
-          `Skipping imported rule migration: ${analysis.reason}${analysis.propertyName ? ` (property: ${analysis.propertyName})` : ''}`,
+          `Skipping imported rule migration: property not available on ` +
+            `target server (property: ${incompatibleProperty})`,
         );
-        return undefined;
+        this.logger.debug(
+          `Skipped rule detail: firstVal=${JSON.stringify(rule.firstVal)} ` +
+            `lastVal=${JSON.stringify(rule.lastVal)} action=${rule.action}`,
+        );
+        continue;
       }
 
-      migratedRules += 1;
-      return this.migrateRuleDto(rule, sourceApp, targetApp, compat.remapping);
-    });
+      if (changed) {
+        migratedRules += 1;
+        const clone: RuleDto = JSON.parse(JSON.stringify(rule));
+        clone.firstVal = newFirst as [number, number];
+        if (rule.lastVal) {
+          clone.lastVal = newLast as [number, number];
+        }
+        result.push(clone);
+      } else {
+        result.push(rule);
+      }
+    }
 
-    return {
-      rules: migrated.filter((rule): rule is RuleDto => rule !== undefined),
-      migratedRules,
-      skippedRules,
-    };
+    // Carry each section's original combine operator onto its first surviving
+    // rule so a dropped boundary can't silently flip the section AND<->OR.
+    reassertSectionBoundaryOperators(result, sectionCombineOp);
+
+    return { rules: result, migratedRules, skippedRules };
   }
 
   /**
    * Get the Application enum value for a media server type.
    */
   private getApplicationId(serverType: MediaServerType): Application {
-    switch (serverType) {
-      case MediaServerType.PLEX:
-        return Application.PLEX;
-      case MediaServerType.JELLYFIN:
-        return Application.JELLYFIN;
-      case MediaServerType.EMBY:
-        return Application.EMBY;
-      default:
-        throw new Error(`Unknown media server type: ${serverType}`);
+    const app = MEDIA_SERVER_TYPE_TO_APP[serverType];
+    if (app === undefined) {
+      throw new Error(`Unknown media server type: ${serverType}`);
     }
+    return app;
   }
 
   /**
@@ -451,27 +517,6 @@ export class RuleMigrationService {
     }
 
     return { canMigrate: true, reason: '' };
-  }
-
-  private detectRuleSourceApp(
-    rule: RuleDto,
-  ): Application.PLEX | Application.JELLYFIN | Application.EMBY | undefined {
-    const firstApp = rule.firstVal?.[0];
-    const lastApp = rule.lastVal?.[0];
-
-    if (
-      firstApp !== Application.PLEX &&
-      firstApp !== Application.JELLYFIN &&
-      firstApp !== Application.EMBY
-    ) {
-      return undefined;
-    }
-
-    if (lastApp !== undefined && lastApp !== firstApp) {
-      return undefined;
-    }
-
-    return firstApp;
   }
 
   private migrateRuleDto(

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -402,6 +402,25 @@ const buildFormDefaults = (editData?: IRuleGroup): RuleGroupFormValues => ({
   ruleHandlerCronSchedule: editData?.ruleHandlerCronSchedule ?? null,
 })
 
+/**
+ * Tell the user that some rules were dropped because a property isn't available
+ * (no equivalent on the configured media server, or an unresolved identifier).
+ * Shared by the community import, YAML import and YAML export paths, so the copy
+ * stays neutral about direction.
+ */
+const notifySkippedRules = (skipped: number) => {
+  if (skipped <= 0) return
+  const plural = skipped !== 1
+  toast.warn(
+    `${skipped} rule${plural ? 's' : ''} ${plural ? 'were' : 'was'} skipped — ${
+      plural
+        ? "they use properties that aren't available"
+        : "it uses a property that isn't available"
+    }.`,
+    { autoClose: 6000 },
+  )
+}
+
 const AddModal = (props: AddModal) => {
   const navigate = useNavigate()
   const { isPlex, isJellyfin, mediaServerType } = useMediaServerType()
@@ -677,6 +696,7 @@ const AddModal = (props: AddModal) => {
 
     if (response.code === 1) {
       setYaml(response.result)
+      notifySkippedRules(response.skipped ?? 0)
 
       if (!yamlImporterModal) {
         setYamlImporterModal(true)
@@ -713,6 +733,7 @@ const AddModal = (props: AddModal) => {
       toast.success('Successfully imported rules from Yaml.', {
         autoClose: 5000,
       })
+      notifySkippedRules(response.skipped ?? 0)
     } else {
       toast.error(response.message, { autoClose: 5000 })
     }
@@ -727,6 +748,7 @@ const AddModal = (props: AddModal) => {
     if (response && response.code === 1) {
       const migratedRules = JSON.parse(response.result) as IRule[]
       updateRules(migratedRules)
+      notifySkippedRules(rules.length - migratedRules.length)
     } else {
       // If migration fails, use original rules
       updateRules(rules)
@@ -1777,7 +1799,7 @@ const AddModal = (props: AddModal) => {
                 label="Save"
                 pendingLabel="Save"
                 contentSize="compact"
-                className="w-full max-w-[160px]"
+                className="w-full max-w-40"
                 isPending={isCreatePending || isUpdatePending}
                 disabled={isCreatePending || isUpdatePending}
                 type="submit"
@@ -1785,7 +1807,7 @@ const AddModal = (props: AddModal) => {
 
               <Button
                 buttonType="default"
-                className="w-full max-w-[160px] justify-center"
+                className="w-full max-w-40 justify-center"
                 type="button"
                 onClick={cancel}
                 disabled={isCreatePending || isUpdatePending}


### PR DESCRIPTION
Follow-up to #2971. Hardens community + YAML rule import so rules don't silently break across media servers.

- Migration remaps `firstVal` and `lastVal` **independently by each field's own app**, so a media-server property compared against a Seerr/Tautulli value is no longer stranded on the source server (Plex/Emby) and rendered blank. Covers Plex/Jellyfin/Emby.
- Rules dropped on import (a property with no equivalent on the configured server, e.g. Plex watchlist → Jellyfin) are now **surfaced to the user** (toast) on both the community and YAML paths, and logged at warn.
- YAML export no longer writes `App.undefined` for an unknown property; import **skips an unresolved rule** (returned as a `skipped` count) instead of rejecting the whole document.
- `validateRule` returns a clean status instead of throwing a `TypeError` on a missing application/property; rule-group create no longer fails when `notifications` is omitted.

### ⚠️ Depends on #2971 — merge after it
This edits the same import/decode code as #2971 and is branched on top of it. Until #2971 merges, this diff includes #2971's commits; it will be rebased onto `development` afterwards, leaving only this change.