### PR TITLE
feat(rules): add Streamystats watchlist rule properties for Jellyfin

### DIFF
--- a/apps/server/src/modules/api/streamystats-api/streamystats-api.constants.ts
+++ b/apps/server/src/modules/api/streamystats-api/streamystats-api.constants.ts
@@ -1,0 +1,12 @@
+// Shared id of the Streamystats NodeCache (see modules/api/lib/cache.ts).
+export const STREAMYSTATS_CACHE_ID = 'streamystats';
+
+// HTTP cache TTL (seconds) for the watchlist endpoints, aligned with the
+// Streamystats NodeCache's default TTL.
+export const WATCHLIST_HTTP_TTL_S = 300;
+
+// Key under which the assembled public-watchlist membership snapshot is stored
+// in the Streamystats NodeCache. That cache is flushed between rule-group runs
+// (CacheManager.flushAll), so the snapshot is rebuilt each run and reused
+// across items within the run.
+export const WATCHLIST_MEMBERSHIP_CACHE_KEY = 'watchlist-membership';

--- a/apps/server/src/modules/api/streamystats-api/streamystats-api.service.spec.ts
+++ b/apps/server/src/modules/api/streamystats-api/streamystats-api.service.spec.ts
@@ -301,4 +301,109 @@ describe('StreamystatsApiService', () => {
       expect(callArgs?.apiKey).toBeUndefined();
     });
   });
+
+  describe('getWatchlistMembership', () => {
+    beforeEach(() => {
+      Object.assign(settings, {
+        streamystats_url: 'http://streamystats',
+        jellyfin_api_key: 'jellyfin-key',
+      });
+      service.init();
+    });
+
+    it('returns null when Streamystats is not configured', async () => {
+      Object.assign(settings, { streamystats_url: undefined });
+      service.init();
+
+      expect(await service.getWatchlistMembership()).toBeNull();
+      expect(apiMock.get).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the watchlists payload fails schema validation', async () => {
+      apiMock.get.mockResolvedValueOnce({ unexpected: true });
+
+      expect(await service.getWatchlistMembership()).toBeNull();
+    });
+
+    it('maps each Jellyfin item ID to the owners of public lists containing it', async () => {
+      apiMock.get.mockImplementation(async (endpoint: string) => {
+        if (endpoint === '/api/watchlists') {
+          return {
+            data: [
+              { id: 1, name: 'List A', userId: 'user-a' },
+              { id: 2, name: 'List B', userId: 'user-b' },
+            ],
+          };
+        }
+        if (endpoint === '/api/watchlists/1') {
+          return {
+            data: { id: 1, name: 'List A', items: ['item-1', 'item-2'] },
+          };
+        }
+        if (endpoint === '/api/watchlists/2') {
+          return { data: { id: 2, name: 'List B', items: ['item-2'] } };
+        }
+        return undefined;
+      });
+
+      const membership = await service.getWatchlistMembership();
+
+      expect(membership.ownersByItemId['item-1']).toEqual(['user-a']);
+      expect([...membership.ownersByItemId['item-2']].sort()).toEqual([
+        'user-a',
+        'user-b',
+      ]);
+      expect(membership.ownersByItemId['item-3']).toBeUndefined();
+    });
+
+    it('authenticates watchlist calls with the MediaBrowser token scheme', async () => {
+      apiMock.get.mockResolvedValue({ data: [] });
+
+      await service.getWatchlistMembership();
+
+      expect(apiMock.get).toHaveBeenCalledWith(
+        '/api/watchlists',
+        expect.objectContaining({
+          headers: { Authorization: 'MediaBrowser Token="jellyfin-key"' },
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('reuses the cached snapshot across calls within a run', async () => {
+      apiMock.get.mockResolvedValue({ data: [] });
+
+      await service.getWatchlistMembership();
+      await service.getWatchlistMembership();
+
+      // Only the first call hits /api/watchlists; the second is served from the
+      // shared cache (which init() / flushAll clears between runs).
+      const listCalls = apiMock.get.mock.calls.filter(
+        (call) => call[0] === '/api/watchlists',
+      );
+      expect(listCalls).toHaveLength(1);
+    });
+
+    it('skips lists whose item payload is malformed but keeps the rest', async () => {
+      apiMock.get.mockImplementation(async (endpoint: string) => {
+        if (endpoint === '/api/watchlists') {
+          return {
+            data: [
+              { id: 1, name: 'Good', userId: 'user-a' },
+              { id: 2, name: 'Bad', userId: 'user-b' },
+            ],
+          };
+        }
+        if (endpoint === '/api/watchlists/1') {
+          return { data: { id: 1, name: 'Good', items: ['item-1'] } };
+        }
+        return { nope: true };
+      });
+
+      const membership = await service.getWatchlistMembership();
+
+      expect(membership.ownersByItemId['item-1']).toEqual(['user-a']);
+      expect(Object.keys(membership.ownersByItemId)).toHaveLength(1);
+    });
+  });
 });

--- a/apps/server/src/modules/api/streamystats-api/streamystats-api.service.ts
+++ b/apps/server/src/modules/api/streamystats-api/streamystats-api.service.ts
@@ -2,6 +2,8 @@ import {
   BasicResponseDto,
   StreamystatsItemDetails,
   streamystatsItemDetailsSchema,
+  streamystatsWatchlistItemIdsResponseSchema,
+  streamystatsWatchlistsResponseSchema,
 } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import { SettingsDataService } from '../../../modules/settings/settings-data.service';
@@ -14,6 +16,12 @@ import {
   MaintainerrLogger,
   MaintainerrLoggerFactory,
 } from '../../logging/logs.service';
+import cacheManager from '../lib/cache';
+import {
+  STREAMYSTATS_CACHE_ID,
+  WATCHLIST_HTTP_TTL_S,
+  WATCHLIST_MEMBERSHIP_CACHE_KEY,
+} from './streamystats-api.constants';
 import { StreamystatsApi } from './helpers/streamystats-api.helper';
 
 interface StreamystatsVersionInfo {
@@ -27,6 +35,14 @@ interface StreamystatsServer {
   id: number;
   url?: string | null;
   name?: string | null;
+}
+
+/**
+ * Public-watchlist membership for the configured Jellyfin server: for each
+ * Jellyfin item ID, the owner Jellyfin user IDs whose public lists contain it.
+ */
+export interface StreamystatsWatchlistMembership {
+  ownersByItemId: Record<string, string[]>;
 }
 
 @Injectable()
@@ -48,6 +64,9 @@ export class StreamystatsApiService {
     // after any settings change.
     this.api = undefined;
     this.resolvedServerId = null;
+    cacheManager
+      .getCache(STREAMYSTATS_CACHE_ID)
+      ?.data.del(WATCHLIST_MEMBERSHIP_CACHE_KEY);
 
     if (!this.settings.streamystats_url || !this.settings.jellyfin_api_key) {
       return;
@@ -116,6 +135,93 @@ export class StreamystatsApiService {
       this.logger.debug(error);
       return null;
     }
+  }
+
+  /**
+   * Resolve which public Streamystats watchlists each Jellyfin item belongs to.
+   * Returns null when it can't be determined (not configured or unreachable)
+   * so callers can skip rather than treat absence as "not watchlisted".
+   *
+   * The watchlist endpoints authenticate via Jellyfin's MediaBrowser token
+   * scheme — unlike the item-details endpoint, the `Bearer` header is rejected
+   * — so each call overrides the Authorization header accordingly.
+   */
+  public async getWatchlistMembership(): Promise<StreamystatsWatchlistMembership | null> {
+    if (!this.api || !this.settings.jellyfin_api_key) {
+      return null;
+    }
+
+    // Reuse the snapshot built earlier in this rule-group run. The shared
+    // Streamystats cache is flushed between runs, so this is rebuilt each run.
+    const cache = cacheManager.getCache(STREAMYSTATS_CACHE_ID)?.data;
+    const cached = cache?.get<StreamystatsWatchlistMembership>(
+      WATCHLIST_MEMBERSHIP_CACHE_KEY,
+    );
+    if (cached) {
+      return cached;
+    }
+
+    const config = {
+      headers: { Authorization: this.mediaBrowserAuthHeader() },
+    };
+
+    try {
+      const watchlists = await this.api.get<unknown>(
+        '/api/watchlists',
+        config,
+        WATCHLIST_HTTP_TTL_S,
+      );
+      // The HTTP helper swallows request failures and returns undefined; treat
+      // that as transient (skip) rather than a schema mismatch.
+      if (watchlists == null) {
+        return null;
+      }
+
+      const parsed = streamystatsWatchlistsResponseSchema.safeParse(watchlists);
+      if (!parsed.success) {
+        this.logger.warn(
+          'Streamystats watchlists payload did not match expected schema',
+        );
+        this.logger.debug(parsed.error);
+        return null;
+      }
+
+      const ownersByItemId: Record<string, string[]> = {};
+      for (const watchlist of parsed.data.data) {
+        const detail = await this.api.get<unknown>(
+          `/api/watchlists/${watchlist.id}`,
+          { ...config, params: { format: 'ids' } },
+          WATCHLIST_HTTP_TTL_S,
+        );
+        const detailParsed =
+          streamystatsWatchlistItemIdsResponseSchema.safeParse(detail);
+        if (!detailParsed.success) {
+          this.logger.debug(
+            `Skipping Streamystats watchlist "${watchlist.name ?? watchlist.id}": unexpected item payload`,
+          );
+          continue;
+        }
+
+        for (const itemId of detailParsed.data.data.items) {
+          const owners = (ownersByItemId[itemId] ??= []);
+          if (!owners.includes(watchlist.userId)) {
+            owners.push(watchlist.userId);
+          }
+        }
+      }
+
+      const value: StreamystatsWatchlistMembership = { ownersByItemId };
+      cache?.set(WATCHLIST_MEMBERSHIP_CACHE_KEY, value);
+      return value;
+    } catch (error) {
+      this.logger.log("Couldn't fetch Streamystats watchlists");
+      this.logger.debug(error);
+      return null;
+    }
+  }
+
+  private mediaBrowserAuthHeader(): string {
+    return `MediaBrowser Token="${this.settings.jellyfin_api_key}"`;
   }
 
   public async testConnection(

--- a/apps/server/src/modules/rules/constants/rules.constants.ts
+++ b/apps/server/src/modules/rules/constants/rules.constants.ts
@@ -1409,6 +1409,35 @@ export class RuleConstants {
         },
       ],
     },
+    {
+      // Streamystats is an optional, Jellyfin-only companion (the Jellyfin
+      // analog of Tautulli for Plex). It is removed from the constants unless
+      // configured and Jellyfin is the active server (see RulesService).
+      //
+      // A Streamystats "watchlist" is a user-created curated list, and only
+      // PUBLIC lists are reachable with Maintainerr's Jellyfin API key — see
+      // the StreamystatsWatchlistMembership contract for why. These properties
+      // act as a "users curated this" protection signal.
+      id: Application.STREAMYSTATS,
+      name: 'Streamystats',
+      mediaType: MediaType.BOTH,
+      props: [
+        {
+          id: 0,
+          name: 'isInWatchlist',
+          humanName: 'Is in a watchlist',
+          mediaType: MediaType.BOTH,
+          type: RuleType.BOOL,
+        },
+        {
+          id: 1,
+          name: 'watchlistedByUsers',
+          humanName: '[list] In watchlist of (username)',
+          mediaType: MediaType.BOTH,
+          type: RuleType.TEXT_LIST, // returns usernames []
+        },
+      ],
+    },
   ];
 
   constructor() {

--- a/apps/server/src/modules/rules/getter/getter.service.ts
+++ b/apps/server/src/modules/rules/getter/getter.service.ts
@@ -16,6 +16,7 @@ import { PlexGetterService } from './plex-getter.service';
 import { RadarrGetterService } from './radarr-getter.service';
 import { SeerrGetterService } from './seerr-getter.service';
 import { SonarrGetterService } from './sonarr-getter.service';
+import { StreamystatsGetterService } from './streamystats-getter.service';
 import { TautulliGetterService } from './tautulli-getter.service';
 
 @Injectable()
@@ -26,6 +27,7 @@ export class ValueGetterService {
     private readonly sonarrGetter: SonarrGetterService,
     private readonly seerrGetter: SeerrGetterService,
     private readonly tautulliGetter: TautulliGetterService,
+    private readonly streamystatsGetter: StreamystatsGetterService,
     private readonly jellyfinGetter: JellyfinGetterService,
     private readonly embyGetter: EmbyGetterService,
     private readonly mediaServerFactory: MediaServerFactory,
@@ -90,6 +92,9 @@ export class ValueGetterService {
           dataType,
           ruleGroup,
         );
+      }
+      case Application.STREAMYSTATS: {
+        return await this.streamystatsGetter.get(val2, libItem);
       }
       default: {
         return null;

--- a/apps/server/src/modules/rules/getter/streamystats-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/streamystats-getter.service.spec.ts
@@ -1,0 +1,141 @@
+import { createMediaItem, createMockLogger } from '../../../../test/utils/data';
+import { MediaServerFactory } from '../../api/media-server/media-server.factory';
+import {
+  StreamystatsApiService,
+  StreamystatsWatchlistMembership,
+} from '../../api/streamystats-api/streamystats-api.service';
+import { StreamystatsGetterService } from './streamystats-getter.service';
+
+const IS_IN_WATCHLIST_PROP_ID = 0;
+const WATCHLISTED_BY_USERS_PROP_ID = 1;
+
+const membershipOf = (
+  entries: Record<string, string[]>,
+): StreamystatsWatchlistMembership => ({
+  ownersByItemId: entries,
+});
+
+describe('StreamystatsGetterService', () => {
+  const createService = (users: { id: string; name: string }[] = []) => {
+    const streamystatsApi = {
+      getWatchlistMembership: jest.fn(),
+    } as unknown as jest.Mocked<StreamystatsApiService>;
+
+    const mediaServerFactory = {
+      getService: jest.fn().mockResolvedValue({
+        getUsers: jest.fn().mockResolvedValue(users),
+      }),
+    } as unknown as jest.Mocked<MediaServerFactory>;
+
+    const service = new StreamystatsGetterService(
+      streamystatsApi,
+      mediaServerFactory,
+      createMockLogger(),
+    );
+
+    return { service, streamystatsApi, mediaServerFactory };
+  };
+
+  describe('isInWatchlist (property id=0)', () => {
+    it('returns true when the item is in at least one public watchlist', async () => {
+      const { service, streamystatsApi } = createService();
+      const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({ 'item-1': ['user-a'] }),
+      );
+
+      expect(await service.get(IS_IN_WATCHLIST_PROP_ID, libItem)).toBe(true);
+    });
+
+    it('returns false when the item is in no watchlist', async () => {
+      const { service, streamystatsApi } = createService();
+      const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({ 'item-2': ['user-a'] }),
+      );
+
+      expect(await service.get(IS_IN_WATCHLIST_PROP_ID, libItem)).toBe(false);
+    });
+
+    it('returns undefined (transient skip) when membership cannot be determined', async () => {
+      const { service, streamystatsApi } = createService();
+      const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(null);
+
+      expect(
+        await service.get(IS_IN_WATCHLIST_PROP_ID, libItem),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('watchlistedByUsers (property id=1)', () => {
+    it('resolves owner user IDs to usernames via the media server', async () => {
+      const { service, streamystatsApi } = createService([
+        { id: 'user-a', name: 'alice' },
+        { id: 'user-b', name: 'bob' },
+        { id: 'user-c', name: 'carol' },
+      ]);
+      const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({ 'item-1': ['user-a', 'user-b'] }),
+      );
+
+      const result = (await service.get(
+        WATCHLISTED_BY_USERS_PROP_ID,
+        libItem,
+      )) as string[];
+
+      expect(result.sort()).toEqual(['alice', 'bob']);
+    });
+
+    it('omits owners that no longer resolve to a known user', async () => {
+      const { service, streamystatsApi } = createService([
+        { id: 'user-a', name: 'alice' },
+      ]);
+      const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({ 'item-1': ['user-a', 'user-gone'] }),
+      );
+
+      expect(await service.get(WATCHLISTED_BY_USERS_PROP_ID, libItem)).toEqual([
+        'alice',
+      ]);
+    });
+
+    it('returns undefined (transient skip) when the user lookup fails closed', async () => {
+      // getUsers() returns [] on failure; with owners present that is a lookup
+      // failure, not "nobody owns it" — must skip, never an empty list.
+      const { service, streamystatsApi } = createService([]);
+      const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({ 'item-1': ['user-a'] }),
+      );
+
+      expect(
+        await service.get(WATCHLISTED_BY_USERS_PROP_ID, libItem),
+      ).toBeUndefined();
+    });
+
+    it('returns an empty list when the item is in no watchlist', async () => {
+      const { service, streamystatsApi, mediaServerFactory } = createService();
+      const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({}),
+      );
+
+      expect(await service.get(WATCHLISTED_BY_USERS_PROP_ID, libItem)).toEqual(
+        [],
+      );
+      // No need to hit the media server when there are no owners to resolve.
+      expect(mediaServerFactory.getService).not.toHaveBeenCalled();
+    });
+  });
+
+  it('returns null for an unknown property id', async () => {
+    const { service, streamystatsApi } = createService();
+    const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+    streamystatsApi.getWatchlistMembership.mockResolvedValue(membershipOf({}));
+
+    expect(await service.get(999, libItem)).toBeNull();
+  });
+});

--- a/apps/server/src/modules/rules/getter/streamystats-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/streamystats-getter.service.ts
@@ -1,0 +1,105 @@
+import { MediaItem } from '@maintainerr/contracts';
+import { Injectable } from '@nestjs/common';
+import { MediaServerFactory } from '../../api/media-server/media-server.factory';
+import { StreamystatsApiService } from '../../api/streamystats-api/streamystats-api.service';
+import { MaintainerrLogger } from '../../logging/logs.service';
+import {
+  Application,
+  Property,
+  RuleConstants,
+} from '../constants/rules.constants';
+
+/**
+ * Resolves Streamystats-backed rule properties for Jellyfin. Streamystats is
+ * the Jellyfin analog of Tautulli: an optional companion service that
+ * contributes its own rule Application. Properties surface membership of
+ * Streamystats watchlists (a "users curated this" protection signal).
+ *
+ * Only PUBLIC watchlists are visible to Maintainerr — see
+ * StreamystatsWatchlistMembership for why. Usernames are resolved through the
+ * server-agnostic media-server abstraction (Jellyfin is the only configured
+ * server when this getter runs, since the Application is gated to it).
+ */
+@Injectable()
+export class StreamystatsGetterService {
+  appProperties: Property[];
+
+  constructor(
+    private readonly streamystatsApi: StreamystatsApiService,
+    private readonly mediaServerFactory: MediaServerFactory,
+    private readonly logger: MaintainerrLogger,
+  ) {
+    logger.setContext(StreamystatsGetterService.name);
+    const ruleConstants = new RuleConstants();
+    this.appProperties = ruleConstants.applications.find(
+      (el) => el.id === Application.STREAMYSTATS,
+    ).props;
+  }
+
+  async get(id: number, libItem: MediaItem) {
+    try {
+      const prop = this.appProperties.find((el) => el.id === id);
+      if (!prop) {
+        return null;
+      }
+
+      const membership = await this.streamystatsApi.getWatchlistMembership();
+      // `undefined` is the transient signal: Streamystats is unconfigured or
+      // unreachable, so skip rather than report a false "not watchlisted".
+      if (!membership) {
+        return undefined;
+      }
+
+      const owners = membership.ownersByItemId[libItem.id];
+
+      switch (prop.name) {
+        case 'isInWatchlist': {
+          return owners != null && owners.length > 0;
+        }
+        case 'watchlistedByUsers': {
+          if (!owners || owners.length === 0) {
+            return [];
+          }
+          // undefined when usernames couldn't be resolved (transient skip).
+          return await this.resolveUsernames(owners);
+        }
+        default: {
+          return null;
+        }
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Streamystats-Getter - Action failed for '${libItem.title}' with id '${libItem.id}'`,
+      );
+      this.logger.debug(
+        `Streamystats-Getter - Action failed for '${libItem.title}' with id '${libItem.id}'`,
+        error,
+      );
+      return undefined;
+    }
+  }
+
+  private async resolveUsernames(
+    userIds: string[],
+  ): Promise<string[] | undefined> {
+    const mediaServer = await this.mediaServerFactory.getService();
+    const users = await mediaServer.getUsers();
+    // getUsers() is fail-closed (returns [] on error). A public watchlist is
+    // always owned by a user, so an empty user list while we have owners to
+    // resolve means the lookup failed — surface that as undefined (transient
+    // skip) rather than an empty list, which would otherwise flip negative
+    // list comparisons and could let protected items match destructive rules.
+    if (users.length === 0) {
+      return undefined;
+    }
+
+    const namesById = new Map(users.map((user) => [user.id, user.name]));
+    return userIds.reduce((acc, userId) => {
+      const name = namesById.get(userId);
+      if (name) {
+        acc.push(name);
+      }
+      return acc;
+    }, [] as string[]);
+  }
+}

--- a/apps/server/src/modules/rules/rules.module.ts
+++ b/apps/server/src/modules/rules/rules.module.ts
@@ -4,6 +4,7 @@ import { MediaServerModule } from '../api/media-server/media-server.module';
 import { SeerrApiModule } from '../api/seerr-api/seerr-api.module';
 import { PlexApiModule } from '../api/plex-api/plex-api.module';
 import { ServarrApiModule } from '../api/servarr-api/servarr-api.module';
+import { StreamystatsApiModule } from '../api/streamystats-api/streamystats-api.module';
 import { TautulliApiModule } from '../api/tautulli-api/tautulli-api.module';
 import { CollectionsModule } from '../collections/collections.module';
 import { Collection } from '../collections/entities/collection.entities';
@@ -25,6 +26,7 @@ import { SeerrGetterService } from './getter/seerr-getter.service';
 import { PlexGetterService } from './getter/plex-getter.service';
 import { RadarrGetterService } from './getter/radarr-getter.service';
 import { SonarrGetterService } from './getter/sonarr-getter.service';
+import { StreamystatsGetterService } from './getter/streamystats-getter.service';
 import { TautulliGetterService } from './getter/tautulli-getter.service';
 import {
   RuleComparatorService,
@@ -58,6 +60,7 @@ import { RuleMaintenanceService } from './tasks/rule-maintenance.service';
     ]),
     SeerrApiModule,
     TautulliApiModule,
+    StreamystatsApiModule,
     MetadataModule,
     forwardRef(() => CollectionsModule),
     TasksModule,
@@ -77,6 +80,7 @@ import { RuleMaintenanceService } from './tasks/rule-maintenance.service';
     SonarrGetterService,
     SeerrGetterService,
     TautulliGetterService,
+    StreamystatsGetterService,
     ValueGetterService,
     RuleYamlService,
     RuleComparatorService,

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -122,6 +122,14 @@ export class RulesService {
           (el) => el.id !== Application.TAUTULLI,
         );
       }
+
+      // remove streamystats if not configured. It is Jellyfin-only and reuses
+      // the Jellyfin API key; the UI further restricts it to Jellyfin servers.
+      if (!settings.streamystats_url || !settings.jellyfin_api_key) {
+        localConstants.applications = localConstants.applications.filter(
+          (el) => el.id !== Application.STREAMYSTATS,
+        );
+      }
     }
 
     return localConstants;

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
@@ -95,8 +95,11 @@ const shouldFilterApplication = (
   ) {
     return true
   }
-  // Filter out Jellyfin on Plex/Emby.
-  if ((isPlex || isEmby) && appId === Application.JELLYFIN) {
+  // Filter out Jellyfin and its Streamystats companion on Plex/Emby.
+  if (
+    (isPlex || isEmby) &&
+    (appId === Application.JELLYFIN || appId === Application.STREAMYSTATS)
+  ) {
     return true
   }
   // Filter out Emby on Plex/Jellyfin.

--- a/packages/contracts/src/rules/constants.ts
+++ b/packages/contracts/src/rules/constants.ts
@@ -69,6 +69,7 @@ export enum Application {
   TAUTULLI = 4,
   JELLYFIN = 6,
   EMBY = 7,
+  STREAMYSTATS = 8,
 }
 
 /**
@@ -82,6 +83,7 @@ export const ApplicationNames: Record<Application, string> = {
   [Application.TAUTULLI]: 'Tautulli',
   [Application.JELLYFIN]: 'Jellyfin',
   [Application.EMBY]: 'Emby',
+  [Application.STREAMYSTATS]: 'Streamystats',
 }
 
 /**

--- a/packages/contracts/src/streamystats/index.ts
+++ b/packages/contracts/src/streamystats/index.ts
@@ -1,1 +1,2 @@
 export * from './itemDetails'
+export * from './watchlists'

--- a/packages/contracts/src/streamystats/watchlists.ts
+++ b/packages/contracts/src/streamystats/watchlists.ts
@@ -1,0 +1,36 @@
+import z from 'zod'
+
+// A Streamystats "watchlist" is a user-created, named curated list of media
+// items with its own visibility flags — NOT a Plex-style personal "want to
+// watch" queue. Maintainerr authenticates to Streamystats with a Jellyfin
+// server API key, which Streamystats resolves to its "system-api-key"
+// pseudo-user; the watchlist endpoints therefore only ever surface PUBLIC
+// lists (those a user shared) plus that pseudo-user's own (none). Private
+// lists are intentionally invisible.
+//
+// These schemas validate only the fields Maintainerr consumes; `.loose()`
+// tolerates the other fields Streamystats returns.
+
+const streamystatsWatchlistSummarySchema = z
+  .object({
+    // `id` is a serial primary key; coerce defensively in case the wire
+    // format serialises it as a string (see itemDetails for prior art).
+    id: z.coerce.number(),
+    // Jellyfin user ID of the list owner.
+    userId: z.string(),
+    // Optional: used only to make skip/diagnostic logs readable. Kept lenient
+    // so an absent/odd name never fails validation and drops the list.
+    name: z.string().nullish(),
+  })
+  .loose()
+
+export const streamystatsWatchlistsResponseSchema = z.object({
+  data: z.array(streamystatsWatchlistSummarySchema),
+})
+
+// `?format=ids` response; we only need the Jellyfin item IDs in the list.
+export const streamystatsWatchlistItemIdsResponseSchema = z.object({
+  data: z.object({
+    items: z.array(z.string()),
+  }),
+})


### PR DESCRIPTION
Adds a Jellyfin-only **Streamystats** rule Application (the Jellyfin analog of Tautulli) with two watchlist-backed properties:

- **Is in a watchlist** (boolean)
- **[list] In watchlist of (username)** (text list)

Upstream Streamystats ([#515](https://github.com/fredrikburmester/streamystats/pull/515)) now accepts Jellyfin API-key auth on its watchlist endpoints, so Maintainerr can reach them via the MediaBrowser token scheme. These act as a "users curated this" protection signal.

Notes:
- Only **public** Streamystats watchlists are reachable with a server API key (it resolves to Streamystats' `system-api-key` pseudo-user); documented in code.
- Membership snapshot is cached in the shared Streamystats NodeCache, which is flushed between rule-group runs.
- The Application is removed from the rule constants unless Streamystats is configured, and the UI hides it on non-Jellyfin servers — mirroring how Tautulli is gated for Plex.
- A username-resolution failure surfaces as a transient skip, never an empty list (so it can't flip negative list comparisons).