### PR TITLE
fix(metadata): keep media-server ids unless corroborated; accept on provider year agreement (#3010)

### DIFF
--- a/apps/server/src/modules/metadata/metadata.service.spec.ts
+++ b/apps/server/src/modules/metadata/metadata.service.spec.ts
@@ -19,6 +19,7 @@ describe('MetadataService', () => {
       getMetadata: jest.fn(),
     },
     providerMocks,
+    preference = MetadataProviderPreference.TVDB_PRIMARY,
   }: {
     tmdbDetails?: {
       title?: string;
@@ -47,6 +48,7 @@ describe('MetadataService', () => {
     };
     tvdbMovieId?: number;
     providerMocks?: MetadataProviderMockConfig[];
+    preference?: MetadataProviderPreference;
   }) => {
     const providers = (
       providerMocks ?? [
@@ -91,7 +93,7 @@ describe('MetadataService', () => {
       providers,
       mediaServerFactory as never,
       {
-        metadata_provider_preference: MetadataProviderPreference.TVDB_PRIMARY,
+        metadata_provider_preference: preference,
       } as never,
       logger,
     );
@@ -630,9 +632,9 @@ describe('MetadataService', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it('rejects direct ids when every configured provider disagrees on year', async () => {
+  it('accepts direct ids on provider agreement when both providers agree on a year the media server disagrees with', async () => {
     const libraryItem = createMediaItem({
-      id: 'movie-fallback-2',
+      id: 'movie-consensus',
       type: 'movie',
       year: 2099,
       title: 'Fixture Runners',
@@ -655,12 +657,48 @@ describe('MetadataService', () => {
 
     const result = await service.resolveIdsFromMediaItem(libraryItem);
 
+    expect(result).toMatchObject({
+      tmdb: 777002,
+      tvdb: 888002,
+      type: 'movie',
+    });
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('provider agreement'),
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('rejects direct ids when providers disagree with the media server and with each other', async () => {
+    const libraryItem = createMediaItem({
+      id: 'movie-no-consensus',
+      type: 'movie',
+      year: 2099,
+      title: 'Fixture Runners',
+      providerIds: { tmdb: ['777003'], imdb: [], tvdb: ['888003'] },
+    });
+    const { service, logger } = createService({
+      tmdbDetails: {
+        title: 'Fixture Runners',
+        year: 2096,
+        type: 'movie',
+        externalIds: { tmdb: 777003, type: 'movie' },
+      },
+      tvdbDetails: {
+        title: 'Fixture Runners',
+        year: 2090,
+        type: 'movie',
+        externalIds: { tvdb: 888003, type: 'movie' },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
     expect(result).toBeUndefined();
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('TMDB returned 2096'),
     );
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('TVDB returned 2096'),
+      expect.stringContaining('TVDB returned 2090'),
     );
   });
 
@@ -718,6 +756,180 @@ describe('MetadataService', () => {
         'Corrected TMDB ID for "Fixture Harbor": 111 to 222',
       ),
     );
+  });
+
+  it('keeps the media-server id when a cross-provider correction does not corroborate (#3010)', async () => {
+    const libraryItem = createMediaItem({
+      id: 'show-3010',
+      type: 'show',
+      year: 2013,
+      title: 'Fixture Province',
+      providerIds: { tmdb: ['65351'], imdb: [], tvdb: ['280331'] },
+    });
+    const { service, logger, tvdbProvider } = createService({
+      preference: MetadataProviderPreference.TMDB_PRIMARY,
+      tmdbDetails: {
+        title: 'Fixture Province',
+        year: 2013,
+        type: 'tv',
+        externalIds: { tmdb: 65351, tvdb: 306261, type: 'tv' },
+      },
+    });
+    tvdbProvider.getDetails.mockImplementation(async (id: number) =>
+      id === 306261
+        ? undefined
+        : {
+            id,
+            title: 'Fixture Province',
+            year: 2013,
+            type: 'tv',
+            externalIds: { tmdb: 65351, tvdb: id, type: 'tv' },
+          },
+    );
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toMatchObject({ tmdb: 65351, tvdb: 280331, type: 'tv' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Kept media-server TVDB ID'),
+    );
+    expect(tvdbProvider.assignId).not.toHaveBeenCalledWith(
+      expect.anything(),
+      306261,
+    );
+  });
+
+  it('overwrites the media-server id when a cross-provider correction round-trips', async () => {
+    const libraryItem = createMediaItem({
+      id: 'show-corroborated',
+      type: 'show',
+      year: 2013,
+      title: 'Fixture Province',
+      providerIds: { tmdb: ['111'], imdb: [], tvdb: ['333'] },
+    });
+    const { service, logger, tvdbProvider } = createService({
+      preference: MetadataProviderPreference.TMDB_PRIMARY,
+      tmdbDetails: {
+        title: 'Fixture Province',
+        year: 2013,
+        type: 'tv',
+        externalIds: { tmdb: 111, tvdb: 444, type: 'tv' },
+      },
+    });
+    tvdbProvider.getDetails.mockImplementation(async (id: number) => ({
+      id,
+      title: 'Fixture Province',
+      year: 2013,
+      type: 'tv',
+      externalIds: { tmdb: 111, tvdb: id, type: 'tv' },
+    }));
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toMatchObject({ tmdb: 111, tvdb: 444, type: 'tv' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Corrected TVDB ID for "Fixture Province": 333 to 444',
+      ),
+    );
+  });
+
+  it('keeps the media-server id when the proposed cross-reference resolves but does not round-trip', async () => {
+    const libraryItem = createMediaItem({
+      id: 'show-mismatch',
+      type: 'show',
+      year: 2013,
+      title: 'Fixture Province',
+      providerIds: { tmdb: ['111'], imdb: [], tvdb: ['333'] },
+    });
+    const { service, logger, tvdbProvider } = createService({
+      preference: MetadataProviderPreference.TMDB_PRIMARY,
+      tmdbDetails: {
+        title: 'Fixture Province',
+        year: 2013,
+        type: 'tv',
+        externalIds: { tmdb: 111, tvdb: 999, type: 'tv' },
+      },
+    });
+    // 999 resolves, but back-references TMDB 777, not the source 111.
+    tvdbProvider.getDetails.mockImplementation(async (id: number) => ({
+      id,
+      title: 'Fixture Detour',
+      year: 2013,
+      type: 'tv',
+      externalIds: { tmdb: 777, tvdb: id, type: 'tv' },
+    }));
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toMatchObject({ tmdb: 111, tvdb: 333, type: 'tv' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Kept media-server TVDB ID'),
+    );
+  });
+
+  it('keeps the media-server id when the corroborating lookup throws', async () => {
+    const libraryItem = createMediaItem({
+      id: 'show-throw',
+      type: 'show',
+      year: 2013,
+      title: 'Fixture Province',
+      providerIds: { tmdb: ['111'], imdb: [], tvdb: ['333'] },
+    });
+    const { service, logger, tvdbProvider } = createService({
+      preference: MetadataProviderPreference.TMDB_PRIMARY,
+      tmdbDetails: {
+        title: 'Fixture Province',
+        year: 2013,
+        type: 'tv',
+        externalIds: { tmdb: 111, tvdb: 999, type: 'tv' },
+      },
+    });
+    tvdbProvider.getDetails.mockRejectedValue(new Error('tvdb unavailable'));
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toMatchObject({ tmdb: 111, tvdb: 333, type: 'tv' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Kept media-server TVDB ID'),
+    );
+  });
+
+  it('does not corroborate against an unavailable provider and keeps the id silently', async () => {
+    const libraryItem = createMediaItem({
+      id: 'show-tmdb-only',
+      type: 'show',
+      year: 2013,
+      title: 'Fixture Province',
+      providerIds: { tmdb: ['111'], imdb: [], tvdb: ['333'] },
+    });
+    const { service, logger, tvdbProvider } = createService({
+      preference: MetadataProviderPreference.TMDB_PRIMARY,
+      providerMocks: [
+        {
+          name: 'TMDB',
+          idKey: 'tmdb',
+          detailsId: 111,
+          details: {
+            title: 'Fixture Province',
+            year: 2013,
+            type: 'tv',
+            externalIds: { tmdb: 111, tvdb: 999, type: 'tv' },
+          },
+        },
+        {
+          name: 'TVDB',
+          idKey: 'tvdb',
+          isAvailable: false,
+        },
+      ],
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toMatchObject({ tmdb: 111, tvdb: 333, type: 'tv' });
+    expect(tvdbProvider.getDetails).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   // Second-opinion path: the media item exposes only TMDB + IMDB tags.

--- a/apps/server/src/modules/metadata/metadata.service.ts
+++ b/apps/server/src/modules/metadata/metadata.service.ts
@@ -24,6 +24,13 @@ import {
 } from './interfaces/metadata.types';
 import { MetadataLookupCandidate } from './metadata-lookup.util';
 
+/** A provider's year that disagreed with the media server's, kept for agreement checks. */
+interface ProviderYearDisagreement {
+  providerName: string;
+  year: number;
+  details: MetadataDetails;
+}
+
 @Injectable()
 export class MetadataService {
   private preference: MetadataProviderPreference =
@@ -524,10 +531,11 @@ export class MetadataService {
       }
 
       if (providerResult.result.externalIds) {
-        this.applyIdCorrections(
+        await this.applyIdCorrections(
           ids,
           providerResult.result.externalIds,
           providerResult.provider,
+          type,
         );
       }
 
@@ -575,35 +583,101 @@ export class MetadataService {
     }
 
     if (merged.externalIds && primaryProviderName) {
-      this.applyIdCorrections(ids, merged.externalIds, primaryProviderName);
+      await this.applyIdCorrections(
+        ids,
+        merged.externalIds,
+        primaryProviderName,
+        type,
+      );
     }
 
     return merged;
   }
 
-  private applyIdCorrections(
+  /**
+   * Media-server IDs are authoritative. A same-provider redirect is trusted; a
+   * cross-provider correction is applied only if it round-trips, so a wrong/dead
+   * cross-reference (#3010) can't overwrite a good ID.
+   */
+  private async applyIdCorrections(
     ids: ProviderIds,
     externalIds: ProviderIds,
     sourceProviderName: string,
+    type: 'movie' | 'tv',
     itemTitle?: string,
-  ): void {
+  ): Promise<void> {
+    const sourceProvider = this.providers.find(
+      (provider) => provider.name === sourceProviderName,
+    );
+    const sourceId = sourceProvider?.extractId(externalIds);
+    const target = itemTitle ? ` for "${itemTitle}"` : '';
+
     for (const provider of this.providers) {
       const currentId = provider.extractId(ids);
-      const correctId = provider.extractId(externalIds);
+      const proposedId = provider.extractId(externalIds);
 
       if (
         currentId === undefined ||
-        correctId === undefined ||
-        currentId === correctId
+        proposedId === undefined ||
+        currentId === proposedId
       ) {
         continue;
       }
 
-      const target = itemTitle ? ` for "${itemTitle}"` : '';
+      // Same-provider id is a redirect — authoritative, no lookup needed.
+      const isRedirect = provider === sourceProvider;
+
+      // Don't corroborate against an unconfigured provider: keep the id silently
+      // rather than fire an outbound request/warning on TMDB-only setups.
+      if (!isRedirect && !provider.isAvailable()) {
+        continue;
+      }
+
+      if (
+        isRedirect ||
+        (await this.crossReferenceRoundTrips(
+          provider,
+          proposedId,
+          sourceProvider,
+          sourceId,
+          type,
+        ))
+      ) {
+        this.logger.warn(
+          `Corrected ${provider.name} ID${target}: ${currentId} to ${proposedId} via ${sourceProviderName} cross-reference. The media server's original ID appears outdated.`,
+        );
+        provider.assignId(ids, proposedId);
+        continue;
+      }
+
       this.logger.warn(
-        `Corrected ${provider.name} ID${target}: ${currentId} to ${correctId} via ${sourceProviderName} cross-reference. The media server may have incorrect metadata for this item.`,
+        `Kept media-server ${provider.name} ID${target}: ${currentId}. ${sourceProviderName} cross-reference suggested ${proposedId}, but a direct ${provider.name} lookup did not corroborate it, so the original media-server ID was preserved.`,
       );
-      provider.assignId(ids, correctId);
+    }
+  }
+
+  /** Fail-closed: the proposed ID must resolve and point back at the source ID. */
+  private async crossReferenceRoundTrips(
+    provider: IMetadataProvider,
+    proposedId: number,
+    sourceProvider: IMetadataProvider | undefined,
+    sourceId: number | undefined,
+    type: 'movie' | 'tv',
+  ): Promise<boolean> {
+    if (!sourceProvider || sourceId === undefined) {
+      return false;
+    }
+
+    try {
+      const proposedDetails = await provider.getDetails(proposedId, type);
+      if (!proposedDetails?.externalIds) {
+        return false;
+      }
+
+      return sourceProvider.extractId(proposedDetails.externalIds) === sourceId;
+    } catch (error) {
+      this.logger.debug(error);
+      return false;
     }
   }
 
@@ -880,7 +954,7 @@ export class MetadataService {
     ids: ResolvedMediaIds,
   ): Promise<MetadataDetails | undefined> {
     const itemYear = this.readItemYear(item);
-    const disagreements: string[] = [];
+    const disagreements: ProviderYearDisagreement[] = [];
     const consulted = new Set<IMetadataProvider>();
 
     const evaluate = async (
@@ -895,10 +969,11 @@ export class MetadataService {
       if (!providerDetails) return undefined;
 
       if (providerDetails.externalIds) {
-        this.applyIdCorrections(
+        await this.applyIdCorrections(
           ids,
           providerDetails.externalIds,
           provider.name,
+          ids.type,
           item.title,
         );
         this.fillMissingIds(ids, providerDetails.externalIds);
@@ -927,7 +1002,9 @@ export class MetadataService {
       if (delta === 0) {
         if (disagreements.length > 0) {
           this.logger.debug(
-            `Direct provider IDs for "${item.title}" validated by ${provider.name} (${providerDetails.year}) after year disagreement from: ${disagreements.join(', ')}.`,
+            `Direct provider IDs for "${item.title}" validated by ${provider.name} (${providerDetails.year}) after year disagreement from: ${this.describeYearDisagreements(
+              disagreements,
+            ).join(', ')}.`,
           );
         }
         return providerDetails;
@@ -941,7 +1018,11 @@ export class MetadataService {
         return providerDetails;
       }
 
-      disagreements.push(`${provider.name} returned ${providerDetails.year}`);
+      disagreements.push({
+        providerName: provider.name,
+        year: providerDetails.year,
+        details: providerDetails,
+      });
       return undefined;
     };
 
@@ -962,13 +1043,68 @@ export class MetadataService {
       }
     }
 
+    // Two providers agreeing on a year the media server disputes ⇒ the media
+    // server is the outlier. Accept rather than reject — we can't write its year
+    // back anyway, so rejecting would only block the rule.
+    const agreement = this.findProviderYearAgreement(disagreements);
+    if (agreement) {
+      this.logger.log(
+        `Accepted direct provider IDs for "${item.title}" on provider agreement: ${agreement.providerNames.join(
+          ' and ',
+        )} agree on ${agreement.year}, but the media server reports ${itemYear}. Treating the media server's year as incorrect.`,
+      );
+      return agreement.details;
+    }
+
     if (disagreements.length > 0) {
       this.logger.warn(
-        `Rejected direct provider IDs for media server item "${item.title}" (${itemYear}) because no configured metadata provider confirmed the release year. Disagreements: ${disagreements.join('; ')}. The media server likely has incorrect metadata for this item, so no external IDs will be returned from this resolution attempt.`,
+        `Rejected direct provider IDs for media server item "${item.title}" (${itemYear}) because no configured metadata provider confirmed the release year. Disagreements: ${this.describeYearDisagreements(
+          disagreements,
+        ).join(
+          '; ',
+        )}. The media server likely has incorrect metadata for this item, so no external IDs will be returned from this resolution attempt.`,
       );
     }
 
     return undefined;
+  }
+
+  /**
+   * A year ≥2 providers agree on. Disagreements are in preference order, so
+   * matches[0] is the preferred provider's details. Undefined if none agree.
+   */
+  private findProviderYearAgreement(
+    disagreements: ProviderYearDisagreement[],
+  ):
+    | { year: number; details: MetadataDetails; providerNames: string[] }
+    | undefined {
+    for (const candidate of disagreements) {
+      const matches = disagreements.filter(
+        (disagreement) => disagreement.year === candidate.year,
+      );
+      const providerNames = [
+        ...new Set(matches.map((match) => match.providerName)),
+      ];
+
+      if (providerNames.length >= 2) {
+        return {
+          year: candidate.year,
+          details: matches[0].details,
+          providerNames,
+        };
+      }
+    }
+
+    return undefined;
+  }
+
+  private describeYearDisagreements(
+    disagreements: ProviderYearDisagreement[],
+  ): string[] {
+    return disagreements.map(
+      (disagreement) =>
+        `${disagreement.providerName} returned ${disagreement.year}`,
+    );
   }
 
   private async bridgeMissingProviderIds(ids: ResolvedMediaIds): Promise<void> {


### PR DESCRIPTION
Reworks #3010 to a minimal, behavior-focused fix (replaces the earlier alternate-id/WeakMap approach — contained to `metadata.service.ts`).

- `applyIdCorrections`: the media-server id is authoritative. A cross-provider correction (e.g. TMDB's external_ids reporting a different TVDB id than the media server holds) is only applied when a direct lookup of the proposed id round-trips back to the source id. The dead TVDB id in #3010 cannot corroborate, so the correct media-server id is preserved. Same-provider redirects (a provider returning a new canonical id for its own key) stay trusted, and a provider the user hasn't configured is never queried to corroborate (no outbound requests on TMDB-only setups).
- `validateDirectIds`: when two providers agree on a release year the media server disagrees with, accept their (corroborated) ids instead of rejecting — the media-server year is the outlier (and Maintainerr does not write years back to the media server). Single-provider mismatches, and providers disagreeing with each other, still reject.

Fixes #3010.