### PR TITLE
fix: use Radarr bulk exclusions endpoint to avoid duplicate 400 failure

### DIFF
--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
@@ -1,9 +1,7 @@
 import { Mocked } from '@suites/doubles.jest';
-import {
-  createRadarrMovie,
-  createRadarrMovieFile,
-} from '../../../../../test/utils/data';
+import { createRadarrMovie } from '../../../../../test/utils/data';
 import { MaintainerrLogger } from '../../../logging/logs.service';
+import { RadarrImportListExclusion } from '../interfaces/radarr.interface';
 import { RadarrApi } from './radarr.helper';
 
 describe('RadarrApi', () => {
@@ -24,7 +22,7 @@ describe('RadarrApi', () => {
     );
   });
 
-  it('returns false when adding an import exclusion fails', async () => {
+  describe('updateMovie import list exclusions', () => {
     const movie = createRadarrMovie({
       id: 5,
       monitored: true,
@@ -33,33 +31,56 @@ describe('RadarrApi', () => {
       year: 2024,
     });
 
-    jest.spyOn(api, 'getWithoutCache').mockImplementation(async (endpoint) => {
-      if (endpoint === 'movie/5') {
-        return movie;
-      }
-
-      if (endpoint === 'moviefile?movieId=5') {
-        return [createRadarrMovieFile()];
-      }
-
-      return undefined;
+    const exclusionFor = (m: typeof movie): RadarrImportListExclusion => ({
+      tmdbId: m.tmdbId,
+      movieTitle: m.title,
+      movieYear: m.year,
     });
 
-    jest.spyOn(api as any, 'runPut').mockResolvedValue(true);
-    jest.spyOn(api as any, 'runDelete').mockResolvedValue(true);
-    jest.spyOn(api, 'post').mockResolvedValue(undefined);
+    let postSpy: jest.SpyInstance;
 
-    await expect(
-      api.updateMovie(5, {
+    beforeEach(() => {
+      jest
+        .spyOn(api, 'getWithoutCache')
+        .mockImplementation(async (endpoint) => {
+          if (endpoint === `movie/${movie.id}`) return movie;
+          return undefined;
+        });
+      jest.spyOn(api as any, 'runPut').mockResolvedValue(true);
+      postSpy = jest.spyOn(api, 'post');
+    });
+
+    const unmonitorWithExclusion = () =>
+      api.updateMovie(movie.id, {
         monitored: false,
         addImportExclusion: true,
-      }),
-    ).resolves.toBe(false);
+      });
 
-    expect(api.post).toHaveBeenCalledWith('/exclusions', {
-      tmdbId: movie.tmdbId,
-      movieTitle: movie.title,
-      movieYear: movie.year,
+    // The bulk endpoint de-dupes server-side, so re-adding an existing
+    // exclusion is a no-op rather than the HTTP 400 the singular endpoint
+    // returns.
+    it('adds the exclusion via the de-duping bulk endpoint', async () => {
+      postSpy.mockResolvedValue([exclusionFor(movie)]);
+
+      await expect(unmonitorWithExclusion()).resolves.toBe(true);
+      expect(postSpy).toHaveBeenCalledWith('/exclusions/bulk', [
+        exclusionFor(movie),
+      ]);
+    });
+
+    // Radarr's bulk endpoint documents 200 with no response schema, so a
+    // successful add can have an empty body (''); only undefined (a failed
+    // request) is a failure.
+    it('treats a successful empty-body response as success', async () => {
+      postSpy.mockResolvedValue('');
+
+      await expect(unmonitorWithExclusion()).resolves.toBe(true);
+    });
+
+    it('returns false when the bulk exclusion request fails', async () => {
+      postSpy.mockResolvedValue(undefined);
+
+      await expect(unmonitorWithExclusion()).resolves.toBe(false);
     });
   });
 

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
@@ -135,16 +135,29 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
       }
 
       if (options?.addImportExclusion) {
-        const exclusion = await this.post<RadarrImportListExclusion>(
-          `/exclusions`,
-          {
-            tmdbId: movieData.tmdbId,
-            movieTitle: movieData.title,
-            movieYear: movieData.year,
-          } satisfies RadarrImportListExclusion,
+        // Use the bulk endpoint, not the singular POST /exclusions: the latter
+        // runs a validator that rejects an already-excluded movie with HTTP 400
+        // ("This exclusion has already been added"), which would fail the whole
+        // collection run on every re-run. /exclusions/bulk skips that validator
+        // and de-dupes server-side (the same idempotent behaviour as Radarr's
+        // movie-delete path and Sonarr's exclusion handling), so re-adding is a
+        // no-op.
+        const result = await this.post<RadarrImportListExclusion[]>(
+          `/exclusions/bulk`,
+          [
+            {
+              tmdbId: movieData.tmdbId,
+              movieTitle: movieData.title,
+              movieYear: movieData.year,
+            } satisfies RadarrImportListExclusion,
+          ],
         );
 
-        if (!exclusion) {
+        // post() returns the body on success and undefined only on a failed
+        // request. Radarr's bulk endpoint documents 200 with no response schema,
+        // so a successful add can have an empty body ('') — check for undefined
+        // rather than falsiness so an empty-body success isn't read as failure.
+        if (result === undefined) {
           return false;
         }
       }


### PR DESCRIPTION
When a collection rule unmonitors a movie with **Add import list exclusions** enabled, Maintainerr added the exclusion via Radarr's singular `POST /api/v3/exclusions`. That endpoint runs a validator (`ImportListExclusionExistsValidator`) that rejects an already-excluded `tmdbId` with `400 Bad Request` ("This exclusion has already been added").

The 400 was swallowed to `undefined`, so `updateMovie` returned `false`, the whole collection run was marked failed, and users got a generic "Oops! Something went wrong" notification on every re-run — even though nothing was actually wrong.

- Switch to `POST /api/v3/exclusions/bulk`. That endpoint skips the uniqueness validator and de-dupes server-side (`ImportListExclusionService.Add(List<>)` → `DeDupeExclusions`), so re-adding an existing exclusion is a no-op instead of a 400.
- This matches the idempotent server-side de-dupe already relied on by Radarr's movie-delete path (`MoviesDeletedEvent`) and Sonarr's exclusion handling (`SeriesDeletedEvent`) — Maintainerr's Sonarr helper only adds exclusions via the delete path, which is why it was never affected.