### PR TITLE
fix: make collection handling failure notifications name the failing collection

### DIFF
--- a/apps/server/src/modules/collections/collection-worker.server.spec.ts
+++ b/apps/server/src/modules/collections/collection-worker.server.spec.ts
@@ -189,6 +189,11 @@ describe('CollectionWorkerService', () => {
     expect(seerrApi.api.post).not.toHaveBeenCalled();
     expect(eventEmitter.emit).toHaveBeenCalledWith(
       MaintainerrEvent.CollectionHandler_Failed,
+      expect.objectContaining({
+        collectionName: collection.title,
+        mediaItems: [{ mediaServerId: collectionMedia.mediaServerId }],
+        identifier: { type: 'collection', value: collection.id },
+      }),
     );
     expect(eventEmitter.emit).not.toHaveBeenCalledWith(
       MaintainerrEvent.CollectionMedia_Handled,
@@ -225,6 +230,11 @@ describe('CollectionWorkerService', () => {
     expect(seerrApi.api.post).toHaveBeenCalled();
     expect(eventEmitter.emit).toHaveBeenCalledWith(
       MaintainerrEvent.CollectionHandler_Failed,
+      expect.objectContaining({
+        collectionName: collection.title,
+        mediaItems: [{ mediaServerId: firstCollectionMedia.mediaServerId }],
+        identifier: { type: 'collection', value: collection.id },
+      }),
     );
   });
 

--- a/apps/server/src/modules/collections/collection-worker.service.ts
+++ b/apps/server/src/modules/collections/collection-worker.service.ts
@@ -11,7 +11,10 @@ import { LessThanOrEqual, Repository } from 'typeorm';
 import { delay } from '../../utils/delay';
 import { MediaServerFactory } from '../api/media-server/media-server.factory';
 import { SeerrApiService } from '../api/seerr-api/seerr-api.service';
-import { CollectionMediaHandledDto } from '../events/events.dto';
+import {
+  CollectionHandlerFailedDto,
+  CollectionMediaHandledDto,
+} from '../events/events.dto';
 import { MaintainerrLogger } from '../logging/logs.service';
 import { SettingsDataService } from '../settings/settings-data.service';
 import {
@@ -85,6 +88,7 @@ export class CollectionWorkerService extends TaskBase {
           'Media server unreachable. Skipping collection handling.',
         );
         this.logger.debug(error);
+        this.eventEmitter.emit(MaintainerrEvent.CollectionHandler_Failed);
         return;
       }
 
@@ -192,9 +196,11 @@ export class CollectionWorkerService extends TaskBase {
 
         this.logger.log(`Handling collection '${collection.title}'`);
         const handledMediaForNotification = [];
+        const failedMediaForNotification: { mediaServerId: string }[] = [];
 
         for (const media of collectionMedia) {
           let mediaHandled = false;
+          let handlingError: unknown;
 
           try {
             mediaHandled = await this.collectionHandler.handleMedia(
@@ -202,23 +208,34 @@ export class CollectionWorkerService extends TaskBase {
               media,
             );
           } catch (error) {
-            collectionHandlingFailed = true;
-            const errorMessage =
-              error instanceof Error ? error.message : 'Unknown error';
-
-            this.logger.warn(
-              `Failed to handle media with id ${media.mediaServerId} in collection '${collection.title}': ${errorMessage}`,
-            );
-            this.logger.debug(error);
+            handlingError = error;
           }
 
-          if (!mediaHandled) {
-            collectionHandlingFailed = true;
-          } else {
+          if (mediaHandled) {
             handledCollectionMedia++;
             handledMediaForNotification.push({
               mediaServerId: media.mediaServerId,
             });
+          } else {
+            collectionHandlingFailed = true;
+            failedMediaForNotification.push({
+              mediaServerId: media.mediaServerId,
+            });
+
+            // Warn so a failed action stays visible without DEBUG; the
+            // per-collection failure notification below is the user-facing
+            // signal. A thrown error carries its message; a soft `false` was
+            // already logged at debug in the API layer.
+            const reason =
+              handlingError instanceof Error
+                ? handlingError.message
+                : 'the configured action could not be completed';
+            this.logger.warn(
+              `Failed to handle media with id ${media.mediaServerId} in collection '${collection.title}': ${reason}`,
+            );
+            if (handlingError) {
+              this.logger.debug(handlingError);
+            }
           }
 
           if (progressedEvent) {
@@ -235,6 +252,20 @@ export class CollectionWorkerService extends TaskBase {
             new CollectionMediaHandledDto(
               handledMediaForNotification,
               collection.title,
+              { type: 'collection', value: collection.id },
+            ),
+          );
+        }
+
+        // Emit per failing collection so the notification can name which
+        // collection failed.
+        if (failedMediaForNotification.length > 0) {
+          this.eventEmitter.emit(
+            MaintainerrEvent.CollectionHandler_Failed,
+            new CollectionHandlerFailedDto(
+              failedMediaForNotification,
+              collection.title,
+              undefined,
               { type: 'collection', value: collection.id },
             ),
           );
@@ -293,11 +324,10 @@ export class CollectionWorkerService extends TaskBase {
       failed = true;
       this.logger.error('Collection handling failed');
       this.logger.debug(error);
+      // Run-level failure with no single collection in context; the per
+      // collection failures above emit their own, more specific events.
+      this.eventEmitter.emit(MaintainerrEvent.CollectionHandler_Failed);
     } finally {
-      if (failed) {
-        this.eventEmitter.emit(MaintainerrEvent.CollectionHandler_Failed);
-      }
-
       release();
 
       this.eventEmitter.emit(

--- a/apps/server/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/server/src/modules/notifications/notifications.service.spec.ts
@@ -1,4 +1,5 @@
 import { MaintainerrEvent } from '@maintainerr/contracts';
+import { ServiceUnavailableException } from '@nestjs/common';
 import { createMockLogger } from '../../../test/utils/data';
 import {
   CollectionMediaAddedDto,
@@ -87,6 +88,66 @@ describe('NotificationService', () => {
     expect(content).toBe(
       "🖼️ Overlay has been applied to 'Test Media' in 'My Collection'.",
     );
+  });
+
+  describe('collection handling failed message', () => {
+    it('names the collection that failed', async () => {
+      const { service } = createService();
+
+      const { message } = (service as any).getContent(
+        NotificationType.COLLECTION_HANDLING_FAILED,
+        false,
+      );
+      const content = await (service as any).transformMessageContent(
+        message,
+        undefined,
+        'My Collection',
+      );
+
+      expect(content).toBe(
+        "⚠️ Couldn't finish handling one or more items in 'My Collection'. Check the Maintainerr logs for details.",
+      );
+    });
+
+    it('drops the collection clause when there is no collection context', async () => {
+      const { service } = createService();
+
+      const { message } = (service as any).getContent(
+        NotificationType.COLLECTION_HANDLING_FAILED,
+        false,
+      );
+      const content = await (service as any).transformMessageContent(message);
+
+      expect(content).toBe(
+        "⚠️ Couldn't finish handling one or more items. Check the Maintainerr logs for details.",
+      );
+      expect(content).not.toContain('{collection_name}');
+    });
+
+    it('still resolves the collection name when the media server is unavailable', async () => {
+      // The media-server-unreachable failure path emits this notification while
+      // the media server throws ServiceUnavailableException. Collection name is
+      // a plain substitution, so it must not leak the raw placeholder.
+      const { service, mediaServerFactory } = createService();
+      mediaServerFactory.getService.mockRejectedValue(
+        new ServiceUnavailableException(),
+      );
+
+      const { message } = (service as any).getContent(
+        NotificationType.COLLECTION_HANDLING_FAILED,
+        false,
+      );
+      const content = await (service as any).transformMessageContent(
+        message,
+        undefined,
+        'My Collection',
+      );
+
+      expect(content).toBe(
+        "⚠️ Couldn't finish handling one or more items in 'My Collection'. Check the Maintainerr logs for details.",
+      );
+      expect(content).not.toContain('{collection_name}');
+    });
   });
 
   describe('rule batch dedupe', () => {

--- a/apps/server/src/modules/notifications/notifications.service.ts
+++ b/apps/server/src/modules/notifications/notifications.service.ts
@@ -17,6 +17,7 @@ import { getErrorMessage } from '../../utils/connection-error';
 import { MediaServerFactory } from '../api/media-server/media-server.factory';
 import { IMediaServerService } from '../api/media-server/media-server.interface';
 import {
+  CollectionHandlerFailedDto,
   CollectionMediaAddedDto,
   CollectionMediaHandledDto,
   CollectionMediaRemovedDto,
@@ -762,7 +763,7 @@ export class NotificationService implements OnModuleInit {
         case NotificationType.COLLECTION_HANDLING_FAILED:
           subject = 'Collection Handling Failed';
           message =
-            '⚠️ Oops! Something went wrong while processing your collections.';
+            "⚠️ Couldn't finish handling one or more items in '{collection_name}'. Check the Maintainerr logs for details.";
           break;
         case NotificationType.RULE_HANDLING_FAILED:
           subject = 'Rule Handling Failed';
@@ -861,57 +862,65 @@ export class NotificationService implements OnModuleInit {
     collectionName?: string,
     dayAmount?: number,
   ): Promise<string> {
-    try {
-      const mediaServer = await this.getMediaServer();
-      if (items) {
-        if (items.length > 1) {
-          // if multiple items
-          const titles = [];
-          let numUnknownItems = 0;
+    // Collection name and day count are plain string substitutions that don't
+    // need the media server — resolve them up front so an unavailable media
+    // server (which only affects the media-title lookups below) can't leave
+    // their placeholders raw. Strip the collection clause entirely when there's
+    // no collection context (e.g. an infrastructure-level failure) so we never
+    // deliver a raw "{collection_name}" token.
+    message = collectionName
+      ? message.replace('{collection_name}', collectionName)
+      : message.replace(" in '{collection_name}'", '');
 
-          for (const i of items) {
-            const item = await mediaServer.getMetadata(i.mediaServerId);
-
-            if (item) {
-              titles.push(this.getTitle(item));
-            } else {
-              numUnknownItems++;
-            }
-          }
-
-          if (numUnknownItems > 0) {
-            titles.push(
-              `${numUnknownItems} item${
-                numUnknownItems > 1 ? 's' : ''
-              } that no longer exist${numUnknownItems > 1 ? '' : 's'} in the media server`,
-            );
-          }
-
-          const result = titles
-            .map((name) => `* ${name.charAt(0).toUpperCase() + name.slice(1)}`)
-            .join(' \n');
-
-          message = message.replace('{media_items}', result);
-        } else {
-          // if 1 item
-          const item = await mediaServer.getMetadata(items[0].mediaServerId);
-          message = message.replace(
-            '{media_title}',
-            item
-              ? this.getTitle(item)
-              : '1 item that no longer exists in the media server',
-          );
-        }
-      }
-
-      message = collectionName
-        ? message.replace('{collection_name}', collectionName)
+    message =
+      dayAmount && dayAmount > 0
+        ? message.replace('{days}', dayAmount.toString())
         : message;
 
-      message =
-        dayAmount && dayAmount > 0
-          ? message.replace('{days}', dayAmount.toString())
-          : message;
+    if (!items) {
+      return message;
+    }
+
+    try {
+      const mediaServer = await this.getMediaServer();
+      if (items.length > 1) {
+        // if multiple items
+        const titles = [];
+        let numUnknownItems = 0;
+
+        for (const i of items) {
+          const item = await mediaServer.getMetadata(i.mediaServerId);
+
+          if (item) {
+            titles.push(this.getTitle(item));
+          } else {
+            numUnknownItems++;
+          }
+        }
+
+        if (numUnknownItems > 0) {
+          titles.push(
+            `${numUnknownItems} item${
+              numUnknownItems > 1 ? 's' : ''
+            } that no longer exist${numUnknownItems > 1 ? '' : 's'} in the media server`,
+          );
+        }
+
+        const result = titles
+          .map((name) => `* ${name.charAt(0).toUpperCase() + name.slice(1)}`)
+          .join(' \n');
+
+        message = message.replace('{media_items}', result);
+      } else {
+        // if 1 item
+        const item = await mediaServer.getMetadata(items[0].mediaServerId);
+        message = message.replace(
+          '{media_title}',
+          item
+            ? this.getTitle(item)
+            : '1 item that no longer exists in the media server',
+        );
+      }
 
       return message;
     } catch (error) {
@@ -961,8 +970,15 @@ export class NotificationService implements OnModuleInit {
   }
 
   @OnEvent(MaintainerrEvent.CollectionHandler_Failed)
-  private async collectionHandlerFailed() {
-    await this.handleNotification(NotificationType.COLLECTION_HANDLING_FAILED);
+  private async collectionHandlerFailed(data?: CollectionHandlerFailedDto) {
+    await this.handleNotification(
+      NotificationType.COLLECTION_HANDLING_FAILED,
+      undefined,
+      data?.collectionName,
+      undefined,
+      undefined,
+      data?.identifier,
+    );
   }
 
   @OnEvent(MaintainerrEvent.RuleHandlerQueue_StatusUpdated)


### PR DESCRIPTION
When a collection rule failed to handle an item, the notification was a generic *"Oops! Something went wrong while processing your collections"* with no indication of which collection failed.

- **Notification names the collection.** `CollectionHandler_Failed` is now emitted **per failing collection** carrying the existing-but-unused `CollectionHandlerFailedDto` (collection title + identifier), mirroring how `RuleHandler_Failed` and `CollectionMedia_Handled` already work. The message reads *"Couldn't finish handling one or more items in '<collection>'. Check the Maintainerr logs for details."* Infrastructure-level failures (media server unreachable, unexpected run errors) still emit a generic alert, and the `{collection_name}` clause is stripped when there's no collection context so a raw placeholder is never delivered.
- **`transformMessageContent` resolves collection name / day count before touching the media server.** These are plain string substitutions; doing them up front means an unavailable media server (which only affects media-title lookups) can't return the raw `{collection_name}` template for the media-server-unreachable failure notification.
- **Per-item failure stays at `warn`** (matching the prior behaviour) so a failed action remains visible without DEBUG; the thrown error's stack stays at debug.