### PR TITLE
chore(dev): add fake Radarr mock and wire seed for arr-action testing

### DIFF
--- a/.github/instructions/project-notes.instructions.md
+++ b/.github/instructions/project-notes.instructions.md
@@ -445,6 +445,15 @@ Playwright against deterministic data. Full workflow is in
   hydration uses this, not `/Items/{id}`). Item images 302-redirect to picsum.
 - `tools/dev/fake-plex.mjs` — stateless mock Plex (`:32400`); covers the Plex-only
   getter paths.
+- `tools/dev/fake-radarr.mjs` — mock Radarr v3 (`:7878`). The media-server mocks
+  don't cover \*arr, so the collection-handler → RadarrActionHandler flow
+  (DELETE / UNMONITOR / add-import-list-exclusion) needs this. Resolves any
+  `tmdbId` to a movie (movie id == tmdbId), and faithfully replicates Radarr's
+  exclusion semantics: `POST /exclusions/bulk` de-dupes server-side (idempotent),
+  singular `POST /exclusions` returns HTTP 400 on a duplicate. The seed's "Stale
+  Movies" collection is UNMONITOR + listExclusions with `tmdbId`s set, so
+  `POST /api/collections/handle` exercises this path end-to-end. No fake Sonarr
+  exists yet, so the seed's show collection is DO_NOTHING.
 - `tools/dev/seed-db.mjs` — the only DB-touching script. Resets and seeds
   collections / rule groups (with rules covering ~all properties) / settings /
   notifications / exclusions / overlays into `data/maintainerr.sqlite`. Target a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,22 +305,30 @@ These specifications provide comprehensive type definitions and endpoint documen
 
 For end-to-end checks of media-server-dependent flows (rules, collections,
 overview, calendar, storage) without a real Plex/Jellyfin, the `tools/dev/` folder
-has three scripts that **complement Playwright** — Playwright drives the UI, these
+has scripts that **complement Playwright** — Playwright drives the UI, these
 provide the backend data:
 
 - `tools/dev/fake-jellyfin.mjs` — stateless mock Jellyfin (`:8096`).
 - `tools/dev/fake-plex.mjs` — stateless mock Plex (`:32400`); covers the Plex-only
   getter paths (smart collections, watch history, accounts, ratings,
   shows/seasons/episodes) that the Jellyfin mock can't.
+- `tools/dev/fake-radarr.mjs` — mock Radarr v3 (`:7878`); covers the
+  collection-handler → RadarrActionHandler flow (DELETE / UNMONITOR / "add import
+  list exclusion") that the media-server mocks can't. Resolves any `tmdbId` to a
+  movie, and replicates Radarr's exclusion semantics: `POST /exclusions/bulk`
+  de-dupes (idempotent), singular `POST /exclusions` 400s on a duplicate.
 - `tools/dev/seed-db.mjs` — the **only** DB-touching script. Seeds settings,
   collections, and rule groups **with rules** covering ~all rule properties, plus
-  notifications, cron, logs, exclusions, and overlays. Target a server with
-  `MEDIA_SERVER=plex|jellyfin` (default `jellyfin`).
+  notifications, cron, logs, exclusions, and overlays. The "Stale Movies"
+  collection is seeded as UNMONITOR + listExclusions with `tmdbId`s set, so it
+  exercises the Radarr exclusion path against `fake-radarr.mjs`. Target a server
+  with `MEDIA_SERVER=plex|jellyfin` (default `jellyfin`).
 
-Workflow: start the matching mock, stop `yarn dev` (SQLite is single-writer),
+Workflow: start the matching mock(s), stop `yarn dev` (SQLite is single-writer),
 run the seed, restart `yarn dev`. Inspect a getter's live output with
-`POST /api/rules/test {"mediaId","rulegroupId"}` or run a rule with
-`POST /api/rules/:id/execute`. Note: after editing server code, **restart
+`POST /api/rules/test {"mediaId","rulegroupId"}`, run a rule with
+`POST /api/rules/:id/execute`, or run collection handling with
+`POST /api/collections/handle`. Note: after editing server code, **restart
 `yarn dev`** — a long-lived dev server can serve stale getter logic. Watchlist
 and plex.tv user enrichment can't be mocked locally (they hit plex.tv) and
 degrade gracefully.

--- a/tools/dev/fake-radarr.mjs
+++ b/tools/dev/fake-radarr.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Dev-only mock Radarr (v3 API) HTTP server for Maintainerr.
+ *
+ * Maintainerr's Radarr client (apps/server/.../servarr-api/helpers/radarr.helper.ts)
+ * talks to a real Radarr over HTTP. The fake media servers (fake-jellyfin /
+ * fake-plex) don't cover Radarr, so the collection-handler -> RadarrActionHandler
+ * flow (DELETE / UNMONITOR / "add import list exclusion") can't be exercised from a
+ * DB seed alone. This stub answers the handful of endpoints that flow needs so the
+ * whole thing can be driven without a real Radarr.
+ *
+ * It deliberately replicates the one behaviour this exists to demonstrate: adding an
+ * import list exclusion is idempotent on POST /exclusions/bulk (server de-dupes, no
+ * error), whereas the singular POST /exclusions runs a uniqueness validator and
+ * returns HTTP 400 ("This exclusion has already been added") on a duplicate — exactly
+ * as the real Radarr controller does.
+ *
+ * It is intentionally minimal and invented — no real media names (repo rule). Any
+ * tmdbId queried resolves to a deterministic movie (movie id == tmdbId), so it pairs
+ * with collection_media rows seeded with a tmdbId.
+ *
+ * Usage
+ * -----
+ *   node tools/dev/fake-radarr.mjs                 # listens on :7878 (matches dev seed)
+ *   FAKE_RADARR_PORT=7878 node tools/dev/fake-radarr.mjs
+ *   FAKE_RADARR_LOG=0 node tools/dev/fake-radarr.mjs   # silence the per-request log
+ *
+ * The dev seed (tools/dev/seed-db.mjs) already points radarr_settings.url at
+ * http://localhost:7878, so no settings change is needed — just start this before
+ * (or alongside) `yarn dev`, then trigger a run with `POST /api/collections/handle`.
+ */
+import http from "node:http";
+
+const PORT = Number(process.env.FAKE_RADARR_PORT ?? 7878);
+const LOG = process.env.FAKE_RADARR_LOG !== "0";
+
+// In-memory import-list-exclusion store (tmdbId -> resource). Persists for the
+// lifetime of the process so re-running collection handling demonstrates the
+// idempotent de-dupe.
+const exclusions = new Map();
+let nextExclusionId = 1;
+
+// A deterministic movie for any requested id/tmdbId — id and tmdbId are kept equal
+// so a collection_media.tmdbId resolves straight through to a Radarr "movie".
+const movieFor = (tmdbId) => ({
+  id: tmdbId,
+  tmdbId,
+  title: `Mock Movie ${tmdbId}`,
+  year: 2020,
+  monitored: true,
+  hasFile: true,
+  qualityProfileId: 1,
+  sizeOnDisk: 1024 ** 3,
+  path: `/movies/mock-${tmdbId}`,
+});
+
+const send = (res, status, body) => {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(body === undefined ? "" : JSON.stringify(body));
+  return status;
+};
+
+const readBody = (req) =>
+  new Promise((resolve) => {
+    let data = "";
+    req.on("data", (c) => (data += c));
+    req.on("end", () => {
+      try {
+        resolve(data ? JSON.parse(data) : undefined);
+      } catch {
+        resolve(undefined);
+      }
+    });
+  });
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, "http://localhost");
+  const path = url.pathname.replace(/^\/api\/v3/, ""); // client base ends in /api/v3/
+  const method = req.method ?? "GET";
+  let status;
+
+  // --- Connection / lookups --------------------------------------------------
+  if (method === "GET" && path === "/system/status") {
+    status = send(res, 200, { appName: "Radarr", version: "5.0.0.0" });
+  } else if (method === "GET" && path === "/movie") {
+    const tmdbId = Number(url.searchParams.get("tmdbId"));
+    status = send(res, 200, tmdbId ? [movieFor(tmdbId)] : []);
+  } else if (method === "GET" && /^\/movie\/\d+$/.test(path)) {
+    status = send(res, 200, movieFor(Number(path.split("/")[2])));
+  } else if (method === "PUT" && /^\/movie\/\d+$/.test(path)) {
+    status = send(res, 200, movieFor(Number(path.split("/")[2])));
+  } else if (method === "GET" && path === "/moviefile") {
+    status = send(res, 200, []); // no files to delete in the mock
+
+    // --- Import list exclusions ----------------------------------------------
+  } else if (method === "POST" && path === "/exclusions/bulk") {
+    // Bulk endpoint: de-dupes server-side, never 400s (the idempotent path).
+    const body = (await readBody(req)) ?? [];
+    for (const item of body) {
+      if (!exclusions.has(item.tmdbId)) {
+        exclusions.set(item.tmdbId, { ...item, id: nextExclusionId++ });
+        if (LOG) console.log(`  + exclusion added: tmdbId ${item.tmdbId}`);
+      } else if (LOG) {
+        console.log(
+          `  = exclusion already present (no-op): tmdbId ${item.tmdbId}`,
+        );
+      }
+    }
+    status = send(res, 200, body);
+  } else if (method === "POST" && path === "/exclusions") {
+    // Singular endpoint: uniqueness validator -> HTTP 400 on a duplicate.
+    const body = (await readBody(req)) ?? {};
+    if (exclusions.has(body.tmdbId)) {
+      status = send(res, 400, [
+        {
+          propertyName: "TmdbId",
+          errorMessage: "This exclusion has already been added.",
+          severity: "error",
+        },
+      ]);
+    } else {
+      const resource = { ...body, id: nextExclusionId++ };
+      exclusions.set(body.tmdbId, resource);
+      status = send(res, 201, resource);
+    }
+  } else if (method === "GET" && path === "/exclusions") {
+    status = send(res, 200, [...exclusions.values()]);
+
+    // --- Misc endpoints other flows may probe --------------------------------
+  } else if (
+    method === "GET" &&
+    ["/qualityProfile", "/rootfolder", "/diskspace", "/tag", "/queue"].includes(
+      path,
+    )
+  ) {
+    status = send(res, 200, []);
+  } else {
+    status = send(res, 404, { message: "Not found in fake-radarr" });
+  }
+
+  if (LOG) console.log(`${method} ${url.pathname}${url.search} -> ${status}`);
+});
+
+server.listen(PORT, () => {
+  console.log(`fake-radarr listening on http://localhost:${PORT} (api/v3)`);
+  console.log(
+    "POST /exclusions/bulk de-dupes (idempotent); POST /exclusions 400s on a duplicate.",
+  );
+});

--- a/tools/dev/seed-db.mjs
+++ b/tools/dev/seed-db.mjs
@@ -228,19 +228,19 @@ const run = db.transaction(() => {
   const insCollection = db.prepare(
     `INSERT INTO collection
        (libraryId, title, description, isActive, type, mediaServerType,
-        deleteAfterDays, visibleOnHome, visibleOnRecommended,
+        deleteAfterDays, visibleOnHome, visibleOnRecommended, arrAction, listExclusions,
         radarrSettingsId, sonarrSettingsId, handledMediaAmount,
         handledMediaSizeBytes, totalSizeBytes, lastDurationInSeconds, addDate)
      VALUES
        (@libraryId, @title, @description, 1, @type, @mediaServerType,
-        @deleteAfterDays, @visibleOnHome, 0,
+        @deleteAfterDays, @visibleOnHome, 0, @arrAction, @listExclusions,
         @radarrSettingsId, @sonarrSettingsId, @handledMediaAmount,
         @handledMediaSizeBytes, @totalSizeBytes, @lastDuration, @addDate)`,
   );
   const insMedia = db.prepare(
     `INSERT INTO collection_media
-       (collectionId, mediaServerId, addDate, image_path, isManual, includedByRule, sizeBytes)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+       (collectionId, mediaServerId, addDate, image_path, isManual, includedByRule, sizeBytes, tmdbId)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   const insRuleGroup = db.prepare(
     `INSERT INTO rule_group
@@ -266,6 +266,9 @@ const run = db.transaction(() => {
       mediaServerType: TARGET,
       deleteAfterDays: cfg.deleteAfterDays,
       visibleOnHome: cfg.visibleOnHome ? 1 : 0,
+      // ServarrAction: DELETE=0, UNMONITOR_DELETE_ALL=1, UNMONITOR=3, DO_NOTHING=4.
+      arrAction: cfg.arrAction ?? 0,
+      listExclusions: cfg.listExclusions ? 1 : 0,
       radarrSettingsId: cfg.type === "movie" ? radarrId : null,
       sonarrSettingsId: cfg.type === "show" ? sonarrId : null,
       handledMediaAmount: cfg.slugs.length,
@@ -277,6 +280,10 @@ const run = db.transaction(() => {
 
     cfg.slugs.forEach((slug, i) => {
       const age = Math.round((i / cfg.slugs.length) * cfg.maxAge);
+      // Movies get a deterministic tmdbId so the Radarr action handler resolves
+      // them without the media server (fake-radarr returns a movie for any
+      // tmdbId). Shows are left null (Sonarr resolves via tvdb, not exercised).
+      const tmdbId = cfg.type === "movie" ? colId * 1000 + i : null;
       insMedia.run(
         colId,
         jellyfinId(),
@@ -285,6 +292,7 @@ const run = db.transaction(() => {
         0,
         1,
         sizes[i],
+        tmdbId,
       );
     });
 
@@ -312,6 +320,10 @@ const run = db.transaction(() => {
       visibleOnHome: true,
       slugs: STALE_MOVIES,
       maxAge: 120,
+      // Unmonitor + add import list exclusion: exercises the Radarr exclusion
+      // path against tools/dev/fake-radarr.mjs (POST /exclusions/bulk).
+      arrAction: 3, // UNMONITOR
+      listExclusions: true,
     }),
     seedCollection({
       title: "Unwatched Series",
@@ -322,6 +334,9 @@ const run = db.transaction(() => {
       visibleOnHome: true,
       slugs: UNWATCHED_SHOWS,
       maxAge: 200,
+      // Do nothing: there is no fake Sonarr, so keep collection-handling runs
+      // focused on the Radarr path. Set to a real action once one exists.
+      arrAction: 4, // DO_NOTHING
     }),
     seedCollection({
       title: "Archive Queue",
@@ -332,6 +347,7 @@ const run = db.transaction(() => {
       visibleOnHome: false,
       slugs: ARCHIVE_MOVIES,
       maxAge: 365,
+      arrAction: 4, // DO_NOTHING (null deleteAfterDays would otherwise be "due now")
     }),
   ];
 


### PR DESCRIPTION
The dev seed mocks the media server (fake-jellyfin / fake-plex) but had no \*arr mock, so the collection-handler → RadarrActionHandler flow (DELETE / UNMONITOR / "add import list exclusion") couldn't be driven locally. This adds that piece.

- **`tools/dev/fake-radarr.mjs`** — minimal mock Radarr v3 (`:7878`, the URL the seed already configures). Resolves any `tmdbId` to a movie (id == tmdbId), and faithfully replicates Radarr's exclusion semantics: `POST /exclusions/bulk` de-dupes server-side (idempotent), singular `POST /exclusions` returns HTTP 400 on a duplicate.
- **`seed-db.mjs`** — collections now carry `arrAction` / `listExclusions`, and movie media get a deterministic `tmdbId` so the action handler resolves them without the media server. "Stale Movies" is seeded as UNMONITOR + listExclusions (exercises the exclusion path); the show collection is DO_NOTHING since there's no fake Sonarr.
- Docs (AGENTS.md, project-notes) updated to list the new mock and the `POST /api/collections/handle` workflow.

Run: start `fake-jellyfin` + `fake-radarr`, seed, start the app, then `POST /api/collections/handle`.