### PR TITLE
feat(logging): honour LOG_LEVEL env var on startup

### DIFF
--- a/apps/server/src/modules/logging/logLevel.spec.ts
+++ b/apps/server/src/modules/logging/logLevel.spec.ts
@@ -1,0 +1,33 @@
+import { LOG_LEVELS } from '@maintainerr/contracts';
+import { resolveLogLevel } from './logLevel';
+
+describe('resolveLogLevel', () => {
+  it('uses the persisted level when LOG_LEVEL is unset', () => {
+    expect(resolveLogLevel(undefined, 'warn')).toEqual({ level: 'warn' });
+  });
+
+  it('lets a recognised LOG_LEVEL override the persisted level', () => {
+    expect(resolveLogLevel('debug', 'info')).toEqual({ level: 'debug' });
+  });
+
+  it('normalises case and surrounding whitespace', () => {
+    expect(resolveLogLevel('  DEBUG  ', 'info')).toEqual({ level: 'debug' });
+  });
+
+  it('treats an empty / whitespace-only LOG_LEVEL as unset', () => {
+    expect(resolveLogLevel('   ', 'error')).toEqual({ level: 'error' });
+  });
+
+  it('falls back to the persisted level and reports an unrecognised value', () => {
+    expect(resolveLogLevel('not-a-level', 'info')).toEqual({
+      level: 'info',
+      invalidEnvValue: 'not-a-level',
+    });
+  });
+
+  it('accepts every level advertised by the contract', () => {
+    for (const level of LOG_LEVELS) {
+      expect(resolveLogLevel(level, 'info')).toEqual({ level });
+    }
+  });
+});

--- a/apps/server/src/modules/logging/logLevel.ts
+++ b/apps/server/src/modules/logging/logLevel.ts
@@ -1,0 +1,38 @@
+import { LOG_LEVELS, LogLevel } from '@maintainerr/contracts';
+
+const ALLOWED_LOG_LEVELS = new Set<string>(LOG_LEVELS);
+
+export interface ResolvedLogLevel {
+  /** The level the logger should actually use. */
+  level: LogLevel;
+  /**
+   * The raw `LOG_LEVEL` value when it was set but not recognised. Present only
+   * so the caller can warn about the typo; absent when the env var is unset or
+   * valid.
+   */
+  invalidEnvValue?: string;
+}
+
+/**
+ * Resolve the effective winston log level.
+ *
+ * `LOG_LEVEL`, when set to one of the recognised levels, overrides the
+ * persisted setting for the lifetime of the process so operators can change
+ * verbosity for a single container without writing the database. An empty or
+ * whitespace-only value is treated as unset. An unrecognised value is ignored
+ * (reported via `invalidEnvValue` so the caller can warn) and the persisted
+ * level is used instead.
+ */
+export function resolveLogLevel(
+  rawEnvValue: string | undefined,
+  dbLevel: LogLevel,
+): ResolvedLogLevel {
+  const envLevel = rawEnvValue?.trim().toLowerCase();
+  if (!envLevel) {
+    return { level: dbLevel };
+  }
+  if (ALLOWED_LOG_LEVELS.has(envLevel)) {
+    return { level: envLevel as LogLevel };
+  }
+  return { level: dbLevel, invalidEnvValue: rawEnvValue };
+}

--- a/apps/server/src/modules/logging/logs.module.ts
+++ b/apps/server/src/modules/logging/logs.module.ts
@@ -7,8 +7,14 @@ import path from 'path';
 import { Repository } from 'typeorm';
 import winston from 'winston';
 import DailyRotateFile from 'winston-daily-rotate-file';
-import { LogSettings } from './entities/logSettings.entities';
+import {
+  DEFAULT_LOG_LEVEL,
+  DEFAULT_LOG_MAX_FILES,
+  DEFAULT_LOG_MAX_SIZE,
+  LogSettings,
+} from './entities/logSettings.entities';
 import { formatLogMessage, sanitizeLogInfo } from './logFormatting';
+import { resolveLogLevel } from './logLevel';
 import { LogsController } from './logs.controller';
 import {
   LogSettingsService,
@@ -44,8 +50,24 @@ const sanitizeLogFormat = winston.format(
         eventEmitter: EventEmitter2,
       ) => {
         const logSettings = await logSettingsRepo.findOne({ where: {} });
-        const maxSize = `${logSettings.max_size}m`;
-        const maxFiles = `${logSettings.max_files}d`;
+        // LOG_LEVEL env var takes precedence over the persisted setting so
+        // operators can change verbosity for a single container without
+        // touching the database. The persisted setting is the user-facing UI
+        // value; the env var is the ops-facing override. Defaults cover the
+        // first-boot window before the log_settings row exists.
+        const { level: resolvedLevel, invalidEnvValue } = resolveLogLevel(
+          process.env.LOG_LEVEL,
+          logSettings?.level ?? DEFAULT_LOG_LEVEL,
+        );
+        if (invalidEnvValue !== undefined) {
+          // Surface the typo early; the winston logger does not exist yet here,
+          // so console is the only channel.
+          console.warn(
+            `LOG_LEVEL=${JSON.stringify(invalidEnvValue)} is not a recognised level; using ${resolvedLevel}.`,
+          );
+        }
+        const maxSize = `${logSettings?.max_size ?? DEFAULT_LOG_MAX_SIZE}m`;
+        const maxFiles = `${logSettings?.max_files ?? DEFAULT_LOG_MAX_FILES}d`;
 
         const dailyRotateFileTransport = new DailyRotateFile({
           filename: path.join(dataDir, 'logs/maintainerr-%DATE%.log'),
@@ -65,7 +87,7 @@ const sanitizeLogFormat = winston.format(
         });
 
         return winston.createLogger({
-          level: logSettings.level,
+          level: resolvedLevel,
           levels: {
             fatal: 0,
             error: 1,


### PR DESCRIPTION
## What

The winston factory now reads an optional `LOG_LEVEL` env var. When set to one of `fatal|error|warn|info|verbose|debug` it overrides the value persisted in the `log_settings` row for the lifetime of the process. Unknown values produce a single warning at startup and fall back to the persisted level. When the env var is unset, behaviour is identical to before.

The factory also tolerates a missing `log_settings` row during the first-boot migration window.

## Why

Today the only way to change verbosity is to flip it in the UI, which writes the database. That is awkward in two common ops situations: triage a single container with extra debug logs, and keep an unattended container on a quieter level without baking it into the DB. The env override is the standard knob for both.

## How

- Read `process.env.LOG_LEVEL`, trim, lower-case.
- If it matches the allowed set, use it; otherwise warn once and fall through.
- Default to the persisted row's `level`, or `'info'` if the row hasn't been created yet.
- Apply the same null-safety to `max_size`/`max_files` so the factory does not throw on a fresh DB.

## Notes

- Pre-existing TypeScript strict-mode warnings in the logging module are untouched (decorators, `logSettings` narrowing, etc.) — they are not introduced by this change.