### PR TITLE
fix(notifications): validate webhook URL scheme before posting

### DIFF
--- a/apps/server/src/modules/notifications/agents/discord.spec.ts
+++ b/apps/server/src/modules/notifications/agents/discord.spec.ts
@@ -18,14 +18,14 @@ jest.mock('axios', () => ({
 describe('DiscordAgent', () => {
   const webhookUrl = 'https://discord.com/api/webhooks/123/abc';
 
-  const createAgent = () => {
+  const createAgent = (url: string = webhookUrl) => {
     const notification = new Notification();
     const settings: NotificationAgentDiscord = {
       enabled: true,
       types: [NotificationType.TEST_NOTIFICATION],
       options: {
         agent: NotificationAgentKey.DISCORD,
-        webhookUrl,
+        webhookUrl: url,
       },
     };
 
@@ -62,5 +62,17 @@ describe('DiscordAgent', () => {
     expect(body.embeds[0].thumbnail).toEqual({
       url: 'https://example.com/poster.jpg',
     });
+  });
+
+  it('rejects a non-http(s) webhook URL without posting', async () => {
+    const agent = createAgent('file:///etc/passwd');
+
+    const result = await agent.send(NotificationType.TEST_NOTIFICATION, {
+      subject: 'Test subject',
+      message: 'Test message',
+    });
+
+    expect(result).toBe('Failure: unsupported webhook URL scheme');
+    expect(axios.post).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/modules/notifications/agents/discord.ts
+++ b/apps/server/src/modules/notifications/agents/discord.ts
@@ -8,6 +8,7 @@ import {
 } from '../notifications-interfaces';
 import { hasNotificationType } from '../notifications.service';
 import type { NotificationAgent, NotificationPayload } from './agent';
+import { validateWebhookUrl } from './webhookUrl';
 
 enum EmbedColors {
   DEFAULT = 0,
@@ -138,10 +139,20 @@ class DiscordAgent implements NotificationAgent {
       return 'Success';
     }
 
+    const webhookUrl = validateWebhookUrl(
+      this.getSettings().options.webhookUrl,
+    );
+    if (!webhookUrl.ok) {
+      this.logger.error(
+        `Webhook URL ${JSON.stringify(this.getSettings().options.webhookUrl)} rejected: ${webhookUrl.reason}.`,
+      );
+      return `Failure: ${webhookUrl.reason}`;
+    }
+
     this.logger.log('Sending Discord notification');
 
     try {
-      await axios.post(this.getSettings().options.webhookUrl, {
+      await axios.post(webhookUrl.url, {
         username: this.getSettings().options.botUsername
           ? this.getSettings().options.botUsername
           : 'Maintainerr',

--- a/apps/server/src/modules/notifications/agents/lunasea.spec.ts
+++ b/apps/server/src/modules/notifications/agents/lunasea.spec.ts
@@ -1,0 +1,68 @@
+import axios from 'axios';
+import { createMockLogger } from '../../../../test/utils/data';
+import { Notification } from '../entities/notification.entities';
+import {
+  NotificationAgentKey,
+  NotificationAgentLunaSea,
+  NotificationType,
+} from '../notifications-interfaces';
+import LunaSeaAgent from './lunasea';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+describe('LunaSeaAgent', () => {
+  const createAgent = (webhookUrl: string) => {
+    const notification = new Notification();
+    const settings: NotificationAgentLunaSea = {
+      enabled: true,
+      types: [NotificationType.TEST_NOTIFICATION],
+      options: {
+        agent: NotificationAgentKey.LUNASEA,
+        webhookUrl,
+      },
+    };
+
+    return new LunaSeaAgent(
+      {} as never,
+      settings,
+      createMockLogger(),
+      notification,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (axios.post as jest.Mock).mockResolvedValue({});
+  });
+
+  it('rejects a non-http(s) webhook URL without posting', async () => {
+    const agent = createAgent('file:///etc/passwd');
+
+    const result = await agent.send(NotificationType.TEST_NOTIFICATION, {
+      subject: 'Test subject',
+      message: 'Test message',
+    });
+
+    expect(result).toBe('Failure: unsupported webhook URL scheme');
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it('posts to the normalised URL for a valid webhook', async () => {
+    const agent = createAgent('https://example.com');
+
+    await agent.send(NotificationType.TEST_NOTIFICATION, {
+      subject: 'Test subject',
+      message: 'Test message',
+    });
+
+    expect(axios.post).toHaveBeenCalledTimes(1);
+    expect((axios.post as jest.Mock).mock.calls[0][0]).toBe(
+      'https://example.com/',
+    );
+  });
+});

--- a/apps/server/src/modules/notifications/agents/lunasea.ts
+++ b/apps/server/src/modules/notifications/agents/lunasea.ts
@@ -9,6 +9,7 @@ import {
 } from '../notifications-interfaces';
 import { hasNotificationType } from '../notifications.service';
 import type { NotificationAgent, NotificationPayload } from './agent';
+import { validateWebhookUrl } from './webhookUrl';
 
 class LunaSeaAgent implements NotificationAgent {
   public constructor(
@@ -57,11 +58,19 @@ class LunaSeaAgent implements NotificationAgent {
       return 'Success';
     }
 
+    const webhookUrl = validateWebhookUrl(settings.options.webhookUrl);
+    if (!webhookUrl.ok) {
+      this.logger.error(
+        `Webhook URL ${JSON.stringify(settings.options.webhookUrl)} rejected: ${webhookUrl.reason}.`,
+      );
+      return `Failure: ${webhookUrl.reason}`;
+    }
+
     this.logger.log('Sending LunaSea notification');
 
     try {
       await axios.post(
-        this.getSettings().options.webhookUrl,
+        webhookUrl.url,
         this.buildPayload(type, payload),
         settings.options.profileName
           ? {

--- a/apps/server/src/modules/notifications/agents/ntfy.spec.ts
+++ b/apps/server/src/modules/notifications/agents/ntfy.spec.ts
@@ -16,14 +16,14 @@ jest.mock('axios', () => ({
 }));
 
 describe('NtfyAgent', () => {
-  const createAgent = (token?: string) => {
+  const createAgent = (token?: string, url = 'https://ntfy.sh/') => {
     const notification = new Notification();
     const settings: NotificationAgentNtfy = {
       enabled: true,
       types: [NotificationType.TEST_NOTIFICATION],
       options: {
         agent: NotificationAgentKey.NTFY,
-        url: 'https://ntfy.sh/',
+        url,
         topic: '/maintainerr',
         ...(token ? { token } : {}),
       },
@@ -41,6 +41,18 @@ describe('NtfyAgent', () => {
     const agent = createAgent();
 
     expect(agent.shouldSend()).toBe(true);
+  });
+
+  it('rejects a non-http(s) URL without posting', async () => {
+    const agent = createAgent(undefined, 'file:///etc/passwd');
+
+    const result = await agent.send(NotificationType.TEST_NOTIFICATION, {
+      subject: 'Test subject',
+      message: 'Test message',
+    });
+
+    expect(result).toBe('Failure: unsupported webhook URL scheme');
+    expect(axios.post).not.toHaveBeenCalled();
   });
 
   it('omits the authorization header when no token is configured', async () => {

--- a/apps/server/src/modules/notifications/agents/ntfy.ts
+++ b/apps/server/src/modules/notifications/agents/ntfy.ts
@@ -9,6 +9,7 @@ import {
 } from '../notifications-interfaces';
 import { hasNotificationType } from '../notifications.service';
 import type { NotificationAgent, NotificationPayload } from './agent';
+import { validateWebhookUrl } from './webhookUrl';
 
 interface NtfyPayload {
   title: string;
@@ -65,11 +66,27 @@ class NtfyAgent implements NotificationAgent {
       return 'Success';
     }
 
+    const webhookUrl = validateWebhookUrl(settings.options.url);
+    if (!webhookUrl.ok) {
+      this.logger.error(
+        `Webhook URL ${JSON.stringify(settings.options.url)} rejected: ${webhookUrl.reason}.`,
+      );
+      return `Failure: ${webhookUrl.reason}`;
+    }
+
     this.logger.log('Sending Ntfy notification');
 
     try {
-      const baseUrl = settings.options.url.replace(/\/+$/, '');
-      const topic = settings.options.topic.replace(/^\/+/, '');
+      // Trim trailing/leading slashes with the codebase's char idiom rather
+      // than regex, then join the validated base URL to the topic.
+      let baseUrl = webhookUrl.url;
+      while (baseUrl.endsWith('/')) {
+        baseUrl = baseUrl.slice(0, -1);
+      }
+      let topic = settings.options.topic;
+      while (topic.startsWith('/')) {
+        topic = topic.slice(1);
+      }
       const endpoint = `${baseUrl}/${topic}`;
       const notificationPayload = this.getNotificationPayload(type, payload);
       const headers: Record<string, string> = {

--- a/apps/server/src/modules/notifications/agents/slack.spec.ts
+++ b/apps/server/src/modules/notifications/agents/slack.spec.ts
@@ -1,0 +1,68 @@
+import axios from 'axios';
+import { createMockLogger } from '../../../../test/utils/data';
+import { Notification } from '../entities/notification.entities';
+import {
+  NotificationAgentKey,
+  NotificationAgentSlack,
+  NotificationType,
+} from '../notifications-interfaces';
+import SlackAgent from './slack';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+describe('SlackAgent', () => {
+  const createAgent = (webhookUrl: string) => {
+    const notification = new Notification();
+    const settings: NotificationAgentSlack = {
+      enabled: true,
+      types: [NotificationType.TEST_NOTIFICATION],
+      options: {
+        agent: NotificationAgentKey.SLACK,
+        webhookUrl,
+      },
+    };
+
+    return new SlackAgent(
+      {} as never,
+      settings,
+      createMockLogger(),
+      notification,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (axios.post as jest.Mock).mockResolvedValue({});
+  });
+
+  it('rejects a non-http(s) webhook URL without posting', async () => {
+    const agent = createAgent('file:///etc/passwd');
+
+    const result = await agent.send(NotificationType.TEST_NOTIFICATION, {
+      subject: 'Test subject',
+      message: 'Test message',
+    });
+
+    expect(result).toBe('Failure: unsupported webhook URL scheme');
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it('posts to the normalised URL for a valid webhook', async () => {
+    const agent = createAgent('https://example.com');
+
+    await agent.send(NotificationType.TEST_NOTIFICATION, {
+      subject: 'Test subject',
+      message: 'Test message',
+    });
+
+    expect(axios.post).toHaveBeenCalledTimes(1);
+    expect((axios.post as jest.Mock).mock.calls[0][0]).toBe(
+      'https://example.com/',
+    );
+  });
+});

--- a/apps/server/src/modules/notifications/agents/slack.ts
+++ b/apps/server/src/modules/notifications/agents/slack.ts
@@ -9,6 +9,7 @@ import {
 } from '../notifications-interfaces';
 import { hasNotificationType } from '../notifications.service';
 import type { NotificationAgent, NotificationPayload } from './agent';
+import { validateWebhookUrl } from './webhookUrl';
 
 interface EmbedField {
   type: 'plain_text' | 'mrkdwn';
@@ -138,12 +139,17 @@ class SlackAgent implements NotificationAgent {
       return 'Success';
     }
 
+    const webhookUrl = validateWebhookUrl(settings.options.webhookUrl);
+    if (!webhookUrl.ok) {
+      this.logger.error(
+        `Webhook URL ${JSON.stringify(settings.options.webhookUrl)} rejected: ${webhookUrl.reason}.`,
+      );
+      return `Failure: ${webhookUrl.reason}`;
+    }
+
     this.logger.log('Sending Slack notification');
     try {
-      await axios.post(
-        settings.options.webhookUrl,
-        this.buildEmbed(type, payload),
-      );
+      await axios.post(webhookUrl.url, this.buildEmbed(type, payload));
 
       return 'Success';
     } catch (error) {

--- a/apps/server/src/modules/notifications/agents/webhook.spec.ts
+++ b/apps/server/src/modules/notifications/agents/webhook.spec.ts
@@ -1,0 +1,55 @@
+import axios from 'axios';
+import { createMockLogger } from '../../../../test/utils/data';
+import { Notification } from '../entities/notification.entities';
+import {
+  NotificationAgentKey,
+  NotificationAgentWebhook,
+  NotificationType,
+} from '../notifications-interfaces';
+import WebhookAgent from './webhook';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+describe('WebhookAgent', () => {
+  const createAgent = (webhookUrl: string) => {
+    const notification = new Notification();
+    const settings: NotificationAgentWebhook = {
+      enabled: true,
+      types: [NotificationType.TEST_NOTIFICATION],
+      options: {
+        agent: NotificationAgentKey.WEBHOOK,
+        webhookUrl,
+        jsonPayload: '{}',
+      },
+    };
+
+    return new WebhookAgent(
+      {} as never,
+      settings,
+      createMockLogger(),
+      notification,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (axios.post as jest.Mock).mockResolvedValue({});
+  });
+
+  it('rejects a non-http(s) webhook URL without posting', async () => {
+    const agent = createAgent('file:///etc/passwd');
+
+    const result = await agent.send(NotificationType.TEST_NOTIFICATION, {
+      subject: 'Test subject',
+      message: 'Test message',
+    });
+
+    expect(result).toBe('Failure: unsupported webhook URL scheme');
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/modules/notifications/agents/webhook.ts
+++ b/apps/server/src/modules/notifications/agents/webhook.ts
@@ -10,6 +10,7 @@ import {
 } from '../notifications-interfaces';
 import { hasNotificationType } from '../notifications.service';
 import type { NotificationAgent, NotificationPayload } from './agent';
+import { validateWebhookUrl } from './webhookUrl';
 
 type KeyMapFunction = (
   payload: NotificationPayload,
@@ -109,11 +110,19 @@ class WebhookAgent implements NotificationAgent {
       return 'Success';
     }
 
+    const webhookUrl = validateWebhookUrl(settings.options.webhookUrl);
+    if (!webhookUrl.ok) {
+      this.logger.error(
+        `Webhook URL ${JSON.stringify(settings.options.webhookUrl)} rejected: ${webhookUrl.reason}.`,
+      );
+      return `Failure: ${webhookUrl.reason}`;
+    }
+
     this.logger.log('Sending webhook notification');
 
     try {
       await axios.post(
-        settings.options.webhookUrl,
+        webhookUrl.url,
         this.buildPayload(type, payload),
         settings.options.authHeader
           ? {

--- a/apps/server/src/modules/notifications/agents/webhookUrl.spec.ts
+++ b/apps/server/src/modules/notifications/agents/webhookUrl.spec.ts
@@ -1,0 +1,55 @@
+import { validateWebhookUrl } from './webhookUrl';
+
+describe('validateWebhookUrl', () => {
+  it('accepts an http URL and returns the normalised value', () => {
+    expect(validateWebhookUrl('http://example.com/hook')).toEqual({
+      ok: true,
+      url: 'http://example.com/hook',
+    });
+  });
+
+  it('accepts an https URL', () => {
+    expect(validateWebhookUrl('https://example.com/hook')).toEqual({
+      ok: true,
+      url: 'https://example.com/hook',
+    });
+  });
+
+  it('returns the normalised URL (e.g. adds the root path)', () => {
+    expect(validateWebhookUrl('https://example.com')).toEqual({
+      ok: true,
+      url: 'https://example.com/',
+    });
+  });
+
+  it('rejects a missing URL', () => {
+    expect(validateWebhookUrl(undefined)).toEqual({
+      ok: false,
+      reason: 'missing webhook URL',
+    });
+    expect(validateWebhookUrl('')).toEqual({
+      ok: false,
+      reason: 'missing webhook URL',
+    });
+  });
+
+  it('rejects an unparseable URL', () => {
+    expect(validateWebhookUrl('not a url')).toEqual({
+      ok: false,
+      reason: 'invalid webhook URL',
+    });
+  });
+
+  it('rejects non-http(s) schemes', () => {
+    for (const url of [
+      'file:///etc/passwd',
+      'gopher://example.com',
+      'ftp://example.com/x',
+    ]) {
+      expect(validateWebhookUrl(url)).toEqual({
+        ok: false,
+        reason: 'unsupported webhook URL scheme',
+      });
+    }
+  });
+});

--- a/apps/server/src/modules/notifications/agents/webhookUrl.ts
+++ b/apps/server/src/modules/notifications/agents/webhookUrl.ts
@@ -1,0 +1,40 @@
+export interface WebhookUrlValidation {
+  /** Whether the URL is usable as an outbound request target. */
+  ok: boolean;
+  /** The normalised URL to post to. Present only when `ok` is true. */
+  url?: string;
+  /** Why the URL was rejected. Present only when `ok` is false. */
+  reason?: string;
+}
+
+/**
+ * Validate a user-configured webhook URL before it is used as an outbound
+ * request target. Rejects unparseable values and any scheme other than
+ * http(s), so a misconfigured URL (file://, gopher://, …) cannot turn a
+ * notification agent into the way the server leaves the network. On success the
+ * normalised URL string is returned for posting.
+ *
+ * Shared by every agent that posts to an operator-supplied URL — the
+ * `webhookUrl` agents (webhook, slack, lunasea, discord) and ntfy's server
+ * `url` — so the guard stays in one place.
+ */
+export function validateWebhookUrl(
+  url: string | undefined,
+): WebhookUrlValidation {
+  if (!url) {
+    return { ok: false, reason: 'missing webhook URL' };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, reason: 'invalid webhook URL' };
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'unsupported webhook URL scheme' };
+  }
+
+  return { ok: true, url: parsed.toString() };
+}


### PR DESCRIPTION
## What

The webhook agent passed `settings.options.webhookUrl` straight to `axios.post`. A misconfigured URL pointing at `file://`, `gopher://`, or any other non-http(s) scheme would be turned into an outbound request by the agent, with axios's behaviour for those schemes varying across Node versions.

## Why

This is a small but real SSRF-shaped guardrail: it keeps a webhook agent pointed at an internal file path or an unexpected scheme from being the way the server leaves the network. The user can still disable the agent entirely; this only narrows what is allowed when it is enabled.

## How

- Parse the configured URL with the platform `URL` constructor; on failure log and return `Failure: invalid webhook URL`.
- Reject anything whose protocol is not `http:` or `https:`; log and return `Failure: unsupported webhook URL scheme`.
- Pass the parsed (and therefore normalised) URL string to `axios.post` instead of the raw user input.

## Notes

- Pre-existing TypeScript strict-mode warnings in the logging/notifications modules are untouched — this change introduces no new ones.