### PR TITLE
fix(collections): find manual collections across libraries on Jellyfin/Emby (#3026)

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -1,20 +1,33 @@
 import { AxiosError } from 'axios';
+import { EMBY_CACHE_TTL } from './emby.constants';
 import { EmbyAdapterService } from './emby-adapter.service';
+
+const embyCacheMocks = {
+  flush: jest.fn(),
+  data: {
+    has: jest.fn(),
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    flushAll: jest.fn(),
+    keys: jest.fn(),
+  },
+};
 
 jest.mock('../../lib/cache', () => ({
   __esModule: true,
   default: {
-    getCache: jest.fn().mockReturnValue({
-      flush: jest.fn(),
+    getCache: jest.fn().mockImplementation(() => ({
+      flush: (...args: unknown[]) => embyCacheMocks.flush(...args),
       data: {
-        get: jest.fn(),
-        set: jest.fn(),
-        has: jest.fn(),
-        del: jest.fn(),
-        keys: jest.fn(),
-        flushAll: jest.fn(),
+        has: (...args: unknown[]) => embyCacheMocks.data.has(...args),
+        get: (...args: unknown[]) => embyCacheMocks.data.get(...args),
+        set: (...args: unknown[]) => embyCacheMocks.data.set(...args),
+        del: (...args: unknown[]) => embyCacheMocks.data.del(...args),
+        flushAll: (...args: unknown[]) => embyCacheMocks.data.flushAll(...args),
+        keys: (...args: unknown[]) => embyCacheMocks.data.keys(...args),
       },
-    }),
+    })),
   },
 }));
 
@@ -173,6 +186,185 @@ describe('EmbyAdapterService', () => {
           sortTitle: 'A Sorted Title',
         }),
       );
+    });
+  });
+
+  // Mirrors the Jellyfin adapter's collection cache so the cross-library
+  // manual-collection lookup stays cheap on repeated rule runs, while
+  // create/rename/delete stay immediately visible.
+  describe('collection caching', () => {
+    it('caches non-empty getCollections results and serves them on the next call', async () => {
+      http.get.mockResolvedValueOnce({
+        data: { Items: [{ Id: 'box-1', Name: 'Shared', ChildCount: 2 }] },
+      });
+
+      await service.getCollections('library-1');
+
+      // A configured Emby user means the user-scoped read: literal /Items path
+      // with UserId in the query param (no user value in the request path).
+      expect(http.get).toHaveBeenCalledWith(
+        '/Items',
+        expect.objectContaining({
+          params: expect.objectContaining({
+            UserId: 'user-1',
+            ParentId: 'library-1',
+            IncludeItemTypes: 'BoxSet',
+          }),
+        }),
+      );
+      expect(embyCacheMocks.data.set).toHaveBeenCalledWith(
+        'emby:collections:library-1',
+        expect.arrayContaining([expect.objectContaining({ id: 'box-1' })]),
+        EMBY_CACHE_TTL.COLLECTIONS,
+      );
+
+      const cached = [{ id: 'cached', title: 'Cached' }];
+      embyCacheMocks.data.get.mockReturnValueOnce(cached);
+
+      const second = await service.getCollections('library-1');
+      expect(second).toBe(cached);
+      // Only the first call hit the API.
+      expect(http.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache an empty getCollections result', async () => {
+      http.get.mockResolvedValueOnce({ data: { Items: [] } });
+
+      await service.getCollections('library-1');
+
+      expect(embyCacheMocks.data.set).not.toHaveBeenCalledWith(
+        'emby:collections:library-1',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('invalidates the per-library collections cache after createCollection', async () => {
+      http.post.mockResolvedValueOnce({ data: { Id: 'box-new', Name: 'New' } });
+
+      await service.createCollection({
+        libraryId: 'library-1',
+        title: 'New',
+        type: 'movie',
+      });
+
+      expect(embyCacheMocks.data.del).toHaveBeenCalledWith(
+        'emby:collections:library-1',
+      );
+    });
+
+    it('invalidates the per-library collections cache after updateCollection', async () => {
+      http.get.mockResolvedValueOnce({ data: { Id: 'box-1', Name: 'Old' } });
+      http.post.mockResolvedValueOnce({ data: undefined });
+      jest
+        .spyOn(service, 'getCollection')
+        .mockResolvedValue({ id: 'box-1', title: 'New', smart: false } as any);
+
+      await service.updateCollection({
+        libraryId: 'library-1',
+        collectionId: 'box-1',
+        title: 'New',
+      });
+
+      expect(embyCacheMocks.data.del).toHaveBeenCalledWith(
+        'emby:collections:library-1',
+      );
+    });
+
+    it('clears every per-library collections entry on deleteCollection', async () => {
+      embyCacheMocks.data.keys.mockReturnValueOnce([
+        'emby:collections:library-1',
+        'emby:collections:library-2',
+        'emby:users',
+      ]);
+
+      await service.deleteCollection('box-1');
+
+      expect(embyCacheMocks.data.del).toHaveBeenCalledWith([
+        'emby:collections:library-1',
+        'emby:collections:library-2',
+      ]);
+    });
+  });
+
+  // Collection reads must be user-scoped: Emby resolves the BoxSet query
+  // against a user's library view, so the plain /Items path can miss or 404,
+  // which would break the manual-collection bootstrap (incl. the cross-library
+  // lookup). Maintainerr only ever operates as an admin, so when no user is
+  // configured we resolve one rather than degrade to /Items.
+  describe('user-scoped collection reads', () => {
+    const clearConfiguredUser = () => {
+      // Clear the user directly: setHttp(undefined) would hit its default param.
+      (service as unknown as { embyUserId?: string }).embyUserId = undefined;
+    };
+
+    it('scopes reads to the configured admin user without querying /Users', async () => {
+      http.get.mockResolvedValue({ data: { Items: [] } });
+
+      await service.getCollections('library-1');
+      await service.getCollectionChildren('box-1');
+
+      expect(http.get).toHaveBeenCalledWith(
+        '/Items',
+        expect.objectContaining({
+          params: expect.objectContaining({
+            UserId: 'user-1',
+            ParentId: 'library-1',
+          }),
+        }),
+      );
+      expect(http.get).toHaveBeenCalledWith(
+        '/Items',
+        expect.objectContaining({
+          params: expect.objectContaining({
+            UserId: 'user-1',
+            ParentId: 'box-1',
+          }),
+        }),
+      );
+      expect(http.get).not.toHaveBeenCalledWith('/Users/Query');
+    });
+
+    it('auto-resolves an admin user when none is configured (token-only setup)', async () => {
+      clearConfiguredUser();
+      http.get.mockImplementation((path: string) =>
+        path === '/Users/Query'
+          ? Promise.resolve({
+              data: [
+                { Id: 'viewer-1', Policy: { IsAdministrator: false } },
+                { Id: 'admin-9', Policy: { IsAdministrator: true } },
+              ],
+            })
+          : Promise.resolve({ data: { Items: [] } }),
+      );
+
+      await service.getCollections('library-1');
+
+      expect(http.get).toHaveBeenCalledWith(
+        '/Items',
+        expect.objectContaining({
+          params: expect.objectContaining({
+            UserId: 'admin-9',
+            ParentId: 'library-1',
+          }),
+        }),
+      );
+    });
+
+    it('falls back to an unscoped read (no UserId) when no admin can be resolved', async () => {
+      clearConfiguredUser();
+      http.get.mockImplementation((path: string) =>
+        path === '/Users/Query'
+          ? Promise.resolve({ data: { Items: [] } })
+          : Promise.resolve({ data: { Items: [] } }),
+      );
+
+      await service.getCollections('library-1');
+
+      const itemsCall = http.get.mock.calls.find((c) => c[0] === '/Items');
+      expect(itemsCall).toBeDefined();
+      expect(itemsCall[1].params.ParentId).toBe('library-1');
+      expect(itemsCall[1].params.UserId).toBeUndefined();
     });
   });
 

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -808,9 +808,24 @@ export class EmbyAdapterService implements IMediaServerService {
 
   async getCollections(libraryId: string): Promise<MediaCollection[]> {
     if (!this.http) return [];
+
+    const cacheKey = `${EMBY_CACHE_KEYS.COLLECTIONS}:${libraryId}`;
+    const cached = this.cache.data.get<MediaCollection[]>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
     try {
+      // User-scoped read: Emby resolves the BoxSet query against a user's
+      // library view, so an unscoped read can miss or 404. Pass the user via the
+      // UserId query param on the literal /Items path — functionally the same as
+      // /Users/{id}/Items, and the param idiom already used elsewhere here. (A
+      // user value interpolated into the request path is a CodeQL SSRF sink; a
+      // query param is not.)
+      const userId = await this.resolveUserId();
       const { data } = await this.http.get<EmbyItemsQueryResponse>('/Items', {
         params: {
+          ...(userId ? { UserId: userId } : {}),
           ParentId: libraryId,
           IncludeItemTypes: 'BoxSet',
           Recursive: true,
@@ -818,13 +833,71 @@ export class EmbyAdapterService implements IMediaServerService {
           Limit: EMBY_BATCH_SIZE.MAX_PAGE_SIZE,
         },
       });
-      return (data.Items ?? []).map(EmbyMapper.toMediaCollection);
+      const collections = (data.Items ?? []).map(EmbyMapper.toMediaCollection);
+      // Skip caching empty results so a transient zero-collection response
+      // (e.g. mid-library-scan) can't mask a just-created entry.
+      if (collections.length > 0) {
+        this.cache.data.set(cacheKey, collections, EMBY_CACHE_TTL.COLLECTIONS);
+      }
+      return collections;
     } catch (error) {
       this.logger.debug(
         `Emby getCollections(${libraryId}) failed: ${formatConnectionFailureMessage(error, 'Connection failed')}`,
       );
       return [];
     }
+  }
+
+  /**
+   * The userId to scope item reads to. Emby resolves ParentId/BoxSet/recursive
+   * queries against a user's library view, so those reads need a userId even
+   * though auth is a server-level admin key. Prefer the configured admin user;
+   * otherwise resolve and cache the first admin so token-only setups still get
+   * a user-scoped read instead of the unreliable plain /Items path. Returns
+   * undefined only when no admin can be resolved (callers then fall back to
+   * /Items).
+   */
+  private async resolveUserId(): Promise<string | undefined> {
+    if (this.embyUserId) return this.embyUserId;
+    if (!this.http) return undefined;
+
+    const cached = this.cache.data.get<string>(
+      EMBY_CACHE_KEYS.RESOLVED_USER_ID,
+    );
+    if (cached) return cached;
+
+    try {
+      const users = await this.fetchUsersQuery(this.http);
+      const adminId = users.find((u) => u.Policy?.IsAdministrator)?.Id;
+      if (adminId) {
+        this.cache.data.set(
+          EMBY_CACHE_KEYS.RESOLVED_USER_ID,
+          adminId,
+          EMBY_CACHE_TTL.USERS,
+        );
+        return adminId;
+      }
+    } catch (error) {
+      this.logger.debug(
+        `Emby resolveUserId failed: ${formatConnectionFailureMessage(error, 'Connection failed')}`,
+      );
+    }
+    return undefined;
+  }
+
+  /**
+   * Drop the cached getCollections() result so a create/rename/delete is
+   * visible immediately. Mirrors the Jellyfin adapter: pass a libraryId to
+   * clear that library, or omit it to clear every library's cache.
+   */
+  private invalidateCollectionsCache(libraryId?: string): void {
+    if (libraryId) {
+      this.cache.data.del(`${EMBY_CACHE_KEYS.COLLECTIONS}:${libraryId}`);
+      return;
+    }
+    const prefix = `${EMBY_CACHE_KEYS.COLLECTIONS}:`;
+    const stale = this.cache.data.keys().filter((k) => k.startsWith(prefix));
+    if (stale.length > 0) this.cache.data.del(stale);
   }
 
   async getCollection(
@@ -891,6 +964,7 @@ export class EmbyAdapterService implements IMediaServerService {
           );
         }
       }
+      this.invalidateCollectionsCache(params.libraryId);
       return collection;
     } catch (error) {
       const message = formatConnectionFailureMessage(
@@ -906,6 +980,7 @@ export class EmbyAdapterService implements IMediaServerService {
     if (!this.http) throw new Error('Emby not initialized');
     try {
       await this.http.delete(`/Items/${collectionId}`);
+      this.invalidateCollectionsCache();
     } catch (error) {
       const message = formatConnectionFailureMessage(
         error,
@@ -944,8 +1019,14 @@ export class EmbyAdapterService implements IMediaServerService {
   async getCollectionChildren(collectionId: string): Promise<MediaItem[]> {
     if (!this.http) return [];
     try {
+      // User-scoped read for the same reason as getCollections; Jellyfin's
+      // adapter likewise requires a userId to enumerate BoxSet children. UserId
+      // goes in the query param (not the path) to stay clear of CodeQL's SSRF
+      // sink while keeping the read user-scoped.
+      const userId = await this.resolveUserId();
       const { data } = await this.http.get<EmbyItemsQueryResponse>('/Items', {
         params: {
+          ...(userId ? { UserId: userId } : {}),
           ParentId: collectionId,
           Fields: 'ProviderIds,DateCreated,Overview',
           Limit: EMBY_BATCH_SIZE.MAX_PAGE_SIZE,
@@ -1036,6 +1117,8 @@ export class EmbyAdapterService implements IMediaServerService {
         ForcedSortName: params.sortTitle ?? current.ForcedSortName,
       };
       await this.http.post(`/Items/${params.collectionId}`, updated);
+      // Title/sortTitle may have changed, which affects name-based lookups.
+      this.invalidateCollectionsCache(params.libraryId);
       const refreshed = await this.getCollection(params.collectionId);
       if (!refreshed) {
         throw new Error('Collection vanished after update');

--- a/apps/server/src/modules/api/media-server/emby/emby.constants.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby.constants.ts
@@ -22,6 +22,8 @@ export const EMBY_CACHE_KEYS = {
   USERS: 'emby:users',
   LIBRARIES: 'emby:libraries',
   STATUS: 'emby:status',
+  COLLECTIONS: 'emby:collections',
+  RESOLVED_USER_ID: 'emby:resolved-user-id',
 } as const;
 
 // Emby uses the same .NET DateTime tick convention as Jellyfin.

--- a/apps/server/src/modules/collections/collection-worker.server.spec.ts
+++ b/apps/server/src/modules/collections/collection-worker.server.spec.ts
@@ -193,7 +193,7 @@ describe('CollectionWorkerService', () => {
 
     collectionRepository.find.mockResolvedValue([collection]);
     collectionMediaRepository.find.mockResolvedValue([playingMedia, idleMedia]);
-    collectionHandler.handleMedia.mockResolvedValue(true);
+    collectionHandler.handleMedia.mockResolvedValue('handled');
 
     await collectionWorkerService.execute();
 

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -1,4 +1,8 @@
-import { MediaServerFeature, MediaServerType } from '@maintainerr/contracts';
+import {
+  MediaCollection,
+  MediaServerFeature,
+  MediaServerType,
+} from '@maintainerr/contracts';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Mocked, TestBed } from '@suites/unit';
 import { DataSource, Repository } from 'typeorm';
@@ -2066,6 +2070,98 @@ describe('CollectionsService', () => {
       await service.removeStaleCollectionMedia();
 
       expect(collectionMediaRepo.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findMediaServerCollection', () => {
+    const boxset = (props: Partial<MediaCollection>): MediaCollection =>
+      ({ id: 'box-1', title: 'Shared', smart: false, ...props }) as never;
+
+    beforeEach(() => {
+      mediaServer.getCollections = jest.fn().mockResolvedValue([]);
+      mediaServer.getLibraries = jest.fn().mockResolvedValue([
+        { id: 'movies', title: 'Movies', type: 'movie' },
+        { id: 'shows', title: 'Shows', type: 'show' },
+      ]);
+    });
+
+    it('returns a match from the requested library without searching others', async () => {
+      mediaServer.getCollections.mockResolvedValue([
+        boxset({ title: 'Shared' }),
+      ]);
+
+      const found = await service.findMediaServerCollection('Shared', 'shows');
+
+      expect(found?.id).toBe('box-1');
+      expect(mediaServer.getCollections).toHaveBeenCalledTimes(1);
+      expect(mediaServer.getCollections).toHaveBeenCalledWith('shows');
+      expect(mediaServer.getLibraries).not.toHaveBeenCalled();
+    });
+
+    it('ignores smart collections when matching by name', async () => {
+      mediaServer.getCollections.mockResolvedValue([
+        boxset({ title: 'Shared', smart: true }),
+      ]);
+
+      const found = await service.findMediaServerCollection('Shared', 'shows');
+
+      expect(found).toBeUndefined();
+    });
+
+    it('falls back to other libraries for a cross-library server when opted in', async () => {
+      // The shared boxset is only reported under the movie library (it holds
+      // movies but no shows yet), mirroring the reported Emby/Jellyfin issue.
+      mediaServer.supportsFeature.mockImplementation(
+        (feature) => feature === MediaServerFeature.CROSS_LIBRARY_COLLECTIONS,
+      );
+      mediaServer.getCollections.mockImplementation(
+        async (libraryId: string) =>
+          libraryId === 'movies' ? [boxset({ title: 'Shared' })] : [],
+      );
+
+      const found = await service.findMediaServerCollection(
+        'Shared',
+        'shows',
+        true,
+      );
+
+      expect(found?.id).toBe('box-1');
+      // Own library searched first, then the other one — never re-searching it.
+      expect(mediaServer.getCollections).toHaveBeenCalledWith('shows');
+      expect(mediaServer.getCollections).toHaveBeenCalledWith('movies');
+      expect(mediaServer.getCollections).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not search other libraries when not opted in', async () => {
+      mediaServer.supportsFeature.mockImplementation(
+        (feature) => feature === MediaServerFeature.CROSS_LIBRARY_COLLECTIONS,
+      );
+      mediaServer.getCollections.mockImplementation(
+        async (libraryId: string) =>
+          libraryId === 'movies' ? [boxset({ title: 'Shared' })] : [],
+      );
+
+      const found = await service.findMediaServerCollection('Shared', 'shows');
+
+      expect(found).toBeUndefined();
+      expect(mediaServer.getLibraries).not.toHaveBeenCalled();
+    });
+
+    it('does not search other libraries when the server lacks cross-library collections (Plex)', async () => {
+      mediaServer.supportsFeature.mockReturnValue(false);
+      mediaServer.getCollections.mockImplementation(
+        async (libraryId: string) =>
+          libraryId === 'movies' ? [boxset({ title: 'Shared' })] : [],
+      );
+
+      const found = await service.findMediaServerCollection(
+        'Shared',
+        'shows',
+        true,
+      );
+
+      expect(found).toBeUndefined();
+      expect(mediaServer.getLibraries).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -1509,6 +1509,7 @@ export class CollectionsService {
         const foundCollection = await this.findMediaServerCollection(
           collection.manualCollectionName,
           collection.libraryId,
+          true,
         );
         if (foundCollection) {
           // Handle visibility settings (Plex-only feature)
@@ -1741,6 +1742,7 @@ export class CollectionsService {
       const foundColl = await this.findMediaServerCollection(
         collection.manualCollectionName,
         collection.libraryId,
+        true,
       );
       if (foundColl) {
         collection.mediaServerId = foundColl.id;
@@ -2017,6 +2019,7 @@ export class CollectionsService {
             newColl = await this.findMediaServerCollection(
               collection.manualCollectionName,
               collection.libraryId,
+              true,
             );
           } else {
             newColl = await this.findMediaServerCollection(
@@ -3107,6 +3110,7 @@ export class CollectionsService {
   public async findMediaServerCollection(
     name: string,
     libraryId: string,
+    searchAllLibraries = false,
   ): Promise<MediaCollection | undefined> {
     // Cannot search for collections without a valid library ID
     if (!libraryId || libraryId === '') {
@@ -3118,13 +3122,58 @@ export class CollectionsService {
 
     try {
       const mediaServer = await this.getMediaServer();
-      const collections = await mediaServer.getCollections(libraryId);
-      if (collections) {
-        const found = collections.find((coll) => {
-          return coll.title.trim() === name.trim() && !coll.smart;
-        });
+
+      // Primary lookup: the collection's own library.
+      const found = await this.matchCollectionInLibrary(
+        mediaServer,
+        name,
+        libraryId,
+      );
+      if (found) {
         return found;
       }
+
+      // Fallback for manual collections on servers where a single collection
+      // can span libraries (Jellyfin/Emby BoxSets are server-global; Plex
+      // collections are bound to one library). A manual collection reused
+      // across e.g. a movie rule and a show rule may currently hold items from
+      // one library only, so the server reports it under that library alone and
+      // the own-library lookup misses. Search the remaining libraries so the
+      // shared collection can still be located; once seeded it becomes
+      // discoverable under its own library on subsequent runs.
+      //
+      // getLibraries() already returns only movie/show libraries (never
+      // music/photos), so the search stays scoped to relevant types. The
+      // movie<->show crossover is intentional and required: a BoxSet is one
+      // server-global container that can hold both, and this fallback exists
+      // precisely to let a show rule find a BoxSet currently populated with
+      // movies only. Do not narrow this to the collection's own type — that
+      // would reintroduce the bug. Matching reuses matchCollectionInLibrary so
+      // the primary and fallback share one comparison; the name match only
+      // bootstraps the first link, after which the stored mediaServerId is used.
+      if (
+        searchAllLibraries &&
+        mediaServer.supportsFeature(
+          MediaServerFeature.CROSS_LIBRARY_COLLECTIONS,
+        )
+      ) {
+        const libraries = await mediaServer.getLibraries();
+        for (const library of libraries) {
+          if (library.id === libraryId) {
+            continue;
+          }
+          const crossLibraryMatch = await this.matchCollectionInLibrary(
+            mediaServer,
+            name,
+            library.id,
+          );
+          if (crossLibraryMatch) {
+            return crossLibraryMatch;
+          }
+        }
+      }
+
+      return undefined;
     } catch (error) {
       this.logger.warn(
         'An error occurred while searching for a specific collection.',
@@ -3132,6 +3181,21 @@ export class CollectionsService {
       this.logger.debug(error);
       return undefined;
     }
+  }
+
+  private async matchCollectionInLibrary(
+    mediaServer: IMediaServerService,
+    name: string,
+    libraryId: string,
+  ): Promise<MediaCollection | undefined> {
+    const collections = await mediaServer.getCollections(libraryId);
+    if (!collections) {
+      return undefined;
+    }
+    const target = name.trim();
+    return collections.find(
+      (coll) => coll.title.trim() === target && !coll.smart,
+    );
   }
 
   async getCollectionLogsWithPaging(

--- a/packages/contracts/src/media-server/enums.ts
+++ b/packages/contracts/src/media-server/enums.ts
@@ -58,4 +58,10 @@ export enum MediaServerFeature {
   COLLECTION_POSTER = 'collection_poster',
   /** Ability to sort collections */
   COLLECTION_SORT = 'collection_sort',
+  /**
+   * A single collection can span multiple libraries. Jellyfin/Emby BoxSets are
+   * server-global and may hold items from any library; Plex collections are
+   * bound to one library. Gates the cross-library lookup for manual collections.
+   */
+  CROSS_LIBRARY_COLLECTIONS = 'cross_library_collections',
 }

--- a/packages/contracts/src/media-server/features.ts
+++ b/packages/contracts/src/media-server/features.ts
@@ -21,6 +21,7 @@ export const MEDIA_SERVER_FEATURES: Record<
     MediaServerFeature.LABELS, // Tags in Jellyfin
     MediaServerFeature.PLAYLISTS,
     MediaServerFeature.COLLECTION_POSTER,
+    MediaServerFeature.CROSS_LIBRARY_COLLECTIONS, // BoxSets are server-global
     // Note: COLLECTION_VISIBILITY not supported
     // Note: WATCHLIST not supported (no API)
     // Note: CENTRAL_WATCH_HISTORY not supported (requires user iteration)
@@ -30,6 +31,7 @@ export const MEDIA_SERVER_FEATURES: Record<
     MediaServerFeature.LABELS,
     MediaServerFeature.PLAYLISTS,
     MediaServerFeature.COLLECTION_POSTER,
+    MediaServerFeature.CROSS_LIBRARY_COLLECTIONS, // BoxSets are server-global
     // Conservative defaults mirroring Jellyfin:
     // - COLLECTION_VISIBILITY: Emby has no Plex-style home/recommended pinning.
     // - WATCHLIST: no public watchlist API.

--- a/tools/dev/fake-emby.mjs
+++ b/tools/dev/fake-emby.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Dev-only mock Emby HTTP server for Maintainerr.
+ *
+ * Maintainerr's Emby adapter (apps/server/.../emby/emby-adapter.service.ts) talks
+ * to a real Emby over HTTP via raw axios (X-Emby-Token auth). Unlike the Jellyfin
+ * SDK, it sends PascalCase query params (ParentId, UserId, IncludeItemTypes), so
+ * this mock reads those casings. It answers the handful of endpoints the
+ * collection flows need so the Emby path can be exercised without a real Emby.
+ *
+ * It deliberately models the #3026 condition: a server-global BoxSet that holds
+ * movies only, so the server reports it under the movie library and NOT the show
+ * library. A show rule's own-library lookup misses; the cross-library fallback
+ * must find it under the movie library.
+ *
+ * No real media names (repo rule). Pairs with a DB configured for Emby:
+ *   - settings.media_server_type = 'emby'
+ *   - settings.emby_url = http://localhost:8097
+ *   - library ids: emby-movies / emby-shows
+ *
+ * Usage:
+ *   node tools/dev/fake-emby.mjs            # listens on :8097
+ *   FAKE_EMBY_PORT=8097 FAKE_EMBY_LOG=1 node tools/dev/fake-emby.mjs
+ */
+import http from 'node:http';
+
+const PORT = Number(process.env.FAKE_EMBY_PORT ?? 8097);
+const LOG = process.env.FAKE_EMBY_LOG === '1';
+const ISO = (d) => new Date(d).toISOString();
+
+// --- Libraries -------------------------------------------------------------------
+const LIBRARIES = [
+  { Id: 'emby-movies', Name: 'Movies (mock)', CollectionType: 'movies' },
+  { Id: 'emby-shows', Name: 'Shows (mock)', CollectionType: 'tvshows' },
+];
+
+// --- Users (admin + non-admin, to exercise admin auto-resolve) -------------------
+const USERS = [
+  { Id: 'emby-viewer', Name: 'viewer', Policy: { IsAdministrator: false } },
+  { Id: 'emby-admin', Name: 'admin', Policy: { IsAdministrator: true } },
+];
+
+// --- Items -----------------------------------------------------------------------
+function show(id, name) {
+  return {
+    Id: id,
+    Name: name,
+    Type: 'Series',
+    ParentId: 'emby-shows',
+    ProductionYear: 2020,
+    DateCreated: ISO('2026-01-01'),
+    ProviderIds: {},
+  };
+}
+const SHOWS = [show('emby-show-1', 'Mock Show Alpha')];
+
+// The shared manual ("custom name") BoxSet. Server-global, but reported only under
+// libraries whose content it holds — and it holds movies only.
+const SHARED_BOXSET = {
+  Id: 'emby-boxset-shared',
+  Name: 'Franchise A Collection',
+  Type: 'BoxSet',
+  ParentId: 'emby-movies',
+  ChildCount: 3,
+  DateCreated: ISO('2026-01-01'),
+  Overview: 'Shared manual collection (mock)',
+};
+
+const ITEMS_BY_ID = new Map(
+  [...SHOWS, SHARED_BOXSET].map((item) => [item.Id, item]),
+);
+
+// --- HTTP helpers ----------------------------------------------------------------
+function send(res, status, body) {
+  const json = body === undefined ? '' : JSON.stringify(body);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(json),
+  });
+  res.end(json);
+}
+const itemsResponse = (items) => ({
+  Items: items,
+  TotalRecordCount: items.length,
+  StartIndex: 0,
+});
+
+const SYSTEM_INFO = {
+  Id: 'mockembyserver',
+  ServerName: 'Emby (mock)',
+  Version: '4.8.0.0',
+  ProductName: 'Emby Server',
+  OperatingSystem: 'Linux',
+};
+
+const server = http.createServer((req, res) => {
+  const u = new URL(req.url, `http://localhost:${PORT}`);
+  const path = u.pathname;
+  if (LOG) process.stdout.write(`[fake-emby] ${req.method} ${path}${u.search}\n`);
+
+  // Connection check
+  if (path === '/System/Info' || path === '/System/Info/Public') {
+    return send(res, 200, SYSTEM_INFO);
+  }
+  // Users (Emby returns a query-result envelope for /Users/Query)
+  if (path === '/Users/Query') return send(res, 200, itemsResponse(USERS));
+  if (path === '/Users') return send(res, 200, USERS);
+  if (/^\/Users\/[^/]+$/.test(path)) {
+    const id = path.split('/')[2];
+    return send(res, 200, USERS.find((x) => x.Id === id) ?? USERS[1]);
+  }
+  // Libraries
+  if (
+    path === '/Library/MediaFolders' ||
+    path === '/Library/VirtualFolders' ||
+    /^\/Users\/[^/]+\/Views$/.test(path)
+  ) {
+    return send(res, 200, itemsResponse(LIBRARIES));
+  }
+  // Sessions (active-playback check)
+  if (path === '/Sessions') return send(res, 200, []);
+
+  // Single item by id: /Items/{id} or /Users/{userId}/Items/{id}
+  const itemMatch =
+    path.match(/^\/Items\/([^/]+)$/) ||
+    path.match(/^\/Users\/[^/]+\/Items\/([^/]+)$/);
+  if (req.method === 'GET' && itemMatch) {
+    const id = itemMatch[1];
+    return send(res, 200, ITEMS_BY_ID.get(id) ?? show(id, `Mock item ${id}`));
+  }
+
+  // Item list: /Items or /Users/{userId}/Items — Emby sends PascalCase params.
+  if (
+    req.method === 'GET' &&
+    (path === '/Items' || /^\/Users\/[^/]+\/Items$/.test(path))
+  ) {
+    const ids = u.searchParams.get('Ids');
+    if (ids) {
+      return send(
+        res,
+        200,
+        itemsResponse(
+          ids.split(',').map((id) => ITEMS_BY_ID.get(id) ?? show(id, id)),
+        ),
+      );
+    }
+    const parentId = u.searchParams.get('ParentId');
+    const itemTypes = u.searchParams.get('IncludeItemTypes');
+    // BoxSet listing: server-global but surfaced only under libraries whose
+    // content the boxset holds. This one holds movies only — the #3026 condition.
+    if (itemTypes && itemTypes.includes('BoxSet')) {
+      if (parentId === 'emby-movies') {
+        return send(res, 200, itemsResponse([SHARED_BOXSET]));
+      }
+      return send(res, 200, itemsResponse([]));
+    }
+    if (parentId === 'emby-shows' || itemTypes === 'Series') {
+      return send(res, 200, itemsResponse(SHOWS));
+    }
+    return send(res, 200, itemsResponse([]));
+  }
+
+  // Image redirect so any grid hydration renders.
+  if (req.method === 'GET' && /^\/Items\/[^/]+\/Images\//.test(path)) {
+    res.writeHead(302, {
+      Location: 'https://picsum.photos/seed/emby/300/450',
+    });
+    return res.end();
+  }
+
+  // Writes: create collection, add/remove items, update item -> accept.
+  if (req.method === 'POST' || req.method === 'DELETE') {
+    if (path === '/Collections') {
+      return send(res, 200, { Id: 'emby-boxset-new' });
+    }
+    return send(res, 204, undefined);
+  }
+
+  if (LOG) process.stdout.write(`[fake-emby] UNHANDLED ${req.method} ${path}\n`);
+  return send(res, 200, itemsResponse([]));
+});
+
+server.listen(PORT, () => {
+  process.stdout.write(`[fake-emby] listening on http://localhost:${PORT}\n`);
+});

--- a/tools/dev/fake-jellyfin.mjs
+++ b/tools/dev/fake-jellyfin.mjs
@@ -126,8 +126,24 @@ const SHOWS = [
   }),
 ];
 
+// A manual ("custom name") collection the user created in Jellyfin/Emby. BoxSets
+// are server-global, but the server only reports one under libraries whose content
+// it currently holds. This one holds movies only, so it is visible under the movie
+// library and INVISIBLE under the show library — exactly the #3026 reproduction.
+const SHARED_BOXSET = {
+  Id: 'mock-boxset-shared',
+  Name: 'Franchise A Collection',
+  Type: 'BoxSet',
+  ServerId: 'mockserver',
+  ParentId: 'jellyfin-movies',
+  ChildCount: 3,
+  DateCreated: ISO('2026-01-01'),
+  Overview: 'Shared manual collection (mock)',
+  ImageTags: { Primary: 'mocktag' },
+};
+
 const ITEMS_BY_ID = new Map(
-  [...MOVIES, ...SHOWS].map((item) => [item.Id, item]),
+  [...MOVIES, ...SHOWS, SHARED_BOXSET].map((item) => [item.Id, item]),
 );
 
 // --- HTTP helpers ----------------------------------------------------------------
@@ -227,13 +243,24 @@ const server = http.createServer((req, res) => {
     }
     const parentId = u.searchParams.get('parentId');
     const itemTypes = u.searchParams.get('includeItemTypes');
+    // BoxSet (collection) listing. A BoxSet is server-global but the server only
+    // reports it under libraries whose content it currently holds. Our shared
+    // boxset holds movies only -> surfaced under the movie library, absent under
+    // the show library. This is the #3026 condition. (Checked before the generic
+    // parentId branches, which would otherwise return the library's media.)
+    if (itemTypes && itemTypes.includes('BoxSet')) {
+      if (parentId === 'jellyfin-movies') {
+        return send(res, 200, itemsResponse([SHARED_BOXSET]));
+      }
+      return send(res, 200, itemsResponse([]));
+    }
     if (parentId === 'jellyfin-movies' || itemTypes === 'Movie') {
       return send(res, 200, itemsResponse(MOVIES));
     }
     if (parentId === 'jellyfin-shows' || itemTypes === 'Series') {
       return send(res, 200, itemsResponse(SHOWS));
     }
-    // BoxSets / collections, episodes, etc. -> empty for now
+    // Episodes, etc. -> empty for now
     return send(res, 200, itemsResponse([]));
   }
   // Item images -> redirect to a deterministic placeholder so grids render.

--- a/tools/dev/seed-db.mjs
+++ b/tools/dev/seed-db.mjs
@@ -11,6 +11,7 @@
  * This is the only one of the three dev scripts that touches the DB; the
  * companion mocks are stateless HTTP servers:
  *   - tools/dev/fake-jellyfin.mjs  (mock Jellyfin, :8096) — pairs with MEDIA_SERVER=jellyfin
+ *   - tools/dev/fake-emby.mjs      (mock Emby, :8097)     — pairs with MEDIA_SERVER=emby
  *   - tools/dev/fake-plex.mjs      (mock Plex, :32400)    — pairs with MEDIA_SERVER=plex
  *
  * Notes
@@ -34,6 +35,7 @@
  *   1. Start the matching mock (tools/dev/fake-jellyfin.mjs or tools/dev/fake-plex.mjs).
  *   2. Stop `yarn dev` (SQLite allows a single writer).
  *   3. node tools/dev/seed-db.mjs                 # Jellyfin (default)
+ *      MEDIA_SERVER=emby node tools/dev/seed-db.mjs   # Emby
  *      MEDIA_SERVER=plex node tools/dev/seed-db.mjs   # Plex
  *   4. Start `yarn dev` and open http://localhost:3000/collections
  */
@@ -66,12 +68,19 @@ const jellyfinId = () =>
     .join("");
 
 // --- Target media server + rule coverage -------------------------------------
-const TARGET = process.env.MEDIA_SERVER === "plex" ? "plex" : "jellyfin";
-const APP = TARGET === "plex" ? 0 : 6; // Application id: Plex=0, Jellyfin=6
+const TARGET =
+  process.env.MEDIA_SERVER === "plex"
+    ? "plex"
+    : process.env.MEDIA_SERVER === "emby"
+      ? "emby"
+      : "jellyfin";
+const APP = TARGET === "plex" ? 0 : TARGET === "emby" ? 7 : 6; // Application id: Plex=0, Jellyfin=6, Emby=7
 const LIB =
   TARGET === "plex"
     ? { movie: "1", show: "2" } // tools/dev/fake-plex.mjs section ids
-    : { movie: "jellyfin-movies", show: "jellyfin-shows" }; // tools/dev/fake-jellyfin.mjs
+    : TARGET === "emby"
+      ? { movie: "emby-movies", show: "emby-shows" } // tools/dev/fake-emby.mjs
+      : { movie: "jellyfin-movies", show: "jellyfin-shows" }; // tools/dev/fake-jellyfin.mjs
 
 // ruleTypeId: NUMBER=0 DATE=1 TEXT=2 BOOL=3 TEXT_LIST=4. Property ids/types
 // differ per server, so keep one map each (mirrors RuleConstants).
@@ -91,6 +100,10 @@ const COVERAGE = {
     show: [0,2,4,11,12,13,14,15,16,17,18,19,25,26,27,29,31,35,36,37,38,40,41,42],
   },
 };
+// Emby mirrors Jellyfin's rule-property constants (RulesConstants clones the
+// Jellyfin application as Application.EMBY), so reuse the same maps.
+TYPES.emby = TYPES.jellyfin;
+COVERAGE.emby = COVERAGE.jellyfin;
 const EXISTS = 18; // RulePossibility.EXISTS — valid for every RuleType
 const ruleType = TYPES[TARGET];
 const ruleJson = (id, i) =>
@@ -183,6 +196,25 @@ const run = db.transaction(() => {
       port: 32400,
       token: "devseed000000000000000000000plex",
       machine: "mockplexmachine0000000000000000",
+      tmdb: "devseed00000000000000000000000tmdb",
+    });
+  } else if (TARGET === "emby") {
+    // Points at tools/dev/fake-emby.mjs. emby_user_id is the mock's admin user;
+    // leave it null instead to exercise the admin auto-resolve path.
+    db.prepare(
+      `UPDATE settings SET
+         media_server_type = 'emby',
+         emby_url = @url,
+         emby_api_key = @key,
+         emby_user_id = @user,
+         emby_server_name = @name,
+         tmdb_api_key = @tmdb
+       WHERE id = 1`,
+    ).run({
+      url: "http://localhost:8097",
+      key: "devseed00000000000000000000000emby",
+      user: "emby-admin",
+      name: "Emby (dev seed)",
       tmdb: "devseed00000000000000000000000tmdb",
     });
   } else {
@@ -451,7 +483,7 @@ console.log(
   `Seeded ${results.length} collections, ${totalItems} media items, ${totalRules} rules into ${dbPath}`,
 );
 console.log(
-  `Media server set to ${TARGET === "plex" ? "Plex" : "Jellyfin"} (dev seed); Radarr + Sonarr configured.`,
+  `Media server set to ${TARGET === "plex" ? "Plex" : TARGET === "emby" ? "Emby" : "Jellyfin"} (dev seed); Radarr + Sonarr configured.`,
 );
 console.log(
   "Also seeded: notifications, cron schedules, collection logs, exclusions, overlays.",


### PR DESCRIPTION
Fixes #3026.

Custom (manual) collections shared between a movie rule and a show rule failed to resolve on Emby/Jellyfin. BoxSets are server-global and only reported under the libraries whose content they currently hold, so a show rule couldn't find a BoxSet that (so far) holds only movies — while the movie rule found it fine.

### Fix
- Add a `CROSS_LIBRARY_COLLECTIONS` capability (Jellyfin/Emby; **not** Plex). For manual collections, when the own-library lookup misses, fall back to the other movie/show libraries (`getLibraries()` already returns only movie/show; the movie↔show crossover is intentional since one BoxSet spans both). Primary and fallback share the single `matchCollectionInLibrary` helper.
- Make Emby `getCollections` / `getCollectionChildren` **user-scoped** — Emby resolves BoxSet queries against a user's library view, so an unscoped read can miss or 404 and break the manual-collection bootstrap. The user is passed via the `UserId` query param on the literal `/Items` path (not interpolated into the request path, so no request-forgery sink). When `emby_user_id` is unset, resolve and cache the first admin user (Maintainerr only ever operates as an admin).
- Cache Emby `getCollections` per library (skip-empty) with create/update/delete invalidation, mirroring the Jellyfin adapter, so the fallback stays cheap.
- Fix a pre-existing type error in `collection-worker.server.spec.ts` (`handleMedia` returns `HandleMediaResult`).

### Dev tooling
- New `tools/dev/fake-emby.mjs` mock + `MEDIA_SERVER=emby` support in `seed-db.mjs`, and `fake-jellyfin` now models a server-global BoxSet reported under the movie library only — so this cross-library bug reproduces end-to-end against both adapters.