### PR TITLE
fix(rules): save rule groups from incomplete payloads and clarify YAML import errors

### DIFF
--- a/apps/server/src/modules/rules/helpers/yaml.service.spec.ts
+++ b/apps/server/src/modules/rules/helpers/yaml.service.spec.ts
@@ -198,4 +198,15 @@ describe('RuleYamlService', () => {
     expect(rules[0].operator).toBeNull(); // first rule of the group
     expect(rules[1].operator).toBe(RuleOperators.AND); // section boundary, not OR
   });
+
+  it('returns a clear, structured message when the YAML is not valid', () => {
+    // Malformed YAML (an unterminated flow sequence) makes the parser throw,
+    // which the decoder catches and reports as a structured failure.
+    const decoded = service.decode('rules: [unterminated', 'movie');
+
+    expect(decoded.code).toBe(0);
+    expect(decoded.message).toBe(
+      'Validation failed - Please check your YAML structure.',
+    );
+  });
 });

--- a/apps/server/src/modules/rules/helpers/yaml.service.ts
+++ b/apps/server/src/modules/rules/helpers/yaml.service.ts
@@ -250,7 +250,7 @@ export class RuleYamlService {
       this.logger.debug(error);
       return {
         code: 0,
-        message: 'Import failed, please check your yaml',
+        message: 'Validation failed - Please check your YAML structure.',
       };
     }
   }

--- a/apps/server/src/modules/rules/rules.controller.ts
+++ b/apps/server/src/modules/rules/rules.controller.ts
@@ -330,11 +330,19 @@ export class RulesController {
     @Body() body: { yaml: string; mediaType: MediaItemType },
   ): Promise<ReturnStatus> {
     try {
-      return this.rulesService.decodeFromYaml(body.yaml, body.mediaType);
+      return await this.rulesService.decodeFromYaml(body.yaml, body.mediaType);
     } catch (error) {
+      // A genuine YAML syntax/structure error is already handled inside the
+      // service (it returns a clear message). Reaching here means a later
+      // failure (e.g. rule migration) threw, which is not a YAML problem - log
+      // the real fault and surface a plain, accurate message instead.
+      this.logger.error('Failed to import rules from YAML');
+      this.logger.debug(error);
+      const message = 'Failed to import rules';
       return {
         code: 0,
-        result: 'Invalid input',
+        result: message,
+        message,
       };
     }
   }

--- a/apps/server/src/modules/rules/rules.service.setRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.setRules.spec.ts
@@ -1,0 +1,194 @@
+import { createMockLogger } from '../../../test/utils/data';
+import { Application, RulePossibility } from './constants/rules.constants';
+import { RulesService } from './rules.service';
+
+describe('RulesService.setRules', () => {
+  const logger = createMockLogger();
+
+  const createRulesService = (
+    overrides: Partial<{
+      rulesRepository: unknown;
+      ruleGroupRepository: unknown;
+      collectionMediaRepository: unknown;
+      communityRuleKarmaRepository: unknown;
+      exclusionRepo: unknown;
+      settingsRepo: unknown;
+      radarrSettingsRepo: unknown;
+      sonarrSettingsRepo: unknown;
+      collectionService: unknown;
+      mediaServerFactory: unknown;
+      connection: unknown;
+      ruleYamlService: unknown;
+      ruleComparatorServiceFactory: unknown;
+      ruleMigrationService: unknown;
+      eventEmitter: unknown;
+    }> = {},
+  ) =>
+    new RulesService(
+      (overrides.rulesRepository ?? {}) as any,
+      (overrides.ruleGroupRepository ?? {}) as any,
+      (overrides.collectionMediaRepository ?? {}) as any,
+      (overrides.communityRuleKarmaRepository ?? {}) as any,
+      (overrides.exclusionRepo ?? {}) as any,
+      (overrides.settingsRepo ?? {}) as any,
+      (overrides.radarrSettingsRepo ?? {}) as any,
+      (overrides.sonarrSettingsRepo ?? {}) as any,
+      (overrides.collectionService ?? {}) as any,
+      (overrides.mediaServerFactory ?? {}) as any,
+      (overrides.connection ?? {}) as any,
+      (overrides.ruleYamlService ?? {}) as any,
+      (overrides.ruleComparatorServiceFactory ?? {}) as any,
+      (overrides.ruleMigrationService ?? {}) as any,
+      (overrides.eventEmitter ?? {}) as any,
+      logger as any,
+    );
+
+  // A minimal, valid single-rule section (Plex "date added" EXISTS). EXISTS is
+  // self-contained so the rule needs no second value to pass validation.
+  const validRules = [
+    {
+      operator: null,
+      action: RulePossibility.EXISTS,
+      firstVal: [Application.PLEX, 0],
+      section: 0,
+    },
+  ];
+
+  const createMediaServerFactory = () => ({
+    getService: jest.fn().mockReturnValue({
+      getLibraries: jest
+        .fn()
+        .mockResolvedValue([{ id: '1', title: 'Movies', type: 'movie' }]),
+    }),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('persists a valid rule group and reports success', async () => {
+    const createCollection = jest
+      .fn()
+      .mockResolvedValue({ dbCollection: { id: 99 } });
+    const rulesRepository = { save: jest.fn().mockResolvedValue(undefined) };
+
+    const service = createRulesService({
+      rulesRepository,
+      collectionService: { createCollection },
+      mediaServerFactory: createMediaServerFactory(),
+    });
+
+    jest.spyOn(service as any, 'createOrUpdateGroup').mockResolvedValue(7);
+
+    const result = await service.setRules({
+      libraryId: '1',
+      name: 'Valid group',
+      description: '',
+      useRules: true,
+      isActive: true,
+      rules: validRules,
+      collection: { keepLogsForMonths: 6 },
+    } as any);
+
+    expect(rulesRepository.save).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      code: 1,
+      result: 'Success',
+      message: 'Success',
+    });
+  });
+
+  // Regression for #3044: an incomplete payload that omits the `collection`
+  // block used to make `+params.collection?.keepLogsForMonths` evaluate to NaN,
+  // which better-sqlite3 cannot bind - the insert threw and the group silently
+  // failed to save. It must now fall back to the column default (6) and persist.
+  it('falls back to the default keepLogsForMonths when the collection block is omitted', async () => {
+    const createCollection = jest
+      .fn()
+      .mockResolvedValue({ dbCollection: { id: 99 } });
+
+    const service = createRulesService({
+      rulesRepository: { save: jest.fn().mockResolvedValue(undefined) },
+      collectionService: { createCollection },
+      mediaServerFactory: createMediaServerFactory(),
+    });
+
+    jest.spyOn(service as any, 'createOrUpdateGroup').mockResolvedValue(7);
+
+    const result = await service.setRules({
+      libraryId: '1',
+      name: 'No collection block',
+      description: '',
+      useRules: true,
+      isActive: true,
+      rules: validRules,
+    } as any);
+
+    expect(createCollection).toHaveBeenCalledWith(
+      expect.objectContaining({ keepLogsForMonths: 6 }),
+    );
+    expect(result).toEqual({
+      code: 1,
+      result: 'Success',
+      message: 'Success',
+    });
+  });
+
+  // Regression for #3044: when collection creation fails, setRules used to
+  // `return undefined`, which NestJS serialized as a silent HTTP 201 with an
+  // empty body - indistinguishable from success to the client. It must now
+  // return a structured failure the UI can surface.
+  it('returns a structured failure (not undefined) when collection creation fails', async () => {
+    const service = createRulesService({
+      collectionService: {
+        createCollection: jest
+          .fn()
+          .mockResolvedValue({ dbCollection: undefined }),
+      },
+      mediaServerFactory: createMediaServerFactory(),
+    });
+
+    const result = await service.setRules({
+      libraryId: '1',
+      name: 'Collection fails',
+      description: '',
+      useRules: true,
+      isActive: true,
+      rules: validRules,
+      collection: { keepLogsForMonths: 6 },
+    } as any);
+
+    expect(result).toEqual({
+      code: 0,
+      result: 'Failed to create collection',
+      message: 'Failed to create collection',
+    });
+  });
+
+  it('returns a structured failure (not undefined) when saving throws', async () => {
+    const service = createRulesService({
+      collectionService: {
+        createCollection: jest
+          .fn()
+          .mockRejectedValue(new Error('database is locked')),
+      },
+      mediaServerFactory: createMediaServerFactory(),
+    });
+
+    const result = await service.setRules({
+      libraryId: '1',
+      name: 'Throws',
+      description: '',
+      useRules: true,
+      isActive: true,
+      rules: validRules,
+      collection: { keepLogsForMonths: 6 },
+    } as any);
+
+    expect(result).toEqual({
+      code: 0,
+      result: 'Failed to save the rule group',
+      message: 'Failed to save the rule group',
+    });
+  });
+});

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -384,7 +384,7 @@ export class RulesService {
           deleteAfterDays: params.collection?.deleteAfterDays ?? null,
           manualCollection: params.collection?.manualCollection,
           manualCollectionName: params.collection?.manualCollectionName,
-          keepLogsForMonths: +params.collection?.keepLogsForMonths,
+          keepLogsForMonths: params.collection?.keepLogsForMonths ?? 6,
           sortTitle: params.collection?.sortTitle,
           mediaServerSort: params.collection?.mediaServerSort ?? null,
           overlayEnabled: params.collection?.overlayEnabled,
@@ -393,7 +393,7 @@ export class RulesService {
       )?.dbCollection;
 
       if (!collection) {
-        return undefined;
+        return this.createReturnStatus(false, 'Failed to create collection');
       }
 
       const groupId = await this.createOrUpdateGroup(
@@ -428,7 +428,7 @@ export class RulesService {
     } catch (error) {
       this.logger.warn('Rules - Action failed');
       this.logger.debug(error);
-      return undefined;
+      return this.createReturnStatus(false, 'Failed to save the rule group');
     }
   }
 
@@ -477,9 +477,11 @@ export class RulesService {
         if (
           dbCollection &&
           (group.dataType !== params.dataType ||
-            params.collection.manualCollection !==
+            (params.collection?.manualCollection ??
+              dbCollection.manualCollection) !==
               dbCollection.manualCollection ||
-            params.collection.manualCollectionName !==
+            (params.collection?.manualCollectionName ??
+              dbCollection.manualCollectionName) !==
               dbCollection.manualCollectionName ||
             params.libraryId !== dbCollection.libraryId)
         ) {
@@ -558,7 +560,7 @@ export class RulesService {
           deleteAfterDays: params.collection?.deleteAfterDays ?? null,
           manualCollection: params.collection?.manualCollection,
           manualCollectionName: params.collection?.manualCollectionName,
-          keepLogsForMonths: +params.collection?.keepLogsForMonths,
+          keepLogsForMonths: params.collection?.keepLogsForMonths ?? 6,
           sortTitle: params.collection?.sortTitle,
           mediaServerSort: params.collection?.mediaServerSort ?? null,
           overlayEnabled: params.collection?.overlayEnabled,
@@ -640,7 +642,7 @@ export class RulesService {
     } catch (error) {
       this.logger.warn('Rules - Action failed');
       this.logger.debug(error);
-      return undefined;
+      return this.createReturnStatus(false, 'Failed to save the rule group');
     }
   }
   async setExclusion(data: ExclusionContextDto) {

--- a/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
@@ -330,6 +330,76 @@ describe('RulesService.updateRules', () => {
     });
   });
 
+  // Regression for #3044: an update payload that omits the `collection` block
+  // used to throw on `params.collection.manualCollection` during the
+  // "crucial setting changed" check. It must now update without throwing, fall
+  // back to the default keepLogsForMonths (6), and not trigger a spurious media
+  // wipe (an absent field means "unchanged", not "changed to undefined").
+  it('updates without throwing when the collection block is omitted', async () => {
+    const group = { id: 5, collectionId: 42, dataType: 'movie' };
+    const dbCollection = {
+      id: 42,
+      libraryId: 'lib-1',
+      mediaServerId: 'col-1',
+      manualCollection: false,
+      manualCollectionName: '',
+    };
+
+    const collectionMediaRepository = { delete: jest.fn() };
+    const collectionService = {
+      getCollection: jest.fn().mockResolvedValue(dbCollection),
+      saveCollection: jest.fn().mockResolvedValue(undefined),
+      addLogRecord: jest.fn().mockResolvedValue(undefined),
+      updateCollection: jest
+        .fn()
+        .mockResolvedValue({ dbCollection: { id: 42 } }),
+    };
+    const mediaServer = {
+      cleanupCollectionForLibrary: jest.fn().mockResolvedValue(undefined),
+      getLibraries: jest
+        .fn()
+        .mockResolvedValue([{ id: 'lib-1', title: 'Movies', type: 'movie' }]),
+    };
+
+    const service = createRulesService({
+      rulesRepository: { delete: jest.fn(), save: jest.fn() },
+      ruleGroupRepository: { findOne: jest.fn().mockResolvedValue(group) },
+      collectionMediaRepository,
+      exclusionRepo: { delete: jest.fn() },
+      collectionService,
+      mediaServerFactory: {
+        getService: jest.fn().mockReturnValue(mediaServer),
+      },
+    });
+
+    jest
+      .spyOn(service as any, 'createOrUpdateGroup')
+      .mockResolvedValue(group.id);
+
+    const result = await service.updateRules({
+      id: group.id,
+      libraryId: 'lib-1',
+      dataType: 'movie',
+      name: 'No collection block',
+      description: '',
+      rules: [],
+      useRules: true,
+      isActive: true,
+      // collection intentionally omitted
+    } as any);
+
+    // Absent collection settings must not be read as a "crucial" change.
+    expect(collectionMediaRepository.delete).not.toHaveBeenCalled();
+    expect(collectionService.updateCollection).toHaveBeenCalledWith(
+      expect.objectContaining({ keepLogsForMonths: 6 }),
+    );
+    expect(result).toEqual({
+      code: 1,
+      result: 'Success',
+      message: 'Success',
+    });
+  });
+
   const buildSortTransitionFixture = (options: {
     previousSort: string | null;
     nextSort: string | null;


### PR DESCRIPTION
Hardens rule-group saving against incomplete API payloads and improves YAML import error reporting (see #3044). The normal UI flow was never broken; these fixes close the robustness gaps the report surfaced.

- `keepLogsForMonths` now defaults to 6 when the collection block is omitted, instead of `+undefined` becoming `NaN` and crashing the insert (create and update).
- Save failures return a structured `{code:0}` error instead of a silent empty 201.
- `updateRules` no longer throws when the collection block is missing, and treats absent collection settings as unchanged (no spurious media/exclusion wipe).
- Invalid YAML returns a clearer message; genuine server-side faults during import are logged with an accurate message instead of being mislabeled as YAML syntax errors.
