### PR TITLE
fix(rules): preserve collection link and visibility on partial updates

### DIFF
--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -555,11 +555,21 @@ export class RulesService {
           sonarrSettingsId: params.sonarrSettingsId ?? null,
           radarrQualityProfileId: params.radarrQualityProfileId ?? null,
           sonarrQualityProfileId: params.sonarrQualityProfileId ?? null,
-          visibleOnRecommended: params.collection?.visibleOnRecommended,
-          visibleOnHome: params.collection?.visibleOnHome,
+          // If the collection block is left out of an update, keep the saved
+          // values instead of sending undefined — otherwise we'd unlink a manual
+          // collection or switch off Plex visibility.
+          visibleOnRecommended:
+            params.collection?.visibleOnRecommended ??
+            dbCollection?.visibleOnRecommended,
+          visibleOnHome:
+            params.collection?.visibleOnHome ?? dbCollection?.visibleOnHome,
           deleteAfterDays: params.collection?.deleteAfterDays ?? null,
-          manualCollection: params.collection?.manualCollection,
-          manualCollectionName: params.collection?.manualCollectionName,
+          manualCollection:
+            params.collection?.manualCollection ??
+            dbCollection?.manualCollection,
+          manualCollectionName:
+            params.collection?.manualCollectionName ??
+            dbCollection?.manualCollectionName,
           keepLogsForMonths: params.collection?.keepLogsForMonths ?? 6,
           sortTitle: params.collection?.sortTitle,
           mediaServerSort: params.collection?.mediaServerSort ?? null,

--- a/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
@@ -330,19 +330,19 @@ describe('RulesService.updateRules', () => {
     });
   });
 
-  // Regression for #3044: an update payload that omits the `collection` block
-  // used to throw on `params.collection.manualCollection` during the
-  // "crucial setting changed" check. It must now update without throwing, fall
-  // back to the default keepLogsForMonths (6), and not trigger a spurious media
-  // wipe (an absent field means "unchanged", not "changed to undefined").
-  it('updates without throwing when the collection block is omitted', async () => {
+  // Leaving the collection block out of an update shouldn't throw, wipe media,
+  // or quietly drop the saved keepLogsForMonths, manual link, or visibility
+  // (#3044 + partial-update review).
+  it('keeps existing collection settings when the collection block is omitted', async () => {
     const group = { id: 5, collectionId: 42, dataType: 'movie' };
     const dbCollection = {
       id: 42,
       libraryId: 'lib-1',
       mediaServerId: 'col-1',
-      manualCollection: false,
-      manualCollectionName: '',
+      manualCollection: true,
+      manualCollectionName: 'Shared Collection',
+      visibleOnHome: true,
+      visibleOnRecommended: true,
     };
 
     const collectionMediaRepository = { delete: jest.fn() };
@@ -388,10 +388,16 @@ describe('RulesService.updateRules', () => {
       // collection intentionally omitted
     } as any);
 
-    // Absent collection settings must not be read as a "crucial" change.
+    // An absent block means "unchanged", not a crucial change or a reset.
     expect(collectionMediaRepository.delete).not.toHaveBeenCalled();
     expect(collectionService.updateCollection).toHaveBeenCalledWith(
-      expect.objectContaining({ keepLogsForMonths: 6 }),
+      expect.objectContaining({
+        keepLogsForMonths: 6,
+        manualCollection: true,
+        manualCollectionName: 'Shared Collection',
+        visibleOnHome: true,
+        visibleOnRecommended: true,
+      }),
     );
     expect(result).toEqual({
       code: 1,


### PR DESCRIPTION
Follow-up to #3045. An external review found that a `PUT /api/rules` payload that omits the `collection` block forwards `undefined` for the collection-owned fields, which then:

- **Unlinks a manual collection.** `updateCollection` clears `mediaServerId` because `undefined !== dbCollection.manualCollection`. The save looks successful but the rule group is detached from its media-server collection.
- **Wipes Plex Home/Recommended visibility.** `undefined` is coerced to `false` in the Plex adapter, disabling both flags.

Fix: in `updateRules`, fall back to the persisted values (`?? dbCollection?.x`) for `manualCollection`, `manualCollectionName`, `visibleOnHome` and `visibleOnRecommended`, so an omitted block means "unchanged" rather than "reset". The `??` (not `||`) keeps an explicit `false` honoured.

The existing omitted-block regression test is extended to assert the four fields are preserved.