### PR TITLE
fix(plex): use /identity for the connection probe and v2 resources for server discovery

### DIFF
--- a/apps/server/src/modules/api/lib/plexApi.ts
+++ b/apps/server/src/modules/api/lib/plexApi.ts
@@ -242,8 +242,10 @@ class PlexApi {
 
   public async getStatus(): Promise<boolean> {
     try {
+      // `/identity` (not `/`): returns the server MediaContainer without the
+      // 401 that bare `/` gives behind reverse proxies.
       const status: { MediaContainer: any } = await this.query(
-        { uri: `/` },
+        { uri: `/identity` },
         false,
       );
       return status?.MediaContainer ? true : false;

--- a/apps/server/src/modules/api/lib/plextvApi.spec.ts
+++ b/apps/server/src/modules/api/lib/plextvApi.spec.ts
@@ -2,6 +2,7 @@ import { AxiosError, AxiosResponse } from 'axios';
 import axiosRetry from 'axios-retry';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { createMockLogger } from '../../../../test/utils/data';
+import cacheManager from './cache';
 import { PlexTvApi } from './plextvApi';
 
 jest.mock('axios', () => {
@@ -74,5 +75,84 @@ describe('PlexTvApi.validateToken', () => {
     get.mockRejectedValue(new AxiosError('timeout', 'ECONNABORTED'));
 
     await expect(createApi().validateToken()).resolves.toBe('unreachable');
+  });
+});
+
+describe('PlexTvApi.getDevices', () => {
+  const get = jest.fn();
+
+  const createApi = () =>
+    new PlexTvApi(
+      'a-token',
+      createMockLogger() as unknown as MaintainerrLogger,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Responses are cached by endpoint; flush so cases don't leak into each other.
+    cacheManager.getCache('plextv').data.flushAll();
+    axios.create.mockReturnValue({ get });
+    (axiosRetry as unknown as jest.Mock).mockImplementation(() => undefined);
+  });
+
+  it('queries v2 with the client identifier and maps owned servers v1 omits', async () => {
+    get.mockResolvedValue({
+      data: [
+        {
+          name: 'plex',
+          product: 'Plex Media Server',
+          productVersion: '1.43.2',
+          platform: 'Linux',
+          platformVersion: '6.8',
+          device: 'Docker Container (hotio)',
+          clientIdentifier: 'owned-server-id',
+          provides: 'server',
+          owned: true,
+          ownerId: null,
+          createdAt: '2026-06-07T16:14:08Z',
+          lastSeenAt: '2026-06-07T16:14:08Z',
+          connections: [
+            {
+              protocol: 'https',
+              address: 'plex.example.info',
+              port: 443,
+              uri: 'https://plex.example.info:443',
+              local: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const devices = await createApi().getDevices('client-123');
+
+    // v2 requires X-Plex-Client-Identifier; v1 did not.
+    expect(get).toHaveBeenCalledWith(
+      '/api/v2/resources?includeHttps=1',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Plex-Client-Identifier': 'client-123',
+        }),
+      }),
+    );
+    expect(devices).toHaveLength(1);
+    expect(devices[0]).toMatchObject({
+      name: 'plex',
+      clientIdentifier: 'owned-server-id',
+      owned: true,
+      provides: ['server'],
+    });
+    expect(devices[0].createdAt).toBeInstanceOf(Date);
+    expect(devices[0].connection[0]).toMatchObject({
+      port: 443,
+      local: false,
+      uri: 'https://plex.example.info:443',
+    });
+  });
+
+  it('returns [] when plex.tv errors', async () => {
+    get.mockRejectedValue(new AxiosError('boom', 'ERR_BAD_REQUEST'));
+
+    await expect(createApi().getDevices('client-123')).resolves.toEqual([]);
   });
 });

--- a/apps/server/src/modules/api/lib/plextvApi.ts
+++ b/apps/server/src/modules/api/lib/plextvApi.ts
@@ -70,6 +70,8 @@ interface PlexV2Resource {
   home?: boolean;
   presence?: boolean;
   publicAddressMatches?: boolean;
+  dnsRebindingProtection?: boolean;
+  natLoopbackSupported?: boolean;
   connections: PlexV2Connection[];
 }
 
@@ -321,6 +323,8 @@ export class PlexTvApi extends ExternalApiService {
         synced: resource.synced,
         relay: resource.relay,
         presence: resource.presence,
+        dnsRebindingProtection: resource.dnsRebindingProtection,
+        natLoopbackSupported: resource.natLoopbackSupported,
         ownerID:
           resource.ownerId != null ? String(resource.ownerId) : undefined,
         home: resource.home,

--- a/apps/server/src/modules/api/lib/plextvApi.ts
+++ b/apps/server/src/modules/api/lib/plextvApi.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios';
-import xml2js, { parseStringPromise } from 'xml2js';
+import { parseStringPromise } from 'xml2js';
 import { PlexDevice } from '../../api/plex-api/interfaces/server.interface';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { ExternalApiService } from '../external-api/external-api.service';
@@ -35,43 +35,42 @@ export interface PlexUser {
   entitlements: string[];
 }
 
-interface ConnectionResponse {
-  $: {
-    protocol: string;
-    address: string;
-    port: string;
-    uri: string;
-    local: string;
-  };
+// plex.tv v2 resource shapes (JSON). Unlike the legacy v1 /api/resources XML,
+// v2 returns native booleans/numbers and ISO-8601 timestamps, and includes
+// owned servers that v1 omits.
+interface PlexV2Connection {
+  protocol: string;
+  address: string;
+  port: number;
+  uri: string;
+  local: boolean;
+  relay?: boolean;
+  IPv6?: boolean;
 }
 
-interface DeviceResponse {
-  $: {
-    name: string;
-    product: string;
-    productVersion: string;
-    platform: string;
-    platformVersion: string;
-    device: string;
-    clientIdentifier: string;
-    createdAt: string;
-    lastSeenAt: string;
-    provides: string;
-    owned: string;
-    accessToken?: string;
-    publicAddress?: string;
-    httpsRequired?: string;
-    synced?: string;
-    relay?: string;
-    dnsRebindingProtection?: string;
-    natLoopbackSupported?: string;
-    publicAddressMatches?: string;
-    presence?: string;
-    ownerID?: string;
-    home?: string;
-    sourceTitle?: string;
-  };
-  Connection: ConnectionResponse[];
+interface PlexV2Resource {
+  name: string;
+  product: string;
+  productVersion: string;
+  platform: string;
+  platformVersion: string;
+  device: string;
+  clientIdentifier: string;
+  createdAt: string;
+  lastSeenAt: string;
+  provides: string;
+  owned: boolean;
+  ownerId?: number | null;
+  sourceTitle?: string | null;
+  publicAddress?: string;
+  accessToken?: string | null;
+  httpsRequired?: boolean;
+  synced?: boolean;
+  relay?: boolean;
+  home?: boolean;
+  presence?: boolean;
+  publicAddressMatches?: boolean;
+  connections: PlexV2Connection[];
 }
 
 interface ServerResponse {
@@ -284,53 +283,54 @@ export class PlexTvApi extends ExternalApiService {
     }
   }
 
-  public async getDevices(): Promise<PlexDevice[]> {
+  public async getDevices(clientIdentifier: string): Promise<PlexDevice[]> {
     try {
-      const devicesResp = await this.get('/api/resources?includeHttps=1', {
-        transformResponse: [],
-        responseType: 'text',
-      });
+      // v2 /api/v2/resources returns owned servers that legacy v1 /api/resources
+      // omits. It requires X-Plex-Client-Identifier — use the same id the UI
+      // authenticates with so plex.tv sees a consistent client.
+      const resources = await this.get<PlexV2Resource[]>(
+        '/api/v2/resources?includeHttps=1',
+        {
+          headers: {
+            'X-Plex-Client-Identifier': clientIdentifier,
+            'X-Plex-Product': 'Maintainerr',
+          },
+        },
+      );
 
-      if (!devicesResp) {
+      if (!resources) {
         throw new Error('Failed to fetch devices from plex.tv');
       }
 
-      const parsedXml = await xml2js.parseStringPromise(
-        devicesResp as DeviceResponse,
-      );
-      return parsedXml?.MediaContainer?.Device?.map((pxml: DeviceResponse) => ({
-        name: pxml.$.name,
-        product: pxml.$.product,
-        productVersion: pxml.$.productVersion,
-        platform: pxml.$?.platform,
-        platformVersion: pxml.$?.platformVersion,
-        device: pxml.$?.device,
-        clientIdentifier: pxml.$.clientIdentifier,
-        createdAt: new Date(parseInt(pxml.$?.createdAt, 10) * 1000),
-        lastSeenAt: new Date(parseInt(pxml.$?.lastSeenAt, 10) * 1000),
-        provides: pxml.$.provides.split(','),
-        owned: pxml.$.owned == '1' ? true : false,
-        accessToken: pxml.$?.accessToken,
-        publicAddress: pxml.$?.publicAddress,
-        publicAddressMatches:
-          pxml.$?.publicAddressMatches == '1' ? true : false,
-        httpsRequired: pxml.$?.httpsRequired == '1' ? true : false,
-        synced: pxml.$?.synced == '1' ? true : false,
-        relay: pxml.$?.relay == '1' ? true : false,
-        dnsRebindingProtection:
-          pxml.$?.dnsRebindingProtection == '1' ? true : false,
-        natLoopbackSupported:
-          pxml.$?.natLoopbackSupported == '1' ? true : false,
-        presence: pxml.$?.presence == '1' ? true : false,
-        ownerID: pxml.$?.ownerID,
-        home: pxml.$?.home == '1' ? true : false,
-        sourceTitle: pxml.$?.sourceTitle,
-        connection: pxml?.Connection?.map((conn: ConnectionResponse) => ({
-          protocol: conn.$.protocol,
-          address: conn.$.address,
-          port: parseInt(conn.$.port, 10),
-          uri: conn.$.uri,
-          local: conn.$.local == '1' ? true : false,
+      return resources.map((resource) => ({
+        name: resource.name,
+        product: resource.product,
+        productVersion: resource.productVersion,
+        platform: resource.platform,
+        platformVersion: resource.platformVersion,
+        device: resource.device,
+        clientIdentifier: resource.clientIdentifier,
+        createdAt: new Date(resource.createdAt),
+        lastSeenAt: new Date(resource.lastSeenAt),
+        provides: resource.provides.split(','),
+        owned: resource.owned,
+        accessToken: resource.accessToken ?? undefined,
+        publicAddress: resource.publicAddress,
+        publicAddressMatches: resource.publicAddressMatches,
+        httpsRequired: resource.httpsRequired,
+        synced: resource.synced,
+        relay: resource.relay,
+        presence: resource.presence,
+        ownerID:
+          resource.ownerId != null ? String(resource.ownerId) : undefined,
+        home: resource.home,
+        sourceTitle: resource.sourceTitle ?? undefined,
+        connection: (resource.connections ?? []).map((conn) => ({
+          protocol: conn.protocol,
+          address: conn.address,
+          port: conn.port,
+          uri: conn.uri,
+          local: conn.local,
         })),
       }));
     } catch (error) {

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -599,6 +599,21 @@ describe('PlexApiService.initialize', () => {
     expect(logger.error).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalledWith('Plex status probe failed');
   });
+
+  it('probes /identity (not bare /) so it works behind reverse proxies', async () => {
+    jest.restoreAllMocks();
+    // Bare `/` 401s behind reverse proxies; `/identity` returns the same
+    // machineIdentifier + version without auth quirks.
+    const query = jest.fn().mockResolvedValue({
+      MediaContainer: { machineIdentifier: 'm1', version: '1.43.2' },
+    });
+    (service as any).plexClient = { query };
+
+    const status = await service.getStatus();
+
+    expect(query).toHaveBeenCalledWith('/identity', false);
+    expect(status).toEqual({ machineIdentifier: 'm1', version: '1.43.2' });
+  });
 });
 
 describe('PlexApiService overlay helpers', () => {

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -343,8 +343,12 @@ export class PlexApiService {
         this.logger.debug('Plex client not initialized, skipping getStatus');
         return undefined;
       }
+      // Probe `/identity`, not `/`: it returns machineIdentifier + version
+      // without auth quirks. Bare `/` returns 401 behind reverse proxies (it
+      // redirects to the web UI), which would break connection/machine-id
+      // detection for proxied servers.
       const response: PlexStatusResponse = await this.plexClient.query(
-        '/',
+        '/identity',
         false,
       );
       return response.MediaContainer;

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -1221,11 +1221,11 @@ export class PlexApiService {
         this.loggerFactory.createLogger(),
       );
 
-      const devices = (await this.plexTvClient?.getDevices())?.filter(
-        (device) => {
-          return device.provides.includes('server') && device.owned;
-        },
-      );
+      const devices = (
+        await this.plexTvClient?.getDevices(settings.clientId)
+      )?.filter((device) => {
+        return device.provides.includes('server') && device.owned;
+      });
 
       if (devices) {
         await Promise.all(

--- a/apps/ui/src/components/Settings/Plex/index.tsx
+++ b/apps/ui/src/components/Settings/Plex/index.tsx
@@ -470,9 +470,7 @@ const PlexSettings = () => {
           <p className="description">Plex configuration</p>
         </div>
 
-        {tokenValidationPending && hasStoredPlexToken ? (
-          <Alert type="info" title="Validating stored Plex authentication..." />
-        ) : !isAuthenticated ? (
+        {!isAuthenticated && !(tokenValidationPending && hasStoredPlexToken) ? (
           <Alert
             type="info"
             title="Plex configuration is required. Authenticate with Plex to get started."


### PR DESCRIPTION
Two Plex connection fixes (plus a small UI cleanup) found while testing against a remotely-hosted Plex server:

- **Connection probe hits `/identity` instead of bare `/`.** Bare `/` returns `401` behind reverse proxies, so the health check could report a reachable server as down.
- **Server discovery uses plex.tv's v2 `/api/v2/resources` (JSON) instead of v1 `/api/resources` (XML).** v1 omits *owned* servers, so the server picker could come up empty for the admin's own server; v2 lists them (and needs `X-Plex-Client-Identifier`).
- Drops a flickering "Validating Plex token" banner on the Plex settings page.
