### PR TITLE
refactor(plex): remove unused getWatchlist and getDiscoverDataUserState helpers

### DIFF
--- a/apps/server/src/modules/api/lib/plextvApi.ts
+++ b/apps/server/src/modules/api/lib/plextvApi.ts
@@ -104,36 +104,6 @@ interface UsersResponse {
   };
 }
 
-interface WatchlistResponse {
-  MediaContainer: {
-    totalSize: number;
-    Metadata?: {
-      ratingKey: string;
-    }[];
-  };
-}
-
-interface MetadataResponse {
-  MediaContainer: {
-    Metadata: {
-      ratingKey: string;
-      type: 'movie' | 'show';
-      title: string;
-      Guid: {
-        id: `imdb://tt${number}` | `tmdb://${number}` | `tvdb://${number}`;
-      }[];
-    }[];
-  };
-}
-
-export interface PlexWatchlistItem {
-  ratingKey: string;
-  tmdbId: number;
-  tvdbId?: number;
-  type: 'movie' | 'show';
-  title: string;
-}
-
 export class PlexTvApi extends ExternalApiService {
   private authToken: string;
 
@@ -210,79 +180,6 @@ export class PlexTvApi extends ExternalApiService {
 
     const parsedXml = (await parseStringPromise(response)) as UsersResponse;
     return parsedXml;
-  }
-
-  public async getWatchlist({
-    offset = 0,
-    size = 20,
-  }: { offset?: number; size?: number } = {}): Promise<{
-    offset: number;
-    size: number;
-    totalSize: number;
-    items: PlexWatchlistItem[];
-  }> {
-    try {
-      const response = await this.get<WatchlistResponse>(
-        '/library/sections/watchlist/all',
-        {
-          params: {
-            'X-Plex-Container-Start': offset,
-            'X-Plex-Container-Size': size,
-          },
-          baseURL: 'https://metadata.provider.plex.tv',
-        },
-      );
-
-      const watchlistDetails = await Promise.all(
-        (response.MediaContainer.Metadata ?? []).map(async (watchlistItem) => {
-          const detailedResponse = await this.getRolling<MetadataResponse>(
-            `/library/metadata/${watchlistItem.ratingKey}`,
-            {
-              baseURL: 'https://metadata.provider.plex.tv',
-            },
-          );
-
-          const metadata = detailedResponse.MediaContainer.Metadata[0];
-
-          const tmdbString = metadata.Guid.find((guid) =>
-            guid.id.startsWith('tmdb'),
-          );
-          const tvdbString = metadata.Guid.find((guid) =>
-            guid.id.startsWith('tvdb'),
-          );
-
-          return {
-            ratingKey: metadata.ratingKey,
-            // This should always be set? But I guess it also cannot be?
-            // We will filter out the 0's afterwards
-            tmdbId: tmdbString ? Number(tmdbString.id.split('//')[1]) : 0,
-            tvdbId: tvdbString
-              ? Number(tvdbString.id.split('//')[1])
-              : undefined,
-            title: metadata.title,
-            type: metadata.type,
-          };
-        }),
-      );
-
-      const filteredList = watchlistDetails.filter((detail) => detail.tmdbId);
-
-      return {
-        offset,
-        size,
-        totalSize: response.MediaContainer.totalSize,
-        items: filteredList,
-      };
-    } catch (error) {
-      this.logger.error('Failed to retrieve watchlist items');
-      this.logger.debug(error);
-      return {
-        offset,
-        size,
-        totalSize: 0,
-        items: [],
-      };
-    }
   }
 
   public async getDevices(clientIdentifier: string): Promise<PlexDevice[]> {

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -51,14 +51,6 @@ import {
 } from './interfaces/server.interface';
 import { PLEX_PAGE_SIZE, PLEX_REQUEST_TIMEOUT_MS } from './plex-api.constants';
 
-type PlexDiscoverUserState = Record<string, unknown>;
-
-type PlexDiscoverUserStateResponse = {
-  MediaContainer: {
-    UserState: PlexDiscoverUserState;
-  };
-};
-
 @Injectable()
 export class PlexApiService {
   private plexClient: PlexApi;
@@ -628,32 +620,6 @@ export class PlexApiService {
         uri: `/library/metadata/${mediaId}`,
       }),
     );
-  }
-
-  public async getDiscoverDataUserState(
-    metaDataRatingKey: string,
-  ): Promise<PlexDiscoverUserState | undefined> {
-    const settings = this.getDbSettings();
-
-    try {
-      const response = await axios.get<PlexDiscoverUserStateResponse>(
-        `https://discover.provider.plex.tv/library/metadata/${metaDataRatingKey}/userState`,
-        {
-          headers: {
-            'content-type': 'application/json',
-            'X-Plex-Token': settings.auth_token,
-          },
-        },
-      );
-
-      return response.data.MediaContainer.UserState;
-    } catch (error) {
-      this.logger.error(
-        "Outbound call to discover.provider.plex.tv failed. Couldn't fetch userState",
-      );
-      this.logger.debug(error);
-      return undefined;
-    }
   }
 
   public async getUserDataFromPlexTv(): Promise<PlexTvUser[] | undefined> {

--- a/apps/ui/src/components/Settings/ExternalServiceSettingsPage.spec.tsx
+++ b/apps/ui/src/components/Settings/ExternalServiceSettingsPage.spec.tsx
@@ -89,7 +89,9 @@ describe('ExternalServiceSettingsPage', () => {
       name: 'Save Changes',
     })
 
-    expect((saveButton as HTMLButtonElement).disabled).toBe(false)
+    await waitFor(() => {
+      expect((saveButton as HTMLButtonElement).disabled).toBe(false)
+    })
 
     fireEvent.change(screen.getByLabelText(/URL/), {
       target: { value: 'http://seerr.internal' },


### PR DESCRIPTION
Removes two dead Plex API helpers, no behavior change:

- **`PlexTvApi.getWatchlist()`** (+ `WatchlistResponse` / `MetadataResponse` / `PlexWatchlistItem`) — no production callers; the live Plex watchlist-rule path is `getWatchlistIdsForUser` via `PlexCommunityApi` (community.plex.tv GraphQL). This REST helper predated and was superseded by it, and still pointed at `metadata.provider.plex.tv` (which now 404s the watchlist section).
- **`getDiscoverDataUserState()`** (+ its `PlexDiscoverUserState` types) — added in 2023 "for potential future usage" and never wired up.

Pure deletions; `PlexTvApi`/`PlexApiService` otherwise unchanged (getUser/getUsers/getDevices and the live community watchlist path stay).
