### PR TITLE
perf: bulk-prefetch Plex watch history before rule evaluation

### DIFF
--- a/apps/server/src/modules/api/lib/cache.ts
+++ b/apps/server/src/modules/api/lib/cache.ts
@@ -4,6 +4,7 @@ type AvailableCacheIds =
   | 'tmdb'
   | 'tvdb'
   | 'plexguid'
+  | 'plexwatchhistory'
   | 'plextv'
   | 'seerr'
   | 'plexcommunity'
@@ -24,6 +25,11 @@ type CacheOptions = {
   // If true, this cache is NOT flushed by flushAll(). Use for external metadata
   // caches (e.g. TMDB, TVDB) whose data doesn't change between rule group runs.
   persistent?: boolean;
+  // If false, NodeCache stores and returns object references without cloning.
+  // Required for non-POJO values (Maps, Sets) and for high-frequency lookups
+  // where cloning large objects on every get() would be prohibitively expensive.
+  // Never mutate values returned from caches that set this to false.
+  useClones?: boolean;
 };
 
 export class Cache {
@@ -46,6 +52,7 @@ export class Cache {
     this.data = new NodeCache({
       stdTTL: options.stdTtl ?? DEFAULT_TTL,
       checkperiod: options.checkPeriod ?? DEFAULT_CHECK_PERIOD,
+      useClones: options.useClones ?? true,
     });
   }
 
@@ -71,6 +78,20 @@ class CacheManager {
       persistent: true,
     }),
     plexguid: new Cache('plexguid', 'Plex GUID', 'plexguid'),
+    // Holds the bulk watch-history maps built by PlexApiService.prefetchWatchHistory.
+    // Persistent so the maps survive flushAll() between rule groups in the same
+    // cron window; useClones is off because the values are large Maps —
+    // getWatchHistory returns copies of the per-item arrays instead.
+    plexwatchhistory: new Cache(
+      'plexwatchhistory',
+      'Plex watch history',
+      'plexwatchhistory',
+      {
+        stdTtl: 3600, // 1 hour
+        persistent: true,
+        useClones: false,
+      },
+    ),
     plextv: new Cache('plextv', 'Plex.tv', 'plextv'),
     seerr: new Cache('seerr', 'Seerr API', 'seerr'),
     plexcommunity: new Cache(

--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -160,6 +160,17 @@ export interface IMediaServerService {
   searchContent(query: string): Promise<MediaItem[]>;
 
   /**
+   * Prefetch watch history for all library items in a single bulk request,
+   * caching the result so that subsequent per-item getWatchHistory / getWatchState
+   * calls can be served from memory instead of making individual HTTP requests.
+   *
+   * This is an optional optimisation — implementations that do not support bulk
+   * fetching may omit it. If absent, rule evaluation falls back to per-item
+   * queries as before.
+   */
+  prefetchWatchHistory?(): Promise<void>;
+
+  /**
    * Get watch history for a specific item.
    * Implementation varies by server:
    * - Plex: Single API call to history endpoint
@@ -179,6 +190,8 @@ export interface IMediaServerService {
   getWatchState(
     itemId: string,
     nativeViewCount?: number,
+    itemTitle?: string,
+    itemType?: MediaItemType,
   ): Promise<MediaWatchState>;
 
   /**

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -431,6 +431,14 @@ describe('PlexAdapterService', () => {
     });
   });
 
+  describe('prefetchWatchHistory', () => {
+    it('delegates to plexApi.prefetchWatchHistory', async () => {
+      plexApi.prefetchWatchHistory = jest.fn().mockResolvedValue(undefined);
+      await service.prefetchWatchHistory();
+      expect(plexApi.prefetchWatchHistory).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('getWatchHistory', () => {
     it('should return empty array when Plex returned no history entries', async () => {
       plexApi.getWatchHistory.mockResolvedValue([]);
@@ -471,7 +479,11 @@ describe('PlexAdapterService', () => {
         viewCount: 1,
         isWatched: true,
       });
-      expect(plexApi.getWatchHistory).toHaveBeenCalledWith('item123', false);
+      expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
+        'item123',
+        false,
+        undefined,
+      );
     });
 
     it('should return unwatched state when history is empty', async () => {
@@ -483,7 +495,11 @@ describe('PlexAdapterService', () => {
         viewCount: 0,
         isWatched: false,
       });
-      expect(plexApi.getWatchHistory).toHaveBeenCalledWith('item123', false);
+      expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
+        'item123',
+        false,
+        undefined,
+      );
     });
 
     it('should fall back to nativeViewCount for isWatched when history is empty', async () => {

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -19,6 +19,7 @@ import {
 import { Injectable } from '@nestjs/common';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { EPlexDataType } from '../../plex-api/enums/plex-data-type-enum';
+import { PlexLibraryItem } from '../../plex-api/interfaces/library.interfaces';
 import { PLEX_PAGE_SIZE } from '../../plex-api/plex-api.constants';
 import { PlexApiService } from '../../plex-api/plex-api.service';
 import {
@@ -220,6 +221,10 @@ export class PlexAdapterService implements IMediaServerService {
     return results.map(PlexMapper.metadataToMediaItem);
   }
 
+  async prefetchWatchHistory(): Promise<void> {
+    await this.plexApi.prefetchWatchHistory();
+  }
+
   async getWatchHistory(itemId: string): Promise<WatchRecord[]> {
     const history = await this.plexApi.getWatchHistory(itemId);
     return history.map(PlexMapper.toWatchRecord);
@@ -229,8 +234,9 @@ export class PlexAdapterService implements IMediaServerService {
     itemId: string,
     nativeViewCount?: number,
     itemTitle?: string,
+    itemType?: PlexLibraryItem['type'],
   ): Promise<MediaWatchState> {
-    const history = await this.plexApi.getWatchHistory(itemId, false);
+    const history = await this.plexApi.getWatchHistory(itemId, false, itemType);
 
     if (history.length > 0) {
       return {

--- a/apps/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
+++ b/apps/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
@@ -5,6 +5,10 @@ export interface PlexLibraryItem {
   ratingKey: string;
   parentRatingKey?: string;
   grandparentRatingKey?: string;
+  // Path-format parent keys returned by the history endpoint
+  // (e.g. "/library/metadata/13693"); the numeric ID is the last path segment.
+  parentKey?: string;
+  grandparentKey?: string;
   title: string;
   parentTitle?: string;
   guid: string;

--- a/apps/server/src/modules/api/plex-api/plex-api.constants.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.constants.ts
@@ -7,3 +7,13 @@ export const PLEX_PAGE_SIZE = {
 // executor indefinitely. Connection probes use the shorter
 // CONNECTION_TEST_TIMEOUT_MS; this applies to the long-lived runtime client.
 export const PLEX_REQUEST_TIMEOUT_MS = 30_000;
+
+// Keys in the 'plexwatchhistory' cache for the bulk maps built by
+// prefetchWatchHistory(). Three maps are written in a single sweep:
+//   BULK     — leaf items (movies + episodes) keyed by own ratingKey
+//   SHOW     — episode records grouped by show ratingKey (from grandparentKey)
+//   SEASON   — episode records grouped by season ratingKey (from parentKey)
+// TTL and flush behaviour live on the cache definition in lib/cache.ts.
+export const WATCH_HISTORY_BULK_CACHE_KEY = 'watch-history-bulk';
+export const WATCH_HISTORY_SHOW_BULK_CACHE_KEY = 'watch-history-show-bulk';
+export const WATCH_HISTORY_SEASON_BULK_CACHE_KEY = 'watch-history-season-bulk';

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -5,6 +5,11 @@ import {
 } from '../../logging/logs.service';
 import { Settings } from '../../settings/entities/settings.entities';
 import { SettingsDataService } from '../../settings/settings-data.service';
+import {
+  WATCH_HISTORY_BULK_CACHE_KEY,
+  WATCH_HISTORY_SEASON_BULK_CACHE_KEY,
+  WATCH_HISTORY_SHOW_BULK_CACHE_KEY,
+} from './plex-api.constants';
 import { PlexConnection } from './interfaces/server.interface';
 import { PlexApiService } from './plex-api.service';
 
@@ -613,6 +618,444 @@ describe('PlexApiService.initialize', () => {
 
     expect(query).toHaveBeenCalledWith('/identity', false);
     expect(status).toEqual({ machineIdentifier: 'm1', version: '1.43.2' });
+  });
+});
+
+describe('PlexApiService.prefetchWatchHistory', () => {
+  let service: PlexApiService;
+  let logger: Mocked<MaintainerrLogger>;
+  let loggerFactory: Mocked<MaintainerrLoggerFactory>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(PlexApiService).compile();
+
+    service = unit;
+    logger = unitRef.get(MaintainerrLogger);
+    loggerFactory = unitRef.get(MaintainerrLoggerFactory);
+
+    loggerFactory.createLogger.mockReturnValue({
+      setContext: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as any);
+
+    // Clear the bulk watch-history cache entries between tests
+    const cacheManager = (await import('../lib/cache')).default;
+    const bulkCache = cacheManager.getCache('plexwatchhistory')?.data;
+    bulkCache?.del(WATCH_HISTORY_BULK_CACHE_KEY);
+    bulkCache?.del(WATCH_HISTORY_SHOW_BULK_CACHE_KEY);
+    bulkCache?.del(WATCH_HISTORY_SEASON_BULK_CACHE_KEY);
+  });
+
+  it('indexes movie records in the leaf map by ratingKey', async () => {
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: {
+        Metadata: [
+          {
+            ratingKey: '1',
+            type: 'movie',
+            accountID: 10,
+            viewedAt: 1700000000,
+          },
+          {
+            ratingKey: '2',
+            type: 'movie',
+            accountID: 11,
+            viewedAt: 1710000000,
+          },
+          {
+            ratingKey: '1',
+            type: 'movie',
+            accountID: 12,
+            viewedAt: 1720000000,
+          },
+        ],
+      },
+    });
+
+    (service as any).plexClient = { queryAll };
+
+    await service.prefetchWatchHistory();
+
+    expect(queryAll).toHaveBeenCalledWith(
+      { uri: '/status/sessions/history/all?sort=viewedAt:desc' },
+      false,
+    );
+
+    const cacheManager = (await import('../lib/cache')).default;
+    const leafMap = cacheManager
+      .getCache('plexwatchhistory')
+      .data.get<Map<string, unknown[]>>(WATCH_HISTORY_BULK_CACHE_KEY);
+
+    expect(leafMap).toBeDefined();
+    expect(leafMap?.get('1')).toHaveLength(2);
+    expect(leafMap?.get('2')).toHaveLength(1);
+  });
+
+  it('indexes episode records in the leaf, show, and season maps', async () => {
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: {
+        Metadata: [
+          {
+            ratingKey: '101',
+            type: 'episode',
+            grandparentKey: '/library/metadata/10',
+            parentKey: '/library/metadata/20',
+            accountID: 1,
+            viewedAt: 1700000001,
+          },
+          {
+            ratingKey: '102',
+            type: 'episode',
+            grandparentKey: '/library/metadata/10',
+            parentKey: '/library/metadata/21',
+            accountID: 1,
+            viewedAt: 1700000002,
+          },
+          {
+            ratingKey: '103',
+            type: 'episode',
+            grandparentKey: '/library/metadata/11',
+            parentKey: '/library/metadata/21',
+            accountID: 2,
+            viewedAt: 1700000003,
+          },
+        ],
+      },
+    });
+
+    (service as any).plexClient = { queryAll };
+    await service.prefetchWatchHistory();
+
+    const cacheManager = (await import('../lib/cache')).default;
+    const bulkCache = cacheManager.getCache('plexwatchhistory').data;
+
+    const leafMap = bulkCache.get<Map<string, unknown[]>>(
+      WATCH_HISTORY_BULK_CACHE_KEY,
+    );
+    expect(leafMap?.get('101')).toHaveLength(1);
+    expect(leafMap?.get('102')).toHaveLength(1);
+    expect(leafMap?.get('103')).toHaveLength(1);
+
+    const showMap = bulkCache.get<Map<string, unknown[]>>(
+      WATCH_HISTORY_SHOW_BULK_CACHE_KEY,
+    );
+    expect(showMap?.get('10')).toHaveLength(2); // episodes 101 + 102
+    expect(showMap?.get('11')).toHaveLength(1); // episode 103
+
+    const seasonMap = bulkCache.get<Map<string, unknown[]>>(
+      WATCH_HISTORY_SEASON_BULK_CACHE_KEY,
+    );
+    expect(seasonMap?.get('20')).toHaveLength(1); // episode 101
+    expect(seasonMap?.get('21')).toHaveLength(2); // episodes 102 + 103 (different shows, same season id)
+  });
+
+  it('skips the fetch when the bulk map is already cached', async () => {
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: { Metadata: [] },
+    });
+
+    (service as any).plexClient = { queryAll };
+
+    // First call populates the cache
+    await service.prefetchWatchHistory();
+    // Second call should not hit the API again
+    await service.prefetchWatchHistory();
+
+    expect(queryAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs a warning and does not throw when the Plex API call fails', async () => {
+    const queryAll = jest.fn().mockRejectedValue(new Error('network error'));
+
+    (service as any).plexClient = { queryAll };
+
+    await expect(service.prefetchWatchHistory()).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Watch history prefetch failed'),
+    );
+  });
+});
+
+describe('PlexApiService.getWatchHistory bulk map', () => {
+  let service: PlexApiService;
+  let loggerFactory: Mocked<MaintainerrLoggerFactory>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(PlexApiService).compile();
+
+    service = unit;
+    loggerFactory = unitRef.get(MaintainerrLoggerFactory);
+
+    loggerFactory.createLogger.mockReturnValue({
+      setContext: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as any);
+
+    // Clear the bulk watch-history cache entries between tests
+    const cacheManager = (await import('../lib/cache')).default;
+    const bulkCache = cacheManager.getCache('plexwatchhistory')?.data;
+    bulkCache?.del(WATCH_HISTORY_BULK_CACHE_KEY);
+    bulkCache?.del(WATCH_HISTORY_SHOW_BULK_CACHE_KEY);
+    bulkCache?.del(WATCH_HISTORY_SEASON_BULK_CACHE_KEY);
+  });
+
+  it('returns results from the bulk map for movie items when the map is populated', async () => {
+    const cacheManager = (await import('../lib/cache')).default;
+    const bulkMap = new Map([
+      ['42', [{ ratingKey: '42', accountID: 10, viewedAt: 1700000000 }]],
+    ]);
+    cacheManager
+      .getCache('plexwatchhistory')
+      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, bulkMap);
+
+    const queryAll = jest.fn();
+    (service as any).plexClient = { queryAll };
+
+    const result = await service.getWatchHistory('42', true, 'movie');
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).ratingKey).toBe('42');
+    // Should NOT have hit the network
+    expect(queryAll).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty array for a movie not in the bulk map', async () => {
+    const cacheManager = (await import('../lib/cache')).default;
+    const bulkMap = new Map<string, unknown[]>();
+    cacheManager
+      .getCache('plexwatchhistory')
+      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, bulkMap);
+
+    const queryAll = jest.fn();
+    (service as any).plexClient = { queryAll };
+
+    const result = await service.getWatchHistory('99', true, 'movie');
+
+    expect(result).toEqual([]);
+    expect(queryAll).not.toHaveBeenCalled();
+  });
+
+  it('serves show queries from the show map without a per-item call', async () => {
+    const cacheManager = (await import('../lib/cache')).default;
+    const showRecord = {
+      ratingKey: '101',
+      type: 'episode',
+      accountID: 7,
+      viewedAt: 1700000000,
+    };
+    const showMap = new Map([['10', [showRecord]]]);
+    cacheManager
+      .getCache('plexwatchhistory')
+      .data.set(WATCH_HISTORY_SHOW_BULK_CACHE_KEY, showMap);
+
+    const queryAll = jest.fn();
+    (service as any).plexClient = { queryAll };
+
+    const result = await service.getWatchHistory('10', true, 'show');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].ratingKey).toBe('101');
+    expect(queryAll).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array for a show not in the show map', async () => {
+    const cacheManager = (await import('../lib/cache')).default;
+    cacheManager
+      .getCache('plexwatchhistory')
+      .data.set(WATCH_HISTORY_SHOW_BULK_CACHE_KEY, new Map());
+
+    const queryAll = jest.fn();
+    (service as any).plexClient = { queryAll };
+
+    const result = await service.getWatchHistory('99', true, 'show');
+
+    expect(result).toEqual([]);
+    expect(queryAll).not.toHaveBeenCalled();
+  });
+
+  it('serves season queries from the season map without a per-item call', async () => {
+    const cacheManager = (await import('../lib/cache')).default;
+    const seasonRecord = {
+      ratingKey: '201',
+      type: 'episode',
+      accountID: 3,
+      viewedAt: 1700000001,
+    };
+    const seasonMap = new Map([['20', [seasonRecord]]]);
+    cacheManager
+      .getCache('plexwatchhistory')
+      .data.set(WATCH_HISTORY_SEASON_BULK_CACHE_KEY, seasonMap);
+
+    const queryAll = jest.fn();
+    (service as any).plexClient = { queryAll };
+
+    const result = await service.getWatchHistory('20', true, 'season');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].ratingKey).toBe('201');
+    expect(queryAll).not.toHaveBeenCalled();
+  });
+
+  it('serves episode queries from the leaf map without a per-item call', async () => {
+    const cacheManager = (await import('../lib/cache')).default;
+    const epRecord = {
+      ratingKey: '301',
+      type: 'episode',
+      accountID: 5,
+      viewedAt: 1700000002,
+    };
+    const leafMap = new Map([['301', [epRecord]]]);
+    cacheManager
+      .getCache('plexwatchhistory')
+      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, leafMap);
+
+    const queryAll = jest.fn();
+    (service as any).plexClient = { queryAll };
+
+    const result = await service.getWatchHistory('301', true, 'episode');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].ratingKey).toBe('301');
+    expect(queryAll).not.toHaveBeenCalled();
+  });
+
+  it('serves useCache: false callers from the bulk snapshot (flag only opts out of the per-item HTTP cache)', async () => {
+    const cacheManager = (await import('../lib/cache')).default;
+    const bulkMap = new Map([
+      ['42', [{ ratingKey: '42', accountID: 10, viewedAt: 1700000000 }]],
+    ]);
+    cacheManager
+      .getCache('plexwatchhistory')
+      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, bulkMap);
+
+    const queryAll = jest.fn();
+    (service as any).plexClient = { queryAll };
+
+    const result = await service.getWatchHistory('42', false, 'movie');
+
+    expect(result).toHaveLength(1);
+    expect(queryAll).not.toHaveBeenCalled();
+  });
+
+  it('passes useCache: false through to the per-item query when the bulk map is absent', async () => {
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: { Metadata: [] },
+    });
+    (service as any).plexClient = { queryAll };
+
+    await service.getWatchHistory('42', false, 'movie');
+
+    expect(queryAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uri: expect.stringContaining('metadataItemID=42'),
+      }),
+      false,
+    );
+  });
+
+  it('serves untyped callers from the leaf map on a hit', async () => {
+    const cacheManager = (await import('../lib/cache')).default;
+    const bulkMap = new Map([
+      ['42', [{ ratingKey: '42', accountID: 10, viewedAt: 1700000000 }]],
+    ]);
+    cacheManager
+      .getCache('plexwatchhistory')
+      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, bulkMap);
+
+    const queryAll = jest.fn();
+    (service as any).plexClient = { queryAll };
+
+    const result = await service.getWatchHistory('42');
+
+    expect(result).toHaveLength(1);
+    expect(queryAll).not.toHaveBeenCalled();
+  });
+
+  it('falls through to per-item query for untyped callers on a leaf-map miss', async () => {
+    // Untyped callers may pass show or season ratingKeys, which are never in
+    // the leaf map — a miss must not be reported as confirmed-empty history.
+    const cacheManager = (await import('../lib/cache')).default;
+    cacheManager
+      .getCache('plexwatchhistory')
+      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, new Map());
+
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: {
+        Metadata: [{ ratingKey: '101', accountID: 7, viewedAt: 1700000000 }],
+      },
+    });
+    (service as any).plexClient = { queryAll };
+
+    const result = await service.getWatchHistory('10');
+
+    expect(result).toHaveLength(1);
+    expect(queryAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uri: expect.stringContaining('metadataItemID=10'),
+      }),
+      true,
+    );
+  });
+
+  it('returns a copy so callers sorting in place do not mutate the cached array', async () => {
+    const cacheManager = (await import('../lib/cache')).default;
+    const records = [
+      { ratingKey: '42', accountID: 10, viewedAt: 2 },
+      { ratingKey: '42', accountID: 11, viewedAt: 1 },
+    ];
+    const bulkMap = new Map([['42', records]]);
+    cacheManager
+      .getCache('plexwatchhistory')
+      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, bulkMap);
+
+    (service as any).plexClient = { queryAll: jest.fn() };
+
+    const first = await service.getWatchHistory('42', true, 'movie');
+    first.sort((a: any, b: any) => a.viewedAt - b.viewedAt);
+    first.pop();
+
+    const second = await service.getWatchHistory('42', true, 'movie');
+    expect(second.map((r: any) => r.accountID)).toEqual([10, 11]);
+  });
+
+  it('falls through to per-item query for show type when show map is absent', async () => {
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: {
+        Metadata: [{ ratingKey: '101', accountID: 7, viewedAt: 1700000000 }],
+      },
+    });
+    (service as any).plexClient = { queryAll };
+
+    await service.getWatchHistory('10', true, 'show');
+
+    expect(queryAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uri: expect.stringContaining('metadataItemID=10'),
+      }),
+      true,
+    );
+  });
+
+  it('falls through to per-item query when the bulk map is absent', async () => {
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: { Metadata: [] },
+    });
+    (service as any).plexClient = { queryAll };
+
+    await service.getWatchHistory('5', true, 'movie');
+
+    expect(queryAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uri: expect.stringContaining('metadataItemID=5'),
+      }),
+      true,
+    );
   });
 });
 

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -49,7 +49,13 @@ import {
   PlexDevice,
   PlexStatusResponse,
 } from './interfaces/server.interface';
-import { PLEX_PAGE_SIZE, PLEX_REQUEST_TIMEOUT_MS } from './plex-api.constants';
+import {
+  PLEX_PAGE_SIZE,
+  PLEX_REQUEST_TIMEOUT_MS,
+  WATCH_HISTORY_BULK_CACHE_KEY,
+  WATCH_HISTORY_SEASON_BULK_CACHE_KEY,
+  WATCH_HISTORY_SHOW_BULK_CACHE_KEY,
+} from './plex-api.constants';
 
 @Injectable()
 export class PlexApiService {
@@ -57,6 +63,7 @@ export class PlexApiService {
   private plexTvClient: PlexTvApi;
   private plexCommunityClient: PlexCommunityApi;
   private machineId: string;
+  private watchHistoryPrefetch?: Promise<void>;
 
   constructor(
     private readonly settings: SettingsDataService,
@@ -688,10 +695,159 @@ export class PlexApiService {
     }
   }
 
+  /**
+   * Fetches the complete watch history in a single paginated sweep and stores
+   * lookup maps in the 'plexwatchhistory' cache (1 hour TTL). Subsequent
+   * getWatchHistory calls are served from these maps instead of issuing one
+   * HTTP request per item. Returns immediately when the maps are already
+   * cached, so it is safe to call at the start of every rule group.
+   *
+   * On failure the error is logged and swallowed — getWatchHistory falls back
+   * to per-item queries automatically when the maps are absent.
+   */
+  public prefetchWatchHistory(): Promise<void> {
+    const cache = cacheManager.getCache('plexwatchhistory').data;
+    if (cache.has(WATCH_HISTORY_BULK_CACHE_KEY)) {
+      return Promise.resolve();
+    }
+
+    // Deduplicate concurrent callers onto one in-flight fetch.
+    this.watchHistoryPrefetch ??= this.fetchWatchHistoryMaps().finally(() => {
+      this.watchHistoryPrefetch = undefined;
+    });
+    return this.watchHistoryPrefetch;
+  }
+
+  private async fetchWatchHistoryMaps(): Promise<void> {
+    this.logger.log('Prefetching watch history for all library items...');
+
+    try {
+      const response = await this.plexClient.queryAll<PlexLibraryResponse>(
+        { uri: '/status/sessions/history/all?sort=viewedAt:desc' },
+        false,
+      );
+
+      const records =
+        (response?.MediaContainer?.Metadata as PlexSeenBy[]) ?? [];
+
+      const leafMap = new Map<string, PlexSeenBy[]>();
+      const showMap = new Map<string, PlexSeenBy[]>();
+      const seasonMap = new Map<string, PlexSeenBy[]>();
+
+      const append = (
+        map: Map<string, PlexSeenBy[]>,
+        key: string,
+        record: PlexSeenBy,
+      ) => {
+        const existing = map.get(key);
+        if (existing) {
+          existing.push(record);
+        } else {
+          map.set(key, [record]);
+        }
+      };
+
+      for (const record of records) {
+        append(leafMap, record.ratingKey, record);
+
+        // Episode records carry path-format parent keys
+        // (grandparentKey = "/library/metadata/<showId>",
+        //  parentKey = "/library/metadata/<seasonId>"); the numeric id is the
+        // last path segment.
+        if (record.type === 'episode') {
+          const showId = record.grandparentKey?.split('/').pop();
+          if (showId) {
+            append(showMap, showId, record);
+          }
+
+          const seasonId = record.parentKey?.split('/').pop();
+          if (seasonId) {
+            append(seasonMap, seasonId, record);
+          }
+        }
+      }
+
+      const cache = cacheManager.getCache('plexwatchhistory').data;
+      cache.set(WATCH_HISTORY_BULK_CACHE_KEY, leafMap);
+      cache.set(WATCH_HISTORY_SHOW_BULK_CACHE_KEY, showMap);
+      cache.set(WATCH_HISTORY_SEASON_BULK_CACHE_KEY, seasonMap);
+
+      this.logger.log(
+        `Watch history prefetch complete: ${records.length} records — ` +
+          `${leafMap.size} leaf items, ${showMap.size} shows, ${seasonMap.size} seasons.`,
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Watch history prefetch failed — falling back to per-item queries. Error: ${error}`,
+      );
+    }
+  }
+
+  // The 'plexwatchhistory' cache stores by reference (useClones: false), so
+  // always hand callers a copy — plex-getter sorts these arrays in place.
+  private getBulkWatchHistory(
+    mapKey: string,
+    itemId: string,
+  ): PlexSeenBy[] | undefined {
+    const map = cacheManager
+      .getCache('plexwatchhistory')
+      .data.get<Map<string, PlexSeenBy[]>>(mapKey);
+    if (map === undefined) {
+      return undefined;
+    }
+    const records = map.get(itemId);
+    return records ? [...records] : [];
+  }
+
   public async getWatchHistory(
     itemId: string,
     useCache: boolean = true,
+    itemType?: PlexLibraryItem['type'],
   ): Promise<PlexSeenBy[]> {
+    // Serve from the bulk maps when they are populated. This applies even to
+    // useCache: false callers (e.g. getWatchState): that flag opts out of the
+    // stale per-item HTTP response cache (5 min TTL, survives across runs),
+    // whereas the bulk maps are a deliberate snapshot with a run-scoped
+    // lifecycle — rebuilt by prefetchWatchHistory and flushed whenever a rule
+    // group requires a cache reset. Untyped callers may pass any kind of
+    // ratingKey, so only a leaf-map hit is trusted for them — a miss falls
+    // through to the per-item query below.
+    switch (itemType) {
+      case 'show': {
+        const records = this.getBulkWatchHistory(
+          WATCH_HISTORY_SHOW_BULK_CACHE_KEY,
+          itemId,
+        );
+        if (records !== undefined) return records;
+        break;
+      }
+      case 'season': {
+        const records = this.getBulkWatchHistory(
+          WATCH_HISTORY_SEASON_BULK_CACHE_KEY,
+          itemId,
+        );
+        if (records !== undefined) return records;
+        break;
+      }
+      case 'movie':
+      case 'episode': {
+        const records = this.getBulkWatchHistory(
+          WATCH_HISTORY_BULK_CACHE_KEY,
+          itemId,
+        );
+        if (records !== undefined) return records;
+        break;
+      }
+      default: {
+        const records = this.getBulkWatchHistory(
+          WATCH_HISTORY_BULK_CACHE_KEY,
+          itemId,
+        );
+        if (records !== undefined && records.length > 0) return records;
+        break;
+      }
+    }
+
     // Errors must propagate so callers can distinguish a real outage from a
     // confirmed empty history. Returning [] (or undefined) here would
     // misclassify failures as "never watched", which leaks into NOT_EXISTS

--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -181,6 +181,7 @@ describe('PlexGetterService', () => {
         '12345',
         0,
         libItem.title,
+        'movie',
       );
     });
 
@@ -197,6 +198,7 @@ describe('PlexGetterService', () => {
         '12345',
         0,
         libItem.title,
+        'movie',
       );
     });
   });
@@ -292,7 +294,11 @@ describe('PlexGetterService', () => {
       );
 
       expect(result).toEqual(new Date(1_720_000_000 * 1000));
-      expect(plexApi.getWatchHistory).toHaveBeenCalledWith('12345');
+      expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
+        '12345',
+        true,
+        'movie',
+      );
     });
 
     it('filters collection counts by rule and manual collection names case-insensitively (id 6)', async () => {
@@ -447,6 +453,11 @@ describe('PlexGetterService', () => {
       );
 
       expect(result).toEqual(new Date(1_710_000_000 * 1000));
+      expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
+        'show-1',
+        true,
+        'show',
+      );
     });
 
     it('returns season episode counts, watched episode counts, and total views from child metadata and history (ids 14, 15, 17)', async () => {
@@ -569,6 +580,11 @@ describe('PlexGetterService', () => {
       );
 
       expect(result).toEqual(['bob', 'alice']);
+      expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
+        'show-1',
+        true,
+        'show',
+      );
     });
 
     it('dedupes playlists by ratingKey for show-level count and names, then trims names (ids 20 and 21)', async () => {
@@ -1130,9 +1146,21 @@ describe('PlexGetterService', () => {
       expect(plexApi.getCollections).toHaveBeenCalledWith('lib-1', 'movie');
       expect(plexApi.getCollectionChildren).toHaveBeenCalledTimes(1);
       expect(plexApi.getCollectionChildren).toHaveBeenCalledWith('coll-1');
-      expect(plexApi.getWatchHistory).toHaveBeenCalledWith('12345');
-      expect(plexApi.getWatchHistory).toHaveBeenCalledWith('sibling-a');
-      expect(plexApi.getWatchHistory).toHaveBeenCalledWith('sibling-b');
+      expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
+        '12345',
+        true,
+        'movie',
+      );
+      expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
+        'sibling-a',
+        true,
+        'movie',
+      );
+      expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
+        'sibling-b',
+        true,
+        'movie',
+      );
     });
 
     it('returns null when the movie is in no collections', async () => {
@@ -1282,6 +1310,11 @@ describe('PlexGetterService', () => {
       );
 
       expect(result).toEqual(['bob', 'alice']);
+      expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
+        '12345',
+        true,
+        'movie',
+      );
     });
 
     it('returns [] for confirmed-empty history (no one has watched the item)', async () => {

--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -460,6 +460,24 @@ describe('PlexGetterService', () => {
       );
     });
 
+    it('returns null for sw_lastWatched when the show has no view history (id 13)', async () => {
+      // An empty history array is truthy; without a length guard this read
+      // viewedAt off undefined and threw. A never-watched show must yield null.
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({ ratingKey: 'show-1', type: 'show' }),
+      );
+      plexApi.getWatchHistory.mockResolvedValue([]);
+
+      const result = await service.get(
+        13,
+        createMediaItem({ type: 'show' }),
+        'show',
+        createRulesDto({ dataType: 'show' }),
+      );
+
+      expect(result).toBeNull();
+    });
+
     it('returns season episode counts, watched episode counts, and total views from child metadata and history (ids 14, 15, 17)', async () => {
       plexApi.getMetadata.mockResolvedValue(
         makeMetadata({ ratingKey: 'season-1', type: 'season' }),

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -91,6 +91,8 @@ export class PlexGetterService {
           const plexUsers = await this.plexApi.getCorrectedUsers(false);
           const viewers = await this.plexApi.getWatchHistory(
             metadata.ratingKey,
+            true,
+            metadata.type,
           );
           const viewerIds = viewers.map((el) => +el.accountID);
           return mapMatchingRuleUsersToNames(
@@ -122,6 +124,7 @@ export class PlexGetterService {
             metadata.ratingKey,
             libItem.viewCount,
             libItem.title,
+            metadata.type,
           );
           return watchState.viewCount;
         }
@@ -130,6 +133,7 @@ export class PlexGetterService {
             metadata.ratingKey,
             libItem.viewCount,
             libItem.title,
+            metadata.type,
           );
           return watchState.isWatched;
         }
@@ -252,7 +256,11 @@ export class PlexGetterService {
           // Errors must surface so the outer catch returns `undefined` for an
           // unknown watch state instead of collapsing the failure into a
           // confirmed never-watched `null`.
-          const seenby = await this.plexApi.getWatchHistory(metadata.ratingKey);
+          const seenby = await this.plexApi.getWatchHistory(
+            metadata.ratingKey,
+            true,
+            metadata.type,
+          );
           if (seenby && seenby.length > 0) {
             return new Date(
               +seenby
@@ -303,6 +311,8 @@ export class PlexGetterService {
               // `allViewers` and mark the show as unwatched-by-everyone.
               const viewers = await this.plexApi.getWatchHistory(
                 episode.ratingKey,
+                true,
+                'episode',
               );
 
               const arrLength = allViewers.length - 1;
@@ -341,6 +351,8 @@ export class PlexGetterService {
 
           const watchHistory = await this.plexApi.getWatchHistory(
             metadata.ratingKey,
+            true,
+            metadata.type,
           );
 
           const viewers = watchHistory
@@ -361,6 +373,8 @@ export class PlexGetterService {
         case 'sw_lastWatched': {
           let watchHistory = await this.plexApi.getWatchHistory(
             metadata.ratingKey,
+            true,
+            metadata.type,
           );
           watchHistory?.sort((a, b) => a.parentIndex - b.parentIndex).reverse();
           watchHistory = watchHistory?.filter(
@@ -394,6 +408,8 @@ export class PlexGetterService {
             for (const episode of episodes) {
               const views = await this.plexApi.getWatchHistory(
                 episode.ratingKey,
+                true,
+                'episode',
               );
               if (views?.length > 0) {
                 viewCount++;
@@ -416,6 +432,8 @@ export class PlexGetterService {
           if (metadata.type === 'episode') {
             const views = await this.plexApi.getWatchHistory(
               metadata.ratingKey,
+              true,
+              metadata.type,
             );
             viewCount =
               views?.length > 0 ? viewCount + views.length : viewCount;
@@ -432,6 +450,8 @@ export class PlexGetterService {
               for (const episode of episodes) {
                 const views = await this.plexApi.getWatchHistory(
                   episode.ratingKey,
+                  true,
+                  'episode',
                 );
                 viewCount =
                   views?.length > 0 ? viewCount + views.length : viewCount;
@@ -829,6 +849,8 @@ export class PlexGetterService {
               // false delete on a recently-watched sibling collection.
               const history = await this.plexApi.getWatchHistory(
                 child.ratingKey,
+                true,
+                child.type,
               );
               for (const entry of history) {
                 if (entry.viewedAt && +entry.viewedAt > latest) {

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -381,7 +381,9 @@ export class PlexGetterService {
             (el) => el.parentIndex === watchHistory[0].parentIndex,
           );
           watchHistory?.sort((a, b) => a.index - b.index).reverse();
-          return watchHistory
+          // An empty array is truthy, so guard on length: a show with no view
+          // history must return null here, not read viewedAt off undefined.
+          return watchHistory?.length
             ? new Date(+watchHistory[0].viewedAt * 1000)
             : null;
         }

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -1558,6 +1558,7 @@ export class RulesService {
         } else if (serverType === MediaServerType.PLEX) {
           cacheManager.getCache('plextv').flush();
           cacheManager.getCache('plexguid').flush();
+          cacheManager.getCache('plexwatchhistory').flush();
           this.logger.log(
             `Flushed Plex cache because a rule in the group required it`,
           );

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -1612,4 +1612,44 @@ describe('RuleExecutorService', () => {
       expect.anything(),
     );
   });
+
+  describe('prefetchWatchHistory', () => {
+    const ruleGroup = {
+      id: 10,
+      name: 'Test Rule',
+      isActive: true,
+      libraryId: 'library-1',
+      useRules: true,
+      rules: [],
+      collectionId: 1,
+      collection: { title: 'Test Collection' },
+    };
+
+    it('calls prefetchWatchHistory on the media server when the method is present', async () => {
+      const { service, rulesService, mediaServer } = createService(
+        MediaServerType.PLEX,
+      );
+      rulesService.getRuleGroup.mockResolvedValue(ruleGroup as any);
+      rulesService.getRuleGroupById.mockResolvedValue(ruleGroup as any);
+      (mediaServer as any).prefetchWatchHistory = jest
+        .fn()
+        .mockResolvedValue(undefined);
+
+      await service.executeForRuleGroups(10, new AbortController().signal);
+
+      expect((mediaServer as any).prefetchWatchHistory).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
+    it('completes without error when prefetchWatchHistory is absent (e.g. Jellyfin)', async () => {
+      const { service, rulesService } = createService(MediaServerType.JELLYFIN);
+      rulesService.getRuleGroup.mockResolvedValue(ruleGroup as any);
+      rulesService.getRuleGroupById.mockResolvedValue(ruleGroup as any);
+
+      await expect(
+        service.executeForRuleGroups(10, new AbortController().signal),
+      ).resolves.toEqual({ status: 'success' });
+    });
+  });
 });

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -236,6 +236,13 @@ export class RuleExecutorService {
           ruleGroup,
         );
 
+        // Prefetch watch history so per-item getWatchHistory calls during
+        // evaluation are served from an in-memory map instead of individual
+        // HTTP requests. Cached across rule groups in this run; rebuilt here
+        // when the reset above flushed it. A media server that doesn't
+        // support bulk prefetch (e.g. Jellyfin) keeps its per-item path.
+        await mediaServer.prefetchWatchHistory?.();
+
         // prepare
         this.workerData = [];
         this.resultData = [];


### PR DESCRIPTION
This is a follow-up PR to https://github.com/Maintainerr/Maintainerr/pull/2972 to further improve Plex performance on large libraries, using a watch history bulk fetch.

## Summary

Replaces O(items × conditions) per-item HTTP calls to Plex's `/status/sessions/history/all?metadataItemID=<id>` with a single paginated bulk fetch at the start of each rule group execution.

**Measured call times (local Plex, same NAS):**
- Per-item call: ~408 ms (Plex executes a SQLite query per request even on localhost)
- Full prefetch (27,205 records): ~67 s cold — builds all three maps in one pass

**Benchmark: vanilla 3.14.0 vs this PR (same NAS, manual trigger, 2026-06-10):**

| Run | Rule | Vanilla 3.14.0 | This PR | Saving |
|-----|------|----------------|---------|--------|
| Cold (first in cron window) | Movies Leaving Soon | 22m 48s | **1m 25s** (67s prefetch + 18s eval) | **−94%** |
| Same window | TV Leaving Soon | 6m 02s | **1m 09s** (reuses cached maps) | **−81%** |
| Warm (repeat in same window) | Movies Leaving Soon | 22m 48s | **17s** | **−99%** |
| Warm (repeat in same window) | TV Leaving Soon | 6m 02s | **47s** | **−87%** |

**Correctness:** patched and vanilla produced identical match sets — the same 10 movies and 152 shows, verified by comparing `mediaServerId` sets from the DB after each run. Re-verified after every revision of this PR.

## How it works

- `prefetchWatchHistory()` fetches the complete watch history once per rule group run and builds **three maps** in a single pass:
  - **leaf map** — movies and episodes keyed by own `ratingKey`
  - **show map** — episode records grouped by show `ratingKey` (from `grandparentKey`)
  - **season map** — episode records grouped by season `ratingKey` (from `parentKey`)
- The maps live in a **dedicated `plexwatchhistory` cache** (1 h TTL). It is `persistent` so the maps survive the per-group `flushAll()`, and it is flushed alongside the other Plex caches whenever a rule group requires a cache reset — so "fresh data" rules rebuild the snapshot. No behaviour of the existing `plexguid` HTTP-response cache is changed.
- `getWatchHistory()` gains an optional `itemType` and routes typed lookups to the correct map; a typed miss is a confirmed never-watched `[]` with no HTTP call. It always returns a **copy** of the cached array, so callers that sort in place cannot corrupt the cache. Untyped callers (e.g. the watch-history API route, which may receive any kind of ratingKey) fall through to the per-item query on a miss.
- `useCache: false` callers (`getWatchState`) are served from the snapshot too: that flag opts out of the stale per-item HTTP response cache, whereas the snapshot's freshness is governed by the rule-run lifecycle above. The item type is threaded through `getWatchState` so never-watched lookups stay in the map.
- Jellyfin/Emby adapters don't implement the optional `prefetchWatchHistory?()`; the executor's optional-chain call is a no-op and their per-item paths are untouched.

## Test plan

- [x] Full suite passes (1,697 server tests) — new coverage for map building, routing, copy-on-read mutation safety, untyped fallthrough, cache-reset flush, concurrent prefetch dedup, and Jellyfin/Emby no-op
- [x] Benchmarks and identical-match-set verification above, running in production for multiple days across PR revisions

## Incidental correctness fix (separate commit)

While testing this PR against a large Plex TV library I found a **pre-existing bug, unrelated to caching**, and fixed it in a standalone commit (5e020dc) so it can be reviewed or cherry-picked independently:

`PlexGetterService` `sw_lastWatched` did `return watchHistory ? new Date(+watchHistory[0].viewedAt * 1000) : null`. An empty array is truthy, so a never-watched show read `viewedAt` off `undefined` and threw `TypeError: Cannot read properties of undefined (reading 'viewedAt')`. The rule comparator catches it and skips the condition, so **match results are unaffected** — but it logs roughly one error per never-watched show evaluated (~900 per run here). The fix guards on `watchHistory?.length`. This exists in current `development` too; happy to split it into its own PR if you'd prefer.
