### PR TITLE
fix(collections): self-heal empty Plex collections that reject every add

### DIFF
--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -215,6 +215,39 @@ describe('PlexApiService.getMetadata', () => {
     expect(logger.debug).not.toHaveBeenCalled();
   });
 
+  it('unwraps lib/plexApi-wrapped errors to surface the 400 response body', async () => {
+    // lib/plexApi throws a plain Error with the axios failure on `cause`.
+    const putQuery = jest.fn().mockRejectedValue(
+      new Error(
+        'PUT http://plex.local:32400/li...55 failed with exception: Plex Server didnt respond with a valid 2xx status code, response code: 400',
+        {
+          cause: {
+            isAxiosError: true,
+            response: {
+              status: 400,
+              statusText: 'Bad Request',
+              data: { errors: [{ message: 'unable to match items' }] },
+            },
+          },
+        },
+      ),
+    );
+
+    (service as any).machineId = 'machine123';
+    (service as any).plexClient = { putQuery };
+
+    const result = await service.addChildrenToCollection('55', ['1', '2']);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: 'NOK',
+        code: 400,
+        message:
+          'Plex request failed with 400 Bad Request. Response body: {"errors":[{"message":"unable to match items"}]}',
+      }),
+    );
+  });
+
   it('switches a collection into custom sort mode via prefs', async () => {
     const putQuery = jest.fn().mockResolvedValue(undefined);
     (service as any).plexClient = { putQuery };

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -1062,14 +1062,24 @@ export class PlexApiService {
     logLevel: 'warn' | 'error';
     message: string;
   } {
-    if (axios.isAxiosError(error) && error.response?.status) {
-      const responseBody = this.stringifyResponseBody(error.response.data);
-      const statusMessage = `Plex request failed with ${error.response.status}${error.response.statusText ? ` ${error.response.statusText}` : ''}`;
+    // lib/plexApi wraps Axios failures in a plain Error with the original
+    // attached as `cause` — unwrap it, or the status and response body
+    // (Plex's actual rejection reason) never reach the logs.
+    const cause = error instanceof Error ? error.cause : undefined;
+    const axiosError = axios.isAxiosError(error)
+      ? error
+      : axios.isAxiosError(cause)
+        ? cause
+        : undefined;
+
+    if (axiosError && axiosError.response?.status) {
+      const responseBody = this.stringifyResponseBody(axiosError.response.data);
+      const statusMessage = `Plex request failed with ${axiosError.response.status}${axiosError.response.statusText ? ` ${axiosError.response.statusText}` : ''}`;
 
       return {
-        code: error.response.status,
+        code: axiosError.response.status,
         logLevel:
-          error.response.status >= 400 && error.response.status < 500
+          axiosError.response.status >= 400 && axiosError.response.status < 500
             ? 'warn'
             : 'error',
         message: responseBody

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -1,8 +1,10 @@
 import {
+  MaintainerrEvent,
   MediaCollection,
   MediaServerFeature,
   MediaServerType,
 } from '@maintainerr/contracts';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Mocked, TestBed } from '@suites/unit';
 import { DataSource, Repository } from 'typeorm';
@@ -37,6 +39,7 @@ describe('CollectionsService', () => {
   let metadataService: Mocked<MetadataService>;
   let settingsDataService: Mocked<SettingsDataService>;
   let collectionPosterService: Mocked<CollectionPosterService>;
+  let eventEmitter: Mocked<EventEmitter2>;
 
   beforeEach(async () => {
     const { unit, unitRef } =
@@ -54,6 +57,7 @@ describe('CollectionsService', () => {
     metadataService = unitRef.get(MetadataService);
     settingsDataService = unitRef.get(SettingsDataService);
     collectionPosterService = unitRef.get(CollectionPosterService);
+    eventEmitter = unitRef.get(EventEmitter2);
     metadataService.resolveIds.mockResolvedValue({
       tmdb: 1,
       type: 'movie',
@@ -609,6 +613,125 @@ describe('CollectionsService', () => {
     expect(mediaServer.addBatchToCollection).not.toHaveBeenCalled();
   });
 
+  it('deletes and unlinks a shared empty automatic collection that rejects every resynced item', async () => {
+    const collection = createCollection({
+      id: 17,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Shared Empty Rejecting',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Shared Empty Rejecting',
+      childCount: 0,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    mediaServer.addBatchToCollection.mockResolvedValue([
+      'rule-owned-1',
+      'rule-owned-2',
+    ]);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-1',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-2',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+    ]);
+    collectionRepo.save.mockImplementation(async (c) => c as Collection);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(true);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).toHaveBeenCalledWith(
+      'remote-collection',
+    );
+    expect(result.mediaServerId).toBeNull();
+  });
+
+  it('keeps a shared empty automatic collection when only some resynced items are rejected', async () => {
+    const collection = createCollection({
+      id: 18,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Shared Empty Partial Reject',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Shared Empty Partial Reject',
+      childCount: 0,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    mediaServer.addBatchToCollection.mockResolvedValue(['rule-owned-2']);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-1',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-2',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+    ]);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(true);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+  });
+
+  it('keeps the shared collection when emptiness cannot be confirmed at heal time', async () => {
+    const collection = createCollection({
+      id: 19,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Shared Empty Unconfirmed',
+      libraryId: 'library-1',
+    });
+
+    // Link check sees the collection; the heal's verification read fails
+    // (e.g. the server went unreachable), so deletion must not proceed.
+    mediaServer.getCollection
+      .mockResolvedValueOnce({
+        id: 'remote-collection',
+        title: 'Shared Empty Unconfirmed',
+        childCount: 0,
+      } as any)
+      .mockResolvedValue(undefined);
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    mediaServer.addBatchToCollection.mockResolvedValue(['rule-owned-1']);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-1',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+    ]);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(true);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+  });
+
   it('getSiblingRuleOwnedMediaServerIds excludes manual sibling collections', async () => {
     const collection = createCollection({
       id: 20,
@@ -709,6 +832,172 @@ describe('CollectionsService', () => {
       'remote-collection',
       'item-1',
     );
+  });
+
+  it('emits CollectionMedia_Added only for items the media server accepted', async () => {
+    const collection = createCollection({
+      id: 20,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Partial Add',
+    });
+
+    collectionRepo.findOne.mockResolvedValue(collection);
+    collectionMediaRepo.find.mockResolvedValue([]);
+    mediaServer.addBatchToCollection.mockResolvedValue(['item-2']);
+    jest
+      .spyOn(service as any, 'checkAutomaticMediaServerLink')
+      .mockResolvedValue(collection);
+    jest
+      .spyOn(service as any, 'insertCollectionMediaMembership')
+      .mockResolvedValue(undefined);
+
+    await service.addToCollection(collection.id, [
+      { mediaServerId: 'item-1' },
+      { mediaServerId: 'item-2' },
+    ]);
+
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      MaintainerrEvent.CollectionMedia_Added,
+      expect.objectContaining({
+        mediaItems: [expect.objectContaining({ mediaServerId: 'item-1' })],
+      }),
+    );
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+  });
+
+  it('heals an empty automatic collection when the media server rejects every add', async () => {
+    const collection = createCollection({
+      id: 21,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Rejecting Collection',
+    });
+
+    collectionRepo.findOne.mockResolvedValue(collection);
+    collectionMediaRepo.find.mockResolvedValue([]);
+    collectionRepo.save.mockImplementation(async (c) => c as Collection);
+    mediaServer.addBatchToCollection.mockResolvedValue(['item-1', 'item-2']);
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Rejecting Collection',
+      childCount: 0,
+    } as any);
+    jest
+      .spyOn(service as any, 'checkAutomaticMediaServerLink')
+      .mockResolvedValue(collection);
+
+    await service.addToCollection(collection.id, [
+      { mediaServerId: 'item-1' },
+      { mediaServerId: 'item-2' },
+    ]);
+
+    expect(eventEmitter.emit).not.toHaveBeenCalledWith(
+      MaintainerrEvent.CollectionMedia_Added,
+      expect.anything(),
+    );
+    expect(mediaServer.deleteCollection).toHaveBeenCalledWith(
+      'remote-collection',
+    );
+    expect(collectionRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 21, mediaServerId: null }),
+    );
+  });
+
+  it('does not heal when the rejecting collection still has children', async () => {
+    const collection = createCollection({
+      id: 22,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Rejecting Populated Collection',
+    });
+
+    collectionRepo.findOne.mockResolvedValue(collection);
+    collectionMediaRepo.find.mockResolvedValue([]);
+    mediaServer.addBatchToCollection.mockResolvedValue(['item-1']);
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Rejecting Populated Collection',
+      childCount: 3,
+    } as any);
+    jest
+      .spyOn(service as any, 'checkAutomaticMediaServerLink')
+      .mockResolvedValue(collection);
+
+    await service.addToCollection(collection.id, [{ mediaServerId: 'item-1' }]);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+  });
+
+  it('does not heal the same collection twice without an accepted add in between', async () => {
+    const collection = createCollection({
+      id: 23,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Repeat Rejecting Collection',
+    });
+
+    collectionRepo.findOne.mockResolvedValue(collection);
+    collectionMediaRepo.find.mockResolvedValue([]);
+    collectionRepo.save.mockImplementation(async (c) => c as Collection);
+    mediaServer.addBatchToCollection.mockResolvedValue(['item-1']);
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Repeat Rejecting Collection',
+      childCount: 0,
+    } as any);
+    jest
+      .spyOn(service as any, 'checkAutomaticMediaServerLink')
+      .mockResolvedValue(collection);
+
+    await service.addToCollection(collection.id, [{ mediaServerId: 'item-1' }]);
+    expect(mediaServer.deleteCollection).toHaveBeenCalledTimes(1);
+
+    // Relinked to a recreated collection that also rejects everything.
+    collection.mediaServerId = 'remote-collection-2';
+    await service.addToCollection(collection.id, [{ mediaServerId: 'item-1' }]);
+
+    expect(mediaServer.deleteCollection).toHaveBeenCalledTimes(1);
+  });
+
+  it('heals again once the media server has accepted adds in between', async () => {
+    const collection = createCollection({
+      id: 24,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Recovering Collection',
+    });
+
+    collectionRepo.findOne.mockResolvedValue(collection);
+    collectionMediaRepo.find.mockResolvedValue([]);
+    collectionRepo.save.mockImplementation(async (c) => c as Collection);
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Recovering Collection',
+      childCount: 0,
+    } as any);
+    jest
+      .spyOn(service as any, 'checkAutomaticMediaServerLink')
+      .mockResolvedValue(collection);
+    jest
+      .spyOn(service as any, 'insertCollectionMediaMembership')
+      .mockResolvedValue(undefined);
+
+    // First pass: everything rejected → heal.
+    mediaServer.addBatchToCollection.mockResolvedValueOnce(['item-1']);
+    await service.addToCollection(collection.id, [{ mediaServerId: 'item-1' }]);
+    expect(mediaServer.deleteCollection).toHaveBeenCalledTimes(1);
+
+    // Recreated collection accepts the add → guard resets.
+    collection.mediaServerId = 'remote-collection-2';
+    mediaServer.addBatchToCollection.mockResolvedValueOnce([]);
+    await service.addToCollection(collection.id, [{ mediaServerId: 'item-1' }]);
+    expect(mediaServer.deleteCollection).toHaveBeenCalledTimes(1);
+
+    // A later total rejection may heal again.
+    mediaServer.addBatchToCollection.mockResolvedValueOnce(['item-2']);
+    await service.addToCollection(collection.id, [{ mediaServerId: 'item-2' }]);
+    expect(mediaServer.deleteCollection).toHaveBeenCalledTimes(2);
   });
 
   it('recreates collections empty and resyncs existing items separately', async () => {

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -832,6 +832,11 @@ describe('CollectionsService', () => {
       'remote-collection',
       'item-1',
     );
+    expect(eventEmitter.emit).not.toHaveBeenCalledWith(
+      MaintainerrEvent.CollectionMedia_Added,
+      expect.anything(),
+    );
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
   });
 
   it('emits CollectionMedia_Added only for items the media server accepted', async () => {
@@ -925,6 +930,64 @@ describe('CollectionsService', () => {
       .mockResolvedValue(collection);
 
     await service.addToCollection(collection.id, [{ mediaServerId: 'item-1' }]);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+  });
+
+  it('does not heal on Jellyfin even when an empty collection rejects every add', async () => {
+    const collection = createCollection({
+      id: 26,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Rejecting Jellyfin Collection',
+    });
+
+    mediaServerFactory.getConfiguredServerType.mockResolvedValue(
+      MediaServerType.JELLYFIN,
+    );
+    settingsDataService.media_server_type = MediaServerType.JELLYFIN;
+    collectionRepo.findOne.mockResolvedValue(collection);
+    collectionMediaRepo.find.mockResolvedValue([]);
+    mediaServer.addBatchToCollection.mockResolvedValue(['item-1']);
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Rejecting Jellyfin Collection',
+      childCount: 0,
+    } as any);
+    jest
+      .spyOn(service as any, 'checkAutomaticMediaServerLink')
+      .mockResolvedValue(collection);
+
+    await service.addToCollection(collection.id, [{ mediaServerId: 'item-1' }]);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+  });
+
+  it('does not heal a manual collection that rejects every add', async () => {
+    const collection = createCollection({
+      id: 27,
+      mediaServerId: 'remote-collection',
+      manualCollection: true,
+      title: 'Rejecting Manual Collection',
+    });
+
+    collectionRepo.findOne.mockResolvedValue(collection);
+    collectionMediaRepo.find.mockResolvedValue([]);
+    mediaServer.addBatchToCollection.mockResolvedValue(['item-1']);
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Rejecting Manual Collection',
+      childCount: 0,
+    } as any);
+    jest
+      .spyOn(service as any, 'checkAutomaticMediaServerLink')
+      .mockResolvedValue(collection);
+
+    await service.addToCollection(
+      collection.id,
+      [{ mediaServerId: 'item-1' }],
+      true,
+    );
 
     expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
   });

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -444,6 +444,33 @@ describe('CollectionsService', () => {
     expect(result.mediaServerId).toBe('remote-collection');
   });
 
+  // Sibling recovery after a shared-collection heal depends on this
+  // clearing: the surviving rule group must drop its dead link so the
+  // next add pass recreates the collection.
+  it('clears the automatic link when the collection is gone and no title match exists', async () => {
+    const collection = createCollection({
+      id: 28,
+      mediaServerId: 'deleted-remote-collection',
+      manualCollection: false,
+      title: 'Healed Sibling',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue(undefined);
+    collectionRepo.save.mockImplementation(async (c) => c as Collection);
+    jest
+      .spyOn(service as any, 'findMediaServerCollection')
+      .mockResolvedValue(undefined);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(result.mediaServerId).toBeNull();
+    expect(collectionRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 28, mediaServerId: null }),
+    );
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+  });
+
   it('repopulates a shared empty automatic collection from local rule-owned items', async () => {
     const collection = createCollection({
       id: 13,

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -273,9 +273,9 @@ export class CollectionsService {
   private async resyncRuleOwnedItemsToSharedCollection(
     collection: Pick<Collection, 'id' | 'mediaServerId' | 'title'>,
     serverChildIds: Set<string>,
-  ): Promise<void> {
+  ): Promise<{ attempted: number; rejected: number }> {
     if (!collection.mediaServerId) {
-      return;
+      return { attempted: 0, rejected: 0 };
     }
 
     try {
@@ -288,7 +288,7 @@ export class CollectionsService {
         .filter((mediaServerId) => !serverChildIds.has(mediaServerId));
 
       if (missingRuleOwnedIds.length === 0) {
-        return;
+        return { attempted: 0, rejected: 0 };
       }
 
       const mediaServer = await this.getMediaServer();
@@ -310,11 +310,80 @@ export class CollectionsService {
           );
         }
       }
+
+      return {
+        attempted: missingRuleOwnedIds.length,
+        rejected: failedItemIds.size,
+      };
     } catch (error) {
       this.logger.warn(
         'Failed to resync local rule-owned items into shared media server collection',
       );
       this.logger.debug(error);
+      // An exception is not evidence the server rejected the adds, so
+      // report nothing attempted — callers must not heal on this.
+      return { attempted: 0, rejected: 0 };
+    }
+  }
+
+  /**
+   * Collections healed once already (per process). A second total
+   * rejection without an accepted add in between means recreation didn't
+   * fix the cause — stop churning delete/recreate and leave the loud log.
+   */
+  private readonly healedCollectionIds = new Set<number>();
+
+  /**
+   * Last-resort heal for an automatic collection whose media server record
+   * is empty yet rejects every add (e.g. a stale or corrupt Plex collection
+   * record): delete it so the regular add flow recreates it fresh on the
+   * next pass. Deletion is gated on a successful live read confirming the
+   * collection is still empty, so a transient outage never triggers it.
+   * Plex-only, matching the empty-collection cleanup in
+   * checkAutomaticMediaServerLink (Jellyfin lags and auto-deletes empties).
+   */
+  private async deleteEmptyCollectionRejectingAdds(
+    collection: Pick<
+      Collection,
+      'id' | 'title' | 'manualCollection' | 'mediaServerId'
+    >,
+  ): Promise<boolean> {
+    if (
+      collection.manualCollection ||
+      !collection.mediaServerId ||
+      this.settingsDataService.media_server_type !== MediaServerType.PLEX
+    ) {
+      return false;
+    }
+
+    if (this.healedCollectionIds.has(collection.id)) {
+      this.logger.error(
+        `Media server collection for "${collection.title}" still rejects every add after being recreated — leaving it in place. Check the Plex response body logged above for the rejection reason.`,
+      );
+      return false;
+    }
+
+    try {
+      const mediaServer = await this.getMediaServer();
+      const serverColl = await mediaServer.getCollection(
+        collection.mediaServerId,
+      );
+      if (!serverColl || serverColl.childCount !== 0) {
+        return false;
+      }
+
+      this.logger.warn(
+        `Media server collection ${collection.mediaServerId} for "${collection.title}" is empty and rejected every add — deleting it so it can be recreated`,
+      );
+      await mediaServer.deleteCollection(serverColl.id);
+      this.healedCollectionIds.add(collection.id);
+      return true;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to delete unpopulatable media server collection ${collection.mediaServerId} for "${collection.title}"`,
+      );
+      this.logger.debug(error);
+      return false;
     }
   }
 
@@ -1840,10 +1909,34 @@ export class CollectionsService {
           this.logger.debug(
             `[checkAutomaticMediaServerLink] Shared collection ${serverColl.id} has ${serverChildIds.size} children — checking for local rule-owned drift`,
           );
-          await this.resyncRuleOwnedItemsToSharedCollection(
-            collection,
-            serverChildIds,
-          );
+          const resyncResult =
+            await this.resyncRuleOwnedItemsToSharedCollection(
+              collection,
+              serverChildIds,
+            );
+
+          if (
+            resyncResult.attempted > 0 &&
+            resyncResult.rejected < resyncResult.attempted
+          ) {
+            this.healedCollectionIds.delete(collection.id);
+          }
+
+          // An empty shared collection that rejected every resynced item
+          // can't be repaired in place — fall back to delete-and-recreate.
+          // The sibling rule group loses nothing: the collection has no
+          // children, and its link re-establishes via the title relink.
+          if (
+            serverChildIds.size === 0 &&
+            resyncResult.attempted > 0 &&
+            resyncResult.rejected >= resyncResult.attempted
+          ) {
+            const deleted =
+              await this.deleteEmptyCollectionRejectingAdds(collection);
+            if (deleted) {
+              serverColl = undefined;
+            }
+          }
         } else {
           const metadataChildCount = Number.isFinite(serverColl.childCount)
             ? serverColl.childCount
@@ -2160,7 +2253,7 @@ export class CollectionsService {
 
         // add new children to collection
         if (newMedia.length > 0 && collection.mediaServerId) {
-          await this.addChildrenToCollection(
+          const rejectedItemIds = await this.addChildrenToCollection(
             { mediaServerId: collection.mediaServerId, dbId: collection.id },
             newMedia,
             manual,
@@ -2168,16 +2261,40 @@ export class CollectionsService {
             manualMembershipSource,
           );
 
-          this.eventEmitter.emit(
-            MaintainerrEvent.CollectionMedia_Added,
-            new CollectionMediaAddedDto(
-              newMedia,
-              collection.title,
-              { type: 'collection', value: collection.id },
-              collection.id,
-              collection.deleteAfterDays,
-            ),
+          // Only notify for items the media server actually accepted —
+          // rejected items never entered the collection and will be
+          // retried (and re-notified) on a later run.
+          const addedMedia = newMedia.filter(
+            (m) => !rejectedItemIds.has(m.mediaServerId),
           );
+          if (addedMedia.length > 0) {
+            this.eventEmitter.emit(
+              MaintainerrEvent.CollectionMedia_Added,
+              new CollectionMediaAddedDto(
+                addedMedia,
+                collection.title,
+                { type: 'collection', value: collection.id },
+                collection.id,
+                collection.deleteAfterDays,
+              ),
+            );
+          }
+
+          if (rejectedItemIds.size < newMedia.length) {
+            this.healedCollectionIds.delete(collection.id);
+          }
+
+          // Every add rejected: if the collection is also empty it is
+          // unpopulatable in place — heal by delete so the next pass
+          // recreates it fresh.
+          if (rejectedItemIds.size >= newMedia.length) {
+            const deleted =
+              await this.deleteEmptyCollectionRejectingAdds(collection);
+            if (deleted) {
+              collection.mediaServerId = null;
+              collection = await this.saveCollection(collection);
+            }
+          }
         }
 
         // Push collection sort to the media server when membership changed
@@ -2185,16 +2302,6 @@ export class CollectionsService {
         // matches, so this is cheap when nothing actually moved.
         if (collection.mediaServerSort && newMedia.length > 0) {
           await this.applyCollectionSort(collection);
-        }
-
-        if (isSharedManualCollection) {
-          await this.reconcileSharedManualCollectionState(collection, {
-            addedMediaServerIds: new Set(
-              newMedia.map(
-                (collectionMediaItem) => collectionMediaItem.mediaServerId,
-              ),
-            ),
-          });
         }
 
         if (isSharedManualCollection) {
@@ -2840,14 +2947,15 @@ export class CollectionsService {
     }
   }
 
+  /** Returns the ids the media server rejected (empty when none failed). */
   private async addChildrenToCollection(
     collectionIds: { mediaServerId: string; dbId: number },
     childrenMedia: CollectionMediaChange[],
     manual = false,
     skipMediaServerAdd = false,
     manualMembershipSource = CollectionMediaManualMembershipSource.LOCAL,
-  ) {
-    if (childrenMedia.length === 0) return;
+  ): Promise<Set<string>> {
+    if (childrenMedia.length === 0) return new Set();
 
     const mediaServer = await this.getMediaServer();
 
@@ -2905,6 +3013,8 @@ export class CollectionsService {
         }
       }
     }
+
+    return failedItemIds;
   }
 
   public async CollectionLogRecordForChild(

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -2253,19 +2253,21 @@ export class CollectionsService {
 
         // add new children to collection
         if (newMedia.length > 0 && collection.mediaServerId) {
-          const rejectedItemIds = await this.addChildrenToCollection(
-            { mediaServerId: collection.mediaServerId, dbId: collection.id },
-            newMedia,
-            manual,
-            skipMediaServerAdd,
-            manualMembershipSource,
-          );
+          const { serverRejectedIds, persistedIds } =
+            await this.addChildrenToCollection(
+              { mediaServerId: collection.mediaServerId, dbId: collection.id },
+              newMedia,
+              manual,
+              skipMediaServerAdd,
+              manualMembershipSource,
+            );
 
-          // Only notify for items the media server actually accepted —
-          // rejected items never entered the collection and will be
-          // retried (and re-notified) on a later run.
-          const addedMedia = newMedia.filter(
-            (m) => !rejectedItemIds.has(m.mediaServerId),
+          // Only notify for items whose membership was persisted — both
+          // server-rejected items and locally-rolled-back items never
+          // entered the collection and will be retried (and re-notified)
+          // on a later run.
+          const addedMedia = newMedia.filter((m) =>
+            persistedIds.has(m.mediaServerId),
           );
           if (addedMedia.length > 0) {
             this.eventEmitter.emit(
@@ -2280,14 +2282,15 @@ export class CollectionsService {
             );
           }
 
-          if (rejectedItemIds.size < newMedia.length) {
+          if (serverRejectedIds.size < newMedia.length) {
             this.healedCollectionIds.delete(collection.id);
           }
 
-          // Every add rejected: if the collection is also empty it is
-          // unpopulatable in place — heal by delete so the next pass
-          // recreates it fresh.
-          if (rejectedItemIds.size >= newMedia.length) {
+          // Every add rejected by the server: if the collection is also
+          // empty it is unpopulatable in place — heal by delete so the
+          // next pass recreates it fresh. Keyed to server rejections only;
+          // local persistence failures must never delete the collection.
+          if (serverRejectedIds.size >= newMedia.length) {
             const deleted =
               await this.deleteEmptyCollectionRejectingAdds(collection);
             if (deleted) {
@@ -2947,15 +2950,21 @@ export class CollectionsService {
     }
   }
 
-  /** Returns the ids the media server rejected (empty when none failed). */
+  /**
+   * Returns the ids the media server rejected (drives the empty-collection
+   * heal) and the ids whose local membership was persisted (drives the
+   * added notification). An item missing from both sets was accepted by
+   * the server but failed local persistence and got rolled back.
+   */
   private async addChildrenToCollection(
     collectionIds: { mediaServerId: string; dbId: number },
     childrenMedia: CollectionMediaChange[],
     manual = false,
     skipMediaServerAdd = false,
     manualMembershipSource = CollectionMediaManualMembershipSource.LOCAL,
-  ): Promise<Set<string>> {
-    if (childrenMedia.length === 0) return new Set();
+  ): Promise<{ serverRejectedIds: Set<string>; persistedIds: Set<string> }> {
+    if (childrenMedia.length === 0)
+      return { serverRejectedIds: new Set(), persistedIds: new Set() };
 
     const mediaServer = await this.getMediaServer();
 
@@ -2966,6 +2975,7 @@ export class CollectionsService {
     );
 
     let failedItemIds = new Set<string>();
+    const persistedIds = new Set<string>();
 
     if (!skipMediaServerAdd) {
       failedItemIds = new Set(
@@ -2994,6 +3004,7 @@ export class CollectionsService {
           },
           childMedia.reason,
         );
+        persistedIds.add(childMedia.mediaServerId);
       } catch (error) {
         this.logger.warn(
           `Couldn't add media ${childMedia.mediaServerId} to collection`,
@@ -3014,7 +3025,7 @@ export class CollectionsService {
       }
     }
 
-    return failedItemIds;
+    return { serverRejectedIds: failedItemIds, persistedIds };
   }
 
   public async CollectionLogRecordForChild(


### PR DESCRIPTION
Fixes the loop reported on Discord (and the tail of #2412 / #1446-style reports): a stale/corrupt Plex collection record rejects every item add with 400 while reads still succeed. Since #3001 collections are created empty, so such a record sticks forever — #2766 made shared collections never-deleted, every run retried the same adds, and the collection stayed empty/invisible in Plex while 'added' notifications kept firing. The reporter confirmed that manually deleting the Plex collection fixed it; this automates that recovery.

- Restore the delete-and-recreate heal (f0dcea7e) for this case: when every add is rejected and a live read confirms the automatic collection is still empty, delete it and clear the link so the next pass recreates it fresh. Plex-only, matching the existing empty-collection cleanup gate. Shared collections heal too — an empty collection holds nothing a sibling rule group could lose, and the sibling relinks by title.
- Churn guard: a collection heals once per process; a second total rejection without an accepted add in between logs an error instead of looping delete/recreate.
- Emit `CollectionMedia_Added` only for items whose collection membership was actually persisted: server-rejected adds and adds rolled back after a local persistence failure no longer notify as successes. Local failures stay out of the heal's rejection count, so a database hiccup can never delete a healthy collection.
- Unwrap the lib/plexApi error wrapper in `buildCollectionMutationFailure` so Plex's 400 response body (the rejection reason) reaches the logs.
- Drop a duplicated `reconcileSharedManualCollectionState` call.
