### PR TITLE
fix(radarr): treat already-excluded 400 as success when adding import-list exclusions

### DIFF
--- a/apps/server/src/modules/api/external-api/external-api.service.ts
+++ b/apps/server/src/modules/api/external-api/external-api.service.ts
@@ -115,11 +115,17 @@ export class ExternalApiService {
     endpoint: string,
     data?: any,
     config?: RawAxiosRequestConfig,
+    options?: { rethrow?: boolean },
   ): Promise<T> {
     try {
       const response = await this.axios.post<T>(endpoint, data, config);
       return response.data;
     } catch (error) {
+      // rethrow lets a caller inspect the failure (e.g. the HTTP status) instead
+      // of collapsing every error to undefined; it then owns the logging.
+      if (options?.rethrow) {
+        throw error;
+      }
       this.logRequestFailure('POST', endpoint, config, error);
       return undefined;
     }

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
@@ -56,29 +56,35 @@ describe('RadarrApi', () => {
         addImportExclusion: true,
       });
 
-    // The bulk endpoint de-dupes server-side, so re-adding an existing
-    // exclusion is a no-op rather than the HTTP 400 the singular endpoint
-    // returns.
     it('adds the exclusion via the de-duping bulk endpoint', async () => {
       postSpy.mockResolvedValue([exclusionFor(movie)]);
 
       await expect(unmonitorWithExclusion()).resolves.toBe(true);
-      expect(postSpy).toHaveBeenCalledWith('/exclusions/bulk', [
-        exclusionFor(movie),
-      ]);
+      expect(postSpy).toHaveBeenCalledWith(
+        '/exclusions/bulk',
+        [exclusionFor(movie)],
+        undefined,
+        { rethrow: true },
+      );
     });
 
-    // Radarr's bulk endpoint documents 200 with no response schema, so a
-    // successful add can have an empty body (''); only undefined (a failed
-    // request) is a failure.
-    it('treats a successful empty-body response as success', async () => {
-      postSpy.mockResolvedValue('');
+    // Radarr validates the exclusion POST and returns HTTP 400 when the movie is
+    // already excluded; the goal ("movie is excluded") is already met, so a
+    // re-run must not fail the whole collection action (#3084).
+    it('treats an already-excluded 400 as success', async () => {
+      postSpy.mockRejectedValue({
+        isAxiosError: true,
+        response: { status: 400 },
+      });
 
       await expect(unmonitorWithExclusion()).resolves.toBe(true);
     });
 
-    it('returns false when the bulk exclusion request fails', async () => {
-      postSpy.mockResolvedValue(undefined);
+    it('returns false when the exclusion request fails for another reason', async () => {
+      postSpy.mockRejectedValue({
+        isAxiosError: true,
+        response: { status: 500 },
+      });
 
       await expect(unmonitorWithExclusion()).resolves.toBe(false);
     });

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
@@ -1,3 +1,4 @@
+import { isAxiosError } from 'axios';
 import { CONNECTION_TEST_TIMEOUT_MS } from '../../../../utils/connection-error';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { ServarrApi } from '../common/servarr-api.service';
@@ -144,29 +145,7 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
       }
 
       if (options?.addImportExclusion) {
-        // Use the bulk endpoint, not the singular POST /exclusions: the latter
-        // runs a validator that rejects an already-excluded movie with HTTP 400
-        // ("This exclusion has already been added"), which would fail the whole
-        // collection run on every re-run. /exclusions/bulk skips that validator
-        // and de-dupes server-side (the same idempotent behaviour as Radarr's
-        // movie-delete path and Sonarr's exclusion handling), so re-adding is a
-        // no-op.
-        const result = await this.post<RadarrImportListExclusion[]>(
-          `/exclusions/bulk`,
-          [
-            {
-              tmdbId: movieData.tmdbId,
-              movieTitle: movieData.title,
-              movieYear: movieData.year,
-            } satisfies RadarrImportListExclusion,
-          ],
-        );
-
-        // post() returns the body on success and undefined only on a failed
-        // request. Radarr's bulk endpoint documents 200 with no response schema,
-        // so a successful add can have an empty body ('') — check for undefined
-        // rather than falsiness so an empty-body success isn't read as failure.
-        if (result === undefined) {
+        if (!(await this.addImportExclusion(movieData))) {
           return false;
         }
       }
@@ -174,6 +153,57 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
       return true;
     } catch (error) {
       this.logger.warn("Couldn't unmonitor movie. Does it exist in radarr?");
+      this.logger.debug(error);
+      return false;
+    }
+  }
+
+  /**
+   * Add a movie to Radarr's import-list exclusions via the bulk endpoint, which
+   * de-dupes server-side when a request reaches its service layer.
+   *
+   * Letting Radarr handle duplicates is not enough on its own: since Radarr
+   * v5.26.2 (RestController.OnActionExecuting now unpacks and validates
+   * IEnumerable bodies) the controller's ImportListExclusionExistsValidator runs
+   * on every posted resource and throws HTTP 400 ("This exclusion has already
+   * been added") *before* the request reaches that server-side de-dup. The
+   * singular POST /exclusions always validated, so neither endpoint avoids the
+   * duplicate 400 (#3084).
+   *
+   * Adding the exclusion is best-effort and our goal is only "the movie is
+   * excluded", which an already-excluded 400 already satisfies. So treat a 400 as
+   * success rather than failing the whole collection action (its unmonitor/delete
+   * has already run) on every re-run. Other failures still return false. We post a
+   * single-movie array, so a 400 unambiguously means that one movie is already
+   * excluded.
+   *
+   * Goes through the shared post() client (rethrowing so we can read the status)
+   * rather than this.axios directly, keeping the outbound request on the one HTTP
+   * client the rest of servarr uses.
+   */
+  private async addImportExclusion(movie: RadarrMovie): Promise<boolean> {
+    try {
+      await this.post(
+        '/exclusions/bulk',
+        [
+          {
+            tmdbId: movie.tmdbId,
+            movieTitle: movie.title,
+            movieYear: movie.year,
+          } satisfies RadarrImportListExclusion,
+        ],
+        undefined,
+        { rethrow: true },
+      );
+      return true;
+    } catch (error) {
+      if (isAxiosError(error) && error.response?.status === 400) {
+        this.logger.debug(
+          `Movie tmdbId ${movie.tmdbId} is already in Radarr's import exclusion list`,
+        );
+        return true;
+      }
+      this.logger.warn('Failed to add movie to Radarr import exclusion list');
       this.logger.debug(error);
       return false;
     }

--- a/tools/dev/fake-radarr.mjs
+++ b/tools/dev/fake-radarr.mjs
@@ -9,11 +9,12 @@
  * DB seed alone. This stub answers the handful of endpoints that flow needs so the
  * whole thing can be driven without a real Radarr.
  *
- * It deliberately replicates the one behaviour this exists to demonstrate: adding an
- * import list exclusion is idempotent on POST /exclusions/bulk (server de-dupes, no
- * error), whereas the singular POST /exclusions runs a uniqueness validator and
- * returns HTTP 400 ("This exclusion has already been added") on a duplicate — exactly
- * as the real Radarr controller does.
+ * It deliberately replicates the behaviour this exists to demonstrate: Radarr
+ * validates every exclusion POST (RestController.OnActionExecuting runs the
+ * uniqueness validator on each resource), so both the singular POST /exclusions
+ * and POST /exclusions/bulk return HTTP 400 ("This exclusion has already been
+ * added") on a duplicate tmdbId. Maintainerr therefore treats that 400 as
+ * "already excluded" (#3084).
  *
  * It is intentionally minimal and invented — no real media names (repo rule). Any
  * tmdbId queried resolves to a deterministic movie (movie id == tmdbId), so it pairs
@@ -36,7 +37,7 @@ const LOG = process.env.FAKE_RADARR_LOG !== "0";
 
 // In-memory import-list-exclusion store (tmdbId -> resource). Persists for the
 // lifetime of the process so re-running collection handling demonstrates the
-// idempotent de-dupe.
+// duplicate-rejection 400.
 const exclusions = new Map();
 let nextExclusionId = 1;
 
@@ -94,19 +95,26 @@ const server = http.createServer(async (req, res) => {
 
     // --- Import list exclusions ----------------------------------------------
   } else if (method === "POST" && path === "/exclusions/bulk") {
-    // Bulk endpoint: de-dupes server-side, never 400s (the idempotent path).
+    // Bulk endpoint: validated like the singular one. The validator runs on
+    // every posted resource, so a single already-excluded tmdbId fails the whole
+    // request with HTTP 400 and nothing is inserted.
     const body = (await readBody(req)) ?? [];
-    for (const item of body) {
-      if (!exclusions.has(item.tmdbId)) {
+    const duplicate = body.find((item) => exclusions.has(item.tmdbId));
+    if (duplicate) {
+      status = send(res, 400, [
+        {
+          propertyName: "TmdbId",
+          errorMessage: "This exclusion has already been added.",
+          severity: "error",
+        },
+      ]);
+    } else {
+      for (const item of body) {
         exclusions.set(item.tmdbId, { ...item, id: nextExclusionId++ });
         if (LOG) console.log(`  + exclusion added: tmdbId ${item.tmdbId}`);
-      } else if (LOG) {
-        console.log(
-          `  = exclusion already present (no-op): tmdbId ${item.tmdbId}`,
-        );
       }
+      status = send(res, 200, body);
     }
-    status = send(res, 200, body);
   } else if (method === "POST" && path === "/exclusions") {
     // Singular endpoint: uniqueness validator -> HTTP 400 on a duplicate.
     const body = (await readBody(req)) ?? {};
@@ -144,6 +152,6 @@ const server = http.createServer(async (req, res) => {
 server.listen(PORT, () => {
   console.log(`fake-radarr listening on http://localhost:${PORT} (api/v3)`);
   console.log(
-    "POST /exclusions/bulk de-dupes (idempotent); POST /exclusions 400s on a duplicate.",
+    "POST /exclusions and POST /exclusions/bulk both 400 on a duplicate tmdbId.",
   );
 });


### PR DESCRIPTION
Fixes #3084.

Radarr collection actions (UNMONITOR / UNMONITOR_DELETE_ALL with "add import exclusion") stopped removing items: `POST /exclusions/bulk` returns HTTP 400 and fails the whole action on every re-run, so items never leave the collection.

Root cause is a Radarr-side change, not Plex: since **v5.26.2**, `RestController.OnActionExecuting` unpacks and validates `IEnumerable` bodies, so `/exclusions/bulk` now runs the uniqueness validator and 400s ("This exclusion has already been added") on a re-add — *before* the request reaches Radarr's server-side de-dup. The singular `/exclusions` always validated, so neither endpoint avoids it. (This is why #3012's bulk switch worked when written but regressed.)

- Adding the exclusion is best-effort; an already-excluded 400 means the goal is already met, so treat it as success instead of failing an action whose unmonitor/delete already ran. Other failures still fail.
- Keep the bulk endpoint (single-movie array; server de-dup where reachable).
- Route through the shared `post()` client via a new opt-in `{ rethrow }` so the caller can read the HTTP status, keeping the request on the one HTTP client the rest of servarr uses.
- `fake-radarr` dev mock now 400s on a duplicate for both endpoints, matching Radarr v5.26.2+.