### PR TITLE
fix(emby): create collections with an initial item to avoid HTTP 500

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -126,9 +126,9 @@ describe('EmbyAdapterService', () => {
   });
 
   describe('createCollection', () => {
-    it('creates the collection empty without seeding item ids', async () => {
-      // Item ids must never be sent on create (they go in the query string →
-      // HTTP 414 at scale); items are added via addBatchToCollection.
+    it('omits Ids when no initial item is provided', async () => {
+      // The full item set must never be sent on create (the ids go in the query
+      // string → HTTP 414 at scale); they are added via addBatchToCollection.
       http.post.mockResolvedValueOnce({ data: { Id: 'collection-1' } });
       http.get.mockResolvedValueOnce({
         data: {
@@ -159,6 +159,31 @@ describe('EmbyAdapterService', () => {
           title: 'New Collection',
         }),
       );
+    });
+
+    it('creates with a single initial item id when provided', async () => {
+      // Emby 500s on an empty create, so it gets exactly one item; the rest are
+      // added via addBatchToCollection (#3075). One id keeps it under the URL
+      // length limit that an all-ids create would hit (#3001).
+      http.post.mockResolvedValueOnce({
+        data: { Id: 'collection-1', Name: 'New Collection', ChildCount: 1 },
+      });
+
+      await service.createCollection({
+        libraryId: 'library-1',
+        title: 'New Collection',
+        type: 'show',
+        initialItemId: 'item-1',
+      });
+
+      expect(http.post).toHaveBeenCalledWith('/Collections', null, {
+        params: {
+          Name: 'New Collection',
+          ParentId: 'library-1',
+          Ids: 'item-1',
+          IsLocked: true,
+        },
+      });
     });
 
     it('runs the metadata follow-up when sortTitle is provided without summary', async () => {

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -925,7 +925,12 @@ export class EmbyAdapterService implements IMediaServerService {
   ): Promise<MediaCollection> {
     if (!this.http) throw new Error('Emby not initialized');
     try {
-      // Created empty; items are added afterwards via addBatchToCollection.
+      // Create with one item: Emby's create-collection endpoint throws HTTP 500
+      // ("Sequence contains no elements" in CollectionManager) when creating an
+      // empty collection under a library folder, so it needs at least one item
+      // (#3075 — the regression from #3001's empty-create). The rest are added
+      // afterwards via addBatchToCollection; re-adding this item there is an
+      // idempotent no-op (collection membership is a set).
       const { data } = await this.http.post<EmbyBaseItemDto>(
         '/Collections',
         null,
@@ -933,6 +938,7 @@ export class EmbyAdapterService implements IMediaServerService {
           params: {
             Name: params.title,
             ParentId: params.libraryId,
+            ...(params.initialItemId ? { Ids: params.initialItemId } : {}),
             // IsLocked enables composite image generation from items, matching
             // the Jellyfin adapter; without it, Emby may skip the auto-cover.
             IsLocked: true,

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -1533,6 +1533,7 @@ export class CollectionsService {
   async createCollection(
     collection: ICollection,
     empty = true,
+    initialItemId?: string,
   ): Promise<
     | {
         dbCollection: addCollectionDbResponse;
@@ -1555,6 +1556,7 @@ export class CollectionsService {
           summary: collection?.description,
           sortTitle: collection?.sortTitle,
           type: collection.type,
+          initialItemId,
         });
 
         // Store the media server ID from the created collection
@@ -1643,7 +1645,11 @@ export class CollectionsService {
     | undefined
   > {
     try {
-      const createdCollection = await this.createCollection(collection, false);
+      const createdCollection = await this.createCollection(
+        collection,
+        false,
+        media?.[0]?.mediaServerId,
+      );
 
       if (!createdCollection?.dbCollection) {
         return undefined;
@@ -2127,6 +2133,10 @@ export class CollectionsService {
                 summary: collection.description,
                 sortTitle: collection.sortTitle,
                 type: collection.type,
+                // Create with one item so Emby accepts it (it 500s on an empty
+                // create, #3075). The full set is synced below.
+                initialItemId: (newMedia[0] ?? collectionMedia[0])
+                  ?.mediaServerId,
               });
             }
           }

--- a/packages/contracts/src/media-server/types.ts
+++ b/packages/contracts/src/media-server/types.ts
@@ -227,6 +227,16 @@ export interface CreateCollectionParams {
   summary?: string
   type: MediaItemType
   sortTitle?: string
+  /**
+   * Optional id of a single item to include when the collection is created.
+   * Emby's create-collection endpoint throws (HTTP 500) when asked to create an
+   * empty collection under a library folder (#3075), so it must be given at least
+   * one item. Plex and Jellyfin create empty (their behaviour since #3001) and do
+   * not read this. Kept to a single id so the create request stays well under the
+   * URL length limit (#3001); the rest are added afterwards via
+   * addBatchToCollection.
+   */
+  initialItemId?: string
 }
 
 /** Plex-only visibility settings */

--- a/tools/dev/fake-emby.mjs
+++ b/tools/dev/fake-emby.mjs
@@ -171,6 +171,12 @@ const server = http.createServer((req, res) => {
   // Writes: create collection, add/remove items, update item -> accept.
   if (req.method === 'POST' || req.method === 'DELETE') {
     if (path === '/Collections') {
+      // Real Emby 500s when creating an empty collection under a library folder
+      // (CollectionManager "Sequence contains no elements", #3075). It needs at
+      // least one item (Ids), so reject an empty create the same way.
+      if (!u.searchParams.get('Ids')) {
+        return send(res, 500, { error: 'Sequence contains no elements' });
+      }
       return send(res, 200, { Id: 'emby-boxset-new' });
     }
     return send(res, 204, undefined);


### PR DESCRIPTION
Fixes #3075.

On Emby, every rule action failed with `[EmbyAdapterService] Emby createCollection failed: Connection failed: received response 500`, so collections were never created and nothing was deleted.

Root cause: Emby's create-collection endpoint throws HTTP 500 ("Sequence contains no elements" in `CollectionManager`) when asked to create an **empty** collection under a library folder. #3001 (v3.13) switched all servers to create-empty-then-batch-add to avoid a 414 from seeding every item id into the create query string — which broke Emby specifically. That's the reporters' "since 3.13"; #2911 (v3.12) created with items and worked.

- Add optional `initialItemId` to `CreateCollectionParams`; the Emby adapter sends it as `Ids` on create so the collection is created with one member. Plex and Jellyfin create empty and ignore it.
- One id keeps the create request well under the URL length limit the all-ids create hit (#3001); the rest are added via `addBatchToCollection` (re-adding that item there is an idempotent no-op).
- `fake-emby` dev mock now 500s on an empty create, matching the real server.