### PR TITLE
fix(collections): skip remote create for empty collections (Emby)

### DIFF
--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -1607,10 +1607,10 @@ describe('CollectionsService', () => {
 
     await service.createCollectionWithChildren(collection, media);
 
+    // Seeded with the first item so Emby can create it (#3075); the full set is
+    // still added via the batched path below.
     expect(mediaServer.createCollection).toHaveBeenCalledWith(
-      expect.not.objectContaining({
-        initialItemIds: expect.anything(),
-      }),
+      expect.objectContaining({ initialItemId: 'item-1' }),
     );
     expect(addChildrenToCollectionSpy).toHaveBeenCalledWith(
       {
@@ -1621,6 +1621,31 @@ describe('CollectionsService', () => {
       false,
       false,
     );
+  });
+
+  it('creates the DB row only (no remote collection) when no media is provided', async () => {
+    // No items to seed → the remote collection would be empty (pointless
+    // everywhere, a hard 500 on Emby, #3075), so defer it to the first add.
+    const collection = createCollection({
+      id: 41,
+      mediaServerId: null,
+      manualCollection: false,
+      libraryId: 'library-1',
+      title: 'Empty Collection',
+    });
+
+    jest.spyOn(service as any, 'addCollectionToDB').mockResolvedValue({
+      id: collection.id,
+      mediaServerId: null,
+    });
+    const addChildrenToCollectionSpy = jest
+      .spyOn(service as any, 'addChildrenToCollection')
+      .mockResolvedValue(undefined);
+
+    await service.createCollectionWithChildren(collection, []);
+
+    expect(mediaServer.createCollection).not.toHaveBeenCalled();
+    expect(addChildrenToCollectionSpy).not.toHaveBeenCalled();
   });
 
   it('returns undefined without adding media when collection creation fails', async () => {
@@ -2318,10 +2343,11 @@ describe('CollectionsService', () => {
     expect(result[0].mediaData?.title).toBe('Fallback Movie');
   });
 
-  it('creates a new media server collection empty, then batch-adds items', async () => {
-    // Regression: item ids must never be seeded into the create request (they
-    // travel in the query string → HTTP 414 at scale). Create empty, then add
-    // via the batched path.
+  it('creates a new media server collection seeded with one item, then batch-adds the rest', async () => {
+    // The create request carries a single item id (the first), not the whole set
+    // (the full set in the query string → HTTP 414 at scale, #3001). One item is
+    // required so Emby can create the collection at all (#3075); the full set is
+    // then added via the batched path.
     const collection = createCollection({
       id: 21,
       mediaServerId: null,
@@ -2347,11 +2373,10 @@ describe('CollectionsService', () => {
     ]);
 
     expect(mediaServer.createCollection).toHaveBeenCalledWith(
-      expect.not.objectContaining({
-        initialItemIds: expect.anything(),
-      }),
+      expect.objectContaining({ initialItemId: 'episode-1' }),
     );
-    // Not seeded on create, so the batched add path runs (skipMediaServerAdd=false).
+    // The full set is still added via the batched path (skipMediaServerAdd=false);
+    // re-adding the seeded item there is an idempotent no-op.
     expect(addChildrenToCollection).toHaveBeenCalledWith(
       { mediaServerId: 'remote-collection', dbId: collection.id },
       [{ mediaServerId: 'episode-1' }, { mediaServerId: 'episode-2' }],

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -1645,9 +1645,13 @@ export class CollectionsService {
     | undefined
   > {
     try {
+      const hasMedia = !!media && media.length > 0;
+      // With no items to add, create the DB row only and defer the remote
+      // collection to the first add (which seeds it). An empty remote collection
+      // is pointless on every server and Emby rejects it outright (#3075).
       const createdCollection = await this.createCollection(
         collection,
-        false,
+        !hasMedia,
         media?.[0]?.mediaServerId,
       );
 


### PR DESCRIPTION
Follow-up to #3097. Post-merge review found Emby's empty-create 500 is still reachable through a narrower route.

`POST /api/collections` accepts an optional `media`, and the controller passes it straight into `createCollectionWithChildren`, which always called `createCollection(..., false, media?.[0]?.mediaServerId)`. With `media: []` or omitted, the remote collection is still created with no item — pointless on every server, and a hard HTTP 500 on Emby (#3075), the same failure just through the public create endpoint.

- Create the DB row only when there are no items; the remote collection is created lazily on the first add (which seeds it with an item). Server-agnostic — no per-server branching in the shared layer.
- Tests: assert the singular `initialItemId` seed is actually passed on create (the prior assertions guarded the removed *plural* `initialItemIds`, so they passed vacuously even if the seed were dropped), refresh the stale "create empty" comments, and add an empty-media case asserting no remote create.