### PR TITLE
fix(radarr): only swallow the "already excluded" exclusion 400

### DIFF
--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
@@ -68,16 +68,44 @@ describe('RadarrApi', () => {
       );
     });
 
-    // Radarr validates the exclusion POST and returns HTTP 400 when the movie is
-    // already excluded; the goal ("movie is excluded") is already met, so a
-    // re-run must not fail the whole collection action (#3084).
-    it('treats an already-excluded 400 as success', async () => {
+    // Radarr validates the exclusion POST and returns HTTP 400 with the
+    // uniqueness message when the movie is already excluded; the goal ("movie is
+    // excluded") is already met, so a re-run must not fail the whole collection
+    // action (#3084).
+    it('treats the "already added" 400 as success', async () => {
       postSpy.mockRejectedValue({
         isAxiosError: true,
-        response: { status: 400 },
+        response: {
+          status: 400,
+          data: [
+            {
+              propertyName: 'TmdbId',
+              errorMessage: 'This exclusion has already been added.',
+            },
+          ],
+        },
       });
 
       await expect(unmonitorWithExclusion()).resolves.toBe(true);
+    });
+
+    // A 400 from a different validation rule (e.g. an invalid year) is a real
+    // failure — it must not be silently reported as "already excluded".
+    it('returns false on a non-duplicate validation 400', async () => {
+      postSpy.mockRejectedValue({
+        isAxiosError: true,
+        response: {
+          status: 400,
+          data: [
+            {
+              propertyName: 'MovieYear',
+              errorMessage: 'Must be greater than or equal to 0',
+            },
+          ],
+        },
+      });
+
+      await expect(unmonitorWithExclusion()).resolves.toBe(false);
     });
 
     it('returns false when the exclusion request fails for another reason', async () => {

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
@@ -171,11 +171,12 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
    * duplicate 400 (#3084).
    *
    * Adding the exclusion is best-effort and our goal is only "the movie is
-   * excluded", which an already-excluded 400 already satisfies. So treat a 400 as
-   * success rather than failing the whole collection action (its unmonitor/delete
-   * has already run) on every re-run. Other failures still return false. We post a
-   * single-movie array, so a 400 unambiguously means that one movie is already
-   * excluded.
+   * excluded", which an already-excluded 400 already satisfies. So treat the
+   * "already added" 400 as success rather than failing the whole collection
+   * action (its unmonitor/delete has already run) on every re-run. The validator
+   * also enforces non-empty tmdbId/title and a non-negative year, so a 400 from
+   * one of those is a real failure — surface it instead of silently marking the
+   * movie excluded when it isn't.
    *
    * Goes through the shared post() client (rethrowing so we can read the status)
    * rather than this.axios directly, keeping the outbound request on the one HTTP
@@ -197,7 +198,11 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
       );
       return true;
     } catch (error) {
-      if (isAxiosError(error) && error.response?.status === 400) {
+      if (
+        isAxiosError(error) &&
+        error.response?.status === 400 &&
+        this.isAlreadyExcludedError(error.response.data)
+      ) {
         this.logger.debug(
           `Movie tmdbId ${movie.tmdbId} is already in Radarr's import exclusion list`,
         );
@@ -207,6 +212,27 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
       this.logger.debug(error);
       return false;
     }
+  }
+
+  /**
+   * True only for the exclusion validator's uniqueness failure. Radarr returns a
+   * 400 with an array of `{ propertyName, errorMessage }`; the uniqueness rule is
+   * the one that means "already excluded — goal met". Any other validation
+   * failure (empty title, negative year, …) must stay a failure.
+   */
+  private isAlreadyExcludedError(body: unknown): boolean {
+    const entries: unknown[] = Array.isArray(body) ? body : [body];
+    return entries.some((entry) => {
+      if (typeof entry !== 'object' || entry === null) {
+        return false;
+      }
+      const { errorMessage, message } = entry as Record<string, unknown>;
+      const text = errorMessage ?? message;
+      return (
+        typeof text === 'string' &&
+        text.toLowerCase().includes('already been added')
+      );
+    });
   }
 
   public async info(): Promise<RadarrInfo> {


### PR DESCRIPTION
Follow-up to #3096. That PR treated **every** HTTP 400 from `/exclusions/bulk` as "already excluded".

Radarr's exclusion validator also enforces non-empty `tmdbId`/`movieTitle` and `movieYear >= 0`, so a non-duplicate validation 400 was misreported as success — the movie would be unmonitored/deleted but not actually added to the import-exclusion list. The payload is normally Radarr-originated so this is uncommon, but it shouldn't be silently swallowed.

Inspect the 400 body and only treat the uniqueness failure (`"This exclusion has already been added"`) as success; any other validation 400 stays a failure and is surfaced. Adds spec coverage for the duplicate-vs-other-validation 400 split.