### PR TITLE
fix(metadata): resolve movie/show ids from the item, not its parent

### DIFF
--- a/apps/server/src/modules/metadata/metadata.service.spec.ts
+++ b/apps/server/src/modules/metadata/metadata.service.spec.ts
@@ -410,6 +410,43 @@ describe('MetadataService', () => {
     });
   });
 
+  it('resolves a movie from its own ids, not its parent (Emby id-less container, #3065)', async () => {
+    // Emby/Jellyfin set a movie's parentId to an id-less library/container
+    // folder. Resolution must read the movie itself, never walk up to the parent.
+    const movieItem = createMediaItem({
+      id: 'movie-1',
+      type: 'movie',
+      parentId: 'container-1',
+      title: 'Fixture Movie',
+      year: 1994,
+      providerIds: { tmdb: ['555001'], imdb: ['tt5550001'] },
+    });
+    const mediaServer = {
+      getMetadata: jest.fn().mockImplementation(async (id: string) => {
+        if (id === 'movie-1') {
+          return movieItem;
+        }
+        // The id-less container — must never be fetched for a movie.
+        return createMediaItem({
+          id: 'container-1',
+          type: 'movie',
+          providerIds: {},
+        });
+      }),
+    };
+    const { service } = createService({
+      mediaServer,
+      tmdbDetails: {
+        externalIds: { tmdb: 555001, imdb: 'tt5550001', type: 'movie' },
+      },
+    });
+
+    const result = await service.resolveIdsFromHierarchyMediaItem(movieItem);
+
+    expect(mediaServer.getMetadata).not.toHaveBeenCalledWith('container-1');
+    expect(result).toMatchObject({ tmdb: 555001 });
+  });
+
   it('accepts direct provider ids when titles differ but release years agree', async () => {
     const libraryItem = createMediaItem({
       id: 'movie-1',

--- a/apps/server/src/modules/metadata/metadata.service.ts
+++ b/apps/server/src/modules/metadata/metadata.service.ts
@@ -368,7 +368,17 @@ export class MetadataService {
     item: MediaItem,
     sourceMediaServerId?: string,
   ): Promise<MediaItem | undefined> {
-    const hierarchyTargetId = item.grandparentId ?? item.parentId;
+    // Only episodes/seasons resolve their ids from a parent (up to the show).
+    // A movie's (or show's) own provider ids live on the item itself, and on
+    // Emby/Jellyfin a movie's parentId points at an id-less library/container
+    // folder — walking up there discards the real ids and the lookup fails
+    // (#3065). Switch on item.type, never on parentId presence.
+    if (item.type !== 'season' && item.type !== 'episode') {
+      return item;
+    }
+
+    const hierarchyTargetId =
+      item.type === 'episode' ? item.grandparentId : item.parentId;
 
     if (!hierarchyTargetId) {
       return item;


### PR DESCRIPTION
Fixes #3065.

On Emby, every movie rule **action** failed with `Couldn't resolve any supported external IDs for movie with media server ID <id>`, even though the Emby item has TMDB/IMDb ids. Matching worked (collections filled), but the action could never resolve a TMDB id, so nothing could be unmonitored/deleted.

`getHierarchyResolutionItem` resolved ids from `item.grandparentId ?? item.parentId` for any item with a parent. That's correct for episodes/seasons (resolve up to the show), but on Emby/Jellyfin a movie's `parentId` points at an id-less library/container folder — so the movie's own provider ids were discarded → 0 lookup candidates → the `RadarrActionHandler` empty-candidates branch.

- Switch on `item.type` (never `parentId` presence), matching the existing correct pattern in `resolveShowIdsForImage`: only episodes/seasons resolve from a parent; movies and shows use their own ids.
- Plex is unaffected (its top-level movies already had no parent, so they already used their own ids).
- Adds a regression test: a movie with an id-less Emby parent resolves from the movie itself and never fetches the container.

Verified end-to-end against a mock Emby reproducing the reporter's exact shape (movie with tmdb + id-less parent container): the Radarr UNMONITOR action now resolves the tmdb id from the movie and completes, instead of "Couldn't resolve…".