### PR TITLE
test(overlays): raise timeout for sharp-based render tests to avoid CI flake

### DIFF
--- a/apps/server/src/modules/overlays/overlay-render.service.spec.ts
+++ b/apps/server/src/modules/overlays/overlay-render.service.spec.ts
@@ -53,6 +53,11 @@ const isDarkPixel = (
 };
 
 describe('OverlayRenderService', () => {
+  // The render tests do real sharp image processing and TrueType font loading;
+  // the native cold-start can exceed Jest's 5s default on a slow/cold CI runner
+  // (locally the whole suite is ~1.5s). Give the suite headroom to avoid flakes.
+  jest.setTimeout(15000);
+
   afterEach(() => {
     mockedExistsSync.mockImplementation(realExistsSync);
     jest.clearAllMocks();


### PR DESCRIPTION
The `OverlayRenderService` render tests do real `sharp` image processing and TrueType font loading. The native cold-start can exceed Jest's 5s default on a slow/cold CI runner, intermittently failing with `Exceeded timeout of 5000 ms` (seen on an unrelated PR's run; the whole suite is ~1.5s locally). Raise the suite timeout to 15s so the sharp-based tests have headroom.

No production change — test-only.