### PR TITLE
fix(rules): sw_lastWatched returns null for never-watched shows on Plex

### DIFF
--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -1314,4 +1314,72 @@ describe('PlexGetterService', () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe('sw_lastWatched (id 13) - Newest episode view date', () => {
+    const SW_LAST_WATCHED_PROP_ID = 13;
+
+    const getLastWatched = () =>
+      service.get(
+        SW_LAST_WATCHED_PROP_ID,
+        createMediaItem({ type: 'show' }),
+        'show',
+        createRulesDto({ dataType: 'show' }),
+      );
+
+    it('returns the newest watched episode date (highest season, then episode)', async () => {
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({ ratingKey: 'show-1', type: 'show' }),
+      );
+      plexApi.getWatchHistory.mockResolvedValue([
+        makeWatchEntry({ parentIndex: 1, index: 1, viewedAt: 1_700_000_100 }),
+        makeWatchEntry({ parentIndex: 2, index: 1, viewedAt: 1_700_000_200 }),
+        makeWatchEntry({ parentIndex: 2, index: 2, viewedAt: 1_700_000_300 }),
+      ]);
+
+      await expect(getLastWatched()).resolves.toEqual(
+        new Date(1_700_000_300 * 1000),
+      );
+    });
+
+    it('uses the most recent view when the newest episode was watched more than once', async () => {
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({ ratingKey: 'show-1', type: 'show' }),
+      );
+      // getWatchHistory returns viewedAt-descending (the wrapper queries
+      // sort=viewedAt:desc). The newest episode (s2e2) appears twice; the stable
+      // descending sorts must keep the most recent view first, so its latest
+      // view date wins rather than an older one.
+      plexApi.getWatchHistory.mockResolvedValue([
+        makeWatchEntry({ parentIndex: 2, index: 2, viewedAt: 1_700_000_900 }),
+        makeWatchEntry({ parentIndex: 2, index: 1, viewedAt: 1_700_000_500 }),
+        makeWatchEntry({ parentIndex: 2, index: 2, viewedAt: 1_700_000_100 }),
+      ]);
+
+      await expect(getLastWatched()).resolves.toEqual(
+        new Date(1_700_000_900 * 1000),
+      );
+    });
+
+    // #3083: getWatchHistory returns [] for a confirmed-empty history, and [] is
+    // truthy - the getter must return null (never watched), not read viewedAt off
+    // undefined and throw (which the outer catch would surface as a transient
+    // undefined, wrongly preserving the item in its collection).
+    it('returns null for a confirmed-empty history (never watched)', async () => {
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({ ratingKey: 'show-1', type: 'show' }),
+      );
+      plexApi.getWatchHistory.mockResolvedValue([]);
+
+      await expect(getLastWatched()).resolves.toBeNull();
+    });
+
+    it('returns undefined when the history lookup fails (transient)', async () => {
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({ ratingKey: 'show-1', type: 'show' }),
+      );
+      plexApi.getWatchHistory.mockRejectedValue(new Error('plex unreachable'));
+
+      await expect(getLastWatched()).resolves.toBeUndefined();
+    });
+  });
 });

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -359,17 +359,22 @@ export class PlexGetterService {
           return [];
         }
         case 'sw_lastWatched': {
-          let watchHistory = await this.plexApi.getWatchHistory(
+          const watchHistory = await this.plexApi.getWatchHistory(
             metadata.ratingKey,
           );
-          watchHistory?.sort((a, b) => a.parentIndex - b.parentIndex).reverse();
-          watchHistory = watchHistory?.filter(
+          // getWatchHistory returns [] for a confirmed-empty history (it throws
+          // on a real outage). [] is truthy and the sort/filter below index
+          // watchHistory[0], so guard up front: "never watched" returns null
+          // (confirmed absent) rather than reading viewedAt off undefined (#3083).
+          if (!watchHistory.length) {
+            return null;
+          }
+          watchHistory.sort((a, b) => b.parentIndex - a.parentIndex);
+          const newestSeason = watchHistory.filter(
             (el) => el.parentIndex === watchHistory[0].parentIndex,
           );
-          watchHistory?.sort((a, b) => a.index - b.index).reverse();
-          return watchHistory
-            ? new Date(+watchHistory[0].viewedAt * 1000)
-            : null;
+          newestSeason.sort((a, b) => b.index - a.index);
+          return new Date(+newestSeason[0].viewedAt * 1000);
         }
         case 'sw_episodes': {
           if (metadata.type === 'season') {


### PR DESCRIPTION
Fixes #3083.

The Plex `sw_lastWatched` getter ("Newest episode view date") guarded the date branch with a truthy check on `watchHistory`. `getWatchHistory` returns `[]` for a confirmed-empty history (and throws on a real outage), and `[]` is **truthy** — so for a never-watched show it read `viewedAt` off `watchHistory[0]` (`undefined`) and threw `TypeError`. The getter's outer catch surfaces that as `undefined`, which the comparator treats as a **transient** error, so the executor **preserves** the item — never-watched shows get stuck in a collection across runs even when they no longer match the rule.

- Guard on `length` so an empty history takes the existing `null` branch — "never watched" is confirmed-absent, per the getter contract (`null` = absent, `undefined` = error) documented in `project-notes.instructions.md`. The fix stays in the getter layer and makes the value explicit rather than changing comparator behavior.
- Emby/Jellyfin already length-guard their equivalent (`if (watched.length === 0) return null`), so this is Plex-only — consistent with the issue's label.
- Adds Plex coverage: confirmed-empty → `null`, populated → newest episode date, outage → `undefined` (transient). Verified the empty-history test fails without the fix.