### PR TITLE
fix(servarr): fail closed on transient Sonarr/Radarr lookup failures (#3125)

### DIFF
--- a/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -156,9 +156,7 @@ describe('SonarrActionHandler', () => {
       mockMediaServerMetadata(collectionMedia.mediaData);
 
       const mockedSonarrApi = mockSonarrApi(servarrService, logger);
-      jest
-        .spyOn(mockedSonarrApi, 'getSeriesByTvdbId')
-        .mockResolvedValue(undefined);
+      jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(null);
 
       mediaIdFinder.findTvdbId.mockResolvedValue(1);
 
@@ -232,9 +230,7 @@ describe('SonarrActionHandler', () => {
       mockMediaServerMetadata(collectionMedia.mediaData);
 
       const mockedSonarrApi = mockSonarrApi(servarrService, logger);
-      jest
-        .spyOn(mockedSonarrApi, 'getSeriesByTvdbId')
-        .mockResolvedValue(undefined);
+      jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(null);
 
       mediaIdFinder.findTvdbId.mockResolvedValue(1);
 
@@ -246,6 +242,37 @@ describe('SonarrActionHandler', () => {
       validateNoSonarrActionsTaken(mockedSonarrApi);
     },
   );
+
+  // A transient Sonarr lookup failure (getSeriesByTvdbId → undefined) must NOT
+  // be read as "not in Sonarr" and trigger a media-server delete — fail closed
+  // so the item stays in the collection and is retried next run. (#3125)
+  it('fails closed (no delete, no action) when the Sonarr lookup fails transiently for a DELETE action', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      sonarrSettingsId: 1,
+      type: 'show',
+    });
+    const collectionMedia = createCollectionMediaWithMetadata(collection, {
+      tmdbId: 1,
+    });
+
+    mockMediaServerMetadata(collectionMedia.mediaData);
+
+    const mockedSonarrApi = mockSonarrApi(servarrService, logger);
+    jest
+      .spyOn(mockedSonarrApi, 'getSeriesByTvdbId')
+      .mockResolvedValue(undefined);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await expect(
+      sonarrActionHandler.handleAction(collection, collectionMedia),
+    ).resolves.toBe(false);
+
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(mediaServer.deleteFromDisk).not.toHaveBeenCalled();
+    validateNoSonarrActionsTaken(mockedSonarrApi);
+  });
 
   it('should unmonitor season and delete episodes when type SEASONS and action DELETE', async () => {
     const collection = createCollection({

--- a/apps/server/src/modules/actions/sonarr-action-handler.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.ts
@@ -70,6 +70,16 @@ export class SonarrActionHandler {
     });
     let sonarrMedia = matchedResult?.result;
 
+    if (sonarrMedia === undefined) {
+      // Transient Sonarr lookup failure (vs. null = confirmed not tracked):
+      // fail closed instead of falling through to a media-server delete on a
+      // blip. The item stays in the collection and is retried next run. (#3125)
+      this.logger.log(
+        `Couldn't reach Sonarr to resolve a series for media server item ${media.mediaServerId}. No action was taken; will retry next run.`,
+      );
+      return false;
+    }
+
     if (!sonarrMedia?.id) {
       const attemptedIds = formatMetadataLookupCandidates(lookupCandidates);
 

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
@@ -156,6 +156,39 @@ describe('RadarrApi', () => {
     });
   });
 
+  // Same null/undefined contract as Sonarr (#3125): `undefined` = the lookup
+  // itself failed (fail closed), `null` = Radarr confirmed the movie isn't
+  // tracked. getWithoutCache swallows HTTP errors to `undefined` without
+  // throwing, so the failure must be detected from that value.
+  describe('getMovieByTmdbId null/undefined contract (#3125)', () => {
+    it('returns undefined when the lookup fails transiently (getWithoutCache → undefined)', async () => {
+      jest.spyOn(api as any, 'getWithoutCache').mockResolvedValue(undefined);
+
+      await expect(api.getMovieByTmdbId(123)).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Error retrieving movie by TMDb ID 123',
+      );
+    });
+
+    it('returns null when Radarr confirms the movie is not tracked (empty array)', async () => {
+      jest.spyOn(api as any, 'getWithoutCache').mockResolvedValue([]);
+
+      await expect(api.getMovieByTmdbId(123)).resolves.toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Could not find Movie with TMDb id 123 in Radarr',
+      );
+    });
+
+    it('returns the movie when Radarr has it', async () => {
+      const movie = createRadarrMovie({ id: 5, tmdbId: 123 });
+      jest.spyOn(api as any, 'getWithoutCache').mockResolvedValue([movie]);
+
+      await expect(api.getMovieByTmdbId(123)).resolves.toEqual(
+        expect.objectContaining({ id: 5 }),
+      );
+    });
+  });
+
   describe('getDownloadIdsForMovie', () => {
     it('requests the movie history endpoint', async () => {
       const getWithoutCache = jest

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
@@ -50,20 +50,38 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
   // Intentionally uncached: this drives rule evaluation and resolves the
   // movie that actions then mutate — both need Radarr's current truth, not a
   // snapshot that can be up to DEFAULT_TTL stale.
-  public async getMovieByTmdbId(id: number): Promise<RadarrMovie> {
+  // Returns `null` when Radarr confirms the movie isn't tracked (empty
+  // response) and `undefined` when the lookup itself failed (transport, auth,
+  // 5xx). Callers must keep these distinct: a confirmed miss is safe to fall
+  // back from, a failure must fail closed so a transient Radarr outage can't
+  // silently change rule evaluation.
+  public async getMovieByTmdbId(
+    id: number,
+  ): Promise<RadarrMovie | null | undefined> {
     try {
       const response = await this.getWithoutCache<RadarrMovie[]>(
         `/movie?tmdbId=${id}`,
       );
 
+      // getWithoutCache swallows transport/auth/5xx into `undefined` (it never
+      // throws), so the catch below can't see those failures. Distinguish them
+      // here and fail closed (undefined), rather than letting the empty check
+      // collapse a transient outage into `null` ("not tracked"). (#3125)
+      if (response === undefined) {
+        this.logger.warn(`Error retrieving movie by TMDb ID ${id}`);
+        return undefined;
+      }
+
       if (!response[0]) {
         this.logger.warn(`Could not find Movie with TMDb id ${id} in Radarr`);
+        return null;
       }
 
       return response[0];
     } catch (error) {
       this.logger.warn(`Error retrieving movie by TMDb ID ${id}`);
       this.logger.debug(error);
+      return undefined;
     }
   }
 

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
@@ -198,6 +198,44 @@ describe('SonarrApi', () => {
     });
   });
 
+  // The transient-failure protection in rule evaluation depends on this
+  // contract: `undefined` = the lookup itself failed (fail closed), `null` =
+  // Sonarr confirmed the series isn't tracked. getWithoutCache swallows HTTP
+  // errors to `undefined` without throwing, so the failure must be detected
+  // from that value — the catch path never sees it. (#3125)
+  describe('getSeriesByTvdbId null/undefined contract (#3125)', () => {
+    it('returns undefined when the lookup fails transiently (getWithoutCache → undefined)', async () => {
+      jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue(undefined);
+
+      await expect(sonarrApi.getSeriesByTvdbId(555)).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Error retrieving show by tvdb ID 555',
+      );
+    });
+
+    it('returns null when Sonarr confirms the series is not tracked (empty array)', async () => {
+      jest.spyOn(sonarrApi as any, 'getWithoutCache').mockResolvedValue([]);
+
+      await expect(sonarrApi.getSeriesByTvdbId(555)).resolves.toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Could not retrieve show by tvdb ID 555',
+      );
+    });
+
+    it('returns the series when Sonarr has it', async () => {
+      const series = createSonarrSeries({ id: 1, tvdbId: 555 });
+      jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue([series]);
+
+      await expect(sonarrApi.getSeriesByTvdbId(555)).resolves.toEqual(
+        expect.objectContaining({ id: 1 }),
+      );
+    });
+  });
+
   describe('runPut / runDelete failure contract', () => {
     it('should return false when PUT returns undefined (API failure)', async () => {
       jest.spyOn(sonarrApi as any, 'put').mockResolvedValue(undefined);

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
@@ -6,7 +6,6 @@ import {
   SonarrEpisode,
   SonarrEpisodeFile,
   SonarrInfo,
-  SonarrSeason,
   SonarrSeries,
 } from '../interfaces/sonarr.interface';
 
@@ -123,7 +122,16 @@ export class SonarrApi extends ServarrApi<{
         `/series?tvdbId=${id}`,
       );
 
-      if (!response?.[0]) {
+      // getWithoutCache swallows transport/auth/5xx into `undefined` (it never
+      // throws), so the catch below can't see those failures. Distinguish them
+      // here and fail closed (undefined), rather than letting the empty check
+      // collapse a transient outage into `null` ("not tracked"). (#3125)
+      if (response === undefined) {
+        this.logger.warn(`Error retrieving show by tvdb ID ${id}`);
+        return undefined;
+      }
+
+      if (!response[0]) {
         this.logger.warn(`Could not retrieve show by tvdb ID ${id}`);
         return null;
       }
@@ -350,31 +358,6 @@ export class SonarrApi extends ServarrApi<{
       this.logger.debug(error);
       return undefined;
     }
-  }
-
-  private buildSeasonList(
-    seasons: number[],
-    existingSeasons?: SonarrSeason[],
-  ): SonarrSeason[] {
-    if (existingSeasons) {
-      const newSeasons = existingSeasons.map((season) => {
-        if (seasons.includes(season.seasonNumber)) {
-          season.monitored = true;
-        }
-        return season;
-      });
-
-      return newSeasons;
-    }
-
-    const newSeasons = seasons.map(
-      (seasonNumber): SonarrSeason => ({
-        seasonNumber,
-        monitored: true,
-      }),
-    );
-
-    return newSeasons;
   }
 
   public async info(): Promise<SonarrInfo> {

--- a/apps/server/src/modules/rules/getter/radarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.spec.ts
@@ -283,6 +283,48 @@ describe('RadarrGetterService', () => {
     });
   });
 
+  // A transient Radarr outage must fail closed: the getter returns undefined so
+  // the comparator skips the item and preserves collection membership, rather
+  // than returning null (definitive absence) and dropping the item from the
+  // collection for that run. (#3125)
+  describe('transient lookup failure (#3125)', () => {
+    let collectionMedia: CollectionMedia;
+    let mediaItem: MediaItem;
+
+    beforeEach(() => {
+      collectionMedia = createCollectionMedia('movie');
+      collectionMedia.collection.radarrSettingsId = 1;
+      mediaItem = createMediaItem({ type: 'movie' });
+    });
+
+    // id 0 = 'addDate'
+    const callAddDate = () =>
+      radarrGetterService.get(
+        0,
+        mediaItem,
+        createRulesDto({
+          collection: collectionMedia.collection,
+          dataType: 'movie',
+        }),
+      );
+
+    it('returns undefined (fail closed) when the movie lookup fails transiently', async () => {
+      const mockedRadarrApi = mockRadarrApi();
+      jest
+        .spyOn(mockedRadarrApi, 'getMovieByTmdbId')
+        .mockResolvedValue(undefined);
+
+      await expect(callAddDate()).resolves.toBeUndefined();
+    });
+
+    it('returns null when Radarr confirms the movie is not tracked', async () => {
+      const mockedRadarrApi = mockRadarrApi();
+      jest.spyOn(mockedRadarrApi, 'getMovieByTmdbId').mockResolvedValue(null);
+
+      await expect(callAddDate()).resolves.toBeNull();
+    });
+  });
+
   const mockRadarrApi = (movie?: RadarrMovie) => {
     const mockedRadarrApi = new RadarrApi(
       { url: 'http://localhost:7878', apiKey: 'test' },

--- a/apps/server/src/modules/rules/getter/radarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.ts
@@ -100,6 +100,14 @@ export class RadarrGetterService {
       });
       const movieResponse = matchedResult?.result;
 
+      if (movieResponse === undefined) {
+        // The Radarr lookup itself failed (or every candidate's lookup
+        // returned undefined) — could be a transient outage. Fail closed
+        // rather than returning null (definitive absence), which would drop
+        // the item from the collection on a transient blip. (#3125)
+        return undefined;
+      }
+
       if (!movieResponse) {
         const attemptedIds = formatMetadataLookupCandidates(lookupCandidates);
 
@@ -167,7 +175,7 @@ export class RadarrGetterService {
           }
           case 'releaseDate': {
             return movieResponse.physicalRelease && movieResponse.digitalRelease
-              ? (await new Date(movieResponse.physicalRelease)) >
+              ? new Date(movieResponse.physicalRelease) >
                 new Date(movieResponse.digitalRelease)
                 ? new Date(movieResponse.digitalRelease)
                 : new Date(movieResponse.physicalRelease)


### PR DESCRIPTION
Fixes #3125 — collection items flipped in/out across rule runs when Sonarr/Radarr lookups failed transiently (timeouts / 5xx, worst under heavy *arr load).

Root cause: `getWithoutCache` swallows transport/auth/5xx errors into `undefined` without throwing, so `getSeriesByTvdbId` / `getMovieByTmdbId` collapsed a transient failure into `null` ("confirmed not tracked") via the empty-response check — leaving each helper's catch-path `undefined` unreachable for HTTP failures. The rule comparator's transient-removal guard only triggers on strict `=== undefined`, so the misclassified `null` bypassed it: the item was dropped from the collection, then re-added next run once the lookup recovered.

The documented `null` = definitive absence vs `undefined` = transport failure contract (#2870/#3002) was correct on the consumer side; the producer (the arr helpers) just never emitted the `undefined` signal it depends on.

- Both arr helpers now distinguish `response === undefined` (transient → `undefined`, fail closed) from an empty array (`null`, confirmed not tracked).
- Add the missing `=== undefined` fail-closed branch to the Radarr getter (the Sonarr getter already had one — it was simply never fed `undefined`).
- Fail the Sonarr action handler closed on a transient lookup (return `false`, so the collection-handler's `itemExists` check keeps the item and retries next run) instead of falling through to a media-server delete.
- Helper/getter/action-handler paths covered by tests.

Also drops a dead `buildSeasonList` helper (vestige of the old Overseerr Sonarr port) and a no-op `await` on `new Date()` in the Radarr getter.