### PR TITLE
fix(rules): inherit parent show for Streamystats watchlist at season/episode level (#3127)

### DIFF
--- a/apps/server/src/modules/rules/constants/rules.constants.ts
+++ b/apps/server/src/modules/rules/constants/rules.constants.ts
@@ -1436,6 +1436,27 @@ export class RuleConstants {
           mediaType: MediaType.BOTH,
           type: RuleType.TEXT_LIST, // returns usernames []
         },
+        // Parent-inclusive variants: a Streamystats list holds the show item ID,
+        // not its seasons/episodes, so the item-only props above never match a
+        // watchlisted show when evaluated below show level. These roll the
+        // parent show (and season) in. Show-only and season/episode-only — a
+        // show is the top level (no parent) and a movie has no parent show.
+        {
+          id: 2,
+          name: 'isInWatchlist_including_parent',
+          humanName: 'Is in a watchlist (incl. parents)',
+          mediaType: MediaType.SHOW,
+          type: RuleType.BOOL,
+          showType: ['season', 'episode'],
+        },
+        {
+          id: 3,
+          name: 'watchlistedByUsers_including_parent',
+          humanName: '[list] In watchlist of (username) (incl. parents)',
+          mediaType: MediaType.SHOW,
+          type: RuleType.TEXT_LIST, // returns usernames []
+          showType: ['season', 'episode'],
+        },
       ],
     },
   ];

--- a/apps/server/src/modules/rules/getter/streamystats-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/streamystats-getter.service.spec.ts
@@ -8,6 +8,8 @@ import { StreamystatsGetterService } from './streamystats-getter.service';
 
 const IS_IN_WATCHLIST_PROP_ID = 0;
 const WATCHLISTED_BY_USERS_PROP_ID = 1;
+const IS_IN_WATCHLIST_INCLUDING_PARENT_PROP_ID = 2;
+const WATCHLISTED_BY_USERS_INCLUDING_PARENT_PROP_ID = 3;
 
 const membershipOf = (
   entries: Record<string, string[]>,
@@ -16,14 +18,23 @@ const membershipOf = (
 });
 
 describe('StreamystatsGetterService', () => {
-  const createService = (users: { id: string; name: string }[] = []) => {
+  const createService = (
+    users: { id: string; name: string }[] = [],
+    // Items resolvable by getMetadata — the `_including_parent` props look up
+    // the item's parent chain through the media server's metadata path.
+    items: ReturnType<typeof createMediaItem>[] = [],
+  ) => {
     const streamystatsApi = {
       getWatchlistMembership: jest.fn(),
     } as unknown as jest.Mocked<StreamystatsApiService>;
 
+    const getMetadata = jest.fn(async (id: string) =>
+      items.find((item) => item.id === id),
+    );
     const mediaServerFactory = {
       getService: jest.fn().mockResolvedValue({
         getUsers: jest.fn().mockResolvedValue(users),
+        getMetadata,
       }),
     } as unknown as jest.Mocked<MediaServerFactory>;
 
@@ -33,7 +44,7 @@ describe('StreamystatsGetterService', () => {
       createMockLogger(),
     );
 
-    return { service, streamystatsApi, mediaServerFactory };
+    return { service, streamystatsApi, mediaServerFactory, getMetadata };
   };
 
   describe('isInWatchlist (property id=0)', () => {
@@ -128,6 +139,166 @@ describe('StreamystatsGetterService', () => {
       );
       // No need to hit the media server when there are no owners to resolve.
       expect(mediaServerFactory.getService).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isInWatchlist_including_parent (property id=2)', () => {
+    it('inherits the parent show when a season is not directly listed', async () => {
+      const season = createMediaItem({
+        type: 'season',
+        id: 'season-1',
+        parentId: 'show-1',
+      });
+      const { service, streamystatsApi } = createService([], [season]);
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({ 'show-1': ['user-a'] }),
+      );
+
+      expect(
+        await service.get(IS_IN_WATCHLIST_INCLUDING_PARENT_PROP_ID, season),
+      ).toBe(true);
+    });
+
+    it('inherits the grandparent show when an episode is not directly listed', async () => {
+      const episode = createMediaItem({
+        type: 'episode',
+        id: 'ep-1',
+        parentId: 'season-1',
+        grandparentId: 'show-1',
+      });
+      const { service, streamystatsApi } = createService([], [episode]);
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({ 'show-1': ['user-a'] }),
+      );
+
+      expect(
+        await service.get(IS_IN_WATCHLIST_INCLUDING_PARENT_PROP_ID, episode),
+      ).toBe(true);
+    });
+
+    it('returns false when neither the item nor its parents are listed', async () => {
+      const season = createMediaItem({
+        type: 'season',
+        id: 'season-1',
+        parentId: 'show-1',
+      });
+      const { service, streamystatsApi } = createService([], [season]);
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({ 'show-2': ['user-a'] }),
+      );
+
+      expect(
+        await service.get(IS_IN_WATCHLIST_INCLUDING_PARENT_PROP_ID, season),
+      ).toBe(false);
+    });
+
+    it('skips (undefined) when the item metadata cannot be fetched', async () => {
+      // getMetadata returns undefined (item not registered) — the parent chain
+      // is unknown, so skip rather than fall back to an item-only check.
+      const season = createMediaItem({
+        type: 'season',
+        id: 'season-1',
+        parentId: 'show-1',
+      });
+      const { service, streamystatsApi } = createService([], []);
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({ 'show-1': ['user-a'] }),
+      );
+
+      expect(
+        await service.get(IS_IN_WATCHLIST_INCLUDING_PARENT_PROP_ID, season),
+      ).toBeUndefined();
+    });
+
+    it('does not roll up for the base property (item-only)', async () => {
+      const season = createMediaItem({
+        type: 'season',
+        id: 'season-1',
+        parentId: 'show-1',
+      });
+      const { service, streamystatsApi, getMetadata } = createService(
+        [],
+        [season],
+      );
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({ 'show-1': ['user-a'] }),
+      );
+
+      expect(await service.get(IS_IN_WATCHLIST_PROP_ID, season)).toBe(false);
+      // The base prop is item-only — no parent resolution needed.
+      expect(getMetadata).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('watchlistedByUsers_including_parent (property id=3)', () => {
+    it('unions and dedupes owners across the season and its parent show', async () => {
+      const season = createMediaItem({
+        type: 'season',
+        id: 'season-1',
+        parentId: 'show-1',
+      });
+      const { service, streamystatsApi } = createService(
+        [
+          { id: 'user-a', name: 'alice' },
+          { id: 'user-b', name: 'bob' },
+        ],
+        [season],
+      );
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({
+          'season-1': ['user-a'],
+          'show-1': ['user-a', 'user-b'],
+        }),
+      );
+
+      const result = (await service.get(
+        WATCHLISTED_BY_USERS_INCLUDING_PARENT_PROP_ID,
+        season,
+      )) as string[];
+
+      expect(result.sort()).toEqual(['alice', 'bob']);
+    });
+
+    it('resolves the grandparent show owner for an episode not directly listed', async () => {
+      const episode = createMediaItem({
+        type: 'episode',
+        id: 'ep-1',
+        parentId: 'season-1',
+        grandparentId: 'show-1',
+      });
+      const { service, streamystatsApi } = createService(
+        [{ id: 'user-a', name: 'alice' }],
+        [episode],
+      );
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({ 'show-1': ['user-a'] }),
+      );
+
+      expect(
+        await service.get(
+          WATCHLISTED_BY_USERS_INCLUDING_PARENT_PROP_ID,
+          episode,
+        ),
+      ).toEqual(['alice']);
+    });
+
+    it('returns an empty list when neither the item nor its parents are listed', async () => {
+      const season = createMediaItem({
+        type: 'season',
+        id: 'season-1',
+        parentId: 'show-1',
+      });
+      const { service, streamystatsApi } = createService([], [season]);
+      streamystatsApi.getWatchlistMembership.mockResolvedValue(
+        membershipOf({}),
+      );
+
+      expect(
+        await service.get(
+          WATCHLISTED_BY_USERS_INCLUDING_PARENT_PROP_ID,
+          season,
+        ),
+      ).toEqual([]);
     });
   });
 

--- a/apps/server/src/modules/rules/getter/streamystats-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/streamystats-getter.service.ts
@@ -8,6 +8,7 @@ import {
   Property,
   RuleConstants,
 } from '../constants/rules.constants';
+import { definedUniqueValues } from '../helpers/rule-property.helper';
 
 /**
  * Resolves Streamystats-backed rule properties for Jellyfin. Streamystats is
@@ -50,14 +51,26 @@ export class StreamystatsGetterService {
         return undefined;
       }
 
-      const owners = membership.ownersByItemId[libItem.id];
+      const itemIds = await this.resolveWatchlistItemIds(prop.name, libItem);
+      // `undefined` when the parent chain couldn't be resolved — skip rather
+      // than fall back to an item-only check, which would defeat the parent
+      // variant and could let a protected item match a destructive rule.
+      if (!itemIds) {
+        return undefined;
+      }
+
+      const owners = definedUniqueValues(
+        itemIds.flatMap((itemId) => membership.ownersByItemId[itemId] ?? []),
+      );
 
       switch (prop.name) {
-        case 'isInWatchlist': {
-          return owners != null && owners.length > 0;
+        case 'isInWatchlist':
+        case 'isInWatchlist_including_parent': {
+          return owners.length > 0;
         }
-        case 'watchlistedByUsers': {
-          if (!owners || owners.length === 0) {
+        case 'watchlistedByUsers':
+        case 'watchlistedByUsers_including_parent': {
+          if (owners.length === 0) {
             return [];
           }
           // undefined when usernames couldn't be resolved (transient skip).
@@ -77,6 +90,44 @@ export class StreamystatsGetterService {
       );
       return undefined;
     }
+  }
+
+  /**
+   * The Jellyfin item IDs to check for watchlist membership. The base props
+   * check the item alone. The `_including_parent` variants additionally roll
+   * in the parent show (and season) for a season/episode — a Streamystats list
+   * holds the show item ID, not its seasons, so a season would otherwise never
+   * inherit its watchlisted show.
+   *
+   * Parents are resolved through the media server's `getMetadata` (the same
+   * canonical path the other getters use) so the parent IDs come from the
+   * mapper's hierarchy resolution — `SeriesId` for seasons, not the
+   * library-folder `parentId`. Gated on the server-agnostic `type` so a movie
+   * is never rolled up. Returns `undefined` when metadata can't be fetched, so
+   * the caller skips rather than falling back to an item-only check.
+   */
+  private async resolveWatchlistItemIds(
+    propName: string,
+    libItem: MediaItem,
+  ): Promise<string[] | undefined> {
+    if (!propName.endsWith('_including_parent')) {
+      return [libItem.id];
+    }
+
+    const mediaServer = await this.mediaServerFactory.getService();
+    const metadata = await mediaServer.getMetadata(libItem.id);
+    if (!metadata) {
+      return undefined;
+    }
+
+    // Only seasons/episodes have a parent show to inherit from; gate on the
+    // server-agnostic type so a movie's library-folder parentId is never
+    // rolled up. definedUniqueValues drops the undefined parent/grandparent.
+    const ancestors =
+      metadata.type === 'season' || metadata.type === 'episode'
+        ? [metadata.parentId, metadata.grandparentId]
+        : [];
+    return definedUniqueValues([metadata.id, ...ancestors]);
   }
 
   private async resolveUsernames(


### PR DESCRIPTION
Fixes #3127.

A Streamystats watchlist holds the **show** item ID, so the existing item-only `isInWatchlist` / `watchlistedByUsers` props return empty when a rule is evaluated at the season/episode level. A `NOT_CONTAINS <user>` protection rule then wrongly matches a watchlisted show's seasons and sweeps them into deletion/unmonitoring.

- Adds `isInWatchlist_including_parent` and `watchlistedByUsers_including_parent` (show-only, `season`/`episode`), mirroring the existing Jellyfin `sw_favoritedBy_including_parent` precedent.
- Resolves the parent chain through the media server's `getMetadata` — the same canonical path the Jellyfin/Emby/Plex getters use — so parent IDs come from the mapper's hierarchy resolution (`SeriesId` for seasons, not the library-folder `parentId`). Gated on the server-agnostic `type` so a movie is never rolled up.
- Skips (returns `undefined`, transient) when metadata can't be fetched, rather than falling back to an item-only check that could let a protected item match a destructive rule.
- Base props remain item-only (no behavioral change); union/dedupe reuses the shared `definedUniqueValues` helper.