### PR TITLE
fix(collections): heal empty Jellyfin/Emby collections (#3129)

### DIFF
--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -1473,8 +1473,9 @@ export class JellyfinAdapterService implements IMediaServerService {
     try {
       await getLibraryApi(this.api).deleteItem({ itemId: collectionId });
     } catch (error) {
-      // Jellyfin auto-deletes empty BoxSets — this races with our explicit
-      // delete and 404/500s once the item is gone. Re-check and swallow if so.
+      // The BoxSet may already be gone (a concurrent delete, or the user
+      // removed it in Jellyfin), which 404/500s here. Re-check and swallow if
+      // so. Note: Jellyfin does NOT auto-delete BoxSets that merely go empty.
       if (await this.getCollection(collectionId).then(Boolean)) {
         this.logger.error(`Failed to delete collection ${collectionId}`);
         this.logger.debug(error);
@@ -1697,8 +1698,9 @@ export class JellyfinAdapterService implements IMediaServerService {
       );
     }
 
-    // Delete the collection if all items belonged to this library and it's not manual.
-    // Jellyfin auto-deletes empty collections, but we explicitly delete when appropriate.
+    // Delete the collection if all items belonged to this library and it's not
+    // manual. Jellyfin does NOT auto-delete a BoxSet that merely goes empty, so
+    // this explicit delete is what removes it.
     if (childIds.length === itemsToRemove.length && !isManualCollection) {
       await this.deleteCollection(collectionId);
     }

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -834,6 +834,322 @@ describe('CollectionsService', () => {
     expect(result.mediaServerId).toBe('remote-collection');
   });
 
+  it('repopulates a drained Jellyfin automatic collection from local rule-owned items', async () => {
+    settingsDataService.media_server_type = MediaServerType.JELLYFIN;
+    const collection = createCollection({
+      id: 40,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Jellyfin Drained',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Jellyfin Drained',
+      childCount: 0,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-1',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-2',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'manual-only',
+        includedByRule: false,
+        manualMembershipSource: CollectionMediaManualMembershipSource.LOCAL,
+      }),
+    ]);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    // Empty BoxSets are not auto-deleted; repopulate in place, never delete.
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+    expect(mediaServer.addBatchToCollection).toHaveBeenCalledWith(
+      'remote-collection',
+      ['rule-owned-1', 'rule-owned-2'],
+    );
+  });
+
+  it('re-adds only the items a partially-drained Jellyfin collection is missing', async () => {
+    settingsDataService.media_server_type = MediaServerType.JELLYFIN;
+    const collection = createCollection({
+      id: 41,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Jellyfin Partial',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Jellyfin Partial',
+      childCount: 1,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([
+      { id: 'rule-owned-still-present' },
+    ] as any);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-still-present',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-missing',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+    ]);
+
+    await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(mediaServer.addBatchToCollection).toHaveBeenCalledWith(
+      'remote-collection',
+      ['rule-owned-missing'],
+    );
+  });
+
+  it('does not re-add when a Jellyfin collection already holds all rule-owned items', async () => {
+    settingsDataService.media_server_type = MediaServerType.JELLYFIN;
+    const collection = createCollection({
+      id: 42,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Jellyfin In Sync',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Jellyfin In Sync',
+      childCount: 2,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([
+      { id: 'rule-owned-1' },
+      { id: 'rule-owned-2' },
+    ] as any);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-1',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-2',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+    ]);
+
+    await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.addBatchToCollection).not.toHaveBeenCalled();
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+  });
+
+  it('does not resync a Jellyfin collection that was only just linked by title', async () => {
+    settingsDataService.media_server_type = MediaServerType.JELLYFIN;
+    // mediaServerId null on entry → freshly linked this run; the server may not
+    // have finished indexing, so the resync must not fire yet.
+    const collection = createCollection({
+      id: 43,
+      mediaServerId: null,
+      manualCollection: false,
+      title: 'Jellyfin Fresh Link',
+      libraryId: 'library-1',
+    });
+
+    collectionRepo.save.mockImplementation(async (c) => c as Collection);
+    jest.spyOn(service as any, 'findMediaServerCollection').mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Jellyfin Fresh Link',
+      childCount: 0,
+    });
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(result.mediaServerId).toBe('remote-collection');
+    expect(mediaServer.getCollectionChildren).not.toHaveBeenCalled();
+    expect(mediaServer.addBatchToCollection).not.toHaveBeenCalled();
+  });
+
+  it('repopulates a drained Emby automatic collection from local rule-owned items', async () => {
+    settingsDataService.media_server_type = MediaServerType.EMBY;
+    const collection = createCollection({
+      id: 44,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Emby Drained',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Emby Drained',
+      childCount: 0,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-1',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+    ]);
+
+    await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(mediaServer.addBatchToCollection).toHaveBeenCalledWith(
+      'remote-collection',
+      ['rule-owned-1'],
+    );
+  });
+
+  it('deletes a genuinely-empty non-shared Jellyfin automatic collection', async () => {
+    settingsDataService.media_server_type = MediaServerType.JELLYFIN;
+    const collection = createCollection({
+      id: 45,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Jellyfin Truly Empty',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Jellyfin Truly Empty',
+      childCount: 0,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    // Nothing in the DB should be in this collection → genuinely empty.
+    collectionMediaRepo.find.mockResolvedValue([]);
+    collectionRepo.save.mockImplementation(async (c) => c as Collection);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(false);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.addBatchToCollection).not.toHaveBeenCalled();
+    expect(mediaServer.deleteCollection).toHaveBeenCalledWith(
+      'remote-collection',
+    );
+    expect(result.mediaServerId).toBeNull();
+  });
+
+  it('does not delete a genuinely-empty shared Jellyfin collection', async () => {
+    settingsDataService.media_server_type = MediaServerType.JELLYFIN;
+    const collection = createCollection({
+      id: 46,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Jellyfin Empty Shared',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Jellyfin Empty Shared',
+      childCount: 0,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    collectionMediaRepo.find.mockResolvedValue([]);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(true);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+  });
+
+  it('keeps an empty Jellyfin collection whose rule-owned items could not be re-added', async () => {
+    settingsDataService.media_server_type = MediaServerType.JELLYFIN;
+    const collection = createCollection({
+      id: 47,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Jellyfin Stale Ids',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Jellyfin Stale Ids',
+      childCount: 0,
+    } as any);
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    // The DB says these belong here, but every re-add is rejected (stale ids):
+    // the collection must NOT be deleted — it should be repopulated once the
+    // rule re-matches with fresh ids.
+    mediaServer.addBatchToCollection.mockResolvedValue([
+      'rule-owned-1',
+      'rule-owned-2',
+    ]);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-1',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-2',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+    ]);
+    const sharedSpy = jest.spyOn(service, 'isMediaServerCollectionShared');
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+    // Short-circuit: emptiness/share check is skipped when there were items to
+    // re-add, so the shared lookup never runs.
+    expect(sharedSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not delete a Jellyfin collection on a transient empty child read when metadata reports children', async () => {
+    settingsDataService.media_server_type = MediaServerType.JELLYFIN;
+    const collection = createCollection({
+      id: 48,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Jellyfin Transient Empty Read',
+      libraryId: 'library-1',
+    });
+
+    // getCollection succeeds and reports 5 children...
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Jellyfin Transient Empty Read',
+      childCount: 5,
+    } as any);
+    // ...but the child enumeration transiently fails soft (returns []). The
+    // metadata count must veto the delete so a populated collection survives.
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    collectionMediaRepo.find.mockResolvedValue([]);
+    const sharedSpy = jest.spyOn(service, 'isMediaServerCollectionShared');
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+    expect(sharedSpy).not.toHaveBeenCalled();
+  });
+
   it('rolls back a remote add when local bookkeeping fails', async () => {
     const collection = createCollection({
       id: 2,

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -270,7 +270,7 @@ export class CollectionsService {
     );
   }
 
-  private async resyncRuleOwnedItemsToSharedCollection(
+  private async resyncRuleOwnedItemsToMediaServerCollection(
     collection: Pick<Collection, 'id' | 'mediaServerId' | 'title'>,
     serverChildIds: Set<string>,
   ): Promise<{ attempted: number; rejected: number }> {
@@ -293,7 +293,7 @@ export class CollectionsService {
 
       const mediaServer = await this.getMediaServer();
       this.logger.log(
-        `[checkAutomaticMediaServerLink] Resyncing ${missingRuleOwnedIds.length} local rule-owned item(s) into shared media server collection ${collection.mediaServerId} for "${collection.title}"`,
+        `[checkAutomaticMediaServerLink] Resyncing ${missingRuleOwnedIds.length} local rule-owned item(s) into media server collection ${collection.mediaServerId} for "${collection.title}"`,
       );
 
       const failedItemIds = new Set(
@@ -306,7 +306,7 @@ export class CollectionsService {
       for (const itemId of missingRuleOwnedIds) {
         if (failedItemIds.has(itemId)) {
           this.logger.warn(
-            `Failed to resync item ${itemId} into shared media server collection ${collection.mediaServerId}`,
+            `Failed to resync item ${itemId} into media server collection ${collection.mediaServerId}`,
           );
         }
       }
@@ -317,7 +317,7 @@ export class CollectionsService {
       };
     } catch (error) {
       this.logger.warn(
-        'Failed to resync local rule-owned items into shared media server collection',
+        'Failed to resync local rule-owned items into media server collection',
       );
       this.logger.debug(error);
       // An exception is not evidence the server rejected the adds, so
@@ -339,8 +339,9 @@ export class CollectionsService {
    * record): delete it so the regular add flow recreates it fresh on the
    * next pass. Deletion is gated on a successful live read confirming the
    * collection is still empty, so a transient outage never triggers it.
-   * Plex-only, matching the empty-collection cleanup in
-   * checkAutomaticMediaServerLink (Jellyfin lags and auto-deletes empties).
+   * Plex-only: an empty Plex collection rejects every add, so it must be
+   * recreated. Jellyfin/Emby accept adds into an empty BoxSet, so those are
+   * repopulated in place by checkAutomaticMediaServerLink instead of deleted.
    */
   private async deleteEmptyCollectionRejectingAdds(
     collection: Pick<
@@ -1886,13 +1887,13 @@ export class CollectionsService {
         }
       }
 
-      // If the collection is empty, remove it. Otherwise issues when adding media.
-      // ONLY check this if we already had a mediaServerId when entering this function.
-      // If we just linked/found it (originalMediaServerId was null), don't delete it -
-      // the media server may not have finished processing recent additions yet.
+      // Reconcile an automatic collection that already exists on the server.
+      // ONLY act when we had a mediaServerId on entry; if we just linked/found
+      // it (originalMediaServerId was null) the server may not have finished
+      // indexing recent additions yet.
       //
-      // Skip for Jellyfin because API lag causes false positives.
-      // Jellyfin natively auto-deletes empty collections, so no manual cleanup needed.
+      // Plex: an empty Plex collection rejects subsequent adds, so delete the
+      // empty/stale record and let the regular add flow recreate it fresh.
       if (
         this.settingsDataService.media_server_type === MediaServerType.PLEX &&
         serverColl &&
@@ -1920,7 +1921,7 @@ export class CollectionsService {
             `[checkAutomaticMediaServerLink] Shared collection ${serverColl.id} has ${serverChildIds.size} children — checking for local rule-owned drift`,
           );
           const resyncResult =
-            await this.resyncRuleOwnedItemsToSharedCollection(
+            await this.resyncRuleOwnedItemsToMediaServerCollection(
               collection,
               serverChildIds,
             );
@@ -1969,6 +1970,61 @@ export class CollectionsService {
                 ? `[checkAutomaticMediaServerLink] Trusting Plex metadata childCount=${metadataChildCount} for collection ${serverColl.id}, keeping it`
                 : `[checkAutomaticMediaServerLink] Collection ${serverColl.id} has ${actualChildCount} children, keeping it`,
             );
+          }
+        }
+      } else if (
+        serverColl &&
+        collection.mediaServerId !== null &&
+        originalMediaServerId !== null
+      ) {
+        // Jellyfin/Emby: an empty BoxSet is NOT auto-deleted, and a BoxSet
+        // drains when its underlying items are re-imported with new ids
+        // (routine *arr churn), so an automatic collection can sit empty on the
+        // server while the DB still lists its rule-owned items. (#3129)
+        const serverChildren =
+          (await mediaServer.getCollectionChildren(serverColl.id)) ?? [];
+        const serverChildIds = new Set(
+          serverChildren
+            .map((child) => child?.id?.toString())
+            .filter((childId): childId is string => Boolean(childId)),
+        );
+
+        // 1) Repopulate: re-add rule-owned DB items missing from the BoxSet.
+        // Empty BoxSets accept adds, so this fixes them in place — the BoxSet
+        // id (and its overlays/poster) stays stable, no delete/recreate churn.
+        // Re-add only: adding an item already present is an idempotent no-op, so
+        // a transient empty read just re-adds the full set harmlessly.
+        const resyncResult =
+          await this.resyncRuleOwnedItemsToMediaServerCollection(
+            collection,
+            serverChildIds,
+          );
+
+        // 2) Heal a genuinely-empty collection: delete it so it doesn't linger
+        // once its rule stops matching, matching the Plex empty-collection
+        // cleanup. The destructive gate uses the child count from the
+        // (successful) getCollection above — a read that distinguishes a truly
+        // empty collection from a transient child-enumeration failure. Child
+        // reads return [] on failure (see media-server.interface.ts), so an
+        // empty getCollectionChildren() result alone is NOT proof of emptiness
+        // and must never drive a delete. Require all of: a finite metadata
+        // count of 0, an empty live read, nothing rule-owned to re-add, and a
+        // non-shared collection (a sibling rule group may own a shared BoxSet).
+        const metadataChildCount = Number.isFinite(serverColl.childCount)
+          ? serverColl.childCount
+          : undefined;
+        if (
+          metadataChildCount === 0 &&
+          serverChildIds.size === 0 &&
+          resyncResult.attempted === 0
+        ) {
+          const isShared = await this.isMediaServerCollectionShared(collection);
+          if (!isShared) {
+            this.logger.debug(
+              `[checkAutomaticMediaServerLink] Deleting empty collection ${serverColl.id} for "${collection.title}" — server reports no children and there are no rule-owned items to re-add`,
+            );
+            await mediaServer.deleteCollection(serverColl.id);
+            serverColl = undefined;
           }
         }
       }

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -361,6 +361,58 @@ describe('RuleExecutorService', () => {
     );
   });
 
+  it('skips manual import using the pre-run link snapshot even when the collection now reports as linked', async () => {
+    const { service, mediaServer, collectionService, logger } = createService(
+      MediaServerType.JELLYFIN,
+    );
+
+    // Mirrors production: by sync time the collection already has a
+    // mediaServerId because handleCollection linked it to a pre-existing,
+    // same-named BoxSet earlier in this run. The pre-run snapshot (false) must
+    // still win so the BoxSet's existing contents are NOT absorbed as manual.
+    collectionService.getCollection.mockResolvedValue({
+      id: 1,
+      title: 'Test Collection',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+    } as any);
+    collectionService.checkAutomaticMediaServerLink.mockResolvedValue({
+      id: 1,
+      title: 'Test Collection',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+    } as any);
+    collectionService.getCollectionMedia.mockResolvedValue([]);
+    mediaServer.getCollectionChildren.mockResolvedValue([{ id: 'm-existing' }]);
+
+    await (
+      service as unknown as {
+        syncManualMediaServerToCollectionDB: (
+          ruleGroup: { id: number; collectionId: number },
+          collectionSyncChanges: {
+            addedMediaServerIds: Set<string>;
+            removedMediaServerIds: Set<string>;
+          },
+          collectionLinkedBeforeRun: boolean,
+        ) => Promise<void>;
+      }
+    ).syncManualMediaServerToCollectionDB(
+      { id: 10, collectionId: 1 },
+      {
+        addedMediaServerIds: new Set(),
+        removedMediaServerIds: new Set(),
+      },
+      false,
+    );
+
+    expect(
+      collectionService.syncMediaServerChildrenToCollection,
+    ).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Skipping manual child import for newly linked automatic collection 'Test Collection' to avoid marking existing collection contents as manual.",
+    );
+  });
+
   it('skips importing items that are rule-owned by sibling automatic collections', async () => {
     const { service, mediaServer, collectionService } = createService(
       MediaServerType.PLEX,

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -227,6 +227,34 @@ export class RuleExecutorService {
         removedMediaServerIds: new Set<string>(),
       };
 
+      // Snapshot whether this collection was already linked to a media server
+      // collection BEFORE this run. handleCollection below can link a freshly
+      // created automatic collection to a pre-existing, same-named server
+      // collection; the post-handle state would then look "already linked" and
+      // make the sync below import that collection's existing contents as
+      // manual. Capturing the pre-run state lets the run that *establishes* the
+      // link skip that import — the membership-provenance guard (#2663)
+      // otherwise reads the link state too late (after handleCollection has
+      // already linked it) and never skips.
+      //
+      // Be honest about the scope: this only suppresses the import on the run
+      // that adopts the collection. On the NEXT run the collection is already
+      // linked (collectionLinkedBeforeRun === true), so the import runs and the
+      // pre-existing, rule-unselected items get tracked as manual then. We can't
+      // distinguish "was on the BoxSet at adoption time" from "the user added it
+      // to the BoxSet afterwards" without persisted provenance, so the guard
+      // only removes the noisy first-run flood — a long-lived adopted collection
+      // still absorbs its foreign items as manual on a later run.
+      const collectionLinkedBeforeRun = ruleGroup.collection?.id
+        ? Boolean(
+            (
+              await this.collectionService.getCollection(
+                ruleGroup.collection.id,
+              )
+            )?.mediaServerId,
+          )
+        : false;
+
       if (ruleGroup.useRules) {
         this.logger.log(`Executing rules for '${ruleGroup.name}'`);
         this.startTime = new Date();
@@ -290,6 +318,7 @@ export class RuleExecutorService {
       await this.syncManualMediaServerToCollectionDB(
         await this.rulesService.getRuleGroupById(ruleGroup.id), // refetch to get latest changes
         collectionSyncChanges,
+        collectionLinkedBeforeRun,
       );
     } catch (error) {
       const executionBeingAborted =
@@ -339,9 +368,13 @@ export class RuleExecutorService {
   private async syncManualMediaServerToCollectionDB(
     rulegroup: RuleGroup,
     collectionSyncChanges: CollectionMembershipSyncChanges,
+    collectionLinkedBeforeRun?: boolean,
   ) {
     if (rulegroup && rulegroup.collectionId) {
-      const syncContext = await this.getCollectionForMediaServerSync(rulegroup);
+      const syncContext = await this.getCollectionForMediaServerSync(
+        rulegroup,
+        collectionLinkedBeforeRun,
+      );
       const collection = syncContext.collection;
 
       if (collection) {
@@ -530,6 +563,7 @@ export class RuleExecutorService {
 
   private async getCollectionForMediaServerSync(
     rulegroup: RuleGroup,
+    collectionLinkedBeforeRun?: boolean,
   ): Promise<MediaServerSyncContext> {
     const collection = await this.collectionService.getCollection(
       rulegroup.collectionId,
@@ -560,7 +594,14 @@ export class RuleExecutorService {
         : { collection: relinkedCollection };
     }
 
-    const wasLinkedBeforeSync = Boolean(collection.mediaServerId);
+    // Prefer the link state captured BEFORE this run (handleCollection may have
+    // linked a freshly created collection to a pre-existing server collection
+    // in the meantime). A collection linked only during this run must skip the
+    // manual child import so it does not absorb that server collection's
+    // existing contents as manual members. Falls back to the collection's
+    // current link state when the caller didn't capture the pre-run snapshot.
+    const wasLinkedBeforeSync =
+      collectionLinkedBeforeRun ?? Boolean(collection.mediaServerId);
 
     const linkedCollection =
       await this.collectionService.checkAutomaticMediaServerLink(collection);


### PR DESCRIPTION
Closes #3129.

Jellyfin/Emby BoxSets are **not** auto-deleted when they go empty, and a BoxSet drains when its underlying items are re-imported with new ids while Maintainerr's DB keeps the rows. The empty-collection heal in `checkAutomaticMediaServerLink` was Plex-only, so an automatic Jellyfin/Emby collection could sit empty on the server with no path to recover — "exists but empty" while Maintainerr looks fine.

**The heal (Jellyfin/Emby):**
- **Repopulate in place** — re-add rule-owned DB items missing from the BoxSet (empty BoxSets accept adds, so the BoxSet id and its overlays/poster stay stable; re-add is idempotent).
- **Delete when genuinely empty** — remove a confirmed-empty, non-shared collection so it doesn't linger. Gated on the media server's reported `childCount` (a successful read that distinguishes empty from a transient child-enumeration failure, which returns `[]`), plus an empty live read, no rule-owned item to re-add, and the collection not being shared. Plex behaviour is unchanged.

**Also in this PR:**
- Corrected two stale comments claiming Jellyfin auto-deletes empty collections.
- `fix(rules)`: skip the manual child-import on the run that *links* an automatic collection to a pre-existing, same-named BoxSet, so its existing contents aren't flooded in as **manual** at adoption time. The membership-provenance guard (#2663) read the link state too late (in the sync phase, after `handleCollection` had already linked it) and never skipped; it now uses a snapshot taken before the run. **Scope (documented honestly in code):** this suppresses only the first-run flood — on a later run the collection is already linked, so the import runs and pre-existing, rule-unselected items get tracked as manual then. Distinguishing adoption-time contents from items the user adds to the BoxSet afterwards needs persisted provenance and is out of scope.

Verified against a real Jellyfin 10.11.11 (full app, real adapter) across the heal edge cases, plus unit coverage for the delete-safety gate and the manual-import snapshot.