### PR TITLE
fix(collections): don't resurrect a deleted collection's media-server link

### DIFF
--- a/apps/server/src/modules/collections/collection-handler.spec.ts
+++ b/apps/server/src/modules/collections/collection-handler.spec.ts
@@ -511,6 +511,42 @@ describe('CollectionHandler', () => {
     );
   });
 
+  it('persists the cleared link when removing the last item empties (and deletes) the collection', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      type: 'movie',
+      mediaServerId: 'dead-boxset-id',
+    });
+    const collectionMedia = createCollectionMedia(collection);
+
+    mediaServer.getLibraries.mockResolvedValue(
+      createMediaLibraries({
+        id: collection.libraryId.toString(),
+        type: 'movie',
+      }),
+    );
+
+    // Removing the last item empties the collection: removeFromCollection
+    // deletes the media-server BoxSet and returns the persisted collection with
+    // mediaServerId cleared.
+    collectionsService.removeFromCollection.mockResolvedValue({
+      ...collection,
+      mediaServerId: null,
+    } as typeof collection);
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    // The post-handle save must carry the cleared link forward — saving the
+    // stale snapshot would resurrect the dead BoxSet id and force the next rule
+    // run to rediscover it via a 404.
+    expect(collectionsService.saveCollection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaServerId: null,
+        handledMediaAmount: 1,
+      }),
+    );
+  });
+
   it('should call removeMediaByTmdbId for movies', async () => {
     const collection = createCollection({
       arrAction: ServarrAction.DELETE,

--- a/apps/server/src/modules/collections/collection-handler.ts
+++ b/apps/server/src/modules/collections/collection-handler.ts
@@ -210,11 +210,23 @@ export class CollectionHandler {
       }
     }
 
-    await this.collectionService.removeFromCollection(collection.id, [
-      {
-        mediaServerId: media.mediaServerId,
-      },
-    ]);
+    // Removing the last item empties the collection, which deletes the
+    // media-server collection and clears `mediaServerId` in the DB. Continue
+    // from the persisted result, not the stale snapshot passed in: the
+    // `saveCollection` below would otherwise rewrite the whole row and
+    // resurrect the now-dead `mediaServerId`, leaving a link the next rule run
+    // can only discover via a 404.
+    const updatedCollection = await this.collectionService.removeFromCollection(
+      collection.id,
+      [
+        {
+          mediaServerId: media.mediaServerId,
+        },
+      ],
+    );
+    if (updatedCollection) {
+      collection = updatedCollection;
+    }
 
     // The file is gone after a disk-freeing action (DELETE, DELETE_SHOW_IF_EMPTY,
     // and the UNMONITOR_DELETE_* variants all delete files), but the item still


### PR DESCRIPTION
When handling the last item empties an automatic collection, `removeFromCollection` deletes the media-server collection and clears `mediaServerId` in the DB. `handleMedia` discarded that result, then `saveCollection`-ed its stale snapshot and wrote the dead `mediaServerId` back onto the row.

The next rule run then finds a dangling link it can only resolve via a `getCollection` 404 (the AxiosError noise in the logs) before the heal clears it. Verified against a live Jellyfin 10.11.11: emptying a BoxSet does not auto-delete it — Maintainerr's own empty-collection cleanup does — so the resurrected link points at an id that no longer exists.

Continue from `removeFromCollection`'s returned collection so the post-handle save carries the cleared link forward — matching what the rule executor already does.