### PR TITLE
fix(servarr): fail closed on transient Radarr action-handler lookups

### DIFF
--- a/apps/server/src/modules/actions/radarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/radarr-action-handler.spec.ts
@@ -129,6 +129,59 @@ describe('RadarrActionHandler', () => {
     validateNoRadarrActionsTaken(mockedRadarrApi);
   });
 
+  it('should fail closed without deleting when the Radarr lookup is transient (undefined) and action is DELETE', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      radarrSettingsId: 1,
+      type: 'movie',
+    });
+    const collectionMedia = createCollectionMedia(collection, {
+      tmdbId: 1,
+    });
+
+    const mockedRadarrApi = mockRadarrApi(servarrService, logger);
+    // undefined = transient lookup failure (vs. null = confirmed not tracked).
+    jest
+      .spyOn(mockedRadarrApi, 'getMovieByTmdbId')
+      .mockResolvedValue(undefined);
+
+    const result = await radarrActionHandler.handleAction(
+      collection,
+      collectionMedia,
+    );
+
+    expect(result).toBe(false);
+    expect(mediaServer.deleteFromDisk).not.toHaveBeenCalled();
+    validateNoRadarrActionsTaken(mockedRadarrApi);
+  });
+
+  it('should remove via media server when the movie is confirmed not tracked (null) and action is DELETE', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      radarrSettingsId: 1,
+      type: 'movie',
+    });
+    const collectionMedia = createCollectionMedia(collection, {
+      tmdbId: 1,
+    });
+
+    const mockedRadarrApi = mockRadarrApi(servarrService, logger);
+    // null = Radarr confirmed the movie isn't tracked, so fall back to the
+    // media-server delete (the guard above must not swallow this path).
+    jest.spyOn(mockedRadarrApi, 'getMovieByTmdbId').mockResolvedValue(null);
+
+    const result = await radarrActionHandler.handleAction(
+      collection,
+      collectionMedia,
+    );
+
+    expect(result).toBe(true);
+    expect(mediaServer.deleteFromDisk).toHaveBeenCalledWith(
+      collectionMedia.mediaServerId,
+    );
+    validateNoRadarrActionsTaken(mockedRadarrApi);
+  });
+
   it.each([
     { action: ServarrAction.DELETE, title: 'DELETE' },
     {

--- a/apps/server/src/modules/actions/radarr-action-handler.ts
+++ b/apps/server/src/modules/actions/radarr-action-handler.ts
@@ -50,6 +50,16 @@ export class RadarrActionHandler {
       });
       const radarrMedia = matchedResult?.result;
 
+      if (radarrMedia === undefined) {
+        // Transient Radarr lookup failure (vs. null = confirmed not tracked):
+        // fail closed instead of falling through to a media-server delete on a
+        // blip. The item stays in the collection and is retried next run. (#3125)
+        this.logger.log(
+          `Couldn't reach Radarr to resolve a movie for media server item ${media.mediaServerId}. No action was taken; will retry next run.`,
+        );
+        return false;
+      }
+
       if (radarrMedia?.id) {
         const matchedProvider =
           matchedResult.candidate.providerKey.toUpperCase();


### PR DESCRIPTION
Follow-up to #3128, which fixed the same transient-failure data-loss path for the **Sonarr** action handler but left the **Radarr** one exposed (it was wrongly assumed already fail-safe).

A transient Radarr lookup (timeout / 5xx, worst under heavy *arr load) makes `getMovieByTmdbId` return `undefined`. The Radarr action handler treated that the same as a confirmed miss and, on any DELETE-class action, fell through to `mediaServer.deleteFromDisk()` — irreversibly deleting a file Radarr still tracks.

- Fail closed on `radarrMedia === undefined` (`return false`): the collection-handler's `itemExists` check then keeps the item and retries next run, matching the Sonarr handler.
- `null` (Radarr confirmed not tracked) is unchanged — it still removes via the media server.
- Adds two specs: transient `undefined` + DELETE → no disk delete; confirmed `null` + DELETE → disk delete still fires.

Closes the Radarr half of #3125.