### PR TITLE
fix(ui): standardize action buttons on the shared Button + consistent theme colors

### DIFF
--- a/apps/ui/src/components/Collection/CollectionDetail/CollectionInfo/CollectionLogsTable.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/CollectionInfo/CollectionLogsTable.tsx
@@ -122,7 +122,7 @@ const CollectionLogsTable = ({
                       isMetaActionedByRule(row.meta) && (
                         <button
                           type="button"
-                          className="rounded-sm bg-maintainerr-600 px-2 py-1 text-white shadow-md hover:bg-maintainerr"
+                          className="rounded-md bg-maintainerr-600 px-2 py-1 text-white shadow-md hover:bg-maintainerr"
                           title="View Metadata"
                           onClick={() => {
                             if (!isMetaActionedByRule(row.meta)) return

--- a/apps/ui/src/components/Common/Button/index.tsx
+++ b/apps/ui/src/components/Common/Button/index.tsx
@@ -72,7 +72,7 @@ function Button<P extends ElementTypes = 'button'>({
       break
     case 'ghost':
       buttonStyle.push(
-        'text-white bg-transaprent border-zinc-600 hover:border-zinc-200 focus:border-zinc-100 rounded-md active:border-zinc-100',
+        'text-white bg-transparent border-zinc-600 hover:border-zinc-200 focus:border-zinc-100 rounded-md active:border-zinc-100',
       )
       break
     case 'twin-primary-l':

--- a/apps/ui/src/components/Common/CommunityRuleModal/index.tsx
+++ b/apps/ui/src/components/Common/CommunityRuleModal/index.tsx
@@ -345,18 +345,16 @@ const CommunityRuleModal = (props: ICommunityRuleModal) => {
                 />
               </span>
               <span className="float-right">
-                <button
-                  disabled={false}
-                  className="mb-2 flex h-9 w-fit rounded-sm bg-zinc-900 text-zinc-200 shadow-md hover:bg-zinc-800 disabled:opacity-50 md:ml-2"
+                <Button
+                  buttonType="success"
+                  className="mb-2 md:ml-2"
                   onClick={() => {
                     setUploadMyRules(true)
                   }}
                 >
-                  {<UploadIcon className="m-auto ml-5 h-5" />}{' '}
-                  <p className="rules-button-text m-auto mr-5 ml-1">
-                    Upload my rules
-                  </p>
-                </button>
+                  <UploadIcon className="mr-2 h-5 w-5" />
+                  Upload my rules
+                </Button>
               </span>
             </div>
             <Pagination

--- a/apps/ui/src/components/Common/InfoButton/index.tsx
+++ b/apps/ui/src/components/Common/InfoButton/index.tsx
@@ -1,4 +1,5 @@
 import { InformationCircleIcon } from '@heroicons/react/solid'
+import Button from '../Button'
 
 interface IInfoButton {
   text: string
@@ -8,14 +9,15 @@ interface IInfoButton {
 
 const InfoButton = (props: IInfoButton) => {
   return (
-    <button
+    <Button
+      buttonType="success"
       disabled={props.enabled !== undefined ? !props.enabled : false}
-      className="mb-2 flex h-9 w-24 rounded-sm bg-maintainerr-600 text-zinc-200 shadow-md hover:bg-maintainerr disabled:opacity-50 md:ml-2"
+      className="mb-2 md:ml-2"
       onClick={props.onClick}
     >
-      {<InformationCircleIcon className="m-auto ml-5 h-5" />}{' '}
-      <p className="rules-button-text m-auto mr-5 ml-1">{props.text}</p>
-    </button>
+      <InformationCircleIcon className="mr-2 h-5 w-5" />
+      {props.text}
+    </Button>
   )
 }
 

--- a/apps/ui/src/components/Common/Pagination/index.tsx
+++ b/apps/ui/src/components/Common/Pagination/index.tsx
@@ -29,7 +29,7 @@ const Pagination = (props: IPagination) => {
         {props.currentPage === 1 ? undefined : (
           <button
             onClick={() => props.handleBackward()}
-            className="rounded-l bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+            className="rounded-l bg-zinc-600 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-500"
           >
             Prev{' '}
           </button>
@@ -38,7 +38,7 @@ const Pagination = (props: IPagination) => {
           <button
             onClick={() => props.handleForward()}
             className={
-              'rounded-r border-0 border-l border-gray-700 bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800'
+              'rounded-r border-0 border-l border-zinc-700 bg-zinc-600 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-500'
             }
           >
             Next

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -1647,46 +1647,37 @@ const AddModal = (props: AddModal) => {
                       </p>
                     </div>
                     <div className="ml-auto">
-                      <button
-                        className="ml-3 flex h-fit rounded-sm bg-maintainerrdark p-1 text-sm text-zinc-900 shadow-md hover:bg-maintainerrdark-800 md:h-10 md:text-base"
+                      <Button
+                        buttonType="success"
+                        className="ml-3"
                         onClick={toggleCommunityRuleModal}
                         type="button"
                       >
-                        {
-                          <CloudDownloadIcon className="m-auto ml-4 h-6 w-6 text-zinc-200" />
-                        }
-                        <p className="button-text m-auto mr-4 ml-1 text-zinc-100">
-                          Community
-                        </p>
-                      </button>
+                        <CloudDownloadIcon className="mr-2 h-5 w-5" />
+                        Community
+                      </Button>
                     </div>
                   </div>
                   <div className="mt-4 flex items-center justify-center sm:justify-end">
-                    <button
-                      className="ml-3 flex h-fit rounded-sm bg-maintainerr-600 p-1 text-sm text-zinc-900 shadow-md hover:bg-maintainerr md:h-10 md:text-base"
+                    <Button
+                      buttonType="success"
+                      className="ml-3"
                       onClick={toggleYamlImporter}
                       type="button"
                     >
-                      {
-                        <DownloadIcon className="m-auto ml-4 h-6 w-6 text-zinc-200 md:h-6" />
-                      }
-                      <p className="button-text m-auto mr-4 ml-1 text-zinc-100">
-                        Import
-                      </p>
-                    </button>
+                      <DownloadIcon className="mr-2 h-5 w-5" />
+                      Import
+                    </Button>
 
-                    <button
-                      className="ml-3 flex h-fit rounded-sm bg-maintainerrdark p-1 text-sm shadow-md hover:bg-maintainerrdark-800 md:h-10 md:text-base"
+                    <Button
+                      buttonType="success"
+                      className="ml-3"
                       onClick={toggleYamlExporter}
                       type="button"
                     >
-                      {
-                        <UploadIcon className="m-auto ml-4 h-6 w-6 text-zinc-200" />
-                      }
-                      <p className="button-text m-auto mr-4 ml-1 text-zinc-100">
-                        Export
-                      </p>
-                    </button>
+                      <UploadIcon className="mr-2 h-5 w-5" />
+                      Export
+                    </Button>
                   </div>
                 </div>
                 {showCommunityModal && selectedLibraryType && (

--- a/apps/ui/src/components/Settings/Notifications/index.tsx
+++ b/apps/ui/src/components/Settings/Notifications/index.tsx
@@ -103,7 +103,7 @@ const NotificationSettings = () => {
             <li className="flex h-full items-center justify-center rounded-xl border-2 border-dashed border-gray-400 bg-zinc-800 p-4 text-zinc-400 shadow-sm">
               <button
                 type="button"
-                className="add-button m-auto flex h-9 rounded-sm bg-maintainerr-600 px-4 text-zinc-200 shadow-md hover:bg-maintainerr"
+                className="add-button m-auto flex h-9 rounded-md bg-maintainerr-600 px-4 text-zinc-200 shadow-md hover:bg-maintainerr"
                 onClick={() => updateAddModalActive(!addModalActive)}
               >
                 {<PlusCircleIcon className="m-auto h-5" />}

--- a/apps/ui/src/components/Settings/Radarr/index.tsx
+++ b/apps/ui/src/components/Settings/Radarr/index.tsx
@@ -161,7 +161,7 @@ const RadarrSettings = () => {
             <li className="flex h-full min-h-39 items-center justify-center rounded-xl border-2 border-dashed border-gray-400 bg-zinc-800 p-4 text-zinc-400 shadow-sm">
               <button
                 type="button"
-                className="add-button m-auto flex h-9 rounded-sm bg-maintainerr-600 px-4 text-zinc-200 shadow-md hover:bg-maintainerr"
+                className="add-button m-auto flex h-9 rounded-md bg-maintainerr-600 px-4 text-zinc-200 shadow-md hover:bg-maintainerr"
                 onClick={showAddModal}
               >
                 {<PlusCircleIcon className="m-auto h-5" />}

--- a/apps/ui/src/components/Settings/Sonarr/index.tsx
+++ b/apps/ui/src/components/Settings/Sonarr/index.tsx
@@ -161,7 +161,7 @@ const SonarrSettings = () => {
             <li className="flex h-full min-h-39 items-center justify-center rounded-xl border-2 border-dashed border-gray-400 bg-zinc-800 p-4 text-zinc-400 shadow-sm">
               <button
                 type="button"
-                className="add-button m-auto flex h-9 rounded-sm bg-maintainerr-600 px-4 text-zinc-200 shadow-md hover:bg-maintainerr"
+                className="add-button m-auto flex h-9 rounded-md bg-maintainerr-600 px-4 text-zinc-200 shadow-md hover:bg-maintainerr"
                 onClick={showAddModal}
               >
                 {<PlusCircleIcon className="m-auto h-5" />}


### PR DESCRIPTION
Several buttons bypassed the shared `Button` component with inline styles, producing inconsistent corner radii (`rounded-sm` vs `rounded-md`), text sizes/weights, and an arbitrary bright-vs-dark amber split (e.g. the rule toolbar's Import was bright `maintainerr-600` while its peers Export/Community were dark `maintainerrdark`; the community modal had a one-off black `bg-zinc-900` button; pagination Prev/Next were near-black).

Both `bg-maintainerr` and `bg-maintainerrdark` are kept — they're just applied consistently now, via the shared `Button`, with a coherent hierarchy:

- **primary action** → `maintainerr` (bright)
- **secondary brand action** → `maintainerrdark` (dark)
- **neutral** → `zinc`

Changes:
- Rule group toolbar (Community / Import / Export): raw `<button>`s → `Button` (`success`)
- Community rule modal: `InfoButton` + "Upload my rules" → `Button` (`success`); drops the one-off black `bg-zinc-900` button
- `Pagination`: `bg-zinc-900` (near-black) → `zinc-600` neutral (matches Cancel)
- Radarr / Sonarr / Notifications "Add" buttons + collection log button: `rounded-sm` → `rounded-md`
- `Button`: fix `ghost` variant typo `bg-transaprent` → `bg-transparent`