### PR TITLE
fix(ui): align ExecuteButton corner radius with the shared Button

### DIFF
--- a/apps/ui/src/components/Common/ExecuteButton/index.tsx
+++ b/apps/ui/src/components/Common/ExecuteButton/index.tsx
@@ -12,7 +12,7 @@ interface IExecuteButton {
 const ExecuteButton = (props: IExecuteButton) => {
   return (
     <button
-      className="edit-button m-auto flex h-9 rounded-sm text-zinc-200 shadow-md"
+      className="edit-button m-auto flex h-9 rounded-md text-zinc-200 shadow-md"
       onClick={props.onClick}
       disabled={props.disabled}
       title={props.title}


### PR DESCRIPTION
Follow-up to #3143. `ExecuteButton` was the last action button still on `rounded-sm` while the shared `Button` (and the rest of the action buttons) use `rounded-md` — bringing it in line. (Edit/Delete stay as the deliberate responsive joined pair; badges/FAB/toggle keep their intentional radii.)