### PR TITLE
fix(server): log benign SSE client disconnects without a stack trace

### DIFF
--- a/apps/server/src/modules/events/events.controller.ts
+++ b/apps/server/src/modules/events/events.controller.ts
@@ -24,6 +24,7 @@ import { IncomingMessage } from 'http';
 import { interval, Subscription } from 'rxjs';
 import { createSseStreamClient, SseStreamClient } from '../../utils/sse-stream';
 import { MaintainerrLogger } from '../logging/logs.service';
+import { isBrokenPipeError } from '../logging/winston/stdioPipeGuard';
 import { EventsBufferService } from './events-buffer.service';
 
 @Controller('/api/events')
@@ -76,6 +77,13 @@ export class EventsController implements BeforeApplicationShutdown {
         this.connectedClients.delete(clientKey);
       },
       onError: (error) => {
+        // A client disconnecting mid-write surfaces as a broken pipe (EPIPE /
+        // ERR_STREAM_DESTROYED). That's expected for SSE, so log it concisely
+        // instead of dumping a full error stack.
+        if (isBrokenPipeError(error)) {
+          this.logger.debug('SSE client disconnected before a write completed');
+          return;
+        }
         this.logger.debug(error);
       },
     });

--- a/apps/server/src/modules/logging/winston/stdioPipeGuard.ts
+++ b/apps/server/src/modules/logging/winston/stdioPipeGuard.ts
@@ -1,6 +1,6 @@
 const BROKEN_PIPE_CODES = new Set(['EPIPE', 'ERR_STREAM_DESTROYED']);
 
-const isBrokenPipeError = (error: unknown): boolean => {
+export const isBrokenPipeError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') return false;
   const code = (error as NodeJS.ErrnoException).code;
   return typeof code === 'string' && BROKEN_PIPE_CODES.has(code);


### PR DESCRIPTION
Investigated the `write EPIPE` lines in the logs: they come from `EventsController`'s SSE stream (`/api/events/stream`) when a browser disconnects mid-write (tab close / navigate). It's a **benign client disconnect** — the stream already cleans up — but the `onError` handler logged the full `Error: write EPIPE` stack at debug.

This reuses the existing `isBrokenPipeError` guard (EPIPE / ERR_STREAM_DESTROYED) so broken pipes log a single concise line; genuine SSE errors still log verbosely. No behavior change beyond log noise.