### PR TITLE
fix: don't mutate shared Sonarr season array in part_of_latest_season (#3153)

### DIFF
--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
@@ -18,6 +18,7 @@ import { ServarrService } from '../../api/servarr-api/servarr.service';
 import { CollectionMedia } from '../../collections/entities/collection_media.entities';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { MetadataService } from '../../metadata/metadata.service';
+import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 import { SonarrGetterService } from './sonarr-getter.service';
 
 describe('SonarrGetterService', () => {
@@ -241,6 +242,89 @@ describe('SonarrGetterService', () => {
           );
 
           expect(response).toBe(false);
+        },
+      );
+    });
+
+    // #3153: in a full run the comparator resolves several of a show's seasons
+    // concurrently, all sharing ONE memoized `showResponse.seasons` array via the
+    // run-scoped ArrLookupCache. The latest-aired-season scan must not mutate that
+    // shared array, or evaluating one season corrupts the answer for the others.
+    // (Test Media passes no cache, so it never hit this — hence the run/test split.)
+    describe('shared ArrLookupCache across show seasons (#3153)', () => {
+      it.each([
+        { type: 'season', title: 'SEASONS' },
+        { type: 'episode', title: 'EPISODES' },
+      ])(
+        'evaluating an earlier season first does not flip the latest aired season for $title',
+        async ({ type }: { type: string }) => {
+          jest.useFakeTimers().setSystemTime(new Date('2025-06-01'));
+
+          const collectionMedia = createCollectionMedia(type as MediaItemType);
+          collectionMedia.collection.sonarrSettingsId = 1;
+
+          mockMediaServer.getMetadata.mockResolvedValue(
+            createMediaItem({ type: 'show' }),
+          );
+
+          // S0/S1/S2 episode 1 already aired; S3 episode 1 is in the future, so
+          // the latest *aired* season is S2.
+          const series = createSonarrSeries({
+            seasons: [
+              { seasonNumber: 0, monitored: false },
+              { seasonNumber: 1, monitored: true },
+              { seasonNumber: 2, monitored: true },
+              { seasonNumber: 3, monitored: true },
+            ],
+          });
+
+          const airDateUtcBySeason: Record<number, string> = {
+            0: '2024-01-01T00:00:00Z',
+            1: '2024-06-25T00:00:00Z',
+            2: '2025-04-01T00:00:00Z',
+            3: '2025-12-01T00:00:00Z',
+          };
+
+          const mockedSonarrApi = mockSonarrApi(series);
+          jest
+            .spyOn(mockedSonarrApi, 'getEpisodes')
+            .mockImplementation((seriesId, seasonNumber) =>
+              Promise.resolve([
+                createSonarrEpisode({
+                  seriesId,
+                  seasonNumber,
+                  episodeNumber: 1,
+                  airDateUtc: airDateUtcBySeason[seasonNumber as number],
+                }),
+              ]),
+            );
+
+          const evaluate = (seasonNumber: number, cache: ArrLookupCache) =>
+            sonarrGetterService.get(
+              13,
+              createMediaItem({
+                type: type === 'episode' ? 'episode' : 'season',
+                index: seasonNumber,
+                parentIndex: type === 'episode' ? seasonNumber : undefined,
+              }),
+              type as MediaItemType,
+              createRulesDto({
+                collection: collectionMedia.collection,
+                dataType: type as MediaItemType,
+              }),
+              undefined,
+              cache,
+            );
+
+          // One run-shared cache, exactly as the comparator wires it. Evaluating
+          // the older S1 first must not corrupt the shared season array and flip
+          // S2 (the real latest aired season) to false.
+          const cache = new ArrLookupCache();
+          const s1 = await evaluate(1, cache);
+          const s2 = await evaluate(2, cache);
+
+          expect(s1).toBe(false);
+          expect(s2).toBe(true);
         },
       );
     });

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -507,14 +507,17 @@ export class SonarrGetterService {
    *
    * @param {SonarrSeason[]} seasons - The array of seasons to search through.
    * @param {number} showId - The ID of the show.
-   * @return {Promise<SonarrSeason>} The last season found, or undefined if none is found.
+   * @return {Promise<SonarrSeason | undefined>} The last season found, or undefined if none is found.
    */
   private async getLastAiredOrCurrentlyAiringSeason(
     seasons: SonarrSeason[],
     showId: number,
     apiClient: SonarrApi,
-  ): Promise<SonarrSeason> {
-    for (const s of seasons.reverse()) {
+  ): Promise<SonarrSeason | undefined> {
+    // `seasons` belongs to the run-shared memoized series; reversing in place
+    // corrupts season order for the show's other (concurrently evaluated)
+    // seasons (#3153). Reverse a copy.
+    for (const s of [...seasons].reverse()) {
       const epResp = await apiClient.getEpisodes(showId, s.seasonNumber, [1]);
 
       if (epResp[0]?.airDateUtc === undefined) {

--- a/tools/dev/fake-plex.mjs
+++ b/tools/dev/fake-plex.mjs
@@ -145,24 +145,35 @@ const MOVIES = [
 ];
 
 // --- Show / seasons / episodes (section 2) -----------------------------------
+// tvdb id stamped on the show's Guid[] so the Sonarr getter resolves it through
+// fake-sonarr (which maps any tvdbId to a deterministic 4-season series).
+const SHOW_TVDB_ID = 990013;
 const SHOW = baseItem('sh1', 'show', 'Mock Series One', {
   leafCount: 2,
   viewedLeafCount: 1, // sw_markedWatchedEpisodes
-  childCount: 1,
+  childCount: 4,
   addedAt: daysAgo(200),
   originallyAvailableAt: '2023-01-01',
+  Guid: [{ id: `tvdb://${SHOW_TVDB_ID}` }],
   Role: ROLE,
   Genre: GENRE,
   Label: [{ id: 1, tag: 'Keep' }],
   Collection: [{ tag: 'Box Set' }],
 });
-const SEASON = baseItem('se1', 'season', 'Season 1', {
-  parentRatingKey: 'sh1',
-  index: 1,
-  leafCount: 2,
-  addedAt: daysAgo(200),
-  Collection: [{ tag: 'Box Set' }, { tag: 'Season Set' }],
-});
+// Four seasons drive the #3153 part_of_latest_season repro: fake-sonarr dates
+// S0/S1/S2 episode 1 in the past and S3 in the future, so the latest aired season
+// is S2. Evaluated together in one run they share a memoized series object — the
+// case the in-place season reverse corrupted. Season 1 keeps the episodes the
+// sw_* episode rules use.
+const SEASONS = [0, 1, 2, 3].map((n) =>
+  baseItem(`se${n}`, 'season', `Season ${n}`, {
+    parentRatingKey: 'sh1',
+    index: n,
+    leafCount: n === 1 ? 2 : 1,
+    addedAt: daysAgo(200),
+    Collection: n === 1 ? [{ tag: 'Box Set' }, { tag: 'Season Set' }] : [],
+  }),
+);
 const EPISODES = [
   baseItem('ep1', 'episode', 'Episode One', {
     parentRatingKey: 'se1',
@@ -185,12 +196,12 @@ const EPISODES = [
   }),
 ];
 
-const ALL_ITEMS = [...MOVIES, SHOW, SEASON, ...EPISODES];
+const ALL_ITEMS = [...MOVIES, SHOW, ...SEASONS, ...EPISODES];
 const ITEMS_BY_ID = new Map(ALL_ITEMS.map((m) => [m.ratingKey, m]));
 
-// children: show -> [season], season -> [episodes]
+// children: show -> [seasons], season 1 -> [episodes]
 const CHILDREN = {
-  sh1: [SEASON],
+  sh1: SEASONS,
   se1: EPISODES,
 };
 
@@ -294,10 +305,16 @@ const server = http.createServer((req, res) => {
   // Libraries
   if (path === '/library/sections') return send(res, 200, list('Directory', SECTIONS));
 
-  // Section contents: /library/sections/:id/all
+  // Section contents: /library/sections/:id/all. The rule executor passes Plex's
+  // numeric data type (EPlexDataType: movie=1, show=2, season=3, episode=4) so a
+  // season-scoped rule group enumerates seasons, not the show.
   const allMatch = path.match(/^\/library\/sections\/([^/]+)\/all$/);
   if (allMatch) {
-    const items = allMatch[1] === '2' ? [SHOW] : MOVIES;
+    let items = MOVIES;
+    if (allMatch[1] === '2') {
+      const type = u.searchParams.get('type');
+      items = type === '3' ? SEASONS : type === '4' ? EPISODES : [SHOW];
+    }
     return send(res, 200, list('Metadata', items));
   }
 

--- a/tools/dev/fake-sonarr.mjs
+++ b/tools/dev/fake-sonarr.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Dev-only mock Sonarr (v3 API) HTTP server for Maintainerr.
+ *
+ * Maintainerr's Sonarr client (apps/server/.../servarr-api/helpers/sonarr.helper.ts)
+ * talks to a real Sonarr over HTTP. The fake media servers (fake-plex / fake-jellyfin)
+ * don't cover Sonarr, so the show/season getter paths can't be exercised from a DB
+ * seed alone. This stub answers the handful of endpoints those getters need so the
+ * whole thing can be driven without a real Sonarr.
+ *
+ * It exists to reproduce #3153: the `part_of_latest_season` getter scans a show's
+ * seasons newest-first to find the latest *aired* season, probing season episode 1's
+ * airDateUtc. The seeded show therefore has four seasons whose episode-1 air dates are
+ * past, past, past, future — so the latest aired season is S2 and only the live full
+ * run (which shares one memoized series object across the show's seasons) ever
+ * mis-evaluated it. The two endpoints the getter actually calls are answered here:
+ *   - GET /series?tvdbId=<id>            -> the resolved series (getSeriesByTvdbId)
+ *   - GET /episode?seriesId=<id>&seasonNumber=<n> -> that season's episodes
+ *
+ * Like fake-radarr, any tvdbId resolves to a deterministic series (series id == tvdbId)
+ * so a media item carrying any tvdb id pairs straight through. It is intentionally
+ * minimal and invented — no real media names (repo rule).
+ *
+ * Usage
+ * -----
+ *   node tools/dev/fake-sonarr.mjs                 # listens on :8989 (matches dev seed)
+ *   FAKE_SONARR_PORT=8989 node tools/dev/fake-sonarr.mjs
+ *   FAKE_SONARR_LOG=0 node tools/dev/fake-sonarr.mjs   # silence the per-request log
+ *
+ * The dev seed (tools/dev/seed-db.mjs) points sonarr_settings.url at
+ * http://localhost:8989, so no settings change is needed — start this before (or
+ * alongside) `yarn dev`, then trigger a run with `POST /api/rules/:id/execute` or a
+ * single-item check with `POST /api/rules/test`.
+ */
+import http from "node:http";
+
+const PORT = Number(process.env.FAKE_SONARR_PORT ?? 8989);
+const LOG = process.env.FAKE_SONARR_LOG !== "0";
+
+const DAY = 86_400_000;
+// Captured once so a process' answers stay stable across its lifetime.
+const NOW = Date.now();
+const iso = (msFromNow) => new Date(NOW + msFromNow).toISOString();
+
+// Four seasons; specials (0) plus three numbered. Episode 1's air date per season
+// decides "latest aired": S0/S1/S2 already aired, S3 airs in the future, so the
+// latest aired season is S2. The race this mock exists to expose collapsed that to
+// the earliest aired season on a full run.
+const SEASON_NUMBERS = [0, 1, 2, 3];
+const SEASON_EP1_AIR_OFFSET_DAYS = { 0: -900, 1: -400, 2: -30, 3: 400 };
+
+const seasonsFor = () =>
+  SEASON_NUMBERS.map((seasonNumber) => ({
+    seasonNumber,
+    monitored: seasonNumber !== 0,
+    statistics: {
+      episodeFileCount: 1,
+      episodeCount: 1,
+      totalEpisodeCount: 1,
+      sizeOnDisk: 1024 ** 3,
+      percentOfEpisodes: 100,
+    },
+  }));
+
+// A deterministic series for any requested tvdbId — id and tvdbId are kept equal so
+// getEpisodes(seriesId=...) resolves straight back to the same show.
+const seriesFor = (tvdbId) => ({
+  id: tvdbId,
+  tvdbId,
+  title: `Mock Series ${tvdbId}`,
+  sortTitle: `mock series ${tvdbId}`,
+  status: "continuing",
+  ended: false,
+  added: iso(-1000 * DAY),
+  firstAired: iso(-900 * DAY),
+  monitored: true,
+  qualityProfileId: 1,
+  seriesType: "standard",
+  path: `/tv/mock-${tvdbId}`,
+  seasonFolder: true,
+  tags: [],
+  genres: ["Drama"],
+  originalLanguage: { id: 1, name: "English" },
+  ratings: { votes: 100, value: 8 },
+  seasons: seasonsFor(),
+  statistics: {
+    seasonCount: SEASON_NUMBERS.length - 1,
+    episodeFileCount: 3,
+    episodeCount: 3,
+    totalEpisodeCount: 4,
+    sizeOnDisk: 3 * 1024 ** 3,
+    percentOfEpisodes: 100,
+  },
+});
+
+// Episode 1 of a season, dated so the getter's airDateUtc comparison classifies the
+// season as aired/unaired. Sonarr returns every episode for the season; the client
+// filters to episodeNumber 1 itself, so one episode is enough.
+const episodesFor = (seriesId, seasonNumber) => {
+  const offsetDays = SEASON_EP1_AIR_OFFSET_DAYS[seasonNumber] ?? -100;
+  const airDateUtc = iso(offsetDays * DAY);
+  return [
+    {
+      id: seriesId * 100 + seasonNumber,
+      seriesId,
+      seasonNumber,
+      episodeNumber: 1,
+      title: `S${seasonNumber}E1`,
+      airDate: airDateUtc.slice(0, 10),
+      airDateUtc,
+      hasFile: offsetDays < 0,
+      monitored: seasonNumber !== 0,
+      episodeFileId: offsetDays < 0 ? seriesId * 100 + seasonNumber : 0,
+    },
+  ];
+};
+
+const send = (res, status, body) => {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(body === undefined ? "" : JSON.stringify(body));
+  return status;
+};
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, "http://localhost");
+  const path = url.pathname.replace(/^\/api\/v3/, ""); // client base ends in /api/v3/
+  const method = req.method ?? "GET";
+  let status;
+
+  if (method === "GET" && path === "/system/status") {
+    status = send(res, 200, { appName: "Sonarr", version: "4.0.0.0" });
+  } else if (method === "GET" && path === "/series") {
+    // getSeriesByTvdbId -> GET /series?tvdbId=<id>. With no tvdbId this is the
+    // full library list; the getters never need it, so an empty list is fine.
+    const tvdbId = Number(url.searchParams.get("tvdbId"));
+    status = send(res, 200, tvdbId ? [seriesFor(tvdbId)] : []);
+  } else if (method === "GET" && /^\/series\/\d+$/.test(path)) {
+    status = send(res, 200, seriesFor(Number(path.split("/")[2])));
+  } else if (method === "GET" && path === "/series/lookup") {
+    status = send(res, 200, []);
+  } else if (method === "GET" && path === "/episode") {
+    const seriesId = Number(url.searchParams.get("seriesId"));
+    const seasonParam = url.searchParams.get("seasonNumber");
+    if (!seriesId) {
+      status = send(res, 200, []);
+    } else if (seasonParam !== null) {
+      status = send(res, 200, episodesFor(seriesId, Number(seasonParam)));
+    } else {
+      // Whole-series episode list: episode 1 of every season.
+      status = send(
+        res,
+        200,
+        SEASON_NUMBERS.flatMap((n) => episodesFor(seriesId, n)),
+      );
+    }
+  } else if (
+    method === "GET" &&
+    ["/qualityprofile", "/rootfolder", "/tag", "/diskspace", "/queue"].includes(
+      path,
+    )
+  ) {
+    status = send(res, 200, []);
+  } else {
+    status = send(res, 404, { message: "Not found in fake-sonarr" });
+  }
+
+  if (LOG) console.log(`${method} ${url.pathname}${url.search} -> ${status}`);
+});
+
+server.listen(PORT, () => {
+  console.log(`fake-sonarr listening on http://localhost:${PORT} (api/v3)`);
+  console.log(
+    "Any tvdbId resolves to a 4-season show; latest aired season is S2 (S3 airs in the future).",
+  );
+});

--- a/tools/dev/seed-db.mjs
+++ b/tools/dev/seed-db.mjs
@@ -178,7 +178,9 @@ const run = db.transaction(() => {
   // 2) Configure the active media server + metadata + integrations.
   if (TARGET === "plex") {
     // Points at tools/dev/fake-plex.mjs. The fixed machine id lets the primary
-    // connection succeed without plex.tv re-discovery.
+    // connection succeed without plex.tv re-discovery. tvdb_api_key is cleared so
+    // the Sonarr getter's tvdb lookup resolves against fake-sonarr offline instead
+    // of validating the invented id against the real TVDB API (which 404s).
     db.prepare(
       `UPDATE settings SET
          media_server_type = 'plex',
@@ -188,7 +190,8 @@ const run = db.transaction(() => {
          plex_ssl = 0,
          plex_auth_token = @token,
          plex_machine_id = @machine,
-         tmdb_api_key = @tmdb
+         tmdb_api_key = @tmdb,
+         tvdb_api_key = NULL
        WHERE id = 1`,
     ).run({
       name: "Plex (dev seed)",
@@ -382,6 +385,53 @@ const run = db.transaction(() => {
       arrAction: 4, // DO_NOTHING (null deleteAfterDays would otherwise be "due now")
     }),
   ];
+
+  // 4b) #3153 repro (Plex only): a season-scoped group sweeping every season that
+  //     is NOT part of the latest aired season. Pairs tools/dev/fake-plex.mjs's
+  //     four-season show with tools/dev/fake-sonarr.mjs. The latest aired season
+  //     (S2) must be excluded; the rest swept. A full run evaluates the seasons
+  //     together (shared memoized series) where Test Media evaluates one — the
+  //     two must now agree.
+  if (TARGET === "plex") {
+    const seasonColId = insCollection.run({
+      libraryId: LIB.show,
+      title: "Latest Season Sweep",
+      description: "Seasons that are not the latest aired season (#3153).",
+      type: "season",
+      mediaServerType: TARGET,
+      deleteAfterDays: 30,
+      visibleOnHome: 0,
+      arrAction: 4, // DO_NOTHING
+      listExclusions: 0,
+      radarrSettingsId: null,
+      sonarrSettingsId: sonarrId,
+      handledMediaAmount: 0,
+      handledMediaSizeBytes: 0,
+      totalSizeBytes: 0,
+      lastDuration: 0,
+      addDate: daysAgo(30),
+    }).lastInsertRowid;
+    const seasonGroupId = insRuleGroup.run(
+      "Latest Season Sweep",
+      "part_of_latest_season == False",
+      LIB.show,
+      seasonColId,
+      "season",
+    ).lastInsertRowid;
+    // Sonarr (Application.SONARR=2) part_of_latest_season (prop 13, BOOL) EQUALS
+    // False. ruleTypeId BOOL=3, RulePossibility.EQUALS=2; BOOL false encodes as
+    // "0" (the comparator coerces +customVal.value).
+    insRule.run(
+      seasonGroupId,
+      JSON.stringify({
+        customVal: { ruleTypeId: 3, value: "0" },
+        operator: null,
+        firstVal: [2, 13],
+        action: 2,
+        section: 0,
+      }),
+    );
+  }
 
   // 5) Cron schedules (Settings handlers + one per-group override + overlays).
   db.prepare(


### PR DESCRIPTION
Fixes #3153.

`getLastAiredOrCurrentlyAiringSeason` reversed the run-shared, memoized `showResponse.seasons` array in place. Because a full run resolves a show's seasons concurrently, the in-place reverse corrupted season order and the latest aired season collapsed to an earlier one, so `part_of_latest_season` returned `false` for the latest season. Test Media evaluates a single item with no shared cache, so it stayed correct — and the two paths disagreed, letting a `== False` cleanup rule wrongly sweep the latest aired season.

- Reverse a copy (`[...seasons].reverse()`); correct the return type to `SonarrSeason | undefined`.
- Regression test asserting evaluation-order independence under a shared `ArrLookupCache`.
- Dev tooling to exercise the Sonarr season path end-to-end: `tools/dev/fake-sonarr.mjs`, a four-season show in `fake-plex.mjs`, and a seeded `part_of_latest_season == False` season group.