### PR TITLE
Potential fix for code scanning alert no. 199: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -103,6 +103,10 @@ jobs:
           repository: ${{ github.repository }}
           ref: ${{ needs.resolve-pr.outputs.head_sha }}
           fetch-depth: 1
+          # This job builds untrusted PR code, so don't leave the workflow's
+          # GITHUB_TOKEN (packages:write / pull-requests:write) in the worktree's
+          # git config where that code could reach it.
+          persist-credentials: false
 
       - name: Verify checked out commit matches resolved PR SHA
         run: |

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -102,6 +102,16 @@ jobs:
         with:
           repository: ${{ github.repository }}
           ref: ${{ needs.resolve-pr.outputs.head_sha }}
+          fetch-depth: 1
+
+      - name: Verify checked out commit matches resolved PR SHA
+        run: |
+          expected_sha="${{ needs.resolve-pr.outputs.head_sha }}"
+          actual_sha="$(git rev-parse HEAD)"
+          if [ "$actual_sha" != "$expected_sha" ]; then
+            echo "Checked out SHA ($actual_sha) does not match expected SHA ($expected_sha)." >&2
+            exit 1
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Maintainerr/Maintainerr/security/code-scanning/199](https://github.com/Maintainerr/Maintainerr/security/code-scanning/199)

Use defense in depth: keep checkout on immutable SHA **and** verify after checkout that the repository `HEAD` equals the expected SHA from `resolve-pr`.

Best fix here (without changing behavior):
- In `.github/workflows/release_pr.yml`, in `build-docker-image` job, keep existing checkout config.
- Add a new step immediately after checkout:
  - Compute `actual_sha=$(git rev-parse HEAD)`.
  - Compare to `${{ needs.resolve-pr.outputs.head_sha }}`.
  - Fail the job if they differ.
- Optionally set `fetch-depth: 1` explicitly for deterministic shallow checkout behavior (not required for security, but clear).

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
