### PR TITLE
fix(rules): plainer labels for the episode/season rank properties

### DIFF
--- a/apps/server/src/modules/rules/constants/rules.constants.ts
+++ b/apps/server/src/modules/rules/constants/rules.constants.ts
@@ -946,7 +946,7 @@ export class RuleConstants {
         {
           id: 32,
           name: 'episodeFileRank',
-          humanName: 'Episode file rank by air date (newest = 1)',
+          humanName: 'Episode position by air date (1 = latest)',
           mediaType: MediaType.SHOW,
           type: RuleType.NUMBER,
           showType: ['episode'],
@@ -970,7 +970,7 @@ export class RuleConstants {
         {
           id: 35,
           name: 'seasonFileRank',
-          humanName: 'Season file rank by air date (newest = 1)',
+          humanName: 'Season position by air date (1 = latest)',
           mediaType: MediaType.SHOW,
           type: RuleType.NUMBER,
           showType: ['season'],


### PR DESCRIPTION
Renames the two rule-builder labels from #3095/#3223 to plain-word versions chosen for instant readability, including for non-native English speakers:

- `Episode file rank by air date (newest = 1)` -> `Episode position by air date (1 = latest)`
- `Season file rank by air date (newest = 1)` -> `Season position by air date (1 = latest)`

Display-only change: stored rules and YAML exports reference the internal property names/ids, which are unchanged. The downloaded-only pool semantics stay documented in Maintainerr/Maintainerr_docs#106, which is updated to match.