### PR TITLE
fix(collections): accept hex-GUID context.id for manual season/episode actions

### DIFF
--- a/apps/server/src/modules/collections/collections.controller.spec.ts
+++ b/apps/server/src/modules/collections/collections.controller.spec.ts
@@ -192,6 +192,19 @@ describe('CollectionsController', () => {
         action: 0,
       },
     ],
+    [
+      'manual collection action body with an empty context id',
+      manualCollectionActionBodySchema,
+      {
+        collectionId: 1,
+        mediaId: '10',
+        context: {
+          id: '',
+          type: 'season',
+        },
+        action: 0,
+      },
+    ],
   ])('rejects invalid %s payloads', (_name, schema, payload) => {
     const pipe = new ZodValidationPipe(schema);
 
@@ -212,7 +225,7 @@ describe('CollectionsController', () => {
     await controller.ManualActionOnCollection({
       mediaId: '10',
       context: {
-        id: 1,
+        id: '1',
         type: 'movie',
       },
       action: 1,
@@ -223,12 +236,41 @@ describe('CollectionsController', () => {
     ).toHaveBeenCalledWith(
       undefined,
       {
-        id: 1,
+        id: '1',
         type: 'movie',
       },
       { mediaServerId: '10' },
       'remove',
     );
+  });
+
+  it('accepts a hex-GUID context.id for manual season/episode actions (Jellyfin/Emby, #3185)', () => {
+    const pipe = new ZodValidationPipe(manualCollectionActionBodySchema);
+
+    // Jellyfin/Emby item ids are 32-char hex GUIDs, not numeric Plex
+    // ratingKeys. Coercing them to a number yields NaN, which previously
+    // failed validation and 400'd the manual add/remove request.
+    const seasonAction = pipe.transform(
+      {
+        mediaId: '1815bdf1952bd0c75d37a59662895df8',
+        action: 0,
+        collectionId: 7,
+        context: { id: 'cdc55c8c59d63f58697e499aeb6ca210', type: 'season' },
+      },
+      { type: 'body', metatype: Object, data: '' },
+    );
+    expect(seasonAction.context.id).toBe('cdc55c8c59d63f58697e499aeb6ca210');
+
+    // Numeric Plex ratingKeys continue to validate unchanged.
+    const movieAction = pipe.transform(
+      {
+        mediaId: '10',
+        action: 1,
+        context: { id: 12345, type: 'movie' },
+      },
+      { type: 'body', metatype: Object, data: '' },
+    );
+    expect(Number(movieAction.context.id)).toBe(12345);
   });
 
   it('handles a collection item with the configured collection action', async () => {

--- a/apps/server/src/modules/collections/collections.controller.ts
+++ b/apps/server/src/modules/collections/collections.controller.ts
@@ -190,7 +190,10 @@ export const updateScheduleBodySchema = z.object({
     }),
 });
 const manualCollectionContextSchema = z.object({
-  id: z.coerce.number().int(),
+  // Media-server item id: a numeric Plex ratingKey or a hex-GUID Jellyfin/Emby
+  // id. Coerce to a string rather than a number - a GUID coerced to a number is
+  // NaN (#3185), and every consumer already uses the id as a string.
+  id: z.coerce.string().min(1),
   index: z.coerce.number().int().optional(),
   parentIndex: z.coerce.number().int().optional(),
   type: z.enum(MediaItemTypes),

--- a/apps/server/src/modules/collections/interfaces/collection-media.interface.ts
+++ b/apps/server/src/modules/collections/interfaces/collection-media.interface.ts
@@ -19,7 +19,9 @@ export interface CollectionMediaChange {
 }
 
 export interface AlterableMediaContext {
-  id: number;
+  // Numeric Plex ratingKey or hex-GUID Jellyfin/Emby id (#3185); consumers
+  // normalize with String() before use.
+  id: string | number;
   index?: number;
   parentIndex?: number;
   type: MediaItemType;


### PR DESCRIPTION
Manual "Add to collection" returned 400 "Validation failed" when adding a season or episode on Jellyfin. `manualCollectionContextSchema` coerced `context.id` to a number, but Jellyfin/Emby item ids are 32-char hex GUIDs, so coercion produced `NaN` and validation rejected the request. Plex was unaffected because its ratingKeys are numeric.

Everything downstream already treats `context.id` as a string: the service and exclusion handlers wrap it in `String(...)`, the shared media-server interface types it as `string`, and the Plex adapter re-coerces with `Number(...)`. The DTO was the only layer forcing it numeric, a leftover from before Jellyfin support.

- Coerce `context.id` to a string (`z.coerce.string().min(1)`) instead of a number. This also rejects an empty id, which the old schema silently accepted as `0`.
- Widen `AlterableMediaContext.id` to `string | number` to match.
- Add regression tests for the hex-GUID id and the empty-id rejection.

Closes #3185
