### PR TITLE
fix: harden library reconcile against transient errors and clarify sharp-unavailable messaging

### DIFF
--- a/apps/server/src/modules/collections/collection-poster.service.ts
+++ b/apps/server/src/modules/collections/collection-poster.service.ts
@@ -3,7 +3,11 @@ import { Injectable } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
 import { dataDir as configDataDir } from '../../app/config/dataDir';
-import { sharp } from '../../utils/sharp';
+import {
+  isSharpAvailable,
+  sharp,
+  SHARP_UNAVAILABLE_MESSAGE,
+} from '../../utils/sharp';
 import { MediaServerFactory } from '../api/media-server/media-server.factory';
 import { IMediaServerService } from '../api/media-server/media-server.interface';
 import { MaintainerrLogger } from '../logging/logs.service';
@@ -83,6 +87,10 @@ export class CollectionPosterService {
     collectionDbId: number,
     buffer: Buffer,
   ): Promise<{ buffer: Buffer; contentType: string }> {
+    if (!isSharpAvailable) {
+      throw new InvalidCollectionPosterError(SHARP_UNAVAILABLE_MESSAGE);
+    }
+
     let normalised: Buffer;
     try {
       normalised = await sharp(buffer)

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -539,6 +539,33 @@ describe('CollectionsService', () => {
     );
   });
 
+  // A transient failure to fetch the library list must not abort the reconcile
+  // or mislabel the library as missing - clear the stale link with the neutral
+  // auto-create message, exactly like an empty-but-valid library.
+  it('treats a throwing library fetch as inconclusive and clears the link neutrally', async () => {
+    const collection = createCollection({
+      id: 31,
+      mediaServerId: null,
+      manualCollection: false,
+      title: 'Transient Library Blip',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue(undefined);
+    mediaServer.getLibraries.mockRejectedValue(new Error('network blip'));
+    collectionRepo.save.mockImplementation(async (c) => c as Collection);
+    jest
+      .spyOn(service as any, 'findMediaServerCollection')
+      .mockResolvedValue(undefined);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(result.mediaServerId).toBeNull();
+    expect(logger.debug).not.toHaveBeenCalledWith(
+      expect.stringContaining('no longer exists on the media server'),
+    );
+  });
+
   it('repopulates a shared empty automatic collection from local rule-owned items', async () => {
     const collection = createCollection({
       id: 13,

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -2012,7 +2012,16 @@ export class CollectionsService {
         // the collection. Only claim the library is gone when we positively
         // fetched the library list and it's absent; treat an empty/failed
         // fetch as inconclusive so a transient blip never mislabels it.
-        const libraries = (await mediaServer.getLibraries()) ?? [];
+        let libraries: Awaited<ReturnType<typeof mediaServer.getLibraries>> =
+          [];
+        try {
+          libraries = (await mediaServer.getLibraries()) ?? [];
+        } catch (error) {
+          // A throwing fetch is inconclusive too - never let a transient blip
+          // mislabel the library as missing; fall through to the neutral
+          // "will be recreated" message.
+          this.logger.debug(error);
+        }
         const libraryMissing =
           !!collection.libraryId &&
           libraries.length > 0 &&

--- a/apps/server/src/modules/overlays/overlay-render.service.ts
+++ b/apps/server/src/modules/overlays/overlay-render.service.ts
@@ -17,7 +17,11 @@ import * as dateFnsLocales from 'date-fns/locale';
 import * as fs from 'fs';
 import * as path from 'path';
 import { dataDir as configDataDir } from '../../app/config/dataDir';
-import { sharp } from '../../utils/sharp';
+import {
+  isSharpAvailable,
+  sharp,
+  SHARP_UNAVAILABLE_MESSAGE,
+} from '../../utils/sharp';
 import { MaintainerrLogger } from '../logging/logs.service';
 
 export interface TemplateRenderContext {
@@ -330,6 +334,9 @@ export class OverlayRenderService {
     posterBuffer: Buffer,
     opts: OverlayRenderOptions,
   ): Promise<OverlayResult> {
+    if (!isSharpAvailable) {
+      throw new Error(SHARP_UNAVAILABLE_MESSAGE);
+    }
     const meta = await sharp(posterBuffer).metadata();
     const imgW = meta.width!;
     const imgH = meta.height!;
@@ -508,6 +515,9 @@ export class OverlayRenderService {
     canvasHeight: number,
     context: TemplateRenderContext,
   ): Promise<OverlayResult> {
+    if (!isSharpAvailable) {
+      throw new Error(SHARP_UNAVAILABLE_MESSAGE);
+    }
     const meta = await sharp(posterBuffer).metadata();
     const imgW = meta.width!;
     const imgH = meta.height!;

--- a/apps/server/src/modules/overlays/overlays.controller.ts
+++ b/apps/server/src/modules/overlays/overlays.controller.ts
@@ -40,7 +40,11 @@ import { Response } from 'express';
 import * as fs from 'fs';
 import { ZodValidationPipe } from 'nestjs-zod';
 import * as path from 'path';
-import { sharp } from '../../utils/sharp';
+import {
+  isSharpAvailable,
+  sharp,
+  SHARP_UNAVAILABLE_MESSAGE,
+} from '../../utils/sharp';
 import {
   type OverlayProcessRequest,
   overlayProcessRequestSchema,
@@ -418,6 +422,13 @@ export class OverlaysController {
       throw new HttpException(
         `Only ${OVERLAY_IMAGE_EXTENSIONS.join(', ')} image files are supported`,
         HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (!isSharpAvailable) {
+      throw new HttpException(
+        SHARP_UNAVAILABLE_MESSAGE,
+        HttpStatus.SERVICE_UNAVAILABLE,
       );
     }
 


### PR DESCRIPTION
Two LOW-severity hardening items surfaced during the v3.16.0 release review, both consistent with the intent of the PRs that introduced the surrounding code.

**Library reconcile (from #3203).** `checkAutomaticMediaServerLink` added a `getLibraries()` call whose result was guarded against a null return (`?? []`) but not against a throw. A transient network blip would reject and abort the whole reconcile. The code comment already promises to "treat an empty/failed fetch as inconclusive", so this makes the code match: a throwing fetch now falls through to the neutral "will be recreated" path and clears the stale link, instead of throwing. Adds a regression test.

**Sharp-unavailable messaging (from #3184).** `utils/sharp.ts` is a thin loader that re-exports the real `sharp` module (or `null` on CPUs without x86-64-v2) - no image logic is reimplemented. Its doc comment claimed callers "degrade with SHARP_UNAVAILABLE_MESSAGE", but no caller emitted it: poster upload and overlay-image upload reported a misleading "not a valid image", and overlay preview surfaced a generic 500. This guards the user-facing entry points (`storePoster`, the overlay upload handler, `renderOverlay`/`renderFromTemplate`) with `isSharpAvailable` so the clear CPU-remediation message surfaces instead. Guard clauses only; all image work still runs through the genuine sharp library.

No behavior change when sharp is present or the network is healthy.
