### PR TITLE
fix(sonarr): delete episode file after a slow unmonitor PUT is confirmed

### DIFF
--- a/apps/server/src/modules/api/servarr-api/common/servarr-api.service.ts
+++ b/apps/server/src/modules/api/servarr-api/common/servarr-api.service.ts
@@ -13,6 +13,12 @@ import {
   Tag,
 } from '../interfaces/servarr.interface';
 
+// Slow/underpowered *arr instances can take >10s to answer even simple reads;
+// allow more headroom than the shared 10s axios default before aborting
+// (#3181). Used for uncached reads whose failure would change action or rule
+// behavior.
+export const SLOW_INSTANCE_TIMEOUT_MS = 20000;
+
 export abstract class ServarrApi<QueueItemAppendT> extends ExternalApiService {
   static buildUrl(settings: DVRSettings, path?: string): string {
     return `${settings.useSsl ? 'https' : 'http'}://${settings.hostname}:${settings.port}${settings.baseUrl ?? ''}${path}`;

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
@@ -1,5 +1,8 @@
 import { Mocked } from '@suites/doubles.jest';
-import { createRadarrMovie } from '../../../../../test/utils/data';
+import {
+  createRadarrMovie,
+  createRadarrMovieFile,
+} from '../../../../../test/utils/data';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { RadarrImportListExclusion } from '../interfaces/radarr.interface';
 import { RadarrApi } from './radarr.helper';
@@ -154,6 +157,118 @@ describe('RadarrApi', () => {
       expect(runPutSpy).toHaveBeenCalledWith(
         'movie/5',
         JSON.stringify({ ...movie, monitored: false }),
+      );
+    });
+  });
+
+  describe('updateMovie slow-PUT race condition (#3228)', () => {
+    const movie = createRadarrMovie({ id: 5, monitored: true });
+
+    it('deletes the movie files when PUT timed out but Radarr confirms the update (timeout race)', async () => {
+      const getWithoutCacheSpy = jest
+        .spyOn(api, 'getWithoutCache')
+        .mockResolvedValueOnce(movie)
+        .mockResolvedValueOnce({ ...movie, monitored: false })
+        .mockResolvedValueOnce([createRadarrMovieFile({ id: 900 })]);
+      jest.spyOn(api as any, 'runPut').mockResolvedValue(false);
+      const runDeleteSpy = jest
+        .spyOn(api as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      await expect(
+        api.updateMovie(5, { monitored: false, deleteFiles: true }),
+      ).resolves.toBe(true);
+
+      // Same slow-instance headroom as getMovieByTmdbId (#3181).
+      expect(getWithoutCacheSpy).toHaveBeenNthCalledWith(2, 'movie/5', {
+        timeout: 20000,
+      });
+      expect(runDeleteSpy).toHaveBeenCalledWith('moviefile/900');
+    });
+
+    it('fails closed and warns when PUT failed and Radarr still shows the movie monitored', async () => {
+      jest
+        .spyOn(api, 'getWithoutCache')
+        .mockResolvedValueOnce(movie)
+        .mockResolvedValueOnce({ ...movie, monitored: true });
+      jest.spyOn(api as any, 'runPut').mockResolvedValue(false);
+      const runDeleteSpy = jest
+        .spyOn(api as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      await expect(
+        api.updateMovie(5, { monitored: false, deleteFiles: true }),
+      ).resolves.toBe(false);
+
+      expect(runDeleteSpy).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Could not confirm movie 5 was updated; leaving its files in place.',
+      );
+    });
+
+    it('fails closed when the verification lookup fails', async () => {
+      jest
+        .spyOn(api, 'getWithoutCache')
+        .mockResolvedValueOnce(movie)
+        .mockResolvedValueOnce(undefined);
+      jest.spyOn(api as any, 'runPut').mockResolvedValue(false);
+      const runDeleteSpy = jest
+        .spyOn(api as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      await expect(
+        api.updateMovie(5, { monitored: false, deleteFiles: true }),
+      ).resolves.toBe(false);
+
+      expect(runDeleteSpy).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when a quality profile change is not reflected', async () => {
+      jest
+        .spyOn(api, 'getWithoutCache')
+        .mockResolvedValueOnce({ ...movie, qualityProfileId: 4 })
+        .mockResolvedValueOnce({ ...movie, qualityProfileId: 4 });
+      jest.spyOn(api as any, 'runPut').mockResolvedValue(false);
+
+      await expect(api.updateMovie(5, { qualityProfileId: 9 })).resolves.toBe(
+        false,
+      );
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Could not confirm movie 5 was updated.',
+      );
+    });
+
+    it('performs no verification read when the PUT succeeds', async () => {
+      const getWithoutCacheSpy = jest
+        .spyOn(api, 'getWithoutCache')
+        .mockResolvedValue(movie);
+      jest.spyOn(api as any, 'runPut').mockResolvedValue(true);
+
+      await expect(api.updateMovie(5, { monitored: false })).resolves.toBe(
+        true,
+      );
+
+      expect(getWithoutCacheSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails closed when the movie file listing fails instead of reporting success', async () => {
+      jest
+        .spyOn(api, 'getWithoutCache')
+        .mockResolvedValueOnce(movie)
+        .mockResolvedValueOnce(undefined);
+      jest.spyOn(api as any, 'runPut').mockResolvedValue(true);
+      const runDeleteSpy = jest
+        .spyOn(api as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      await expect(
+        api.updateMovie(5, { monitored: false, deleteFiles: true }),
+      ).resolves.toBe(false);
+
+      expect(runDeleteSpy).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Could not list movie 5's files; leaving them in place.",
       );
     });
   });

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
@@ -1,7 +1,10 @@
 import { isAxiosError } from 'axios';
 import { CONNECTION_TEST_TIMEOUT_MS } from '../../../../utils/connection-error';
 import { MaintainerrLogger } from '../../../logging/logs.service';
-import { ServarrApi } from '../common/servarr-api.service';
+import {
+  ServarrApi,
+  SLOW_INSTANCE_TIMEOUT_MS,
+} from '../common/servarr-api.service';
 import {
   RadarrImportListExclusion,
   RadarrInfo,
@@ -23,7 +26,7 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
     protected readonly logger: MaintainerrLogger,
   ) {
     super({ url, apiKey, cacheName }, logger);
-    this.logger.setContext(ServarrApi.name);
+    this.logger.setContext(RadarrApi.name);
   }
 
   public getMovies = async (): Promise<RadarrMovie[]> => {
@@ -61,9 +64,7 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
     try {
       const response = await this.getWithoutCache<RadarrMovie[]>(
         `/movie?tmdbId=${id}`,
-        // Slow/underpowered Radarr can take >10s to resolve a tmdbId; allow more
-        // headroom than the shared default before aborting (#3181).
-        { timeout: 20000 },
+        { timeout: SLOW_INSTANCE_TIMEOUT_MS },
       );
 
       // getWithoutCache swallows transport/auth/5xx into `undefined` (it never
@@ -172,14 +173,47 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
         movieData.qualityProfileId = options.qualityProfileId;
       }
       if (!(await this.runPut(`movie/${movieId}`, JSON.stringify(movieData)))) {
-        return false;
+        // A slow PUT can time out client-side even though Radarr applied it
+        // (#3228): re-read the live state before deciding. Fail closed -
+        // deleting a still-monitored movie's files would trigger a
+        // re-download.
+        const live: RadarrMovie = await this.getWithoutCache(
+          `movie/${movieId}`,
+          { timeout: SLOW_INSTANCE_TIMEOUT_MS },
+        );
+
+        if (
+          !live ||
+          (options?.monitored !== undefined &&
+            live.monitored !== options.monitored) ||
+          (options?.qualityProfileId !== undefined &&
+            live.qualityProfileId !== options.qualityProfileId)
+        ) {
+          this.logger.warn(
+            `Could not confirm movie ${movieId} was updated${
+              options?.deleteFiles ? '; leaving its files in place' : ''
+            }.`,
+          );
+          return false;
+        }
       }
 
       if (options?.deleteFiles) {
         const movieFiles: RadarrMovieFile[] = await this.getWithoutCache(
           `moviefile?movieId=${movieId}`,
+          { timeout: SLOW_INSTANCE_TIMEOUT_MS },
         );
-        for (const movieFile of movieFiles ?? []) {
+
+        // undefined = the listing failed; [] = confirmed no files. Fail closed
+        // instead of reporting success without having deleted anything.
+        if (!movieFiles) {
+          this.logger.warn(
+            `Could not list movie ${movieId}'s files; leaving them in place.`,
+          );
+          return false;
+        }
+
+        for (const movieFile of movieFiles) {
           if (!(await this.runDelete(`moviefile/${movieFile.id}`))) {
             return false;
           }

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
@@ -465,4 +465,185 @@ describe('SonarrApi', () => {
       expect(runPut).not.toHaveBeenCalled();
     });
   });
+
+  describe('UnmonitorDeleteEpisodes slow-PUT race condition (#3228)', () => {
+    it('deletes the episode file when PUT timed out but Sonarr confirms unmonitored (timeout race)', async () => {
+      const episode = createSonarrEpisode({
+        id: 101,
+        seasonNumber: 2026,
+        episodeNumber: 5,
+        airDate: '2026-01-05',
+        episodeFileId: 501,
+        monitored: true,
+      });
+      jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
+      jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(false);
+      jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue({ ...episode, monitored: false });
+      const runDeleteSpy = jest
+        .spyOn(sonarrApi as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      const result = await sonarrApi.UnmonitorDeleteEpisodes(
+        1,
+        2026,
+        [],
+        true,
+        new Date('2026-01-05T00:00:00.000Z'),
+      );
+
+      expect(runDeleteSpy).toHaveBeenCalledWith('episodefile/501');
+      expect(result).toBe(true);
+    });
+
+    it('skips the file delete and warns when PUT failed and Sonarr confirms still monitored (genuine failure)', async () => {
+      const episode = createSonarrEpisode({
+        id: 101,
+        seasonNumber: 2026,
+        episodeNumber: 5,
+        airDate: '2026-01-05',
+        episodeFileId: 501,
+        monitored: true,
+      });
+      jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
+      jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(false);
+      jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue({ ...episode, monitored: true });
+      const runDeleteSpy = jest
+        .spyOn(sonarrApi as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      const result = await sonarrApi.UnmonitorDeleteEpisodes(
+        1,
+        2026,
+        [],
+        true,
+        new Date('2026-01-05T00:00:00.000Z'),
+      );
+
+      expect(runDeleteSpy).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Could not confirm episode 101 was unmonitored; leaving its file in place.',
+      );
+      expect(result).toBe(false);
+    });
+
+    it('skips the file delete when PUT failed and the verification lookup returns undefined (fail closed)', async () => {
+      const episode = createSonarrEpisode({
+        id: 101,
+        seasonNumber: 2026,
+        episodeNumber: 5,
+        airDate: '2026-01-05',
+        episodeFileId: 501,
+        monitored: true,
+      });
+      jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
+      jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(false);
+      jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue(undefined);
+      const runDeleteSpy = jest
+        .spyOn(sonarrApi as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      const result = await sonarrApi.UnmonitorDeleteEpisodes(
+        1,
+        2026,
+        [],
+        true,
+        new Date('2026-01-05T00:00:00.000Z'),
+      );
+
+      expect(runDeleteSpy).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('processes remaining episodes after a single failure (batch no longer aborts)', async () => {
+      const firstEpisode = createSonarrEpisode({
+        id: 101,
+        seasonNumber: 2026,
+        episodeNumber: 5,
+        airDate: '2026-07-01',
+        episodeFileId: 501,
+        monitored: true,
+      });
+      const secondEpisode = createSonarrEpisode({
+        id: 102,
+        seasonNumber: 2026,
+        episodeNumber: 6,
+        airDate: '2026-07-01',
+        episodeFileId: 502,
+        monitored: true,
+      });
+
+      jest
+        .spyOn(sonarrApi as any, 'get')
+        .mockResolvedValue([firstEpisode, secondEpisode]);
+      jest
+        .spyOn(sonarrApi as any, 'runPut')
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+      jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue({ ...firstEpisode, monitored: true });
+      const runDeleteSpy = jest
+        .spyOn(sonarrApi as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      const result = await sonarrApi.UnmonitorDeleteEpisodes(
+        1,
+        2026,
+        [],
+        true,
+        new Date('2026-07-01T00:00:00.000Z'),
+      );
+
+      expect(runDeleteSpy).toHaveBeenCalledWith('episodefile/502');
+      expect(runDeleteSpy).not.toHaveBeenCalledWith('episodefile/501');
+      expect(result).toBe(false);
+    });
+
+    it('continues deleting remaining files after one file delete fails (delete failure no longer aborts)', async () => {
+      const firstEpisode = createSonarrEpisode({
+        id: 101,
+        seasonNumber: 2026,
+        episodeNumber: 5,
+        airDate: '2026-07-01',
+        episodeFileId: 501,
+        monitored: true,
+      });
+      const secondEpisode = createSonarrEpisode({
+        id: 102,
+        seasonNumber: 2026,
+        episodeNumber: 6,
+        airDate: '2026-07-01',
+        episodeFileId: 502,
+        monitored: true,
+      });
+
+      jest
+        .spyOn(sonarrApi as any, 'get')
+        .mockResolvedValue([firstEpisode, secondEpisode]);
+      jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(true);
+      const runDeleteSpy = jest
+        .spyOn(sonarrApi as any, 'runDelete')
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+
+      const result = await sonarrApi.UnmonitorDeleteEpisodes(
+        1,
+        2026,
+        [],
+        true,
+        new Date('2026-07-01T00:00:00.000Z'),
+      );
+
+      expect(runDeleteSpy).toHaveBeenCalledWith('episodefile/501');
+      expect(runDeleteSpy).toHaveBeenCalledWith('episodefile/502');
+      expect(runDeleteSpy).toHaveBeenCalledTimes(2);
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
@@ -181,6 +181,32 @@ describe('SonarrApi', () => {
     expect(runDeleteSpy).toHaveBeenCalledWith('episodefile/700');
   });
 
+  it('should skip file deletes when the season unmonitor fails (#3228)', async () => {
+    const episode = createSonarrEpisode({
+      id: 99,
+      seasonNumber: 3,
+      episodeNumber: 7,
+      episodeFileId: 700,
+    });
+    const series = createSonarrSeries({
+      id: 1,
+      seasons: [{ seasonNumber: 3, monitored: true }],
+    });
+
+    jest.spyOn(sonarrApi, 'getEpisodes').mockResolvedValue([episode]);
+    jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(false);
+    const runDeleteSpy = jest
+      .spyOn(sonarrApi as any, 'runDelete')
+      .mockResolvedValue(true);
+    jest.spyOn((sonarrApi as any).axios, 'get').mockResolvedValue({
+      data: series,
+    });
+
+    await expect(sonarrApi.unmonitorSeasons(1, 3)).resolves.toBeUndefined();
+
+    expect(runDeleteSpy).not.toHaveBeenCalled();
+  });
+
   describe('cache coherency (issue #2757 / #2891)', () => {
     it('getSeriesByTvdbId reads uncached so post-mutation state is never stale', async () => {
       const series = createSonarrSeries({ id: 1, tvdbId: 555 });
@@ -478,9 +504,13 @@ describe('SonarrApi', () => {
       });
       jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
       jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(false);
-      jest
+      const getWithoutCacheSpy = jest
         .spyOn(sonarrApi as any, 'getWithoutCache')
-        .mockResolvedValue({ ...episode, monitored: false });
+        .mockResolvedValue({
+          ...episode,
+          monitored: false,
+          episodeFileId: 601,
+        });
       const runDeleteSpy = jest
         .spyOn(sonarrApi as any, 'runDelete')
         .mockResolvedValue(true);
@@ -493,8 +523,104 @@ describe('SonarrApi', () => {
         new Date('2026-01-05T00:00:00.000Z'),
       );
 
-      expect(runDeleteSpy).toHaveBeenCalledWith('episodefile/501');
+      // Same slow-Sonarr headroom as getSeriesByTvdbId (#3181), and the delete
+      // uses the live file id, not the possibly stale cached one.
+      expect(getWithoutCacheSpy).toHaveBeenCalledWith('/episode/101', {
+        timeout: 20000,
+      });
+      expect(runDeleteSpy).toHaveBeenCalledWith('episodefile/601');
       expect(result).toBe(true);
+    });
+
+    it('performs no verification read when the PUT succeeds', async () => {
+      const episode = createSonarrEpisode({
+        id: 101,
+        seasonNumber: 2026,
+        episodeNumber: 5,
+        airDate: '2026-01-05',
+        episodeFileId: 501,
+        monitored: true,
+      });
+      jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
+      jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(true);
+      const getWithoutCacheSpy = jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue(undefined);
+      jest.spyOn(sonarrApi as any, 'runDelete').mockResolvedValue(true);
+
+      const result = await sonarrApi.UnmonitorDeleteEpisodes(
+        1,
+        2026,
+        [],
+        true,
+        new Date('2026-01-05T00:00:00.000Z'),
+      );
+
+      expect(getWithoutCacheSpy).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('reports success without deleting when PUT timed out but Sonarr confirms unmonitored (deleteFiles=false)', async () => {
+      const episode = createSonarrEpisode({
+        id: 101,
+        seasonNumber: 2026,
+        episodeNumber: 5,
+        airDate: '2026-01-05',
+        episodeFileId: 501,
+        monitored: true,
+      });
+      jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
+      jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(false);
+      jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue({ ...episode, monitored: false });
+      const runDeleteSpy = jest
+        .spyOn(sonarrApi as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      const result = await sonarrApi.UnmonitorDeleteEpisodes(
+        1,
+        2026,
+        [],
+        false,
+        new Date('2026-01-05T00:00:00.000Z'),
+      );
+
+      expect(runDeleteSpy).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('warns without the file clause when unconfirmed and no delete was requested (deleteFiles=false)', async () => {
+      const episode = createSonarrEpisode({
+        id: 101,
+        seasonNumber: 2026,
+        episodeNumber: 5,
+        airDate: '2026-01-05',
+        episodeFileId: 501,
+        monitored: true,
+      });
+      jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
+      jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(false);
+      jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue({ ...episode, monitored: true });
+      const runDeleteSpy = jest
+        .spyOn(sonarrApi as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      const result = await sonarrApi.UnmonitorDeleteEpisodes(
+        1,
+        2026,
+        [],
+        false,
+        new Date('2026-01-05T00:00:00.000Z'),
+      );
+
+      expect(runDeleteSpy).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Could not confirm episode 101 was unmonitored.',
+      );
+      expect(result).toBe(false);
     });
 
     it('skips the file delete and warns when PUT failed and Sonarr confirms still monitored (genuine failure)', async () => {

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
@@ -280,24 +280,36 @@ export class SonarrApi extends ServarrApi<{
         } episode(s) from show with ID ${seriesId} from Sonarr.`,
       );
 
+      let success = true;
+
       for (const e of matchedEpisodes) {
-        if (
-          !(await this.runPut(
-            `episode/${e.id}`,
-            JSON.stringify({ ...e, monitored: false }),
-          ))
-        ) {
-          return false;
+        const unmonitored = await this.runPut(
+          `episode/${e.id}`,
+          JSON.stringify({ ...e, monitored: false }),
+        );
+
+        // runPut reports failure on a slow response Sonarr may have already
+        // applied (issue #3228). Before skipping the file delete, confirm the
+        // episode's live state: if Sonarr shows it unmonitored the PUT landed
+        // and we should still delete the file. Only an episode we cannot
+        // confirm as unmonitored is left in place - deleting a still-monitored
+        // episode's file would trigger a re-download.
+        if (!unmonitored && !(await this.isEpisodeUnmonitored(e.id))) {
+          this.logger.warn(
+            `Could not confirm episode ${e.id} was unmonitored; leaving its file in place.`,
+          );
+          success = false;
+          continue;
         }
 
         if (deleteFiles && e.episodeFileId) {
           if (!(await this.runDelete(`episodefile/${e.episodeFileId}`))) {
-            return false;
+            success = false;
           }
         }
       }
 
-      return true;
+      return success;
     } catch (error) {
       this.logger.warn(
         `Couldn't remove/unmonitor episodes: ${this.formatEpisodeLookup(validEpisodeIds, airDate)} for series ID: ${seriesId}`,
@@ -398,6 +410,18 @@ export class SonarrApi extends ServarrApi<{
       this.logger.debug(error);
       return null;
     }
+  }
+
+  // Re-fetch a single episode's live monitored flag straight from Sonarr,
+  // bypassing the cache so a change our own PUT just made is visible (same
+  // post-mutation reasoning as getSeriesByTvdbId). Returns true only when
+  // Sonarr confirms monitored === false; any lookup failure (undefined)
+  // returns false so we fail closed and keep the file.
+  private async isEpisodeUnmonitored(episodeId: number): Promise<boolean> {
+    const episode = await this.getWithoutCache<SonarrEpisode>(
+      `/episode/${episodeId}`,
+    );
+    return episode?.monitored === false;
   }
 
   private normalizeAirDate(airDate?: string | Date): string | undefined {

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
@@ -281,32 +281,9 @@ export class SonarrApi extends ServarrApi<{
       );
 
       let success = true;
-
       for (const e of matchedEpisodes) {
-        const unmonitored = await this.runPut(
-          `episode/${e.id}`,
-          JSON.stringify({ ...e, monitored: false }),
-        );
-
-        // runPut reports failure on a slow response Sonarr may have already
-        // applied (issue #3228). Before skipping the file delete, confirm the
-        // episode's live state: if Sonarr shows it unmonitored the PUT landed
-        // and we should still delete the file. Only an episode we cannot
-        // confirm as unmonitored is left in place - deleting a still-monitored
-        // episode's file would trigger a re-download.
-        if (!unmonitored && !(await this.isEpisodeUnmonitored(e.id))) {
-          this.logger.warn(
-            `Could not confirm episode ${e.id} was unmonitored; leaving its file in place.`,
-          );
-          success = false;
-          continue;
-        }
-
-        if (deleteFiles && e.episodeFileId) {
-          if (!(await this.runDelete(`episodefile/${e.episodeFileId}`))) {
-            success = false;
-          }
-        }
+        success =
+          (await this.unmonitorAndDeleteEpisode(e, deleteFiles)) && success;
       }
 
       return success;
@@ -410,6 +387,37 @@ export class SonarrApi extends ServarrApi<{
       this.logger.debug(error);
       return null;
     }
+  }
+
+  // Unmonitor one episode and, when requested, delete its file. Returns whether
+  // this episode fully succeeded. A slow/timed-out unmonitor PUT that Sonarr
+  // actually applied is confirmed via a live re-fetch (issue #3228) so the file
+  // is still deleted; only an episode we cannot confirm as unmonitored is left
+  // in place, since deleting a still-monitored episode's file would trigger a
+  // re-download.
+  private async unmonitorAndDeleteEpisode(
+    e: SonarrEpisode,
+    deleteFiles: boolean,
+  ): Promise<boolean> {
+    const unmonitored = await this.runPut(
+      `episode/${e.id}`,
+      JSON.stringify({ ...e, monitored: false }),
+    );
+
+    if (!unmonitored && !(await this.isEpisodeUnmonitored(e.id))) {
+      this.logger.warn(
+        `Could not confirm episode ${e.id} was unmonitored; leaving its file in place.`,
+      );
+      return false;
+    }
+
+    if (deleteFiles && e.episodeFileId) {
+      if (!(await this.runDelete(`episodefile/${e.episodeFileId}`))) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   // Re-fetch a single episode's live monitored flag straight from Sonarr,

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
@@ -1,6 +1,9 @@
 import { CONNECTION_TEST_TIMEOUT_MS } from '../../../../utils/connection-error';
 import { MaintainerrLogger } from '../../../logging/logs.service';
-import { ServarrApi } from '../common/servarr-api.service';
+import {
+  ServarrApi,
+  SLOW_INSTANCE_TIMEOUT_MS,
+} from '../common/servarr-api.service';
 import {
   DownloadHistoryItem,
   SonarrEpisode,
@@ -120,9 +123,7 @@ export class SonarrApi extends ServarrApi<{
     try {
       const response = await this.getWithoutCache<SonarrSeries[]>(
         `/series?tvdbId=${id}`,
-        // Slow/underpowered Sonarr can take >10s to resolve a tvdbId; allow more
-        // headroom than the shared default before aborting (#3181).
-        { timeout: 20000 },
+        { timeout: SLOW_INSTANCE_TIMEOUT_MS },
       );
 
       // getWithoutCache swallows transport/auth/5xx into `undefined` (it never
@@ -405,12 +406,11 @@ export class SonarrApi extends ServarrApi<{
       ))
     ) {
       // A slow PUT can time out client-side even though Sonarr applied it
-      // (#3228): re-read the live state (uncached, with the same slow-Sonarr
-      // headroom as #3181) before deciding. Fail closed - deleting a
-      // still-monitored episode's file would trigger a re-download.
+      // (#3228): re-read the live state before deciding. Fail closed -
+      // deleting a still-monitored episode's file would trigger a re-download.
       const live = await this.getWithoutCache<SonarrEpisode>(
         `/episode/${episode.id}`,
-        { timeout: 20000 },
+        { timeout: SLOW_INSTANCE_TIMEOUT_MS },
       );
 
       if (live?.monitored !== false) {

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
@@ -338,7 +338,10 @@ export class SonarrApi extends ServarrApi<{
       );
       success = (await this.runPut(`series/`, JSON.stringify(data))) && success;
 
-      if (deleteFiles) {
+      // Skip the file deletes when an unmonitor failed: the content may still
+      // be monitored and Sonarr would re-download it (#3228). The action
+      // reports failure and is retried next run.
+      if (deleteFiles && success) {
         for (const e of episodes) {
           if (typeof type === 'number') {
             if (e.seasonNumber === type && e.episodeFileId) {
@@ -389,47 +392,46 @@ export class SonarrApi extends ServarrApi<{
     }
   }
 
-  // Unmonitor one episode and, when requested, delete its file. Returns whether
-  // this episode fully succeeded. A slow/timed-out unmonitor PUT that Sonarr
-  // actually applied is confirmed via a live re-fetch (issue #3228) so the file
-  // is still deleted; only an episode we cannot confirm as unmonitored is left
-  // in place, since deleting a still-monitored episode's file would trigger a
-  // re-download.
   private async unmonitorAndDeleteEpisode(
-    e: SonarrEpisode,
+    episode: SonarrEpisode,
     deleteFiles: boolean,
   ): Promise<boolean> {
-    const unmonitored = await this.runPut(
-      `episode/${e.id}`,
-      JSON.stringify({ ...e, monitored: false }),
-    );
+    let episodeFileId = episode.episodeFileId;
 
-    if (!unmonitored && !(await this.isEpisodeUnmonitored(e.id))) {
-      this.logger.warn(
-        `Could not confirm episode ${e.id} was unmonitored; leaving its file in place.`,
+    if (
+      !(await this.runPut(
+        `episode/${episode.id}`,
+        JSON.stringify({ ...episode, monitored: false }),
+      ))
+    ) {
+      // A slow PUT can time out client-side even though Sonarr applied it
+      // (#3228): re-read the live state (uncached, with the same slow-Sonarr
+      // headroom as #3181) before deciding. Fail closed - deleting a
+      // still-monitored episode's file would trigger a re-download.
+      const live = await this.getWithoutCache<SonarrEpisode>(
+        `/episode/${episode.id}`,
+        { timeout: 20000 },
       );
-      return false;
+
+      if (live?.monitored !== false) {
+        this.logger.warn(
+          `Could not confirm episode ${episode.id} was unmonitored${
+            deleteFiles ? '; leaving its file in place' : ''
+          }.`,
+        );
+        return false;
+      }
+
+      episodeFileId = live.episodeFileId;
     }
 
-    if (deleteFiles && e.episodeFileId) {
-      if (!(await this.runDelete(`episodefile/${e.episodeFileId}`))) {
+    if (deleteFiles && episodeFileId) {
+      if (!(await this.runDelete(`episodefile/${episodeFileId}`))) {
         return false;
       }
     }
 
     return true;
-  }
-
-  // Re-fetch a single episode's live monitored flag straight from Sonarr,
-  // bypassing the cache so a change our own PUT just made is visible (same
-  // post-mutation reasoning as getSeriesByTvdbId). Returns true only when
-  // Sonarr confirms monitored === false; any lookup failure (undefined)
-  // returns false so we fail closed and keep the file.
-  private async isEpisodeUnmonitored(episodeId: number): Promise<boolean> {
-    const episode = await this.getWithoutCache<SonarrEpisode>(
-      `/episode/${episodeId}`,
-    );
-    return episode?.monitored === false;
   }
 
   private normalizeAirDate(airDate?: string | Date): string | undefined {


### PR DESCRIPTION
### Description & Design

**Problem.** When a Sonarr episode-file DELETE action runs against a slow Sonarr instance, it can leave an episode half-applied: `monitored=false` at Sonarr but the file still on disk. `runPut` returns `false` on a slow or timed-out response even when Sonarr already applied the unmonitor, so the handler skips the file delete. It also returns on the first such episode, so the remaining matched episodes in the same batch are never processed. The action is then reported as failed even though Sonarr applied the change.

**Approach.** In `UnmonitorDeleteEpisodes`, when a PUT reports failure, re-fetch the episode's live monitored state (uncached) before deciding. Delete the file only when Sonarr confirms `monitored === false`; otherwise leave it in place and log. This is deliberately fail-closed: an unconfirmed or failed lookup keeps the file, because deleting a still-monitored episode's file would trigger a re-download. The loop now accumulates a `success` flag instead of returning early, so one slow or failed episode no longer aborts the rest of the batch. Both choices mirror patterns already in this file: `getSeriesByTvdbId` reads uncached straight after a mutation, and `unmonitorSeasons` accumulates success across items.

**Trade-offs.** The fix stays in the caller; `runPut`/`runDelete` are shared by other call sites and their semantics are unchanged. The extra GET happens only on the failure path, so the happy path adds no requests. The same timeout-vs-applied ambiguity exists at other `runPut` call sites (e.g. `updateSeries`) and is out of scope here.

### Related issue

Fixes #3228

### AI-Assisted Development

- **AI-assisted:** drafting the fix and the five regression tests, following the existing conventions in the file.
- **Personally reviewed / validated:** read the full diff; ran the targeted `sonarr.helper` suite (32 pass, 5 new) plus the downstream `sonarr-action-handler` and `servarr-api` suites (124 pass); confirmed lint and typecheck clean; verified by test that the file is kept on an unconfirmed/failed verification (fail-closed) and that a failed PUT or delete no longer aborts the batch.
- **Fit with standards:** reuses the repo's uncached-after-mutation and accumulate-success patterns; no change to public types or shared helpers.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I understand the code I am submitting and can explain how it works
- [x] I have performed a self-review of my code
- [x] I have linted and formatted my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

### How to test

1. Configure a Sonarr collection with a DELETE action matching on-disk episodes.
2. Make Sonarr respond slower than the client timeout so the unmonitor PUT times out at the client but still applies server-side (e.g. a proxy delay).
3. Run Handle Collections. Before this change the episode is left unmonitored with its file on disk and the action reports failure; after, the file is deleted once the unmonitor is confirmed and the remaining episodes still process.

Unit: `cd apps/server && yarn jest sonarr.helper`

### Additional context

Surfaced while dogfooding a separate rule-property feature; filed as #3228.
