### PR TITLE
fix(media-server): fail closed on collection children read failures

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -43,6 +43,7 @@ describe('EmbyAdapterService', () => {
     debug: jest.Mock;
     log: jest.Mock;
     warn: jest.Mock;
+    error: jest.Mock;
   };
 
   const createResponseError = (status: number): AxiosError => {
@@ -73,6 +74,7 @@ describe('EmbyAdapterService', () => {
       debug: jest.fn(),
       log: jest.fn(),
       warn: jest.fn(),
+      error: jest.fn(),
     };
     http = {
       get: jest.fn(),
@@ -309,6 +311,16 @@ describe('EmbyAdapterService', () => {
         'emby:collections:library-1',
         'emby:collections:library-2',
       ]);
+    });
+  });
+
+  describe('getCollectionChildren', () => {
+    it('re-throws enumeration failures so callers never mistake a failed read for an empty collection', async () => {
+      http.get.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(service.getCollectionChildren('box-1')).rejects.toThrow(
+        'boom',
+      );
     });
   });
 

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -1033,7 +1033,9 @@ export class EmbyAdapterService implements IMediaServerService {
   }
 
   async getCollectionChildren(collectionId: string): Promise<MediaItem[]> {
-    if (!this.http) return [];
+    if (!this.http) {
+      throw new Error('Emby not initialized');
+    }
     try {
       // User-scoped read for the same reason as getCollections; Jellyfin's
       // adapter likewise requires a userId to enumerate BoxSet children. UserId
@@ -1050,10 +1052,13 @@ export class EmbyAdapterService implements IMediaServerService {
       });
       return (data.Items ?? []).map(EmbyMapper.toMediaItem);
     } catch (error) {
-      this.logger.debug(
+      this.logger.error(
         `Emby getCollectionChildren(${collectionId}) failed: ${formatConnectionFailureMessage(error, 'Connection failed')}`,
       );
-      return [];
+      // A swallowed enumeration failure reads as "the collection is empty"
+      // downstream, which mass-resyncs rule-owned items and adopts stale
+      // server children as ghost manual members.
+      throw error;
     }
   }
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -1476,13 +1476,18 @@ describe('JellyfinAdapterService', () => {
       ).rejects.toThrow(axiosError);
     });
 
-    it('returns empty array for non-400/404 errors', async () => {
-      jellyfinApiMocks.getItems.mockRejectedValueOnce(
-        new Error('random failure'),
-      );
+    it('re-throws non-400/404 errors so callers never mistake a failed read for an empty collection', async () => {
+      const serverError = createResponseError(500);
+      jellyfinApiMocks.getItems.mockRejectedValue(serverError);
 
-      const result = await service.getCollectionChildren('collection-1');
-      expect(result).toEqual([]);
+      await expect(
+        service.getCollectionChildren('collection-1'),
+      ).rejects.toThrow(serverError);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to get collection children for collection-1',
+        serverError,
+      );
     });
 
     it('should create a collection without initial item ids', async () => {

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -1502,7 +1502,9 @@ export class JellyfinAdapterService implements IMediaServerService {
   }
 
   async getCollectionChildren(collectionId: string): Promise<MediaItem[]> {
-    if (!this.api) return [];
+    if (!this.api) {
+      throw new Error('Jellyfin API not initialized');
+    }
 
     const cacheKey = `${JELLYFIN_CACHE_KEYS.COLLECTIONS}:children:${collectionId}`;
     let allCollectionChildren = this.cache.data.get<MediaItem[]>(cacheKey);
@@ -1586,7 +1588,10 @@ export class JellyfinAdapterService implements IMediaServerService {
           `Failed to get collection children for ${collectionId}`,
           error,
         );
-        return [];
+        // A swallowed enumeration failure reads as "the collection is empty"
+        // downstream, which mass-resyncs rule-owned items and adopts stale
+        // server children as ghost manual members.
+        throw error;
       }
     }
 

--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -263,8 +263,13 @@ export interface IMediaServerService {
   ): Promise<void>;
 
   /**
-   * Get items in a collection.
-   * Returns empty array if collection not found or on error.
+   * Get items in a collection. An empty array means the server confirmed
+   * the collection has no children - never "the lookup failed".
+   *
+   * @throws Error on any failure to enumerate (connection, 4xx/5xx).
+   * Callers must treat a throw as "children unknown" and skip membership
+   * reconciliation instead of acting on an empty list; like itemExists,
+   * uncertainty must never add or remove anything.
    */
   getCollectionChildren(collectionId: string): Promise<MediaItem[]>;
 

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -629,6 +629,14 @@ describe('PlexAdapterService', () => {
       expect(children[0].providerIds.tvdb).toEqual([]);
       expect(children[0].providerIds.imdb).toEqual([]);
     });
+
+    it('propagates enumeration failures so callers never mistake a failed read for an empty collection', async () => {
+      plexApi.getCollectionChildren.mockRejectedValue(new Error('boom'));
+
+      await expect(service.getCollectionChildren('col123')).rejects.toThrow(
+        'boom',
+      );
+    });
   });
 
   describe('searchContent', () => {
@@ -885,6 +893,21 @@ describe('PlexAdapterService', () => {
       expect(plexApi.getCollectionChildren).not.toHaveBeenCalled();
       expect(plexApi.setCollectionCustomSort).not.toHaveBeenCalled();
       expect(plexApi.moveCollectionItem).not.toHaveBeenCalled();
+    });
+
+    it('should proceed with the reorder when the current-order read fails', async () => {
+      plexApi.getCollectionChildren.mockRejectedValue(new Error('boom'));
+      plexApi.setCollectionCustomSort.mockResolvedValue(undefined);
+      plexApi.moveCollectionItem.mockResolvedValue(undefined);
+
+      await service.reorderCollectionItems('col123', ['a']);
+
+      expect(plexApi.setCollectionCustomSort).toHaveBeenCalledWith('col123');
+      expect(plexApi.moveCollectionItem).toHaveBeenCalledWith(
+        'col123',
+        'a',
+        undefined,
+      );
     });
 
     it('should short-circuit without writing when current order already matches', async () => {

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -467,8 +467,9 @@ export class PlexAdapterService implements IMediaServerService {
   }
 
   async getCollectionChildren(collectionId: string): Promise<MediaItem[]> {
+    // Throws on enumeration failure (plexApi rethrows) - [] would read as a
+    // confirmed-empty collection downstream.
     const children = await this.plexApi.getCollectionChildren(collectionId);
-    if (!children) return [];
 
     const mappedChildren = children.map(PlexMapper.toMediaItem);
     const incompleteChildren = mappedChildren.filter(
@@ -722,9 +723,14 @@ export class PlexAdapterService implements IMediaServerService {
     }
 
     // Short-circuit when the collection is already in the requested order:
-    // skip both the prefs PUT and every move PUT.
-    const currentChildren =
-      await this.plexApi.getCollectionChildren(collectionId);
+    // skip both the prefs PUT and every move PUT. A failed read only skips
+    // the short-circuit; the reorder itself still proceeds.
+    let currentChildren: PlexLibraryItem[] = [];
+    try {
+      currentChildren = await this.plexApi.getCollectionChildren(collectionId);
+    } catch (error) {
+      this.logger.debug(error);
+    }
     const currentOrder =
       currentChildren?.map((child) => child.ratingKey?.toString() ?? '') ?? [];
     if (

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -183,6 +183,26 @@ describe('PlexApiService.getMetadata', () => {
     expect(await service.getActiveSessions()).toEqual([]);
   });
 
+  it('returns a confirmed empty list when a collection has no children', async () => {
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: { size: 0 },
+    });
+
+    (service as any).plexClient = { queryAll };
+
+    expect(await service.getCollectionChildren('col-1')).toEqual([]);
+  });
+
+  it('re-throws children query failures instead of reporting an empty collection', async () => {
+    const queryAll = jest.fn().mockRejectedValue(new Error('boom'));
+
+    (service as any).plexClient = { queryAll };
+
+    await expect(service.getCollectionChildren('col-1')).rejects.toThrow(
+      'boom',
+    );
+  });
+
   it('builds a single encoded collection uri when adding multiple children', async () => {
     const putQuery = jest.fn().mockResolvedValue({
       MediaContainer: { Metadata: [{ ratingKey: '123' }] },

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -1145,7 +1145,9 @@ export class PlexApiService {
         'Plex api communication failure.. Is the application running?',
       );
       this.logger.debug(error);
-      return undefined;
+      // A swallowed enumeration failure reads as "the collection is empty"
+      // downstream; [] is reserved for a confirmed empty collection.
+      throw error;
     }
   }
 

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -1052,6 +1052,109 @@ describe('CollectionsService', () => {
     expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
   });
 
+  it('skips the drift resync and keeps the link when Jellyfin children cannot be enumerated', async () => {
+    settingsDataService.media_server_type = MediaServerType.JELLYFIN;
+    const collection = createCollection({
+      id: 43,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Jellyfin Unreadable',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Jellyfin Unreadable',
+      childCount: 117,
+    } as any);
+    mediaServer.getCollectionChildren.mockRejectedValue(
+      new Error('Request failed with status code 500'),
+    );
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-1',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+    ]);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    // A failed read is not an empty BoxSet - no blind re-add, link intact.
+    expect(mediaServer.addBatchToCollection).not.toHaveBeenCalled();
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Could not enumerate media server collection remote-collection',
+      ),
+    );
+  });
+
+  it('skips the shared-collection drift resync when Plex children cannot be enumerated', async () => {
+    const collection = createCollection({
+      id: 17,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Shared Unreadable',
+      libraryId: 'library-1',
+    });
+
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Shared Unreadable',
+      childCount: 3,
+    } as any);
+    mediaServer.getCollectionChildren.mockRejectedValue(
+      new Error('Plex api communication failure'),
+    );
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(collection, {
+        mediaServerId: 'rule-owned-1',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+    ]);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(true);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.addBatchToCollection).not.toHaveBeenCalled();
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+  });
+
+  it('keeps a Plex collection when both its child count and children read are inconclusive', async () => {
+    const collection = createCollection({
+      id: 18,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+      title: 'Unknown Count',
+      libraryId: 'library-1',
+    });
+
+    // No usable childCount metadata, and the children read fails: the
+    // empty-delete must not run on an unconfirmed 0.
+    mediaServer.getCollection.mockResolvedValue({
+      id: 'remote-collection',
+      title: 'Unknown Count',
+      childCount: undefined,
+    } as any);
+    mediaServer.getCollectionChildren.mockRejectedValue(
+      new Error('Plex api communication failure'),
+    );
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(false);
+
+    const result = await service.checkAutomaticMediaServerLink(collection);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(result.mediaServerId).toBe('remote-collection');
+  });
+
   it.each([
     { serverType: MediaServerType.JELLYFIN, name: 'Jellyfin' },
     { serverType: MediaServerType.EMBY, name: 'Emby' },

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -1847,6 +1847,27 @@ export class CollectionsService {
     return collection;
   }
 
+  /**
+   * Children for reconciliation decisions: a confirmed list, or undefined
+   * when enumeration failed. A failed read is not an empty collection -
+   * callers must skip membership changes (resync, delete) on undefined.
+   */
+  private async getConfirmedCollectionChildren(
+    collection: Pick<Collection, 'title'>,
+    mediaServer: IMediaServerService,
+    mediaServerCollectionId: string,
+  ): Promise<MediaItem[] | undefined> {
+    try {
+      return await mediaServer.getCollectionChildren(mediaServerCollectionId);
+    } catch (error) {
+      this.logger.warn(
+        `[checkAutomaticMediaServerLink] Could not enumerate media server collection ${mediaServerCollectionId} for "${collection.title}" - skipping membership reconciliation this run`,
+      );
+      this.logger.debug(error);
+      return undefined;
+    }
+  }
+
   public async checkAutomaticMediaServerLink(
     collection: Collection,
   ): Promise<Collection> {
@@ -1910,42 +1931,48 @@ export class CollectionsService {
           // items not among them (partial drift, e.g. items stripped by
           // exclude/unexclude flows), the rule executor's local-DB-only
           // delta can't recover them. Fetch actual children and resync.
-          const serverChildren =
-            (await mediaServer.getCollectionChildren(serverColl.id)) ?? [];
-          const serverChildIds = new Set(
-            serverChildren
-              .map((child) => child?.id?.toString())
-              .filter((childId): childId is string => Boolean(childId)),
+          const serverChildren = await this.getConfirmedCollectionChildren(
+            collection,
+            mediaServer,
+            serverColl.id,
           );
-          this.logger.debug(
-            `[checkAutomaticMediaServerLink] Shared collection ${serverColl.id} has ${serverChildIds.size} children - checking for local rule-owned drift`,
-          );
-          const resyncResult =
-            await this.resyncRuleOwnedItemsToMediaServerCollection(
-              collection,
-              serverChildIds,
+
+          if (serverChildren !== undefined) {
+            const serverChildIds = new Set(
+              serverChildren
+                .map((child) => child?.id?.toString())
+                .filter((childId): childId is string => Boolean(childId)),
             );
+            this.logger.debug(
+              `[checkAutomaticMediaServerLink] Shared collection ${serverColl.id} has ${serverChildIds.size} children - checking for local rule-owned drift`,
+            );
+            const resyncResult =
+              await this.resyncRuleOwnedItemsToMediaServerCollection(
+                collection,
+                serverChildIds,
+              );
 
-          if (
-            resyncResult.attempted > 0 &&
-            resyncResult.rejected < resyncResult.attempted
-          ) {
-            this.healedCollectionIds.delete(collection.id);
-          }
+            if (
+              resyncResult.attempted > 0 &&
+              resyncResult.rejected < resyncResult.attempted
+            ) {
+              this.healedCollectionIds.delete(collection.id);
+            }
 
-          // An empty shared collection that rejected every resynced item
-          // can't be repaired in place - fall back to delete-and-recreate.
-          // The sibling rule group loses nothing: the collection has no
-          // children, and its link re-establishes via the title relink.
-          if (
-            serverChildIds.size === 0 &&
-            resyncResult.attempted > 0 &&
-            resyncResult.rejected >= resyncResult.attempted
-          ) {
-            const deleted =
-              await this.deleteEmptyCollectionRejectingAdds(collection);
-            if (deleted) {
-              serverColl = undefined;
+            // An empty shared collection that rejected every resynced item
+            // can't be repaired in place - fall back to delete-and-recreate.
+            // The sibling rule group loses nothing: the collection has no
+            // children, and its link re-establishes via the title relink.
+            if (
+              serverChildIds.size === 0 &&
+              resyncResult.attempted > 0 &&
+              resyncResult.rejected >= resyncResult.attempted
+            ) {
+              const deleted =
+                await this.deleteEmptyCollectionRejectingAdds(collection);
+              if (deleted) {
+                serverColl = undefined;
+              }
             }
           }
         } else {
@@ -1953,12 +1980,24 @@ export class CollectionsService {
             ? serverColl.childCount
             : undefined;
 
+          // Only a confirmed count may drive the empty-delete below; when
+          // both the metadata count and the children read are inconclusive,
+          // keep the collection.
           const actualChildCount =
             metadataChildCount ??
-            (await mediaServer.getCollectionChildren(serverColl.id))?.length ??
-            0;
+            (
+              await this.getConfirmedCollectionChildren(
+                collection,
+                mediaServer,
+                serverColl.id,
+              )
+            )?.length;
 
-          if (actualChildCount <= 0) {
+          if (actualChildCount === undefined) {
+            this.logger.debug(
+              `[checkAutomaticMediaServerLink] Child count for collection ${serverColl.id} is unknown - keeping it`,
+            );
+          } else if (actualChildCount <= 0) {
             this.logger.debug(
               `[checkAutomaticMediaServerLink] Deleting empty collection ${serverColl.id} (${metadataChildCount !== undefined ? `metadataChildCount=${metadataChildCount}` : `actualChildCount=${actualChildCount}`})`,
             );
@@ -1990,17 +2029,27 @@ export class CollectionsService {
         // sibling rule group shares it), and the (!serverColl) clear-link path
         // below recovers a collection whose BoxSet is already gone. This branch
         // only ever re-adds, never deletes.
-        const serverChildren =
-          (await mediaServer.getCollectionChildren(serverColl.id)) ?? [];
-        const serverChildIds = new Set(
-          serverChildren
-            .map((child) => child?.id?.toString())
-            .filter((childId): childId is string => Boolean(childId)),
-        );
-        await this.resyncRuleOwnedItemsToMediaServerCollection(
+        //
+        // The resync only runs against a confirmed children read: a failed
+        // read is not an empty BoxSet, and re-adding everything on every
+        // failing run churns the server while masking the outage.
+        const serverChildren = await this.getConfirmedCollectionChildren(
           collection,
-          serverChildIds,
+          mediaServer,
+          serverColl.id,
         );
+
+        if (serverChildren !== undefined) {
+          const serverChildIds = new Set(
+            serverChildren
+              .map((child) => child?.id?.toString())
+              .filter((childId): childId is string => Boolean(childId)),
+          );
+          await this.resyncRuleOwnedItemsToMediaServerCollection(
+            collection,
+            serverChildIds,
+          );
+        }
       }
 
       if (!serverColl) {
@@ -2285,10 +2334,16 @@ export class CollectionsService {
           (await this.isMediaServerCollectionShared(collection));
 
         if (isSharedManualCollection && newMedia.length > 0) {
-          const sharedCollectionChildren =
-            (await mediaServer.getCollectionChildren(
+          // Unknown children just skip the already-on-server shortcut; the
+          // regular add flow below handles every item (adds are idempotent).
+          let sharedCollectionChildren: MediaItem[] = [];
+          try {
+            sharedCollectionChildren = await mediaServer.getCollectionChildren(
               collection.mediaServerId,
-            )) ?? [];
+            );
+          } catch (error) {
+            this.logger.debug(error);
+          }
           const sharedCollectionChildIds = new Set(
             sharedCollectionChildren
               .map((child) => child?.id?.toString())

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -849,6 +849,113 @@ describe('RuleExecutorService', () => {
     expect(collectionService.addToCollection).not.toHaveBeenCalled();
   });
 
+  it('leaves existing members untouched when child enumeration fails on Plex', async () => {
+    const { service, mediaServer, collectionService } = createService(
+      MediaServerType.PLEX,
+    );
+
+    // A pure-manual member. Plex has no empty-children removal guard, so a
+    // failed read collapsing to [] would flag it as "removed manually".
+    collectionService.getCollectionMedia.mockResolvedValue([
+      {
+        mediaServerId: 'm-manual',
+        includedByRule: false,
+        manualMembershipSource: 'local',
+      },
+    ] as any);
+    mediaServer.getCollectionChildren.mockRejectedValue(new Error('boom'));
+
+    await (
+      service as unknown as {
+        syncManualMediaServerToCollectionDB: (
+          ruleGroup: {
+            id: number;
+            collectionId: number;
+          },
+          collectionSyncChanges: {
+            addedMediaServerIds: Set<string>;
+            removedMediaServerIds: Set<string>;
+          },
+        ) => Promise<void>;
+      }
+    ).syncManualMediaServerToCollectionDB(
+      { id: 10, collectionId: 1 },
+      {
+        addedMediaServerIds: new Set(),
+        removedMediaServerIds: new Set(),
+      },
+    );
+
+    expect(collectionService.removeFromCollection).not.toHaveBeenCalled();
+    expect(
+      collectionService.syncMediaServerChildrenToCollection,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('adopts only children matching the rule media type as manual members', async () => {
+    const { service, mediaServer, collectionService, logger } = createService(
+      MediaServerType.JELLYFIN,
+    );
+
+    collectionService.getCollectionMedia.mockResolvedValue([]);
+    mediaServer.getCollectionChildren.mockResolvedValue([
+      {
+        id: 'm-season',
+        type: 'season',
+        title: 'Season 2',
+        parentTitle: 'Sample Series',
+      },
+      {
+        id: 'm-episode',
+        type: 'episode',
+        title: 'Sample Episode',
+        grandparentTitle: 'Sample Series',
+      },
+      { id: 'm-series', type: 'show', title: 'Sample Series' },
+    ]);
+
+    await (
+      service as unknown as {
+        syncManualMediaServerToCollectionDB: (
+          ruleGroup: {
+            id: number;
+            collectionId: number;
+            dataType: string;
+          },
+          collectionSyncChanges: {
+            addedMediaServerIds: Set<string>;
+            removedMediaServerIds: Set<string>;
+          },
+        ) => Promise<void>;
+      }
+    ).syncManualMediaServerToCollectionDB(
+      { id: 10, collectionId: 1, dataType: 'season' },
+      {
+        addedMediaServerIds: new Set(),
+        removedMediaServerIds: new Set(),
+      },
+    );
+
+    expect(
+      collectionService.syncMediaServerChildrenToCollection,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      collectionService.syncMediaServerChildrenToCollection,
+    ).toHaveBeenCalledWith(
+      expect.anything(),
+      [expect.objectContaining({ mediaServerId: 'm-season' })],
+      'local',
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Importing 1 item(s) present in the media server collection for 'Test Collection'",
+      ),
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining("'Sample Series - Season 2' (m-season)"),
+    );
+  });
+
   it('does not re-run addToCollection with no additions after resyncing a stale link', async () => {
     const { service, collectionService } = createService(
       MediaServerType.JELLYFIN,

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -468,6 +468,7 @@ export class RuleExecutorService {
             );
             const exclusionCascade = buildExclusionCascadeSets(exclusions);
             const missingManualChildren: CollectionMediaChange[] = [];
+            const adoptedChildLabels: string[] = [];
 
             for (const child of children) {
               if (child && child.id) {
@@ -479,6 +480,21 @@ export class RuleExecutorService {
                   collectionSyncChanges.addedMediaServerIds.has(childId) ||
                   collectionSyncChanges.removedMediaServerIds.has(childId)
                 ) {
+                  continue;
+                }
+
+                // A media server collection can hold any item type (a user
+                // can drop a movie into a seasons BoxSet, and Jellyfin's
+                // recursive child fallback can surface episodes). Only adopt
+                // children of the rule's own media type.
+                if (
+                  rulegroup.dataType &&
+                  child.type &&
+                  child.type !== rulegroup.dataType
+                ) {
+                  this.logger.debug(
+                    `Not importing '${this.describeMediaItemForLog(child)}' from the media server collection for '${collection.title}' - it is a ${child.type} while the rule manages ${rulegroup.dataType} items.`,
+                  );
                   continue;
                 }
 
@@ -499,11 +515,27 @@ export class RuleExecutorService {
                       type: 'media_added_manually',
                     },
                   });
+                  adoptedChildLabels.push(
+                    `'${this.describeMediaItemForLog(child)}' (${childId})`,
+                  );
                 }
               }
             }
 
             if (missingManualChildren.length > 0) {
+              // Name the adopted items: a member that appears with the
+              // "manual" tag without the user having added it is otherwise
+              // undiagnosable from the logs.
+              const maxNamedChildren = 10;
+              const overflowCount =
+                adoptedChildLabels.length - maxNamedChildren;
+              this.logger.log(
+                `Importing ${missingManualChildren.length} item(s) present in the media server collection for '${collection.title}' but not owned by its rule as manual member(s): ${adoptedChildLabels
+                  .slice(0, maxNamedChildren)
+                  .join(
+                    ', ',
+                  )}${overflowCount > 0 ? ` and ${overflowCount} more` : ''}`,
+              );
               await this.collectionService.syncMediaServerChildrenToCollection(
                 collection,
                 missingManualChildren,
@@ -666,6 +698,16 @@ export class RuleExecutorService {
 
       return undefined;
     }
+  }
+
+  private describeMediaItemForLog(item: MediaItem): string {
+    if (item.type === 'season' && item.parentTitle) {
+      return `${item.parentTitle} - ${item.title}`;
+    }
+    if (item.type === 'episode' && item.grandparentTitle) {
+      return `${item.grandparentTitle} - ${item.title}`;
+    }
+    return item.title || item.id;
   }
 
   private async handleCollection(


### PR DESCRIPTION
Fixes the ghost "manual" member class of bugs (Discord report, previously #2464): a failed collection-children read was indistinguishable from an empty collection, so membership reconciliation acted on data it never had.

- `getCollectionChildren` now throws on enumeration failure on all three servers instead of returning `[]` (the contract the executor's child-sync catch was built for in #2550, same convention as `itemExists`). `[]` is reserved for a confirmed-empty collection.
- `checkAutomaticMediaServerLink` skips the drift resync and empty-delete when children are unknown - ends the blind "Resyncing N local rule-owned item(s)" on every run while a BoxSet read keeps failing, and stops a Plex collection delete on an unconfirmed child count.
- The manual-member sweep no longer treats a failed Plex read as "user removed everything": pure-manual members survive transient blips. On current development the same fault deletes them from the DB and from the Plex collection itself while logging success (reproduced on the dev stack).
- Manual adoption filters media-server collection children by the rule's media type (a seasons rule no longer adopts a stray series/episode/movie BoxSet child) and logs an INFO line naming each adopted item, so an unexplained "manual" tag is diagnosable from the logs.
- `cleanupCollectionForLibrary` aborts instead of deleting a BoxSet that a failed read presented as empty.

API note: `GET /api/media-server/collection/:id/children` now returns 500 on enumeration failure instead of a silent `[]` (the UI does not consume this route).

Validated end-to-end against the real dev stack (Jellyfin 10.11.11, Emby 4.9.5, Plex) with a fault-injecting proxy: happy paths, adoption, type filter, faulted runs, recovery, drift heal (#3129), exclusion round-trip, confirmed empty-delete, plus a counterfactual run on pre-fix code demonstrating the wipe.