### PR TITLE
fix(plex): show watch-history prefetch progress so long sweeps don't look stalled

### DIFF
--- a/apps/server/src/modules/api/lib/plexApi.spec.ts
+++ b/apps/server/src/modules/api/lib/plexApi.spec.ts
@@ -59,4 +59,47 @@ describe('PlexApi', () => {
       expect.objectContaining({ timeout: 30000 }),
     );
   });
+
+  it('paginates queryAll and reports fetched/totalSize progress after each page', async () => {
+    const request = jest.fn();
+    (axios.create as jest.Mock).mockReturnValue({ request });
+
+    const api = new PlexApi({
+      hostname: 'plex.local',
+      port: 32400,
+      token: 'token',
+    });
+
+    const totalSize = 250;
+    const page = (start: number, count: number) => ({
+      data: {
+        MediaContainer: {
+          totalSize,
+          Metadata: Array.from({ length: count }, (_v, i) => ({
+            ratingKey: String(start + i),
+          })),
+        },
+      },
+    });
+    // Two full 120-record pages then a short final page.
+    request
+      .mockResolvedValueOnce(page(0, 120))
+      .mockResolvedValueOnce(page(120, 120))
+      .mockResolvedValueOnce(page(240, 10));
+
+    const progress: Array<{ fetched: number; totalSize: number }> = [];
+    const result = await api.queryAll<{
+      MediaContainer: { Metadata: unknown[] };
+    }>({ uri: '/status/sessions/history/all' }, false, undefined, (p) =>
+      progress.push(p),
+    );
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(result.MediaContainer.Metadata).toHaveLength(totalSize);
+    expect(progress).toEqual([
+      { fetched: 120, totalSize },
+      { fetched: 240, totalSize },
+      { fetched: 250, totalSize },
+    ]);
+  });
 });

--- a/apps/server/src/modules/api/lib/plexApi.ts
+++ b/apps/server/src/modules/api/lib/plexApi.ts
@@ -67,17 +67,23 @@ class PlexApi {
    *
    * @param {RequestOptions} options - The options for the query.
    * @param {boolean} [useCache=true] - Whether to use the cache for the query.
+   * @param {AbortSignal} [signal] - Aborts the paginated sweep between pages.
+   * @param {function} [onProgress] - Called after each page with the running
+   *   count of items fetched so far and Plex's reported totalSize, so callers
+   *   can surface progress on long sweeps. Not invoked when totalSize is absent.
    * @return {Promise<T[]>} - A promise that resolves to an array of T.
    */
   async queryAll<T>(
     options: RequestOptions,
     useCache: boolean = true,
     signal?: AbortSignal,
+    onProgress?: (progress: { fetched: number; totalSize: number }) => void,
   ): Promise<T> {
     // vars
     let result = undefined;
     let next = true;
     let page = 0;
+    let fetched = 0;
     const size = 120;
     const requestSignal = signal ?? options.signal;
     options = {
@@ -94,17 +100,22 @@ class PlexApi {
     while (next) {
       requestSignal?.throwIfAborted();
       const query: PlexLibraryResponse = await this.query(options, useCache);
+      const items = query?.MediaContainer
+        ? this.getDataValue(query.MediaContainer)
+        : undefined;
+
       if (result === undefined) {
         // if first response, replace result
         result = query;
-      } else {
+      } else if (items) {
         // if next response, add to previous result
-        const items = this.getDataValue(query.MediaContainer);
+        this.appendToData(result.MediaContainer, items as any[]);
+      }
 
-        // if response is an array
-        if (items) {
-          this.appendToData(result.MediaContainer, items as any[]);
-        }
+      fetched += Array.isArray(items) ? items.length : 0;
+      const totalSize = query?.MediaContainer?.totalSize;
+      if (onProgress && typeof totalSize === 'number') {
+        onProgress({ fetched, totalSize });
       }
 
       // fetch all if more than 120

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -751,6 +751,8 @@ describe('PlexApiService.prefetchWatchHistory', () => {
     expect(queryAll).toHaveBeenCalledWith(
       { uri: '/status/sessions/history/all?sort=viewedAt:desc' },
       false,
+      undefined,
+      expect.any(Function),
     );
 
     const cacheManager = (await import('../lib/cache')).default;
@@ -761,6 +763,102 @@ describe('PlexApiService.prefetchWatchHistory', () => {
     expect(leafMap).toBeDefined();
     expect(leafMap?.get('1')).toHaveLength(2);
     expect(leafMap?.get('2')).toHaveLength(1);
+  });
+
+  it('logs watch-history prefetch progress in 10% steps as pages arrive', async () => {
+    const totalSize = 1000;
+    const queryAll = jest
+      .fn()
+      .mockImplementation(
+        async (
+          _query: unknown,
+          _useCache: unknown,
+          _signal: unknown,
+          onProgress?: (p: { fetched: number; totalSize: number }) => void,
+        ) => {
+          // Drive the callback the way queryAll does, one page at a time.
+          for (let fetched = 100; fetched <= totalSize; fetched += 100) {
+            onProgress?.({ fetched, totalSize });
+          }
+          return {
+            MediaContainer: {
+              Metadata: Array.from({ length: totalSize }, (_v, i) => ({
+                ratingKey: String(i % 3),
+                type: 'movie',
+                accountID: 1,
+                viewedAt: i,
+              })),
+              totalSize,
+            },
+          };
+        },
+      );
+
+    (service as any).plexClient = { queryAll };
+
+    await service.prefetchWatchHistory();
+
+    const progressLogs = (logger.log as jest.Mock).mock.calls
+      .map((call) => call[0])
+      .filter(
+        (message) =>
+          typeof message === 'string' &&
+          message.startsWith('Prefetching watch history:'),
+      );
+
+    // Deciles 10..90 each logged once; the terminal 100% is left to the
+    // "prefetch complete" line, so it is never emitted as progress.
+    expect(progressLogs).toHaveLength(9);
+    expect(progressLogs[0]).toBe(
+      'Prefetching watch history: 100 of 1000 records (10%)...',
+    );
+    expect(progressLogs[8]).toBe(
+      'Prefetching watch history: 900 of 1000 records (90%)...',
+    );
+  });
+
+  it('emits no progress line when the whole history fits in one page', async () => {
+    // The single (final) page reports fetched == totalSize; logging it would
+    // print a misleading partial percentage, so it must stay silent and let the
+    // completion line report the total.
+    const totalSize = 42;
+    const queryAll = jest
+      .fn()
+      .mockImplementation(
+        async (
+          _query: unknown,
+          _useCache: unknown,
+          _signal: unknown,
+          onProgress?: (p: { fetched: number; totalSize: number }) => void,
+        ) => {
+          onProgress?.({ fetched: totalSize, totalSize });
+          return {
+            MediaContainer: {
+              Metadata: Array.from({ length: totalSize }, (_v, i) => ({
+                ratingKey: String(i),
+                type: 'movie',
+                accountID: 1,
+                viewedAt: i,
+              })),
+              totalSize,
+            },
+          };
+        },
+      );
+
+    (service as any).plexClient = { queryAll };
+
+    await service.prefetchWatchHistory();
+
+    const progressLogs = (logger.log as jest.Mock).mock.calls
+      .map((call) => call[0])
+      .filter(
+        (message) =>
+          typeof message === 'string' &&
+          message.startsWith('Prefetching watch history:'),
+      );
+
+    expect(progressLogs).toEqual([]);
   });
 
   it('indexes episode records in the leaf map by ratingKey', async () => {
@@ -879,6 +977,7 @@ describe('PlexApiService.prefetchWatchHistory', () => {
       { uri: '/status/sessions/history/all?sort=viewedAt:desc' },
       false,
       abortController.signal,
+      expect.any(Function),
     );
     expect(logger.warn).not.toHaveBeenCalled();
 

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -738,16 +738,40 @@ export class PlexApiService {
       const historyQuery = {
         uri: '/status/sessions/history/all?sort=viewedAt:desc',
       };
-      const response = abortSignal
-        ? await this.plexClient.queryAll<PlexLibraryResponse>(
-            historyQuery,
-            false,
-            abortSignal,
-          )
-        : await this.plexClient.queryAll<PlexLibraryResponse>(
-            historyQuery,
-            false,
+
+      // The sweep is one sequential Plex request per 120-record page, so a big
+      // watch history can take minutes with no output - which reads as a hang
+      // (users reported the run "stuck" at the single start line). Log each 10%
+      // it crosses so progress is visible without flooding the log. The final
+      // page (fetched == totalSize) is skipped so it never prints a misleading
+      // partial percentage; the completion line below reports the total. A
+      // history that fits in one page stays silent here for the same reason.
+      let loggedDecile = 0;
+      const onProgress = ({
+        fetched,
+        totalSize,
+      }: {
+        fetched: number;
+        totalSize: number;
+      }): void => {
+        if (totalSize <= 0 || fetched >= totalSize) {
+          return;
+        }
+        const decile = Math.floor((fetched / totalSize) * 10) * 10;
+        if (decile > loggedDecile) {
+          loggedDecile = decile;
+          this.logger.log(
+            `Prefetching watch history: ${fetched} of ${totalSize} records (${decile}%)...`,
           );
+        }
+      };
+
+      const response = await this.plexClient.queryAll<PlexLibraryResponse>(
+        historyQuery,
+        false,
+        abortSignal,
+        onProgress,
+      );
 
       const container = response?.MediaContainer;
       const records = (container?.Metadata as PlexSeenBy[]) ?? [];


### PR DESCRIPTION
On large Plex libraries a rule run logs a single `Prefetching watch history for all library items...` line, then sweeps the entire watch history one 120-record page at a time with no further output. Users reported runs "stuck" at prefetching (they were just working through a long sweep, then eventually completed or timed out).

**Change**
- Add an opt-in `onProgress` callback to the shared Plex `queryAll` paginator (per-page `fetched`/`totalSize`). Backwards compatible: every other caller omits it.
- The watch-history prefetch logs each 10% the sweep crosses, e.g. `Prefetching watch history: 6000 of 20000 records (10%)...`. Histories that fit in one page stay silent; the terminal page is skipped so no misleading partial percentage prints, and the existing completion line reports the total.

**Why Plex-only**
Jellyfin/Emby have no central watch-history endpoint (`CENTRAL_WATCH_HISTORY` is Plex-only). Their history is per-user and fetched per item inside the rule-evaluation loop, which is already batched and reports progress. There is no bulk sweep to instrument there.
