### PR TITLE
feat(rules): add Tautulli played-by-user and last-played-date properties

### DIFF
--- a/apps/server/src/modules/api/tautulli-api/tautulli-api.service.ts
+++ b/apps/server/src/modules/api/tautulli-api/tautulli-api.service.ts
@@ -46,7 +46,7 @@ interface TautulliHistory {
   total_duration: string;
 }
 
-interface TautulliHistoryItem {
+export interface TautulliHistoryItem {
   user_id: number;
   user: string;
   watched_status: number;

--- a/apps/server/src/modules/rules/constants/rules.constants.ts
+++ b/apps/server/src/modules/rules/constants/rules.constants.ts
@@ -1106,6 +1106,36 @@ export class RuleConstants {
           type: RuleType.TEXT_LIST, // return usernames []
           showType: ['show', 'season', 'episode'],
         },
+        {
+          id: 9,
+          name: 'playedBy',
+          humanName: '[list] Played by (username)',
+          mediaType: MediaType.MOVIE,
+          type: RuleType.TEXT_LIST, // returns usernames []
+        },
+        {
+          id: 10,
+          name: 'lastPlayedAt',
+          humanName: 'Last played date',
+          mediaType: MediaType.BOTH,
+          type: RuleType.DATE,
+        },
+        {
+          id: 11,
+          name: 'sw_playedBy',
+          humanName: '[list] Users that played at least one episode',
+          mediaType: MediaType.SHOW,
+          type: RuleType.TEXT_LIST, // return usernames []
+          showType: ['show', 'season', 'episode'],
+        },
+        {
+          id: 12,
+          name: 'sw_lastPlayedAt',
+          humanName: 'Newest episode played date',
+          mediaType: MediaType.SHOW,
+          type: RuleType.DATE,
+          showType: ['show', 'season'],
+        },
       ],
     },
     {

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
@@ -43,6 +43,9 @@ export class TautulliGetterService {
   ) {
     try {
       const prop = this.appProperties.find((el) => el.id === id);
+      if (!prop) {
+        return null;
+      }
       const metadata = await this.tautulliApi.getMetadata(libItem.id);
       const collection = await this.collectionRepository.findOne({
         where: { id: ruleGroup.collection.id },
@@ -196,6 +199,81 @@ export class TautulliGetterService {
           newestSeason.sort((a, b) => b.media_index - a.media_index);
 
           return new Date(newestSeason[0].stopped * 1000);
+        }
+        case 'playedBy': {
+          const history = await this.getHistoryForMetadata(metadata);
+          if (history.length > 0) {
+            const viewerIds = history.map((el) => el.user_id);
+            const uniqueViewerIds = [...new Set(viewerIds)];
+            return this.getPlexUsernamesForIds(uniqueViewerIds);
+          }
+          return [];
+        }
+        case 'lastPlayedAt': {
+          const history = await this.getHistoryForMetadata(metadata);
+          const sortedHistory = history
+            .map((el) => el.stopped)
+            .sort()
+            .reverse();
+          return sortedHistory.length > 0
+            ? new Date(sortedHistory[0] * 1000)
+            : null;
+        }
+        case 'sw_playedBy': {
+          const users = await this.tautulliApi.getUsers();
+          let seasons: TautulliMetadata[];
+
+          if (metadata.media_type !== 'season') {
+            seasons = await this.tautulliApi.getChildrenMetadata(
+              metadata.rating_key,
+            );
+          } else {
+            seasons = [metadata];
+          }
+
+          const allPlayerIds = new Set<number>();
+
+          for (const season of seasons) {
+            const episodes = await this.tautulliApi.getChildrenMetadata(
+              season.rating_key,
+            );
+
+            for (const episode of episodes) {
+              const players = await this.tautulliApi.getHistory({
+                rating_key: episode.rating_key,
+              });
+
+              players?.forEach((playEl) => {
+                allPlayerIds.add(playEl.user_id);
+              });
+            }
+          }
+
+          if (allPlayerIds.size > 0) {
+            const allPlayers = users.filter((u) => allPlayerIds.has(u.user_id));
+            const plexUsernames = await this.getPlexUsernamesForIds(
+              allPlayers.map((x) => x.user_id),
+            );
+            return plexUsernames;
+          }
+
+          return [];
+        }
+        case 'sw_lastPlayedAt': {
+          let history = await this.getHistoryForMetadata(metadata);
+
+          history
+            .sort((a, b) => a.parent_media_index - b.parent_media_index)
+            .reverse();
+
+          history = history.filter(
+            (el) => el.parent_media_index === history[0].parent_media_index,
+          );
+          history.sort((a, b) => a.media_index - b.media_index).reverse();
+
+          return history.length > 0
+            ? new Date(history[0].stopped * 1000)
+            : null;
         }
         default: {
           return null;


### PR DESCRIPTION
### Description & Design

Problem: Maintainerr users need "played" metrics (user clicked play) distinct from "viewed" metrics (met Tautulli's watched threshold, default 85%, minimum 50%). Currently, "played" metrics are only available to Jellyfin users via e.g. playCount/sw_playCount. Plex users relying on Tautulli have no way to distinguish "user pressed play" from "user finished watching" - existing Tautulli properties (seenBy, lastViewedAt, sw_watchers, sw_lastWatched) all filter by the watched threshold. This PR adds equivalent "played" metrics for Tautulli users, making them available to Plex users.

Why this approach: Follows the existing pattern established by Jellyfin's playCount/sw_playCount (IDs 30/31) — append new properties at the end of the TAUTULLI application. Reuses the existing getHistoryForMetadata helper and getPlexUsernamesForIds resolver. Mirrors sw_watchers (UNION) and sw_lastWatched (latest season → latest episode) semantics so users can compare "played" vs "viewed" apples-to-apples.

How it works: Adds 4 new TAUTULLI properties (IDs 9–12):

playedBy (TEXT_LIST, MOVIE) - usernames with any play event
lastPlayedAt (DATE, BOTH) - most recent stopped timestamp
sw_playedBy (TEXT_LIST, SHOW) - UNION of users who played ≥1 episode
sw_lastPlayedAt (DATE, SHOW) - newest episode play date in latest season
Getter logic uses raw history entries without watched_status/percent_complete filtering. sw_playedBy collects all unique user_id across episodes (UNION). sw_lastPlayedAt sorts by parent_media_index desc then media_index desc (matching sw_lastWatched).

### Trade-offs / limitations:

- No per-user API filtering (fetches all history, filters in-memory) - acceptable as single-item history is small.
- No UI tooltips explaining "played" vs "viewed" distinction - relies on property naming and docs.
- sw_playedBy does not support "played ALL episodes" (intersection) - only UNION like sw_watchers. Could be added later if needed.

### Related issue

N/A

### AI-Assisted Development

AI-assisted: All code generation (constants, getter logic, unit tests, type exports) was AI-assisted based on detailed design discussions and codebase exploration.
Human review: I reviewed all logic, verified the "played vs viewed" distinction is correctly implemented (no threshold filtering), validated the UNION vs existing INTERSECT patterns, confirmed test coverage (10 new tests), and ensured lint/format/type checks pass.
Standards compliance: Follows existing getter patterns (constants structure, error handling returning undefined/[]/null), Jellyfin playCount precedent for property placement, conventional commit format, and project test patterns (streamystats-getter style unit tests + getter-property-coverage).

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I understand the code I am submitting and can explain how it works
- [x] I have performed a self-review of my code
- [x] I have linted and formatted my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

### How to test

Configure Tautulli in Maintainerr Settings (URL + API key)
Create a movie rule: First Value → Tautulli → select Played by (username) or Last played date
Create a show rule: First Value → Tautulli → select Users that played at least one episode or Newest episode played date
Evaluate rule against media items that were partially watched (< 85% or your threshold)
Compare results in Tautulli web UI: playedBy/sw_playedBy should return users who pressed play; seenBy/sw_watchers should be empty for those same items
Verify timestamps: lastPlayedAt/sw_lastPlayedAt reflect actual play events, not threshold crossings

### Additional context

Briefly discussed with devs in Discord