### PR TITLE
fix(notifications): show media title in "Media Handled" notification (#3249)

### DIFF
--- a/apps/server/src/modules/collections/collection-worker.server.spec.ts
+++ b/apps/server/src/modules/collections/collection-worker.server.spec.ts
@@ -136,6 +136,48 @@ describe('CollectionWorkerService', () => {
     expect(seerrApi.api.post).toHaveBeenCalled();
   });
 
+  it('captures the media title before handling and carries it on the handled event (#3249)', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      type: 'movie',
+    });
+    const collectionMedia = createCollectionMedia(collection, {
+      mediaServerId: 'gone-after-delete',
+    });
+
+    // getMetadata resolves before handling, then reports the item gone once the
+    // delete action has run - the pre-handling snapshot is what the handled
+    // notification relies on.
+    const snapshot = { title: 'A Sample Movie', type: 'movie' };
+    const getMetadata = jest
+      .fn()
+      .mockResolvedValueOnce(snapshot)
+      .mockResolvedValue(undefined);
+    mediaServerFactory.verifyConnection.mockResolvedValue({
+      supportsFeature: jest.fn().mockReturnValue(false),
+      getActiveSessions: jest.fn().mockResolvedValue(new Set<string>()),
+      getMetadata,
+    } as any);
+
+    collectionRepository.find.mockResolvedValue([collection]);
+    collectionMediaRepository.find.mockResolvedValue([collectionMedia]);
+    collectionHandler.handleMedia.mockResolvedValue('handled');
+
+    await collectionWorkerService.execute();
+
+    expect(getMetadata).toHaveBeenCalledWith('gone-after-delete');
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      MaintainerrEvent.CollectionMedia_Handled,
+      expect.objectContaining({
+        collectionName: collection.title,
+        mediaItems: [
+          { mediaServerId: 'gone-after-delete', metadata: snapshot },
+        ],
+        identifier: { type: 'collection', value: collection.id },
+      }),
+    );
+  });
+
   it('skips flagged rule-owned media but still handles flagged manual media', async () => {
     const collection = createCollection({
       arrAction: ServarrAction.DELETE,

--- a/apps/server/src/modules/collections/collection-worker.service.ts
+++ b/apps/server/src/modules/collections/collection-worker.service.ts
@@ -3,6 +3,7 @@ import {
   CollectionHandlerProgressedEventDto,
   CollectionHandlerStartedEventDto,
   MaintainerrEvent,
+  MediaItem,
 } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -15,6 +16,7 @@ import { SeerrApiService } from '../api/seerr-api/seerr-api.service';
 import {
   CollectionHandlerFailedDto,
   CollectionMediaHandledDto,
+  NotificationMediaItem,
 } from '../events/events.dto';
 import { MaintainerrLogger } from '../logging/logs.service';
 import { SettingsDataService } from '../settings/settings-data.service';
@@ -221,10 +223,22 @@ export class CollectionWorkerService extends TaskBase {
         }
 
         this.logger.log(`Handling collection '${collection.title}'`);
-        const handledMediaForNotification = [];
+        const handledMediaForNotification: NotificationMediaItem[] = [];
         const failedMediaForNotification: { mediaServerId: string }[] = [];
 
         for (const media of collectionMedia) {
+          // Snapshot the metadata before handling: a delete-style action removes
+          // the item from the media server, so the handled notification's own
+          // title lookup would come back empty and fall back to a generic
+          // "no longer exists" message (#3249). Best-effort - an unresolved
+          // snapshot just defers to that lookup, preserving prior behaviour.
+          let mediaData: MediaItem | undefined;
+          try {
+            mediaData = await mediaServer.getMetadata(media.mediaServerId);
+          } catch (error) {
+            this.logger.debug(error);
+          }
+
           let result: HandleMediaResult = 'failed';
           let handlingError: unknown;
 
@@ -241,6 +255,7 @@ export class CollectionWorkerService extends TaskBase {
             handledCollectionMedia++;
             handledMediaForNotification.push({
               mediaServerId: media.mediaServerId,
+              metadata: mediaData,
             });
           } else if (result === 'removed-missing') {
             // The item was already gone from the media server and has been

--- a/apps/server/src/modules/events/events.dto.ts
+++ b/apps/server/src/modules/events/events.dto.ts
@@ -1,5 +1,14 @@
 // The types are split up so future additions to specific events will be easier
 
+import { MediaItem } from '@maintainerr/contracts';
+
+export interface NotificationMediaItem {
+  mediaServerId: string;
+  // Snapshot taken before the item was handled: a delete removes it from the
+  // media server, so the notification can't look its title up afterwards (#3249).
+  metadata?: MediaItem;
+}
+
 export class RuleHandlerFailedDto {
   constructor(
     public collectionName?: string,
@@ -9,7 +18,7 @@ export class RuleHandlerFailedDto {
 
 export class CollectionMediaHandledDto {
   constructor(
-    public mediaItems: { mediaServerId: string }[],
+    public mediaItems: NotificationMediaItem[],
     public collectionName: string,
     public identifier?: { type: string; value: number },
   ) {}

--- a/apps/server/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/server/src/modules/notifications/notifications.service.spec.ts
@@ -90,6 +90,127 @@ describe('NotificationService', () => {
     );
   });
 
+  describe('media handled title snapshot (#3249)', () => {
+    it('renders the pre-resolved title without a live lookup when the item is gone', async () => {
+      // A delete action removes the item from the media server, so a live
+      // lookup returns undefined. The snapshot captured before handling is what
+      // keeps the title in the message instead of the generic fallback.
+      const getMetadata = jest.fn().mockResolvedValue(undefined);
+      const mediaServerFactory = {
+        getService: jest.fn().mockResolvedValue({ getMetadata }),
+      };
+      const service = new NotificationService(
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { findOne: jest.fn().mockResolvedValue(null) } as any,
+        {} as any,
+        {} as any,
+        mediaServerFactory as any,
+        createMockLogger() as any,
+        { createLogger: jest.fn().mockReturnValue(createMockLogger()) } as any,
+      );
+
+      const content = await (service as any).transformMessageContent(
+        "✅ '{media_title}' has been handled by '{collection_name}'.",
+        [
+          {
+            mediaServerId: '1',
+            metadata: { title: 'A Sample Movie', type: 'movie' },
+          },
+        ],
+        'My Collection',
+      );
+
+      expect(content).toBe(
+        "✅ 'A Sample Movie' has been handled by 'My Collection'.",
+      );
+      // The snapshot is used directly; the (post-delete, failing) title lookup
+      // is never attempted.
+      expect(getMetadata).not.toHaveBeenCalled();
+    });
+
+    it('renders each pre-resolved title in a multi-item handled message', async () => {
+      const getMetadata = jest.fn().mockResolvedValue(undefined);
+      const mediaServerFactory = {
+        getService: jest.fn().mockResolvedValue({ getMetadata }),
+      };
+      const service = new NotificationService(
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { findOne: jest.fn().mockResolvedValue(null) } as any,
+        {} as any,
+        {} as any,
+        mediaServerFactory as any,
+        createMockLogger() as any,
+        { createLogger: jest.fn().mockReturnValue(createMockLogger()) } as any,
+      );
+
+      const content = await (service as any).transformMessageContent(
+        "✅ These media items have been handled by '{collection_name}'.\n\n{media_items}",
+        [
+          {
+            mediaServerId: '1',
+            metadata: { title: 'A Sample Movie', type: 'movie' },
+          },
+          {
+            mediaServerId: '2',
+            metadata: {
+              type: 'episode',
+              grandparentTitle: 'Sample Series',
+              parentIndex: 2,
+              index: 5,
+            },
+          },
+        ],
+        'My Collection',
+      );
+
+      expect(content).toContain('* A Sample Movie');
+      expect(content).toContain('* Sample Series - season 2 - episode 5');
+      expect(getMetadata).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a live lookup for items without a snapshot', async () => {
+      const { service, mediaServerFactory } = createService();
+
+      const content = await (service as any).transformMessageContent(
+        "✅ '{media_title}' has been handled by '{collection_name}'.",
+        [{ mediaServerId: '1' }],
+        'My Collection',
+      );
+
+      expect(content).toBe(
+        "✅ 'Test Media' has been handled by 'My Collection'.",
+      );
+      expect(mediaServerFactory.getService).toHaveBeenCalled();
+    });
+
+    it('still reports a genuinely unknown item when neither snapshot nor lookup resolves', async () => {
+      const mediaServerFactory = {
+        getService: jest.fn().mockResolvedValue({
+          getMetadata: jest.fn().mockResolvedValue(undefined),
+        }),
+      };
+      const service = new NotificationService(
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { findOne: jest.fn().mockResolvedValue(null) } as any,
+        {} as any,
+        {} as any,
+        mediaServerFactory as any,
+        createMockLogger() as any,
+        { createLogger: jest.fn().mockReturnValue(createMockLogger()) } as any,
+      );
+
+      const content = await (service as any).transformMessageContent(
+        "✅ '{media_title}' has been handled by '{collection_name}'.",
+        [{ mediaServerId: '1' }],
+        'My Collection',
+      );
+
+      expect(content).toBe(
+        "✅ '1 item that no longer exists in the media server' has been handled by 'My Collection'.",
+      );
+    });
+  });
+
   describe('collection handling failed message', () => {
     it('names the collection that failed', async () => {
       const { service } = createService();

--- a/apps/server/src/modules/notifications/notifications.service.ts
+++ b/apps/server/src/modules/notifications/notifications.service.ts
@@ -21,6 +21,7 @@ import {
   CollectionMediaAddedDto,
   CollectionMediaHandledDto,
   CollectionMediaRemovedDto,
+  NotificationMediaItem,
   OverlayAppliedDto,
   OverlayRevertedDto,
   RuleHandlerFailedDto,
@@ -682,7 +683,7 @@ export class NotificationService implements OnModuleInit {
 
   public async handleNotification(
     type: NotificationType,
-    mediaItems?: { mediaServerId: string }[],
+    mediaItems?: NotificationMediaItem[],
     collectionName?: string,
     dayAmount?: number,
     agent?: NotificationAgent,
@@ -711,7 +712,11 @@ export class NotificationService implements OnModuleInit {
     payload.extra.push({ name: 'dayAmount', value: dayAmount?.toString() });
     payload.extra.push({
       name: 'mediaItems',
-      value: JSON.stringify(mediaItems),
+      // Keep the wire shape lean; the pre-resolved metadata snapshot is only
+      // for internal title rendering, not the webhook payload.
+      value: JSON.stringify(
+        mediaItems?.map((item) => ({ mediaServerId: item.mediaServerId })),
+      ),
     });
 
     // get the rulegroup when available
@@ -858,7 +863,7 @@ export class NotificationService implements OnModuleInit {
 
   private async transformMessageContent(
     message: string,
-    items?: { mediaServerId: string }[],
+    items?: NotificationMediaItem[],
     collectionName?: string,
     dayAmount?: number,
   ): Promise<string> {
@@ -889,7 +894,11 @@ export class NotificationService implements OnModuleInit {
         let numUnknownItems = 0;
 
         for (const i of items) {
-          const item = await mediaServer.getMetadata(i.mediaServerId);
+          // Prefer the snapshot captured before handling; a handled item is
+          // often already gone from the media server, so a live lookup would
+          // come back empty (#3249).
+          const item =
+            i.metadata ?? (await mediaServer.getMetadata(i.mediaServerId));
 
           if (item) {
             titles.push(this.getTitle(item));
@@ -913,7 +922,9 @@ export class NotificationService implements OnModuleInit {
         message = message.replace('{media_items}', result);
       } else {
         // if 1 item
-        const item = await mediaServer.getMetadata(items[0].mediaServerId);
+        const item =
+          items[0].metadata ??
+          (await mediaServer.getMetadata(items[0].mediaServerId));
         message = message.replace(
           '{media_title}',
           item


### PR DESCRIPTION
Fixes #3249.

The "Media Handled" notification showed a generic "1 item that no longer exists in the media server" message instead of the media title.

- The collection worker deletes each item, then emits the handled event carrying only its id. The notification resolved the title via `getMetadata` afterwards, but the delete has already removed the item from the media server (Plex `DELETE /library/metadata/{id}` is immediate), so the lookup came back empty.
- Fix: snapshot the metadata in the worker before handling and pass it on the handled event (`NotificationMediaItem`). The notification prefers the snapshot and only falls back to a live lookup for items without one - added/removed/overlay notifications (whose items still exist) are unchanged.
- Reuses the existing `getTitle`, so episode/season formatting stays consistent. The webhook `extra.mediaItems` payload shape is unchanged.