### PR TITLE
fix(rules): apply the watched threshold in Tautulli sw_lastWatched

### DIFF
--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.spec.ts
@@ -1,0 +1,148 @@
+import { MediaItem } from '@maintainerr/contracts';
+import { Repository } from 'typeorm';
+import {
+  createCollection,
+  createMediaItem,
+  createMockLogger,
+} from '../../../../test/utils/data';
+import { PlexApiService } from '../../api/plex-api/plex-api.service';
+import { TautulliApiService } from '../../api/tautulli-api/tautulli-api.service';
+import { Collection } from '../../collections/entities/collection.entities';
+import { RulesDto } from '../dtos/rules.dto';
+import { TautulliGetterService } from './tautulli-getter.service';
+
+const SW_LAST_WATCHED = 7;
+
+// Tautulli grades watched_status as 0 | 0.25 | 0.5 | 0.75 | 1; only 1 means the
+// item crossed the configured watched percent.
+const historyItem = (props: {
+  watched_status: number;
+  percent_complete: number;
+  parent_media_index: number;
+  media_index: number;
+  stopped: number;
+}) => ({ user_id: 1, user: 'user', rating_key: 1, ...props });
+
+const createService = (
+  history: ReturnType<typeof historyItem>[],
+  tautulliWatchedPercentOverride: number | null = null,
+) => {
+  const tautulliApi = {
+    getMetadata: jest
+      .fn()
+      .mockResolvedValue({ media_type: 'show', rating_key: '1' }),
+    getHistory: jest.fn().mockResolvedValue(history),
+  } as unknown as jest.Mocked<TautulliApiService>;
+
+  const collectionRepository = {
+    findOne: jest
+      .fn()
+      .mockResolvedValue(createCollection({ tautulliWatchedPercentOverride })),
+  } as unknown as jest.Mocked<Repository<Collection>>;
+
+  return new TautulliGetterService(
+    tautulliApi,
+    {} as jest.Mocked<PlexApiService>,
+    collectionRepository,
+    createMockLogger(),
+  );
+};
+
+const showItem: MediaItem = createMediaItem({ type: 'show', id: '1' });
+const ruleGroup = { collection: { id: 1 } } as RulesDto;
+
+describe('TautulliGetterService', () => {
+  describe('sw_lastWatched', () => {
+    it('returns null when no episode crossed the watched threshold', async () => {
+      const service = createService([
+        historyItem({
+          watched_status: 0.25,
+          percent_complete: 30,
+          parent_media_index: 1,
+          media_index: 1,
+          stopped: 1_700_000_000,
+        }),
+      ]);
+
+      await expect(
+        service.get(SW_LAST_WATCHED, showItem, undefined, ruleGroup),
+      ).resolves.toBeNull();
+    });
+
+    it('ignores episodes below the watched threshold', async () => {
+      // Tautulli returns history newest-first, so the unwatched season 2 play
+      // leads. Only the season 1 play crossed the threshold.
+      const service = createService([
+        historyItem({
+          watched_status: 0.75,
+          percent_complete: 80,
+          parent_media_index: 2,
+          media_index: 1,
+          stopped: 1_700_000_500,
+        }),
+        historyItem({
+          watched_status: 1,
+          percent_complete: 100,
+          parent_media_index: 1,
+          media_index: 1,
+          stopped: 1_700_000_000,
+        }),
+      ]);
+
+      await expect(
+        service.get(SW_LAST_WATCHED, showItem, undefined, ruleGroup),
+      ).resolves.toEqual(new Date(1_700_000_000 * 1000));
+    });
+
+    it('returns the newest watched episode of the newest watched season', async () => {
+      // The season 1 rewatch is the most recent play, but season 2 is the
+      // newest season - the result must come from there, not from history order.
+      const service = createService([
+        historyItem({
+          watched_status: 1,
+          percent_complete: 100,
+          parent_media_index: 1,
+          media_index: 9,
+          stopped: 1_700_000_900,
+        }),
+        historyItem({
+          watched_status: 1,
+          percent_complete: 100,
+          parent_media_index: 2,
+          media_index: 1,
+          stopped: 1_700_000_100,
+        }),
+        historyItem({
+          watched_status: 1,
+          percent_complete: 100,
+          parent_media_index: 2,
+          media_index: 2,
+          stopped: 1_700_000_200,
+        }),
+      ]);
+
+      await expect(
+        service.get(SW_LAST_WATCHED, showItem, undefined, ruleGroup),
+      ).resolves.toEqual(new Date(1_700_000_200 * 1000));
+    });
+
+    it('counts any play above the collection percent override as watched', async () => {
+      const service = createService(
+        [
+          historyItem({
+            watched_status: 0.25,
+            percent_complete: 30,
+            parent_media_index: 1,
+            media_index: 1,
+            stopped: 1_700_000_000,
+          }),
+        ],
+        20,
+      );
+
+      await expect(
+        service.get(SW_LAST_WATCHED, showItem, undefined, ruleGroup),
+      ).resolves.toEqual(new Date(1_700_000_000 * 1000));
+    });
+  });
+});

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
@@ -178,25 +178,24 @@ export class TautulliGetterService {
           return uniqueEpisodes.length;
         }
         case 'sw_lastWatched': {
-          let history = await this.getHistoryForMetadata(metadata);
-
-          history
-            .filter((x) =>
+          const history = (await this.getHistoryForMetadata(metadata)).filter(
+            (x) =>
               tautulliWatchedPercentOverride != null
                 ? x.percent_complete >= tautulliWatchedPercentOverride
                 : x.watched_status == 1,
-            )
-            .sort((a, b) => a.parent_media_index - b.parent_media_index)
-            .reverse();
+          );
 
-          history = history.filter(
+          if (history.length === 0) {
+            return null;
+          }
+
+          history.sort((a, b) => b.parent_media_index - a.parent_media_index);
+          const newestSeason = history.filter(
             (el) => el.parent_media_index === history[0].parent_media_index,
           );
-          history.sort((a, b) => a.media_index - b.media_index).reverse();
+          newestSeason.sort((a, b) => b.media_index - a.media_index);
 
-          return history.length > 0
-            ? new Date(history[0].stopped * 1000)
-            : null;
+          return new Date(newestSeason[0].stopped * 1000);
         }
         default: {
           return null;


### PR DESCRIPTION
### Description & Design

`sw_lastWatched` ("Newest episode view date") never applied the watched threshold.

The filter ran on a copy of the history array and the result was discarded:

```ts
history
  .filter((x) => ...)   // returns a NEW array
  .sort(...)            // sorts the copy
  .reverse();           // reverses the copy, result thrown away
```

`history` was never reassigned, so the property has been reporting the newest episode of whichever season happened to appear first in Tautulli's history (which is ordered by date), regardless of whether anything crossed the watched percent.

Two consequences:

- A show whose episodes were only ever partially played reported a view date instead of `null`. Compare `lastViewedAt`, which correctly returns `null` in the same situation.
- The "newest season" was taken from history order rather than the season index.

Reshaped to match [the Plex getter's `sw_lastWatched`](https://github.com/Maintainerr/Maintainerr/blob/development/apps/server/src/modules/rules/getter/plex-getter.service.ts), which already has the correct form: filter first, return `null` on an empty result, then sort in place by season and episode index.

Verified against a real Plex + Tautulli, on a show with two episodes played to 30% and 40% (neither crossing the 85% threshold):

| | before | after |
| --- | --- | --- |
| default threshold | `2026-07-13T16:38:57Z` | `null` |
| `tautulliWatchedPercentOverride: 0` | `2026-07-13T16:38:57Z` | `2026-07-13T16:38:57Z` |

After genuinely watching an episode to 96%, it returns that episode's date on both paths.

### Behaviour change

Rules using "Newest episode view date" will now evaluate to `null` for shows where no episode crossed the threshold, instead of silently matching on a partial play. Comparison rules (`BEFORE`, `AFTER`, ...) skip `null`, so this makes those rules *less* likely to add media to a delete collection. `NOT_EXISTS` will now correctly match never-watched shows.

Tautulli had no getter spec; this adds one scoped to the fix. Three of its four cases fail on the current code.

### Related issue

N/A