### PR TITLE
feat(notifications): name the Seerr requester in the pre-deletion warning

### DIFF
--- a/apps/server/src/modules/api/seerr-api/seerr-api.controller.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Delete, Get, Param } from '@nestjs/common';
+import {
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Query,
+} from '@nestjs/common';
 import { SeerrApiService } from './seerr-api.service';
 
 @Controller(['api/seerr', 'api/overseerr', 'api/jellyseerr'])
@@ -8,6 +15,15 @@ export class SeerrApiController {
   @Get('movie/:id')
   getMovie(@Param('id') id: string) {
     return this.seerrApi.getMovie(id);
+  }
+
+  /** Who requested a title; `season` narrows it to one season of a show. */
+  @Get('requests/:tmdbId/users')
+  getRequestedByUsernames(
+    @Param('tmdbId', ParseIntPipe) tmdbId: number,
+    @Query('season', new ParseIntPipe({ optional: true })) season?: number,
+  ): Promise<string[]> {
+    return this.seerrApi.getRequestedByUsernames(tmdbId, season);
   }
 
   @Get('show/:id')

--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.spec.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.spec.ts
@@ -421,4 +421,91 @@ describe('SeerrApiService', () => {
       expect(getWithoutCache).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('getRequestedByUsernames', () => {
+    const requestedBy = (
+      id: number,
+      user: Record<string, string>,
+      seasons?: number[],
+    ): SeerrRequest =>
+      ({
+        ...requestWithTmdb(id, 100),
+        ...(seasons
+          ? {
+              type: 'tv',
+              seasons: seasons.map((seasonNumber) => ({
+                id: seasonNumber,
+                name: `Season ${seasonNumber}`,
+                seasonNumber,
+              })),
+            }
+          : {}),
+        requestedBy: user,
+      }) as unknown as SeerrRequest;
+
+    it('resolves the username per Seerr user type and dedupes', async () => {
+      jest.spyOn(service, 'getRequestsForMedia').mockResolvedValue([
+        requestedBy(1, { plexUsername: 'alice' }),
+        requestedBy(2, { jellyfinUsername: 'bob' }),
+        requestedBy(3, { username: 'carol' }),
+        // Plex username wins over the others on the same user.
+        requestedBy(4, { plexUsername: 'alice', username: 'alice-local' }),
+      ]);
+
+      await expect(service.getRequestedByUsernames(100)).resolves.toEqual([
+        'alice',
+        'bob',
+        'carol',
+      ]);
+    });
+
+    it('credits only the users who requested the given season', async () => {
+      jest
+        .spyOn(service, 'getRequestsForMedia')
+        .mockResolvedValue([
+          requestedBy(1, { plexUsername: 'alice' }, [1]),
+          requestedBy(2, { plexUsername: 'bob' }, [2]),
+          requestedBy(3, { plexUsername: 'carol' }, [2, 3]),
+        ]);
+
+      await expect(service.getRequestedByUsernames(100, 2)).resolves.toEqual([
+        'bob',
+        'carol',
+      ]);
+      // Without a season, every requester of the show is credited.
+      await expect(service.getRequestedByUsernames(100)).resolves.toEqual([
+        'alice',
+        'bob',
+        'carol',
+      ]);
+    });
+
+    it('returns [] when Seerr is unreachable, so the notification still sends', async () => {
+      // The opposite of the rule getter's contract, deliberately.
+      jest.spyOn(service, 'getRequestsForMedia').mockResolvedValue(undefined);
+
+      await expect(service.getRequestedByUsernames(100)).resolves.toEqual([]);
+    });
+
+    it('returns [] without calling Seerr when it is not configured', async () => {
+      settings.seerrConfigured.mockReturnValue(false);
+      const getRequestsForMedia = jest.spyOn(service, 'getRequestsForMedia');
+
+      await expect(service.getRequestedByUsernames(100)).resolves.toEqual([]);
+      expect(getRequestsForMedia).not.toHaveBeenCalled();
+    });
+
+    it('skips requests with no resolvable username', async () => {
+      jest
+        .spyOn(service, 'getRequestsForMedia')
+        .mockResolvedValue([
+          requestedBy(1, {}),
+          requestedBy(2, { plexUsername: 'alice' }),
+        ]);
+
+      await expect(service.getRequestedByUsernames(100)).resolves.toEqual([
+        'alice',
+      ]);
+    });
+  });
 });

--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
@@ -103,6 +103,27 @@ export type SeerrMovieRequest = SeerrBaseRequest & {
 
 export type SeerrRequest = SeerrMovieRequest | SeerrTVRequest;
 
+/**
+ * Reads the name off the request rather than looking the user up on the media
+ * server: media server user IDs don't match Seerr's plexId. Seerr stores the
+ * name per user type - Plex in plexUsername, local in username, Jellyfin/Emby
+ * in jellyfinUsername.
+ */
+export const resolveRequestUsername = (request: {
+  requestedBy?: {
+    plexUsername?: string;
+    jellyfinUsername?: string;
+    username?: string;
+  };
+}): string | undefined => {
+  const user = request.requestedBy;
+  if (!user) return undefined;
+
+  return (
+    user.plexUsername || user.jellyfinUsername || user.username || undefined
+  );
+};
+
 interface SeerrUser {
   id: number;
   email: string;
@@ -382,6 +403,40 @@ export class SeerrApiService {
     // cloneDeep, not structuredClone: it never throws on an unexpected
     // non-cloneable value (which would surface as a per-item warn + skip).
     return requests ? cloneDeep(requests) : [];
+  }
+
+  /**
+   * Usernames of everyone who requested a title. Unlike the rule getter's
+   * contract, an unreachable Seerr yields `[]` rather than `undefined`: failing
+   * to name the requester must never suppress the pre-deletion warning itself.
+   *
+   * `season` is required for TV, since Seerr tracks requests per season -
+   * without it a season-level item credits whoever requested a different season.
+   */
+  public async getRequestedByUsernames(
+    tmdbId: number,
+    season?: number,
+  ): Promise<string[]> {
+    if (!this.isConfigured() || !tmdbId) {
+      return [];
+    }
+
+    const requests = await this.getRequestsForMedia(tmdbId);
+    if (!requests?.length) {
+      return [];
+    }
+
+    const usernames = requests
+      .filter(
+        (request) =>
+          season === undefined ||
+          request.type !== 'tv' ||
+          request.seasons?.some((s) => Number(s.seasonNumber) === season),
+      )
+      .map((request) => resolveRequestUsername(request))
+      .filter((username): username is string => username !== undefined);
+
+    return [...new Set(usernames)];
   }
 
   private async getRequestIndex(): Promise<

--- a/apps/server/src/modules/events/events.dto.ts
+++ b/apps/server/src/modules/events/events.dto.ts
@@ -7,6 +7,8 @@ export interface NotificationMediaItem {
   // Snapshot taken before the item was handled: a delete removes it from the
   // media server, so the notification can't look its title up afterwards (#3249).
   metadata?: MediaItem;
+  // Seerr users who requested this item; absent if unconfigured or unrequested.
+  requestedBy?: string[];
 }
 
 export class RuleHandlerFailedDto {

--- a/apps/server/src/modules/notifications/agents/webhook.spec.ts
+++ b/apps/server/src/modules/notifications/agents/webhook.spec.ts
@@ -16,7 +16,12 @@ jest.mock('axios', () => ({
 }));
 
 describe('WebhookAgent', () => {
-  const createAgent = (webhookUrl: string) => {
+  const createAgent = (
+    webhookUrl: string,
+    // The UI JSON.parses the editor contents before saving, so a stored
+    // jsonPayload is an object - not the string the type claims.
+    jsonPayload: unknown = {},
+  ) => {
     const notification = new Notification();
     const settings: NotificationAgentWebhook = {
       enabled: true,
@@ -24,7 +29,7 @@ describe('WebhookAgent', () => {
       options: {
         agent: NotificationAgentKey.WEBHOOK,
         webhookUrl,
-        jsonPayload: '{}',
+        jsonPayload: jsonPayload as string,
       },
     };
 
@@ -35,6 +40,8 @@ describe('WebhookAgent', () => {
       notification,
     );
   };
+
+  const postedBody = () => (axios.post as jest.Mock).mock.calls[0][1];
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -51,5 +58,66 @@ describe('WebhookAgent', () => {
 
     expect(result).toBe('Failure: unsupported webhook URL scheme');
     expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it('flattens extras onto the posted body', async () => {
+    const agent = createAgent('https://example.com/hook');
+
+    await agent.send(NotificationType.TEST_NOTIFICATION, {
+      subject: 'Test subject',
+      extra: [{ name: 'collectionName', value: 'Stale Movies' }],
+    });
+
+    expect(postedBody()).toMatchObject({
+      subject: 'Test subject',
+      collectionName: 'Stale Movies',
+    });
+  });
+
+  it('resolves the {{extra}} template key to the real extras', async () => {
+    // Regression: buildPayload deleted payload.extra before parseKeys read it,
+    // so a templated {{extra}} always came out as an empty array.
+    const agent = createAgent('https://example.com/hook', { '{{extra}}': '' });
+    const extra = [{ name: 'dayAmount', value: '3' }];
+
+    await agent.send(NotificationType.TEST_NOTIFICATION, {
+      subject: 'Test subject',
+      extra,
+    });
+
+    expect(postedBody().extra).toEqual(extra);
+  });
+
+  it('does not mutate the payload shared with the other agents', async () => {
+    // Regression: buildPayload used to `delete payload.extra` on the object
+    // shared with every other agent, stripping extras from whoever ran next.
+    const agent = createAgent('https://example.com/hook');
+    const payload = {
+      subject: 'Test subject',
+      extra: [{ name: 'collectionName', value: 'Stale Movies' }],
+    };
+
+    await agent.send(NotificationType.TEST_NOTIFICATION, payload);
+
+    expect(payload.extra).toEqual([
+      { name: 'collectionName', value: 'Stale Movies' },
+    ]);
+    expect(payload).not.toHaveProperty('collectionName');
+  });
+
+  it('carries requestedBy through to the posted body', async () => {
+    const agent = createAgent('https://example.com/hook');
+    const mediaItems = JSON.stringify([
+      { mediaServerId: '1', requestedBy: ['alice'] },
+    ]);
+
+    await agent.send(NotificationType.TEST_NOTIFICATION, {
+      subject: 'Media About to be Handled',
+      extra: [{ name: 'mediaItems', value: mediaItems }],
+    });
+
+    expect(JSON.parse(postedBody().mediaItems)).toEqual([
+      { mediaServerId: '1', requestedBy: ['alice'] },
+    ]);
   });
 });

--- a/apps/server/src/modules/notifications/agents/webhook.ts
+++ b/apps/server/src/modules/notifications/agents/webhook.ts
@@ -46,10 +46,11 @@ class WebhookAgent implements NotificationAgent {
     finalPayload: Record<string, unknown>,
     payload: NotificationPayload,
     type: NotificationType,
+    extra: NonNullable<NotificationPayload['extra']>,
   ): Record<string, unknown> {
     Object.keys(finalPayload).forEach((key) => {
       if (key === '{{extra}}') {
-        finalPayload.extra = payload.extra ?? [];
+        finalPayload.extra = extra;
         delete finalPayload[key];
         key = 'extra';
       }
@@ -69,6 +70,7 @@ class WebhookAgent implements NotificationAgent {
           finalPayload[key] as Record<string, unknown>,
           payload,
           type,
+          extra,
         );
       }
     });
@@ -77,17 +79,23 @@ class WebhookAgent implements NotificationAgent {
   }
 
   private buildPayload(type: NotificationType, payload: NotificationPayload) {
-    payload.extra?.forEach((el) => {
-      payload[el.name] = el.value;
-    });
-    delete payload.extra;
+    const extra = payload.extra ?? [];
+
+    // Flatten onto a copy: `sendNotification` hands the same payload object to
+    // every agent, so deleting `extra` here stripped it from any agent that ran
+    // after us (email and LunaSea both forward it) and left `{{extra}}` empty.
+    const flattened: Record<string, unknown> = { ...payload };
+    delete flattened.extra;
+    for (const el of extra) {
+      flattened[el.name] = el.value;
+    }
 
     const payloadString = this.getSettings().options.jsonPayload;
     const parsedJSON = JSON.parse(JSON.stringify(payloadString));
 
-    Object.assign(parsedJSON, payload);
+    Object.assign(parsedJSON, flattened);
 
-    return this.parseKeys(parsedJSON, payload, type);
+    return this.parseKeys(parsedJSON, payload, type, extra);
   }
 
   public shouldSend(): boolean {

--- a/apps/server/src/modules/notifications/notifications-timer.service.spec.ts
+++ b/apps/server/src/modules/notifications/notifications-timer.service.spec.ts
@@ -1,0 +1,204 @@
+import { createMockLogger } from '../../../test/utils/data';
+import { NotificationMediaItem } from '../events/events.dto';
+import { NotificationTimerService } from './notifications-timer.service';
+import { NotificationType } from './notifications-interfaces';
+
+describe('NotificationTimerService', () => {
+  const DELETE_AFTER_DAYS = 30;
+  const ABOUT_SCALE = 3;
+
+  // A due item is one added (deleteAfterDays - aboutScale) days ago.
+  const dueAddDate = () =>
+    new Date(
+      Date.now() - (DELETE_AFTER_DAYS - ABOUT_SCALE) * 86400000,
+    ).toISOString();
+
+  const createService = ({
+    media,
+    metadata,
+    requestedBy = [],
+    agentCount = 1,
+  }: {
+    media: { mediaServerId: string; tmdbId?: number; addDate: string }[];
+    metadata?: Record<string, unknown>;
+    requestedBy?: string[];
+    agentCount?: number;
+  }) => {
+    const agents = Array.from({ length: agentCount }, (_, i) => ({
+      getNotification: () => ({ id: i + 1 }),
+    }));
+
+    const handleNotification = jest.fn().mockResolvedValue('Success');
+    const notificationService = {
+      getActiveAgents: () => agents,
+      getNotificationConfigurations: jest.fn().mockResolvedValue(
+        agents.map((_, i) => ({
+          id: i + 1,
+          enabled: true,
+          aboutScale: ABOUT_SCALE,
+          rulegroups: [
+            {
+              collection: { id: 10, deleteAfterDays: DELETE_AFTER_DAYS },
+            },
+          ],
+        })),
+      ),
+      handleNotification,
+    };
+
+    const getMetadata = jest.fn().mockResolvedValue(metadata);
+    const mediaServerFactory = {
+      getService: jest.fn().mockResolvedValue({ getMetadata }),
+    };
+
+    const getRequestedByUsernames = jest.fn().mockResolvedValue(requestedBy);
+    const seerrApi = { getRequestedByUsernames };
+
+    const collectionService = {
+      getCollectionMedia: jest.fn().mockResolvedValue(media),
+    };
+
+    const service = new NotificationTimerService(
+      {} as never,
+      createMockLogger() as never,
+      collectionService as never,
+      notificationService as never,
+      mediaServerFactory as never,
+      seerrApi as never,
+    );
+
+    return {
+      service,
+      handleNotification,
+      getMetadata,
+      getRequestedByUsernames,
+    };
+  };
+
+  const notifiedItems = (
+    handleNotification: jest.Mock,
+  ): NotificationMediaItem[] => handleNotification.mock.calls[0][1];
+
+  it('attaches the Seerr requesters to a due item', async () => {
+    const { service, handleNotification, getRequestedByUsernames } =
+      createService({
+        media: [{ mediaServerId: '1', tmdbId: 500, addDate: dueAddDate() }],
+        metadata: { title: 'Sample Movie', type: 'movie' },
+        requestedBy: ['alice'],
+      });
+
+    await (service as never as { executeTask(): Promise<void> }).executeTask();
+
+    expect(handleNotification).toHaveBeenCalledTimes(1);
+    expect(handleNotification.mock.calls[0][0]).toBe(
+      NotificationType.MEDIA_ABOUT_TO_BE_HANDLED,
+    );
+    expect(notifiedItems(handleNotification)[0]).toMatchObject({
+      mediaServerId: '1',
+      requestedBy: ['alice'],
+    });
+    // A movie has no season to narrow by.
+    expect(getRequestedByUsernames).toHaveBeenCalledWith(500, undefined);
+  });
+
+  it('narrows the requester lookup to the season of a season item', async () => {
+    // Otherwise a season collection credits whoever requested another season.
+    const { service, getRequestedByUsernames } = createService({
+      media: [{ mediaServerId: '1', tmdbId: 500, addDate: dueAddDate() }],
+      metadata: { title: 'Sample Series', type: 'season', index: 2 },
+    });
+
+    await (service as never as { executeTask(): Promise<void> }).executeTask();
+
+    expect(getRequestedByUsernames).toHaveBeenCalledWith(500, 2);
+  });
+
+  it('narrows to the parent season of an episode item', async () => {
+    const { service, getRequestedByUsernames } = createService({
+      media: [{ mediaServerId: '1', tmdbId: 500, addDate: dueAddDate() }],
+      metadata: {
+        title: 'Sample Series',
+        type: 'episode',
+        index: 4,
+        parentIndex: 2,
+      },
+    });
+
+    await (service as never as { executeTask(): Promise<void> }).executeTask();
+
+    expect(getRequestedByUsernames).toHaveBeenCalledWith(500, 2);
+  });
+
+  it('omits requestedBy when nobody requested the item', async () => {
+    const { service, handleNotification } = createService({
+      media: [{ mediaServerId: '1', tmdbId: 500, addDate: dueAddDate() }],
+      metadata: { title: 'Sample Movie', type: 'movie' },
+      requestedBy: [],
+    });
+
+    await (service as never as { executeTask(): Promise<void> }).executeTask();
+
+    expect(notifiedItems(handleNotification)[0]).not.toHaveProperty(
+      'requestedBy',
+    );
+  });
+
+  it('still notifies when the media server lookup throws', async () => {
+    // Losing the title snapshot must not suppress the warning itself.
+    const { service, handleNotification, getMetadata } = createService({
+      media: [{ mediaServerId: '1', tmdbId: 500, addDate: dueAddDate() }],
+      requestedBy: ['alice'],
+    });
+    getMetadata.mockRejectedValue(new Error('media server down'));
+
+    await (service as never as { executeTask(): Promise<void> }).executeTask();
+
+    expect(handleNotification).toHaveBeenCalledTimes(1);
+    expect(notifiedItems(handleNotification)[0]).toMatchObject({
+      mediaServerId: '1',
+      requestedBy: ['alice'],
+    });
+  });
+
+  it('skips the Seerr lookup for an item with no tmdbId', async () => {
+    const { service, getRequestedByUsernames } = createService({
+      media: [{ mediaServerId: '1', addDate: dueAddDate() }],
+      metadata: { title: 'Sample Movie', type: 'movie' },
+    });
+
+    await (service as never as { executeTask(): Promise<void> }).executeTask();
+
+    expect(getRequestedByUsernames).not.toHaveBeenCalled();
+  });
+
+  it('enriches each item once even when several agents notify it', async () => {
+    const { service, getMetadata, getRequestedByUsernames } = createService({
+      media: [{ mediaServerId: '1', tmdbId: 500, addDate: dueAddDate() }],
+      metadata: { title: 'Sample Movie', type: 'movie' },
+      requestedBy: ['alice'],
+      agentCount: 3,
+    });
+
+    await (service as never as { executeTask(): Promise<void> }).executeTask();
+
+    expect(getMetadata).toHaveBeenCalledTimes(1);
+    expect(getRequestedByUsernames).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify an item that is not due', async () => {
+    const { service, handleNotification } = createService({
+      media: [
+        {
+          mediaServerId: '1',
+          tmdbId: 500,
+          addDate: new Date().toISOString(),
+        },
+      ],
+      metadata: { title: 'Sample Movie', type: 'movie' },
+    });
+
+    await (service as never as { executeTask(): Promise<void> }).executeTask();
+
+    expect(handleNotification).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/modules/notifications/notifications-timer.service.ts
+++ b/apps/server/src/modules/notifications/notifications-timer.service.ts
@@ -1,5 +1,10 @@
+import { MediaItem } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
+import { MediaServerFactory } from '../api/media-server/media-server.factory';
+import { SeerrApiService } from '../api/seerr-api/seerr-api.service';
 import { CollectionsService } from '../collections/collections.service';
+import { CollectionMedia } from '../collections/entities/collection_media.entities';
+import { NotificationMediaItem } from '../events/events.dto';
 import { MaintainerrLogger } from '../logging/logs.service';
 import { TaskBase } from '../tasks/task.base';
 import { TasksService } from '../tasks/tasks.service';
@@ -21,6 +26,8 @@ export class NotificationTimerService extends TaskBase {
     protected readonly logger: MaintainerrLogger,
     protected readonly collectionService: CollectionsService,
     private readonly notificationService: NotificationService,
+    private readonly mediaServerFactory: MediaServerFactory,
+    private readonly seerrApi: SeerrApiService,
   ) {
     logger.setContext(NotificationTimerService.name);
     super(taskService, logger);
@@ -35,6 +42,17 @@ export class NotificationTimerService extends TaskBase {
     const activeAgents = this.notificationService.getActiveAgents();
     const allNotificationConfigurations =
       await this.notificationService.getNotificationConfigurations(true);
+
+    // Agents run concurrently and can share a rule group, so memoise the
+    // in-flight promise to keep each item at one media-server + Seerr lookup.
+    const enriched = new Map<string, Promise<NotificationMediaItem>>();
+    const enrich = (media: CollectionMedia): Promise<NotificationMediaItem> => {
+      const pending =
+        enriched.get(media.mediaServerId) ??
+        this.toNotificationMediaItem(media);
+      enriched.set(media.mediaServerId, pending);
+      return pending;
+    };
 
     await Promise.allSettled(
       activeAgents.map(async (agent) => {
@@ -73,15 +91,11 @@ export class NotificationTimerService extends TaskBase {
           )
         ).flat();
 
-        const transformedItems = itemsToNotify.map((i) => ({
-          mediaServerId: i.mediaServerId,
-        }));
-
         // send the notification if required
-        if (transformedItems.length > 0) {
+        if (itemsToNotify.length > 0) {
           await this.notificationService.handleNotification(
             this.type,
-            transformedItems,
+            await Promise.all(itemsToNotify.map(enrich)),
             undefined,
             notification.aboutScale,
             agent,
@@ -89,5 +103,49 @@ export class NotificationTimerService extends TaskBase {
         }
       }),
     );
+  }
+
+  /**
+   * Title snapshot + requesters, both best-effort: a warning that can't name
+   * the item or the requester still beats no warning.
+   */
+  private async toNotificationMediaItem(
+    media: CollectionMedia,
+  ): Promise<NotificationMediaItem> {
+    let metadata: MediaItem | undefined;
+    try {
+      const mediaServer = await this.mediaServerFactory.getService();
+      metadata = await mediaServer.getMetadata(media.mediaServerId);
+    } catch (error) {
+      this.logger.debug(error);
+    }
+
+    const requestedBy = await this.resolveRequesters(media, metadata);
+
+    return {
+      mediaServerId: media.mediaServerId,
+      metadata,
+      ...(requestedBy.length > 0 ? { requestedBy } : {}),
+    };
+  }
+
+  private async resolveRequesters(
+    media: CollectionMedia,
+    metadata: MediaItem | undefined,
+  ): Promise<string[]> {
+    if (!media.tmdbId) {
+      return [];
+    }
+
+    // Switch on `type`, not parentId presence: Emby/Jellyfin set a movie's
+    // parentId to its library folder, which would misread it as a season.
+    const season =
+      metadata?.type === 'season'
+        ? metadata.index
+        : metadata?.type === 'episode'
+          ? metadata.parentIndex
+          : undefined;
+
+    return this.seerrApi.getRequestedByUsernames(media.tmdbId, season);
   }
 }

--- a/apps/server/src/modules/notifications/notifications.module.ts
+++ b/apps/server/src/modules/notifications/notifications.module.ts
@@ -9,6 +9,7 @@ import { NotificationTimerService } from './notifications-timer.service';
 import { TasksModule } from '../tasks/tasks.module';
 import { CollectionsModule } from '../collections/collections.module';
 import { MediaServerModule } from '../api/media-server/media-server.module';
+import { SeerrApiModule } from '../api/seerr-api/seerr-api.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { MediaServerModule } from '../api/media-server/media-server.module';
     CollectionsModule,
     TasksModule,
     MediaServerModule,
+    SeerrApiModule,
     TypeOrmModule.forFeature([Notification, RuleGroup]),
   ],
   providers: [NotificationService, NotificationTimerService],

--- a/apps/server/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/server/src/modules/notifications/notifications.service.spec.ts
@@ -90,6 +90,149 @@ describe('NotificationService', () => {
     );
   });
 
+  describe('requester in the pre-deletion warning', () => {
+    const aboutToBeHandled = (service: NotificationService) =>
+      (service as any).getContent(
+        NotificationType.MEDIA_ABOUT_TO_BE_HANDLED,
+        false,
+      ).message as string;
+
+    it('names the requester on a single item', async () => {
+      const { service } = createService();
+
+      const content = await (service as any).transformMessageContent(
+        aboutToBeHandled(service),
+        [{ mediaServerId: '1', requestedBy: ['alice'] }],
+        undefined,
+        3,
+      );
+
+      expect(content).toContain("'Test Media' (requested by alice)");
+      expect(content).toContain('will be handled in 3 days');
+    });
+
+    it('joins multiple requesters of the same item', async () => {
+      const { service } = createService();
+
+      const content = await (service as any).transformMessageContent(
+        aboutToBeHandled(service),
+        [{ mediaServerId: '1', requestedBy: ['alice', 'bob'] }],
+        undefined,
+        3,
+      );
+
+      expect(content).toContain("'Test Media' (requested by alice, bob)");
+    });
+
+    it('drops the clause entirely when nobody requested the item', async () => {
+      const { service } = createService();
+
+      const content = await (service as any).transformMessageContent(
+        aboutToBeHandled(service),
+        [{ mediaServerId: '1' }],
+        undefined,
+        3,
+      );
+
+      expect(content).toContain("'Test Media' will be handled in 3 days");
+      // A raw placeholder must never reach a user.
+      expect(content).not.toContain('{requested_by}');
+      expect(content).not.toContain('requested by');
+    });
+
+    it('attributes each item separately in a batch', async () => {
+      const getMetadata = jest
+        .fn()
+        .mockResolvedValueOnce({ title: 'First Title', type: 'movie' })
+        .mockResolvedValueOnce({ title: 'Second Title', type: 'movie' });
+      const mediaServerFactory = {
+        getService: jest.fn().mockResolvedValue({ getMetadata }),
+      };
+      const service = new NotificationService(
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { findOne: jest.fn().mockResolvedValue(null) } as any,
+        {} as any,
+        {} as any,
+        mediaServerFactory as any,
+        createMockLogger() as any,
+        { createLogger: jest.fn().mockReturnValue(createMockLogger()) } as any,
+      );
+
+      const content = await (service as any).transformMessageContent(
+        (service as any).getContent(
+          NotificationType.MEDIA_ABOUT_TO_BE_HANDLED,
+          true,
+        ).message,
+        [
+          { mediaServerId: '1', requestedBy: ['alice'] },
+          { mediaServerId: '2' },
+        ],
+        undefined,
+        3,
+      );
+
+      expect(content).toContain('* First Title (requested by alice)');
+      expect(content).toContain('* Second Title');
+      expect(content).not.toContain('Second Title (requested by');
+      expect(content).not.toContain('{requested_by}');
+    });
+
+    it('still names the requester when the media server is unavailable', async () => {
+      // The requester came from Seerr, so an outage must not leak a raw token.
+      const mediaServerFactory = {
+        getService: jest
+          .fn()
+          .mockRejectedValue(new ServiceUnavailableException()),
+      };
+      const service = new NotificationService(
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { findOne: jest.fn().mockResolvedValue(null) } as any,
+        {} as any,
+        {} as any,
+        mediaServerFactory as any,
+        createMockLogger() as any,
+        { createLogger: jest.fn().mockReturnValue(createMockLogger()) } as any,
+      );
+
+      const content = await (service as any).transformMessageContent(
+        aboutToBeHandled(service),
+        [{ mediaServerId: '1', requestedBy: ['alice'] }],
+        undefined,
+        3,
+      );
+
+      expect(content).toContain('(requested by alice)');
+      expect(content).not.toContain('{requested_by}');
+    });
+
+    it('puts the requester on the wire for external approval workflows', async () => {
+      const { service } = createService();
+      const sendNotification = jest
+        .spyOn(service, 'sendNotification')
+        .mockResolvedValue(undefined);
+
+      await service.handleNotification(
+        NotificationType.MEDIA_ABOUT_TO_BE_HANDLED,
+        [
+          { mediaServerId: '1', requestedBy: ['alice'] },
+          { mediaServerId: '2' },
+        ],
+        undefined,
+        3,
+      );
+
+      const payload = sendNotification.mock.calls[0][1];
+      const mediaItems = JSON.parse(
+        payload.extra!.find((e) => e.name === 'mediaItems')!.value,
+      );
+
+      expect(mediaItems).toEqual([
+        { mediaServerId: '1', requestedBy: ['alice'] },
+        { mediaServerId: '2' },
+      ]);
+    });
+  });
+
   describe('media handled title snapshot (#3249)', () => {
     it('renders the pre-resolved title without a live lookup when the item is gone', async () => {
       // A delete action removes the item from the media server, so a live

--- a/apps/server/src/modules/notifications/notifications.service.ts
+++ b/apps/server/src/modules/notifications/notifications.service.ts
@@ -712,10 +712,16 @@ export class NotificationService implements OnModuleInit {
     payload.extra.push({ name: 'dayAmount', value: dayAmount?.toString() });
     payload.extra.push({
       name: 'mediaItems',
-      // Keep the wire shape lean; the pre-resolved metadata snapshot is only
-      // for internal title rendering, not the webhook payload.
+      // Keep the wire shape lean; the metadata snapshot is only for internal
+      // title rendering. `requestedBy` is the exception: an external workflow
+      // needs it to know who to ask before the item is deleted.
       value: JSON.stringify(
-        mediaItems?.map((item) => ({ mediaServerId: item.mediaServerId })),
+        mediaItems?.map((item) => ({
+          mediaServerId: item.mediaServerId,
+          ...(item.requestedBy?.length
+            ? { requestedBy: item.requestedBy }
+            : {}),
+        })),
       ),
     });
 
@@ -778,7 +784,7 @@ export class NotificationService implements OnModuleInit {
         case NotificationType.MEDIA_ABOUT_TO_BE_HANDLED:
           subject = 'Media About to be Handled';
           message =
-            "⏰ Reminder: '{media_title}' will be handled in {days} days. If you want to keep it, make sure to take action before it's gone. Don’t miss out!";
+            "⏰ Reminder: '{media_title}'{requested_by} will be handled in {days} days. If you want to keep it, make sure to take action before it's gone. Don’t miss out!";
           break;
         case NotificationType.MEDIA_ADDED_TO_COLLECTION:
           subject = 'Media Added to Collection';
@@ -883,7 +889,7 @@ export class NotificationService implements OnModuleInit {
         : message;
 
     if (!items) {
-      return message;
+      return this.applyRequestedBy(message);
     }
 
     try {
@@ -901,7 +907,8 @@ export class NotificationService implements OnModuleInit {
             i.metadata ?? (await mediaServer.getMetadata(i.mediaServerId));
 
           if (item) {
-            titles.push(this.getTitle(item));
+            // Per line, not per message: a batch can mix requesters.
+            titles.push(`${this.getTitle(item)}${this.formatRequestedBy(i)}`);
           } else {
             numUnknownItems++;
           }
@@ -920,6 +927,7 @@ export class NotificationService implements OnModuleInit {
           .join(' \n');
 
         message = message.replace('{media_items}', result);
+        message = this.applyRequestedBy(message);
       } else {
         // if 1 item
         const item =
@@ -931,6 +939,7 @@ export class NotificationService implements OnModuleInit {
             ? this.getTitle(item)
             : '1 item that no longer exists in the media server',
         );
+        message = this.applyRequestedBy(message, items[0]);
       }
 
       return message;
@@ -938,16 +947,38 @@ export class NotificationService implements OnModuleInit {
       if (error instanceof ServiceUnavailableException) {
         // Media server in transition (switched but not yet configured, or
         // mid-switch). Leave the message untransformed; downstream handlers
-        // will still see the raw template.
+        // will still see the raw template. The requester came from Seerr, so it
+        // still resolves.
         this.logger.debug(
           'Skipping notification message transformation; media server not ready',
         );
         this.logger.debug(error);
-        return message;
+        return this.applyRequestedBy(
+          message,
+          items.length === 1 ? items[0] : undefined,
+        );
       }
       this.logger.error("Couldn't transform notification message");
       this.logger.debug(error);
     }
+  }
+
+  /**
+   * The `{requested_by}` placeholder carries its own punctuation so this single
+   * replace always fires, collapsing to '' when nobody requested the item. A
+   * raw token can therefore never reach a user.
+   */
+  private applyRequestedBy(
+    message: string,
+    item?: NotificationMediaItem,
+  ): string {
+    return message.replace('{requested_by}', this.formatRequestedBy(item));
+  }
+
+  private formatRequestedBy(item?: NotificationMediaItem): string {
+    return item?.requestedBy?.length
+      ? ` (requested by ${item.requestedBy.join(', ')})`
+      : '';
   }
 
   private getTitle(item: MediaItem): string {

--- a/apps/server/src/modules/rules/getter/seerr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/seerr-getter.service.ts
@@ -7,6 +7,7 @@ import { Injectable } from '@nestjs/common';
 import _ from 'lodash';
 import { MediaServerFactory } from '../../api/media-server/media-server.factory';
 import {
+  resolveRequestUsername,
   SeerrApiService,
   SeerrMovieResponse,
   SeerrRequest,
@@ -130,7 +131,7 @@ export class SeerrGetterService {
                     continue;
                   }
 
-                  const username = this.resolveRequestUsername(request);
+                  const username = resolveRequestUsername(request);
                   if (username) {
                     userNames.push(username);
                   }
@@ -350,32 +351,5 @@ export class SeerrGetterService {
       (season) => season.seasonNumber === seasonNumber,
     );
     return season !== undefined;
-  }
-
-  /**
-   * Resolves the username from a Seerr request.
-   *
-   * Uses the username fields directly from the Seerr API response
-   * rather than looking up users by ID on the media server, because
-   * media server user IDs don't match Seerr's plexId (Plex.tv ID).
-   *
-   * Seerr user types store their name in different fields:
-   * - Plex (1): plexUsername
-   * - Local (2): username
-   * - Jellyfin (3) / Emby (4): jellyfinUsername
-   */
-  private resolveRequestUsername(request: {
-    requestedBy?: {
-      plexUsername?: string;
-      jellyfinUsername?: string;
-      username?: string;
-    };
-  }): string | undefined {
-    const user = request.requestedBy;
-    if (!user) return undefined;
-
-    return (
-      user.plexUsername || user.jellyfinUsername || user.username || undefined
-    );
   }
 }

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
@@ -164,6 +164,8 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
       string | null
     >(null)
     const [metadata, setMetadata] = useState<MediaItem | null>(null)
+    const [seerrConfigured, setSeerrConfigured] = useState<boolean>(false)
+    const [requestedBy, setRequestedBy] = useState<string[]>([])
     const [maintainerrDetailsState, setMaintainerrDetailsState] = useState<{
       key: string
       details: MaintainerrMediaStatusDetails
@@ -217,6 +219,25 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
       () => mergeProviderIds(metadata?.providerIds, fallbackProviderIds),
       [metadata?.providerIds, fallbackProviderIds],
     )
+    // Seerr tracks TV requests per season, so ask for this item's own season or
+    // the show's other requesters get credited here too.
+    const seerrRequestersPath = useMemo(() => {
+      const tmdbId = providerIds?.tmdb?.[0]
+      if (!seerrConfigured || !tmdbId) {
+        return null
+      }
+
+      const season =
+        metadata?.type === 'season'
+          ? metadata.index
+          : metadata?.type === 'episode'
+            ? metadata.parentIndex
+            : undefined
+
+      const base = `/seerr/requests/${tmdbId}/users`
+      return season != null ? `${base}?season=${season}` : base
+    }, [seerrConfigured, providerIds, metadata])
+
     const backdropRequestPath = buildMetadataImagePath(
       'backdrop',
       mediaType,
@@ -308,6 +329,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
         .then((resp) => {
           if (!active) return
           setTautulliModalUrl(resp?.tautulli_url || null)
+          setSeerrConfigured(!!resp?.seerr_url)
         })
         .catch(() => {})
       // Streamystats is Jellyfin-only (Emby is unsupported upstream), so only
@@ -340,6 +362,26 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
         active = false
       }
     }, [id, isJellyfin])
+
+    useEffect(() => {
+      if (!seerrRequestersPath) {
+        setRequestedBy([])
+        return
+      }
+
+      let active = true
+
+      GetApiHandler<string[]>(seerrRequestersPath)
+        .then((users) => {
+          if (!active) return
+          setRequestedBy(users ?? [])
+        })
+        .catch(() => {})
+
+      return () => {
+        active = false
+      }
+    }, [seerrRequestersPath])
 
     useEffect(() => {
       if (!backdropRequestPath) {
@@ -661,6 +703,13 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
             <div className="mt-2 text-gray-300">
               <p>{metadata?.summary || summary || 'No summary available.'}</p>
             </div>
+
+            {requestedBy.length > 0 ? (
+              <div className="mt-2 text-sm text-zinc-400">
+                Requested by{' '}
+                <span className="text-zinc-200">{requestedBy.join(', ')}</span>
+              </div>
+            ) : null}
 
             {isJellyfin && streamystatsItemUrl ? (
               <StreamystatsStatsPanel


### PR DESCRIPTION
Partially addresses [feature board #213](https://features.maintainerr.info/posts/213/notify-requester-before-automatic-deletion-and-allow-them-to-keep-the-media).

The "Media About to be Handled" notification says an item will be handled in N days, but not who requested it.

This resolves the Seerr requester(s) for each due item and carries them through:

- **Notification message:** `'Some Title' (requested by alice) will be handled in 3 days`. Multi-item batches attribute per line.
- **Webhook payload:** `requestedBy` on each `mediaItems` entry, so an external tool can identify who to ask. Board #213 asks for this ("API support so external tools such as Home Assistant can build custom approval workflows").
- **Media modal:** a "Requested by" line, backed by a new `GET /api/seerr/requests/:tmdbId/users?season=N`.

The lookup is season-aware: Seerr tracks TV requests per season, so without a season a season-level item would credit whoever requested a different season. It is best-effort - an unconfigured or unreachable Seerr yields no requester rather than suppressing the warning itself. That is deliberately the opposite of the rule getter's contract, where an unresolved value must skip the item.

`resolveRequestUsername` moves from the Seerr rule getter into the Seerr API module so both callers share it. No behaviour change there.

### Cost

The notification timer previously made no Seerr or media-server calls of its own. It now performs at most one bulk Seerr `/request` sweep per run (via the existing cached request index), and resolves `getMetadata` per due item. The metadata lookup is not new work overall: `transformMessageContent` already did it once per item *per agent* to render titles, and it now reuses the snapshot instead. Enrichment is memoised per item, so several agents notifying the same item resolve it once.

### Also fixes two webhook agent bugs

`sendNotification` passes the same payload object to every active agent, and `buildPayload` mutated it in place:

- `delete payload.extra` removed the extras from any agent that ran after the webhook. The email and LunaSea agents both forward them.
- Because `parseKeys` then re-read that deleted key, a templated `{{extra}}` always resolved to `[]`.

Both have regression tests that fail against the previous code.

### Not in scope

Board #213 also asks for the requester to be notified directly and given a "Keep" action. Every notification agent is single-destination, Seerr has no API to notify a specific user ([seerr-team/seerr#3247](https://github.com/seerr-team/seerr/issues/3247)), and a requester-facing action would need authentication that Maintainerr does not currently have.
