### PR TITLE
fix(media-server): reflect a manually marked Jellyfin season in rule getters (#3274)

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -1325,9 +1325,9 @@ export class EmbyAdapterService implements IMediaServerService {
   // ============================================================================
 
   resetMetadataCache(_itemId?: string): void {
-    // The Emby cache only stores library/server-wide aggregates, never
-    // per-item entries, so per-item invalidation collapses to a full flush.
-    // Mirrors the Jellyfin adapter, which keeps the same cache shape.
+    // The Emby cache only stores server-wide aggregates (users/libraries/status/
+    // collections), never per-item watch entries (getWatchHistory hits the API
+    // fresh), so a full flush is the simplest correct reset.
     void _itemId;
     this.cache.flush();
   }

--- a/apps/server/src/modules/api/media-server/emby/emby.constants.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby.constants.ts
@@ -1,14 +1,15 @@
 // Emby cache and batching tuning. Values mirror Jellyfin defaults until tuned
-// against a live Emby server.
+// against a live Emby server. TTLs are in SECONDS - node-cache takes ttl in
+// seconds, not milliseconds (see api/lib/cache.ts and #3274).
 
 export const EMBY_CACHE_TTL = {
-  WATCH_HISTORY: 300000,
-  USER_DATA: 300000,
-  PLAYED_THRESHOLD: 300000,
-  USERS: 1800000,
-  LIBRARIES: 1800000,
-  STATUS: 60000,
-  COLLECTIONS: 600,
+  WATCH_HISTORY: 300, // 5 min
+  USER_DATA: 300, // 5 min
+  PLAYED_THRESHOLD: 300, // 5 min
+  USERS: 1800, // 30 min
+  LIBRARIES: 1800, // 30 min
+  STATUS: 60, // 1 min
+  COLLECTIONS: 600, // 10 min
 } as const;
 
 export const EMBY_BATCH_SIZE = {

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -10,7 +10,7 @@ import { delay } from '../../../../utils/delay';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { SettingsDataService } from '../../../settings/settings-data.service';
 import { JellyfinAdapterService } from './jellyfin-adapter.service';
-import { JELLYFIN_BATCH_SIZE } from './jellyfin.constants';
+import { JELLYFIN_BATCH_SIZE, JELLYFIN_CACHE_TTL } from './jellyfin.constants';
 
 const jellyfinApiMocks = {
   getPublicSystemInfo: jest.fn(),
@@ -896,7 +896,7 @@ describe('JellyfinAdapterService', () => {
       expect(jellyfinCacheMocks.data.set).toHaveBeenCalledWith(
         'jellyfin:watch:95:item123',
         history,
-        300000,
+        JELLYFIN_CACHE_TTL.WATCH_HISTORY,
       );
       expect(jellyfinApiMocks.getItems).toHaveBeenCalledWith({
         userId: 'user-1',
@@ -1215,7 +1215,7 @@ describe('JellyfinAdapterService', () => {
       expect(jellyfinCacheMocks.data.set).toHaveBeenCalledWith(
         'jellyfin:favorited-by:item123',
         ['user-2'],
-        300000,
+        JELLYFIN_CACHE_TTL.USER_DATA,
       );
       expect(jellyfinApiMocks.getItems).toHaveBeenCalledWith({
         userId: 'user-1',
@@ -1284,7 +1284,7 @@ describe('JellyfinAdapterService', () => {
       expect(jellyfinCacheMocks.data.set).toHaveBeenCalledWith(
         'jellyfin:total-play-count:item123',
         4,
-        300000,
+        JELLYFIN_CACHE_TTL.USER_DATA,
       );
     });
 
@@ -1304,17 +1304,23 @@ describe('JellyfinAdapterService', () => {
   });
 
   describe('resetMetadataCache', () => {
-    it('should remove threshold-specific watch history entries for one item', () => {
+    it('clears every watch-history entry (incl. descendant episodes) plus this item’s favorite/play-count, keeping aggregates', () => {
       jellyfinCacheMocks.data.keys.mockReturnValue([
-        'jellyfin:watch:90:item123',
-        'jellyfin:watch:95:item123',
+        'jellyfin:watch:90:item123', // this item's watch history
+        'jellyfin:watch:95:item123', // ...at another played threshold
+        'jellyfin:watch:90:episode-999', // a DESCENDANT episode (#3274) - different id
+        'jellyfin:watch:90:episode-watchers:item123', // descendant-watchers rollup
         'jellyfin:favorited-by:item123',
         'jellyfin:total-play-count:item123',
-        'jellyfin:watch:90:item999',
+        'jellyfin:favorited-by:other-item', // unrelated item - must be kept
+        'jellyfin:users', // server-wide aggregate - must be kept
+        'jellyfin:libraries', // server-wide aggregate - must be kept
       ]);
 
       service.resetMetadataCache('item123');
 
+      // Every watch-history key is cleared, including the descendant episode
+      // whose id != itemId - the regression that caused #3274.
       expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
         'jellyfin:watch:90:item123',
       );
@@ -1322,14 +1328,34 @@ describe('JellyfinAdapterService', () => {
         'jellyfin:watch:95:item123',
       );
       expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
+        'jellyfin:watch:90:episode-999',
+      );
+      expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
+        'jellyfin:watch:90:episode-watchers:item123',
+      );
+      // This item's per-item favorite/play-count entries still cleared as before.
+      expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
         'jellyfin:favorited-by:item123',
       );
       expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
         'jellyfin:total-play-count:item123',
       );
+      // Unrelated per-item and server-wide aggregate caches are preserved.
       expect(jellyfinCacheMocks.data.del).not.toHaveBeenCalledWith(
-        'jellyfin:watch:90:item999',
+        'jellyfin:favorited-by:other-item',
       );
+      expect(jellyfinCacheMocks.data.del).not.toHaveBeenCalledWith(
+        'jellyfin:users',
+      );
+      expect(jellyfinCacheMocks.data.del).not.toHaveBeenCalledWith(
+        'jellyfin:libraries',
+      );
+    });
+
+    it('flushes the whole cache when called without an item id', () => {
+      service.resetMetadataCache();
+
+      expect(jellyfinCacheMocks.data.flushAll).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -2067,12 +2067,20 @@ export class JellyfinAdapterService implements IMediaServerService {
 
   resetMetadataCache(itemId?: string): void {
     if (itemId) {
+      // Watch-history entries are keyed per item. Season/show getters
+      // (e.g. sw_allEpisodesSeenBy) aggregate their DESCENDANT episodes' entries,
+      // which carry the episode id - not the season/show id passed here - so
+      // scoping the watch invalidation to `:${itemId}` left them stale: a season
+      // stayed "not watched by everyone" for hours after a manual mark in
+      // Jellyfin (#3274). Clear the whole watch-history namespace instead (cheap,
+      // and flushed each run anyway). The item's favourite/play-count entries and
+      // the server-wide aggregate caches (users/libraries/status/collections) are
+      // invalidated exactly as before.
       this.cache.data
         .keys()
         .filter(
           (key) =>
-            (key.startsWith(`${JELLYFIN_CACHE_KEYS.WATCH_HISTORY}:`) &&
-              key.endsWith(`:${itemId}`)) ||
+            key.startsWith(`${JELLYFIN_CACHE_KEYS.WATCH_HISTORY}:`) ||
             key === `${JELLYFIN_CACHE_KEYS.FAVORITED_BY}:${itemId}` ||
             key === `${JELLYFIN_CACHE_KEYS.TOTAL_PLAY_COUNT}:${itemId}`,
         )

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin.constants.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin.constants.ts
@@ -1,11 +1,15 @@
+// TTLs are in SECONDS - node-cache takes ttl in seconds, not milliseconds (see
+// api/lib/cache.ts, DEFAULT_TTL = 300). These were previously written in
+// milliseconds, so watch history lived ~83h instead of 5min and a season's
+// watched-state stayed stale for hours after a manual mark in Jellyfin (#3274).
 export const JELLYFIN_CACHE_TTL = {
-  WATCH_HISTORY: 300000,
-  USER_DATA: 300000,
-  PLAYED_THRESHOLD: 300000,
-  USERS: 1800000,
-  LIBRARIES: 1800000,
-  STATUS: 60000,
-  COLLECTIONS: 600,
+  WATCH_HISTORY: 300, // 5 min
+  USER_DATA: 300, // 5 min
+  PLAYED_THRESHOLD: 300, // 5 min
+  USERS: 1800, // 30 min
+  LIBRARIES: 1800, // 30 min
+  STATUS: 60, // 1 min
+  COLLECTIONS: 600, // 10 min
 } as const;
 
 export const JELLYFIN_BATCH_SIZE = {


### PR DESCRIPTION
Fixes #3274.

A Jellyfin season marked watched via the season-level checkmark stayed missing from **Users that watched every episode** for hours - Test Media returned an empty list while **Users that watched at least one episode** was correct. Verified against a real Jellyfin that the mark propagates to every episode instantly, so the staleness was Maintainerr's watch cache, not Jellyfin.

- `resetMetadataCache` scoped the watch-history clear to the item id, so a season/show never invalidated its **descendant episodes'** watch caches (they carry the episode id). It now clears the whole watch-history namespace; the item's favourite/play-count entries and the server-wide aggregate caches (users/libraries/status/collections) are invalidated exactly as before.
- Jellyfin/Emby cache TTLs were written in milliseconds, but `node-cache` takes seconds, so watch history lived ~83h instead of 5min (status ~16.7h, users ~20d). Corrected to the intended seconds.

Before: a freshly marked season returned `every episode = []`, `result: false`. After: `[user]`, `result: true`.
