### PR TITLE
fix: bound external API response cache key counts (#3284)

### DIFF
--- a/apps/server/src/modules/api/lib/cache.spec.ts
+++ b/apps/server/src/modules/api/lib/cache.spec.ts
@@ -1,0 +1,109 @@
+import cacheManager, { Cache, DEFAULT_MAX_KEYS } from './cache';
+
+describe('Cache key-count bound (#3284)', () => {
+  const fill = (cache: Cache, count: number, prefix = 'k') => {
+    for (let i = 0; i < count; i++) {
+      cache.data.set(`${prefix}${i}`, { i });
+    }
+  };
+
+  describe('bounded cache', () => {
+    it('holds at the ceiling and evicts the oldest key first (FIFO)', () => {
+      const cache = new Cache('t', 't', 'tmdb', { maxKeys: 3 });
+
+      cache.data.set('a', 1);
+      cache.data.set('b', 2);
+      cache.data.set('c', 3);
+      expect(cache.data.keys().sort()).toEqual(['a', 'b', 'c']);
+
+      // Inserting a 4th key evicts the oldest ('a'), not a newer one.
+      cache.data.set('d', 4);
+      expect(cache.data.keys()).toHaveLength(3);
+      expect(cache.data.has('a')).toBe(false);
+      expect(cache.data.keys().sort()).toEqual(['b', 'c', 'd']);
+      // The just-inserted value is retrievable.
+      expect(cache.data.get('d')).toBe(4);
+    });
+
+    it('stays bounded no matter how many distinct keys are inserted', () => {
+      const cache = new Cache('t', 't', 'tmdb', { maxKeys: 10 });
+      fill(cache, 1000);
+      expect(cache.data.keys()).toHaveLength(10);
+      // FIFO: only the most-recent 10 survive.
+      expect(cache.data.has('k999')).toBe(true);
+      expect(cache.data.has('k989')).toBe(false);
+    });
+
+    it('overwriting an existing key reuses its slot (no eviction)', () => {
+      const cache = new Cache('t', 't', 'tmdb', { maxKeys: 2 });
+      cache.data.set('a', 1);
+      cache.data.set('b', 2);
+      cache.data.set('a', 99); // overwrite, not a new key
+
+      expect(cache.data.keys()).toHaveLength(2);
+      expect(cache.data.get('a')).toBe(99);
+      expect(cache.data.has('b')).toBe(true);
+    });
+
+    it('preserves the ttl argument on set()', () => {
+      const cache = new Cache('t', 't', 'tmdb', { maxKeys: 5 });
+      cache.data.set('a', 1, 100);
+      const ttl = cache.data.getTtl('a');
+      expect(ttl).toBeGreaterThan(Date.now());
+    });
+  });
+
+  describe('unbounded opt-out (maxKeys: 0)', () => {
+    it('never evicts - for single-aggregate prefetch caches', () => {
+      const cache = new Cache('t', 't', 'plexwatchhistory', {
+        maxKeys: 0,
+        useClones: false,
+      });
+      fill(cache, DEFAULT_MAX_KEYS + 25);
+      expect(cache.data.keys()).toHaveLength(DEFAULT_MAX_KEYS + 25);
+    });
+  });
+
+  describe('default configuration', () => {
+    it('bounds a cache with no explicit maxKeys at DEFAULT_MAX_KEYS', () => {
+      const cache = new Cache('t', 't', 'tmdb');
+      fill(cache, DEFAULT_MAX_KEYS + 25);
+      expect(cache.data.keys()).toHaveLength(DEFAULT_MAX_KEYS);
+    });
+
+    it('bounds the shared per-item response caches (tmdb, plexguid)', () => {
+      for (const id of ['tmdb', 'plexguid'] as const) {
+        const cache = cacheManager.getCache(id);
+        cache.data.flushAll();
+        fill(cache, DEFAULT_MAX_KEYS + 25);
+        expect(cache.data.keys()).toHaveLength(DEFAULT_MAX_KEYS);
+        cache.data.flushAll();
+      }
+    });
+
+    it('leaves the prefetch-Map caches unbounded (plexwatchhistory, seerrrequests)', () => {
+      for (const id of ['plexwatchhistory', 'seerrrequests'] as const) {
+        const cache = cacheManager.getCache(id);
+        cache.data.flushAll();
+        fill(cache, DEFAULT_MAX_KEYS + 25);
+        expect(cache.data.keys()).toHaveLength(DEFAULT_MAX_KEYS + 25);
+        cache.data.flushAll();
+      }
+    });
+  });
+
+  describe('existing behaviour is preserved', () => {
+    it('flushAll() skips persistent caches and clears the rest', () => {
+      const tmdb = cacheManager.getCache('tmdb'); // persistent
+      const plexguid = cacheManager.getCache('plexguid'); // not persistent
+      tmdb.data.set('keep', 1);
+      plexguid.data.set('drop', 1);
+
+      cacheManager.flushAll();
+
+      expect(tmdb.data.has('keep')).toBe(true);
+      expect(plexguid.data.has('drop')).toBe(false);
+      tmdb.data.flushAll();
+    });
+  });
+});

--- a/apps/server/src/modules/api/lib/cache.ts
+++ b/apps/server/src/modules/api/lib/cache.ts
@@ -19,6 +19,13 @@ type CacheType = AvailableCacheIds | 'radarr' | 'sonarr';
 
 const DEFAULT_TTL = 300; // 5 min
 const DEFAULT_CHECK_PERIOD = 120; // 2 min
+// Default hard ceiling on distinct keys per cache. A bulk rule sweep caches one
+// response per library item, and the metadata TTLs (up to 6h) far outlast a run,
+// so without a count bound the caches grow to library size and can OOM a small
+// container (#3284). 1000 keeps the dominant tmdb cache to roughly a quarter of a
+// 512MB heap while staying far above any paginated/working-set flow, so normal
+// use never evicts.
+export const DEFAULT_MAX_KEYS = 1000;
 
 type CacheOptions = {
   stdTtl?: number;
@@ -31,7 +38,50 @@ type CacheOptions = {
   // where cloning large objects on every get() would be prohibitively expensive.
   // Never mutate values returned from caches that set this to false.
   useClones?: boolean;
+  // Hard ceiling on distinct keys. When full, inserting a new key first evicts
+  // the oldest inserted key (FIFO), so peak memory stays bounded regardless of
+  // library size. Defaults to DEFAULT_MAX_KEYS. Set to 0 to disable the bound -
+  // used for single-aggregate caches that intentionally hold one large value
+  // (the prefetch Maps), never one entry per item.
+  maxKeys?: number;
 };
+
+/**
+ * A NodeCache with a hard key-count ceiling and FIFO eviction. node-cache's own
+ * `maxKeys` throws ECACHEFULL on overflow instead of evicting, and every caller
+ * `set()`s directly (external-api.service, plexApi), so the bound is enforced
+ * here by overriding `set()` to evict the oldest key before inserting a new one.
+ */
+class BoundedNodeCache extends NodeCache {
+  constructor(
+    private readonly maxKeys: number,
+    options: NodeCache.Options,
+  ) {
+    super(options);
+  }
+
+  override set<T>(
+    key: NodeCache.Key,
+    value: T,
+    ttl?: number | string,
+  ): boolean {
+    // Only a genuinely new key grows the count; overwriting an existing key
+    // reuses its slot. getStats().keys is maintained by node-cache (kept
+    // accurate through TTL expiry too), so this stays O(1) below the cap.
+    if (!this.has(key) && this.getStats().keys >= this.maxKeys) {
+      // keys() returns Object.keys(data) in insertion order, so [0] is the
+      // oldest inserted key.
+      const oldest = this.keys()[0];
+      if (oldest !== undefined) {
+        this.del(oldest);
+      }
+    }
+
+    return ttl === undefined
+      ? super.set(key, value)
+      : super.set(key, value, ttl);
+  }
+}
 
 export class Cache {
   public id: string;
@@ -50,11 +100,16 @@ export class Cache {
     this.name = name;
     this.type = type;
     this.persistent = options.persistent ?? false;
-    this.data = new NodeCache({
+    const nodeCacheOptions: NodeCache.Options = {
       stdTTL: options.stdTtl ?? DEFAULT_TTL,
       checkperiod: options.checkPeriod ?? DEFAULT_CHECK_PERIOD,
       useClones: options.useClones ?? true,
-    });
+    };
+    const maxKeys = options.maxKeys ?? DEFAULT_MAX_KEYS;
+    this.data =
+      maxKeys > 0
+        ? new BoundedNodeCache(maxKeys, nodeCacheOptions)
+        : new NodeCache(nodeCacheOptions);
   }
 
   public getStats() {
@@ -91,6 +146,9 @@ class CacheManager {
         stdTtl: 3600, // 1 hour
         persistent: true,
         useClones: false,
+        // Holds a single prefetched Map, not one entry per item - exempt from
+        // the key-count bound so it is never evicted mid-run.
+        maxKeys: 0,
       },
     ),
     plextv: new Cache('plextv', 'Plex.tv', 'plextv'),
@@ -108,6 +166,9 @@ class CacheManager {
       {
         stdTtl: 3600, // 1 hour
         useClones: false,
+        // Single prefetched request index (one Map), not one entry per item -
+        // exempt from the key-count bound so it is never evicted mid-run.
+        maxKeys: 0,
       },
     ),
     plexcommunity: new Cache(


### PR DESCRIPTION
Fixes #3284.

The external API response caches in `apps/server/src/modules/api/lib/cache.ts` were bounded only by TTL, not by key count. During a bulk rule sweep the executor caches one response per library item far faster than the TTL (up to 6h for `tmdb`/`tvdb`) can expire them, so a cache grows to library size and can exhaust a small container's heap before the run finishes.

- `BoundedNodeCache` evicts the oldest key (FIFO) before inserting once the key ceiling is reached. `node-cache`'s own `maxKeys` throws `ECACHEFULL` on overflow instead of evicting, and callers `set()` directly, so the bound is enforced by overriding `set()`.
- The ceiling (`DEFAULT_MAX_KEYS = 1000`) applies to the per-item response caches. The single-aggregate prefetch Maps (`plexwatchhistory`, `seerrrequests`) opt out with `maxKeys: 0`; they hold one large value, not one entry per item, and must never be evicted mid-run.

Peak memory during a rule run is now bounded independent of library size. Verified against a real Plex + Radarr stack: with a low ceiling, a sweep that previously grew the caches one key per movie held flat at the cap, with unchanged rule output. Complements #3285.
