### PR TITLE
perf: memoize metadata id-resolution per item during rule evaluation (#3285)

### DIFF
--- a/apps/server/src/modules/rules/getter/radarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.spec.ts
@@ -16,7 +16,11 @@ import { ServarrService } from '../../api/servarr-api/servarr.service';
 import { CollectionMedia } from '../../collections/entities/collection_media.entities';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { MetadataService } from '../../metadata/metadata.service';
+import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 import { RadarrGetterService } from './radarr-getter.service';
+
+// Let the memo's eviction callback (chained on the resolved promise) run.
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
 
 describe('RadarrGetterService', () => {
   let radarrGetterService: RadarrGetterService;
@@ -372,6 +376,69 @@ describe('RadarrGetterService', () => {
       jest.spyOn(mockedRadarrApi, 'getMovieByTmdbId').mockResolvedValue(null);
 
       await expect(call(26)).resolves.toBeNull();
+    });
+  });
+
+  // The candidate resolution that precedes the arr lookup ran once per rule
+  // condition; the run-scoped ArrLookupCache now memoizes it so it runs once per
+  // item (#3285). Mirrors the arr identity lookup's run-scoped dedup (#2897).
+  describe('candidate resolution memoization (#3285)', () => {
+    let collectionMedia: CollectionMedia;
+    let mediaItem: MediaItem;
+
+    beforeEach(() => {
+      collectionMedia = createCollectionMedia('movie');
+      collectionMedia.collection.radarrSettingsId = 1;
+      mediaItem = createMediaItem({ type: 'movie' });
+      mockRadarrApi(createRadarrMovie());
+    });
+
+    // id 25 = movieTitle - a plain lookup that goes through candidate resolution.
+    const call = (arrLookupCache?: ArrLookupCache) =>
+      radarrGetterService.get(
+        25,
+        mediaItem,
+        createRulesDto({
+          collection: collectionMedia.collection,
+          dataType: 'movie',
+        }),
+        undefined,
+        arrLookupCache,
+      );
+
+    it('resolves candidates once per item across conditions sharing a run cache', async () => {
+      const cache = new ArrLookupCache();
+
+      await call(cache);
+      await call(cache); // second condition, same item + same run cache
+
+      expect(
+        metadataService.resolveLookupCandidatesFromMediaItemForService,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-resolves per call when no run cache is provided (unchanged behaviour)', async () => {
+      await call();
+      await call();
+
+      expect(
+        metadataService.resolveLookupCandidatesFromMediaItemForService,
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    it('evicts an empty resolution so a later condition retries (transient safety, #3125)', async () => {
+      metadataService.resolveLookupCandidatesFromMediaItemForService
+        .mockResolvedValueOnce([]) // transient: nothing resolved
+        .mockResolvedValue([{ providerKey: 'tmdb', id: 1 }]);
+      const cache = new ArrLookupCache();
+
+      await call(cache); // empty -> evicted from the memo
+      await flushMicrotasks();
+      await call(cache); // retries instead of serving the stale empty result
+
+      expect(
+        metadataService.resolveLookupCandidatesFromMediaItemForService,
+      ).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/server/src/modules/rules/getter/radarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.ts
@@ -67,8 +67,10 @@ export class RadarrGetterService {
         );
       }
 
-      const lookupCandidates =
-        await this.findLookupCandidatesFromMediaItem(libItem);
+      const lookupCandidates = await this.findLookupCandidatesFromMediaItem(
+        libItem,
+        arrLookupCache,
+      );
 
       if (lookupCandidates.length === 0) {
         this.logger.warn(
@@ -251,10 +253,27 @@ export class RadarrGetterService {
 
   public async findLookupCandidatesFromMediaItem(
     libItem: MediaItem,
+    arrLookupCache?: ArrLookupCache,
   ): Promise<MetadataLookupCandidate[]> {
-    return this.metadataService.resolveLookupCandidatesFromMediaItemForService(
-      libItem,
-      'radarr',
-    );
+    // Candidate resolution (media-server ids -> validated provider ids) is
+    // identical for an item across every condition in a run, yet ran once per
+    // condition - redundant CPU, response cloning and duplicate logs (#3285).
+    // Dedupe it through the same run-scoped memo the arr identity lookup uses.
+    // Evict an empty result so a transient metadata-provider failure retries on
+    // the next condition instead of sticking for the run (mirrors resolveMovie's
+    // evict-on-failure and keeps the #3125 fail-closed behaviour).
+    const resolve = () =>
+      this.metadataService.resolveLookupCandidatesFromMediaItemForService(
+        libItem,
+        'radarr',
+      );
+
+    return arrLookupCache
+      ? arrLookupCache.memoize(
+          `metadata:radarr:${libItem.id}`,
+          resolve,
+          (candidates) => candidates.length === 0,
+        )
+      : resolve();
   }
 }

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
@@ -21,6 +21,9 @@ import { MetadataService } from '../../metadata/metadata.service';
 import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 import { SonarrGetterService } from './sonarr-getter.service';
 
+// Let the memo's eviction callback (chained on the resolved promise) run.
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
 describe('SonarrGetterService', () => {
   let sonarrGetterService: SonarrGetterService;
   let servarrService: Mocked<ServarrService>;
@@ -327,6 +330,70 @@ describe('SonarrGetterService', () => {
           expect(s2).toBe(true);
         },
       );
+    });
+
+    // Candidate resolution preceding the series lookup ran once per rule
+    // condition; the run-scoped ArrLookupCache now memoizes it so it runs once
+    // per show (#3285). Mirrors the arr identity lookup's run-scoped dedup (#2897).
+    describe('candidate resolution memoization (#3285)', () => {
+      let collectionMedia: CollectionMedia;
+      let showItem: MediaItem;
+
+      beforeEach(() => {
+        collectionMedia = createCollectionMedia('show');
+        collectionMedia.collection.sonarrSettingsId = 1;
+        showItem = createMediaItem({ type: 'show' });
+        mockSonarrApi(createSonarrSeries());
+      });
+
+      // id 0 = addDate - a plain show lookup that goes through candidate resolution.
+      const call = (arrLookupCache?: ArrLookupCache) =>
+        sonarrGetterService.get(
+          0,
+          showItem,
+          'show',
+          createRulesDto({
+            collection: collectionMedia.collection,
+            dataType: 'show',
+          }),
+          undefined,
+          arrLookupCache,
+        );
+
+      it('resolves candidates once per show across conditions sharing a run cache', async () => {
+        const cache = new ArrLookupCache();
+
+        await call(cache);
+        await call(cache); // second condition, same show + same run cache
+
+        expect(
+          metadataService.resolveLookupCandidatesFromMediaItemForService,
+        ).toHaveBeenCalledTimes(1);
+      });
+
+      it('re-resolves per call when no run cache is provided (unchanged behaviour)', async () => {
+        await call();
+        await call();
+
+        expect(
+          metadataService.resolveLookupCandidatesFromMediaItemForService,
+        ).toHaveBeenCalledTimes(2);
+      });
+
+      it('evicts an empty resolution so a later condition retries (transient safety, #3125)', async () => {
+        metadataService.resolveLookupCandidatesFromMediaItemForService
+          .mockResolvedValueOnce([]) // transient: nothing resolved
+          .mockResolvedValue([{ providerKey: 'tvdb', id: 1 }] as any);
+        const cache = new ArrLookupCache();
+
+        await call(cache); // empty -> evicted from the memo
+        await flushMicrotasks();
+        await call(cache); // retries instead of serving the stale empty result
+
+        expect(
+          metadataService.resolveLookupCandidatesFromMediaItemForService,
+        ).toHaveBeenCalledTimes(2);
+      });
     });
   });
 

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -100,8 +100,10 @@ export class SonarrGetterService {
         );
       }
 
-      const lookupCandidates =
-        await this.findLookupCandidatesFromMediaItem(libItem);
+      const lookupCandidates = await this.findLookupCandidatesFromMediaItem(
+        libItem,
+        arrLookupCache,
+      );
 
       if (lookupCandidates.length === 0) {
         this.logger.warn(
@@ -729,11 +731,30 @@ export class SonarrGetterService {
 
   public async findLookupCandidatesFromMediaItem(
     libItem: MediaItem,
+    arrLookupCache?: ArrLookupCache,
   ): Promise<MetadataLookupCandidate[]> {
-    return this.metadataService.resolveLookupCandidatesFromMediaItemForService(
-      libItem,
-      'sonarr',
-    );
+    // Candidate resolution (media-server ids -> validated provider ids) is
+    // identical for an item across every condition in a run, yet ran once per
+    // condition - redundant CPU, response cloning and duplicate logs (#3285).
+    // Dedupe it through the same run-scoped memo the arr identity lookup uses.
+    // libItem here is already the parent show (season/episode items are resolved
+    // up to it above), so the key collapses every season/episode of a show onto
+    // one entry. Evict an empty result so a transient metadata-provider failure
+    // retries next condition instead of sticking (mirrors resolveSeries's
+    // evict-on-failure and keeps the #3125 fail-closed behaviour).
+    const resolve = () =>
+      this.metadataService.resolveLookupCandidatesFromMediaItemForService(
+        libItem,
+        'sonarr',
+      );
+
+    return arrLookupCache
+      ? arrLookupCache.memoize(
+          `metadata:sonarr:${libItem.id}`,
+          resolve,
+          (candidates) => candidates.length === 0,
+        )
+      : resolve();
   }
 
   // Sonarr properties whose semantics match cleanly across Sonarr / TMDB /


### PR DESCRIPTION
Fixes #3285.

During rule evaluation the Radarr/Sonarr getters resolved an item's metadata lookup candidates (`MetadataService.resolveLookupCandidatesFromMediaItemForService`, via `findLookupCandidatesFromMediaItem`) once per rule *condition* instead of once per item. The provider response is served from cache, so this is not extra network, but each redundant call still deep-clones the response, re-runs year-drift validation and re-emits its log line - scaling with (conditions x library size). `ArrLookupCache` (#2897) already dedupes the arr identity lookup that follows, but not the candidate resolution that precedes it.

- Route the candidate resolution through the same run-scoped `ArrLookupCache`, keyed `metadata:${service}:${libItem.id}`. For Sonarr the key is the parent show, so every season/episode of a show collapses onto one entry.
- Empty results are evicted so a transient metadata-provider failure retries on the next condition instead of sticking for the run, preserving the #3125 fail-closed behaviour (mirrors the existing `resolveMovie`/`resolveSeries` eviction).

The memo is the eval-only instance created in the executor and never handed to the collection/action phase, so cleanup still resolves fresh (same lifecycle as #2897).

Verified on a real Plex + Radarr stack: a 2-condition Radarr group over a 5-movie library ran the resolution 10 times before and 5 times after, with identical rule output. Complements #3284.
