### PR TITLE
feat(collections): postpone deletion for a single collection item

### DIFF
--- a/apps/server/src/modules/collections/collections.controller.spec.ts
+++ b/apps/server/src/modules/collections/collections.controller.spec.ts
@@ -40,6 +40,7 @@ describe('CollectionsController', () => {
     getCollectionRecord: jest.fn(),
     getCollectionMediaRecord: jest.fn(),
     MediaCollectionActionWithContext: jest.fn(),
+    postponeCollectionMedia: jest.fn(),
   } as unknown as jest.Mocked<CollectionsService>;
 
   const collectionWorkerService = {
@@ -407,6 +408,57 @@ describe('CollectionsController', () => {
         mediaId: media.mediaServerId,
       }),
     ).resolves.not.toThrow();
+  });
+
+  describe('postponeCollectionMedia', () => {
+    const body = { collectionId: 3, mediaId: '5', days: 14 };
+
+    it('postpones under the execution lock and returns the result', async () => {
+      const release = jest.fn();
+      executionLock.tryAcquire.mockReturnValue(release);
+      const result = {
+        collectionId: 3,
+        mediaServerId: '5',
+        addDate: new Date(2026, 6, 8),
+        deleteAfterDays: 30,
+        deletionDate: new Date(2026, 7, 7),
+      };
+      (
+        collectionsService.postponeCollectionMedia as jest.Mock
+      ).mockResolvedValue(result);
+
+      await expect(controller.postponeCollectionMedia(body)).resolves.toBe(
+        result,
+      );
+      expect(collectionsService.postponeCollectionMedia).toHaveBeenCalledWith(
+        3,
+        '5',
+        14,
+      );
+      expect(release).toHaveBeenCalled();
+    });
+
+    it('throws ConflictException when the execution lock is held', async () => {
+      executionLock.tryAcquire.mockReturnValue(null);
+
+      await expect(controller.postponeCollectionMedia(body)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(collectionsService.postponeCollectionMedia).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException and releases the lock when the item is missing', async () => {
+      const release = jest.fn();
+      executionLock.tryAcquire.mockReturnValue(release);
+      (
+        collectionsService.postponeCollectionMedia as jest.Mock
+      ).mockResolvedValue(undefined);
+
+      await expect(controller.postponeCollectionMedia(body)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(release).toHaveBeenCalled();
+    });
   });
 
   describe('uploadCollectionPoster', () => {

--- a/apps/server/src/modules/collections/collections.controller.ts
+++ b/apps/server/src/modules/collections/collections.controller.ts
@@ -216,6 +216,14 @@ export const handleCollectionMediaBodySchema = z.object({
   collectionId: z.number().int(),
   mediaId: z.string().min(1),
 });
+export const postponeCollectionMediaBodySchema = z.object({
+  collectionId: z.number().int(),
+  mediaId: z.string().min(1),
+  // Omit to reset the full grace window; provide to push the deadline out by
+  // this many days. Upper bound mirrors the UI (PostponeButton) and keeps the
+  // resulting date well within Date range.
+  days: z.coerce.number().int().positive().max(3650).optional(),
+});
 
 type CreateCollectionBody = z.infer<typeof createCollectionBodySchema>;
 type AddToCollectionBody = z.infer<typeof addToCollectionBodySchema>;
@@ -228,6 +236,9 @@ type ManualCollectionActionBody = z.infer<
 >;
 type HandleCollectionMediaBody = z.infer<
   typeof handleCollectionMediaBodySchema
+>;
+type PostponeCollectionMediaBody = z.infer<
+  typeof postponeCollectionMediaBodySchema
 >;
 
 @Controller('api/collections')
@@ -442,6 +453,50 @@ export class CollectionsController {
           'The collection action could not be executed for this item',
         );
       }
+    } finally {
+      release();
+    }
+  }
+
+  @Post('/media/postpone')
+  @ApiOperation({
+    summary: 'Postpone (or reset) the deletion timer for one collection item',
+  })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Returns the new addDate, the collection deleteAfterDays, and the resulting deletionDate.',
+  })
+  async postponeCollectionMedia(
+    @Body(new ZodValidationPipe(postponeCollectionMediaBodySchema))
+    request: PostponeCollectionMediaBody,
+  ) {
+    // Share the collection/rule execution lock: a worker run that has already
+    // selected this item for deletion would otherwise delete it despite the
+    // postpone. Fail fast so the caller retries once the run finishes, rather
+    // than silently losing the "keep" (the worker re-reads addDate next pass).
+    const release = this.executionLock.tryAcquire(
+      RULES_COLLECTIONS_EXECUTION_LOCK_KEY,
+    );
+
+    if (!release) {
+      throw new ConflictException(
+        'Collection handling is already running. Try again when the current collection or rule execution finishes.',
+      );
+    }
+
+    try {
+      const result = await this.collectionService.postponeCollectionMedia(
+        request.collectionId,
+        request.mediaId,
+        request.days,
+      );
+
+      if (!result) {
+        throw new NotFoundException('Media not found in collection');
+      }
+
+      return result;
     } finally {
       release();
     }

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -1,4 +1,5 @@
 import {
+  ECollectionLogType,
   MaintainerrEvent,
   MediaCollection,
   MediaServerFeature,
@@ -103,6 +104,95 @@ describe('CollectionsService', () => {
     jest
       .spyOn(service, 'updateCollectionTotalSize')
       .mockResolvedValue(undefined);
+  });
+
+  describe('postponeCollectionMedia', () => {
+    it('pushes the deadline out by whole days and normalises addDate to midnight', async () => {
+      const collection = createCollection({ id: 1, deleteAfterDays: 30 });
+      const media = createCollectionMedia(collection, {
+        id: 5,
+        mediaServerId: 'item-5',
+        // deliberately mid-day, to prove normalisation to midnight
+        addDate: new Date(2026, 5, 24, 16, 12, 49),
+      });
+      collectionRepo.findOne.mockResolvedValue(collection);
+      collectionMediaRepo.findOne.mockResolvedValue(media);
+      const logSpy = jest
+        .spyOn(service, 'addLogRecord')
+        .mockResolvedValue(undefined);
+
+      const result = await service.postponeCollectionMedia(1, 'item-5', 14);
+
+      // June 24 + 14 days = July 8 2026, at local midnight
+      expect(collectionMediaRepo.update).toHaveBeenCalledWith(5, {
+        addDate: new Date(2026, 6, 8),
+      });
+      expect(result).toEqual({
+        collectionId: 1,
+        mediaServerId: 'item-5',
+        addDate: new Date(2026, 6, 8),
+        deleteAfterDays: 30,
+        // July 8 + 30 days = Aug 7 2026
+        deletionDate: new Date(2026, 7, 7),
+      });
+      expect(logSpy).toHaveBeenCalledWith(
+        collection,
+        'Postponed deletion of media item-5 by 14 day(s)',
+        ECollectionLogType.MEDIA,
+      );
+    });
+
+    it('resets the full window to today at midnight when days is omitted', async () => {
+      jest.useFakeTimers().setSystemTime(new Date(2026, 6, 19, 15, 30, 0));
+      try {
+        const collection = createCollection({ id: 1, deleteAfterDays: 30 });
+        const media = createCollectionMedia(collection, {
+          id: 5,
+          mediaServerId: 'item-5',
+          addDate: new Date(2026, 4, 1),
+        });
+        collectionRepo.findOne.mockResolvedValue(collection);
+        collectionMediaRepo.findOne.mockResolvedValue(media);
+        const logSpy = jest
+          .spyOn(service, 'addLogRecord')
+          .mockResolvedValue(undefined);
+
+        const result = await service.postponeCollectionMedia(1, 'item-5');
+
+        expect(collectionMediaRepo.update).toHaveBeenCalledWith(5, {
+          addDate: new Date(2026, 6, 19),
+        });
+        expect(result?.addDate).toEqual(new Date(2026, 6, 19));
+        // today + 30 days = Aug 18 2026
+        expect(result?.deletionDate).toEqual(new Date(2026, 7, 18));
+        expect(logSpy).toHaveBeenCalledWith(
+          collection,
+          'Reset deletion timer for media item-5',
+          ECollectionLogType.MEDIA,
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('returns undefined and does not write when the item is not in the collection', async () => {
+      collectionRepo.findOne.mockResolvedValue(createCollection({ id: 1 }));
+      collectionMediaRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.postponeCollectionMedia(1, 'missing', 14);
+
+      expect(result).toBeUndefined();
+      expect(collectionMediaRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when the collection does not exist', async () => {
+      collectionRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.postponeCollectionMedia(999, 'item-5', 14);
+
+      expect(result).toBeUndefined();
+      expect(collectionMediaRepo.update).not.toHaveBeenCalled();
+    });
   });
 
   describe('removeMediaFromOtherCollections', () => {

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -85,6 +85,14 @@ interface SharedManualCollectionReconciliationOptions {
   serverChildren?: MediaItem[];
 }
 
+export interface PostponeCollectionMediaResult {
+  collectionId: number;
+  mediaServerId: string;
+  addDate: Date;
+  deleteAfterDays: number | null;
+  deletionDate: Date | null;
+}
+
 @Injectable()
 export class CollectionsService {
   constructor(
@@ -162,6 +170,70 @@ export class CollectionsService {
         mediaServerId,
       },
     });
+  }
+
+  /**
+   * Postpone the deletion timer for one collection-media item by moving its
+   * `addDate` - the worker deletes once `addDate + deleteAfterDays` has passed,
+   * so no schema or worker change is needed. `days` pushes the deadline out;
+   * omitting it restarts the full window. For external automation (Home
+   * Assistant, Ombi, Seerr) - Maintainerr never contacts the requester itself.
+   */
+  async postponeCollectionMedia(
+    collectionId: number,
+    mediaServerId: string,
+    days?: number,
+  ): Promise<PostponeCollectionMediaResult | undefined> {
+    const collection = await this.getCollectionRecord(collectionId);
+    if (!collection) {
+      return undefined;
+    }
+
+    const media = await this.getCollectionMediaRecord(
+      collectionId,
+      mediaServerId,
+    );
+    if (!media) {
+      return undefined;
+    }
+
+    // Add whole calendar days (DST-safe, unlike ms arithmetic) and store at
+    // date granularity to match insertCollectionMediaMembership - every other
+    // addDate is a midnight value, so "days left" stays stable regardless of
+    // the time of day this call arrives.
+    const newAddDate = days != null ? new Date(media.addDate) : new Date();
+    if (days != null) {
+      newAddDate.setDate(newAddDate.getDate() + days);
+    }
+    newAddDate.setHours(0, 0, 0, 0);
+
+    await this.CollectionMediaRepo.update(media.id, { addDate: newAddDate });
+
+    await this.addLogRecord(
+      collection,
+      days != null
+        ? `Postponed deletion of media ${mediaServerId} by ${days} day(s)`
+        : `Reset deletion timer for media ${mediaServerId}`,
+      ECollectionLogType.MEDIA,
+    );
+
+    // Surface the resulting deadline (addDate + deleteAfterDays) so the caller
+    // can confirm it. Null when the collection has no deletion window.
+    let deletionDate: Date | null = null;
+    if (collection.deleteAfterDays != null) {
+      deletionDate = new Date(newAddDate);
+      deletionDate.setDate(
+        deletionDate.getDate() + +collection.deleteAfterDays,
+      );
+    }
+
+    return {
+      collectionId,
+      mediaServerId,
+      addDate: newAddDate,
+      deleteAfterDays: collection.deleteAfterDays ?? null,
+      deletionDate,
+    };
   }
 
   async setCollectionMediaRuleEvaluationFailed(

--- a/apps/server/src/modules/notifications/notifications-timer.service.spec.ts
+++ b/apps/server/src/modules/notifications/notifications-timer.service.spec.ts
@@ -79,6 +79,26 @@ describe('NotificationTimerService', () => {
     handleNotification: jest.Mock,
   ): NotificationMediaItem[] => handleNotification.mock.calls[0][1];
 
+  it('stops warning once the item has been postponed past its notify day', async () => {
+    // The timer warns on the single day an item sits `aboutScale` days before
+    // deletion. Postpone pushes addDate forward, so a previously-due item no
+    // longer matches that day and drops out of the pre-deletion warning - the
+    // requester "kept" it, so they should stop being nagged.
+    const postponedAddDate = new Date(
+      new Date(dueAddDate()).getTime() + 5 * 86400000,
+    ).toISOString();
+
+    const { service, handleNotification } = createService({
+      media: [{ mediaServerId: '1', tmdbId: 500, addDate: postponedAddDate }],
+      metadata: { title: 'Sample Movie', type: 'movie' },
+      requestedBy: ['alice'],
+    });
+
+    await (service as never as { executeTask(): Promise<void> }).executeTask();
+
+    expect(handleNotification).not.toHaveBeenCalled();
+  });
+
   it('attaches the Seerr requesters to a due item', async () => {
     const { service, handleNotification, getRequestedByUsernames } =
       createService({

--- a/apps/ui/src/api/collections.ts
+++ b/apps/ui/src/api/collections.ts
@@ -2,7 +2,7 @@ import type {
   CollectionPosterDeleteResponse,
   CollectionPosterUploadResponse,
 } from '@maintainerr/contracts'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
 import type { ICollection } from '../components/Collection'
 import GetApiHandler, {
   API_BASE_PATH,
@@ -62,6 +62,39 @@ export const triggerCollectionItemAction = async (
     collectionId,
     mediaId: String(mediaId),
   })
+}
+
+export interface PostponeCollectionItemResponse {
+  collectionId: number
+  mediaServerId: string
+  addDate: string
+  deleteAfterDays: number | null
+  deletionDate: string | null
+}
+
+export const postponeCollectionItem = async (
+  collectionId: number,
+  mediaId: string | number,
+  days: number,
+) => {
+  return await PostApiHandler<PostponeCollectionItemResponse>(
+    '/collections/media/postpone',
+    {
+      collectionId,
+      mediaId: String(mediaId),
+      days,
+    },
+  )
+}
+
+// Refresh every view whose data depends on collection membership or deletion
+// timing after an item-level action (handle, postpone, ...).
+export const invalidateCollectionQueries = async (queryClient: QueryClient) => {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ['collections'] }),
+    queryClient.invalidateQueries({ queryKey: ['calendar'] }),
+    queryClient.invalidateQueries({ queryKey: ['overlay-data'] }),
+  ])
 }
 
 // ── Custom collection poster ───────────────────────────────────────────────

--- a/apps/ui/src/components/Collection/CollectionDetail/PostponeButton/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/PostponeButton/index.tsx
@@ -1,0 +1,150 @@
+import { ClockIcon } from '@heroicons/react/solid'
+import { useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import {
+  invalidateCollectionQueries,
+  postponeCollectionItem,
+} from '../../../../api/collections'
+import { getApiErrorMessage } from '../../../../utils/ApiError'
+import { logClientError } from '../../../../utils/ClientLogger'
+import Alert from '../../../Common/Alert'
+import Button from '../../../Common/Button'
+import Modal from '../../../Common/Modal'
+import PendingButton from '../../../Common/PendingButton'
+import { Input } from '../../../Forms/Input'
+import type { ICollection } from '../../index'
+
+interface PostponeButtonProps {
+  collection: ICollection
+  mediaServerId: number | string
+  // Receives the new addDate so the caller can refresh the "days left" badge
+  // without a full refetch.
+  onPostponed?: (addDate: string) => void
+  buttonLabel?: string
+}
+
+// Keep in sync with the server-side bound (postponeCollectionMediaBodySchema).
+const MIN_DAYS = 1
+const MAX_DAYS = 3650
+const DEFAULT_DAYS = 14
+
+const PostponeButton = ({
+  collection,
+  mediaServerId,
+  onPostponed,
+  buttonLabel = 'Postpone',
+}: PostponeButtonProps) => {
+  const queryClient = useQueryClient()
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [executing, setExecuting] = useState(false)
+  const [error, setError] = useState<string | undefined>()
+  const [days, setDays] = useState(DEFAULT_DAYS)
+
+  const daysInvalid =
+    !Number.isInteger(days) || days < MIN_DAYS || days > MAX_DAYS
+
+  const handlePostpone = async () => {
+    if (!collection.id || executing || daysInvalid) {
+      return
+    }
+
+    setExecuting(true)
+    setError(undefined)
+
+    try {
+      const result = await postponeCollectionItem(
+        collection.id,
+        mediaServerId,
+        days,
+      )
+
+      await invalidateCollectionQueries(queryClient)
+
+      setExecuting(false)
+      setConfirmOpen(false)
+      onPostponed?.(result.addDate)
+    } catch (error) {
+      void logClientError(
+        'Failed to postpone the deletion for this item.',
+        error,
+        'PostponeButton.handlePostpone',
+      )
+
+      setError(
+        getApiErrorMessage(
+          error,
+          'Failed to postpone the deletion for this item.',
+        ),
+      )
+      setExecuting(false)
+    }
+  }
+
+  return (
+    <>
+      <Button buttonType="default" onClick={() => setConfirmOpen(true)}>
+        <ClockIcon className="mr-2 h-4 w-4" />
+        {buttonLabel}
+      </Button>
+
+      {confirmOpen ? (
+        <Modal
+          title="Postpone deletion"
+          onCancel={() => {
+            if (!executing) {
+              setConfirmOpen(false)
+            }
+          }}
+          backgroundClickable={!executing}
+          footerActions={
+            <PendingButton
+              buttonType="primary"
+              className="ml-3"
+              disabled={executing || daysInvalid}
+              isPending={executing}
+              idleLabel="Postpone now"
+              pendingLabel="Postponing..."
+              onClick={() => {
+                void handlePostpone()
+              }}
+            />
+          }
+        >
+          <p>
+            Push this item&apos;s deletion further out. Its current deletion
+            date moves later by the number of days below.
+          </p>
+          <div className="form-input mt-3">
+            <label className="text-sm font-semibold" htmlFor="postpone_days">
+              Days to postpone
+            </label>
+            <div className="form-input-field mt-1">
+              <Input
+                type="number"
+                name="postpone_days"
+                id="postpone_days"
+                min={MIN_DAYS}
+                max={MAX_DAYS}
+                error={daysInvalid}
+                value={Number.isNaN(days) ? '' : days}
+                onChange={(e) => setDays(e.target.valueAsNumber)}
+              />
+            </div>
+            {daysInvalid ? (
+              <p className="mt-1 text-xs text-error-400">
+                Enter a whole number between {MIN_DAYS} and {MAX_DAYS}.
+              </p>
+            ) : null}
+          </div>
+          {error ? (
+            <div className="mt-3">
+              <Alert type="error" title={error} />
+            </div>
+          ) : null}
+        </Modal>
+      ) : null}
+    </>
+  )
+}
+
+export default PostponeButton

--- a/apps/ui/src/components/Collection/CollectionDetail/TriggerRuleActionButton/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/TriggerRuleActionButton/index.tsx
@@ -2,7 +2,10 @@ import { PlayIcon } from '@heroicons/react/solid'
 import { ServarrAction } from '@maintainerr/contracts'
 import { useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
-import { triggerCollectionItemAction } from '../../../../api/collections'
+import {
+  invalidateCollectionQueries,
+  triggerCollectionItemAction,
+} from '../../../../api/collections'
 import { getApiErrorMessage } from '../../../../utils/ApiError'
 import { logClientError } from '../../../../utils/ClientLogger'
 import Alert from '../../../Common/Alert'
@@ -69,11 +72,7 @@ const TriggerRuleActionButton = ({
     try {
       await triggerCollectionItemAction(collection.id, mediaServerId)
 
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['collections'] }),
-        queryClient.invalidateQueries({ queryKey: ['calendar'] }),
-        queryClient.invalidateQueries({ queryKey: ['overlay-data'] }),
-      ])
+      await invalidateCollectionQueries(queryClient)
 
       setExecuting(false)
       setConfirmOpen(false)

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
@@ -24,6 +24,7 @@ import {
   rememberMaintainerrStatusDetails,
 } from '../maintainerrStatus'
 import type { ICollection } from '../../../Collection'
+import PostponeButton from '../../../Collection/CollectionDetail/PostponeButton'
 import TriggerRuleButton from '../../../Collection/CollectionDetail/TriggerRuleActionButton'
 
 interface ModalContentProps {
@@ -40,6 +41,7 @@ interface ModalContentProps {
   forceStatusLoad?: boolean
   onStatusLink?: (targetPath: string) => void
   onCollectionItemRemoved?: () => void
+  onCollectionItemPostponed?: (addDate: string) => void
 }
 
 const mergeProviderIds = (
@@ -148,6 +150,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
     forceStatusLoad = false,
     onStatusLink,
     onCollectionItemRemoved,
+    onCollectionItemPostponed,
   }) => {
     useLockBodyScroll(true)
 
@@ -214,6 +217,14 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
       collection != null &&
       collection.arrAction !== ServarrAction.DO_NOTHING &&
       !isManual &&
+      exclusionType == null
+    // Postpone only makes sense when the item is actually on a deletion
+    // countdown: the collection has a grace period and an action to run, and the
+    // item isn't excluded from it.
+    const canPostpone =
+      collection != null &&
+      collection.deleteAfterDays != null &&
+      collection.arrAction !== ServarrAction.DO_NOTHING &&
       exclusionType == null
     const providerIds = useMemo(
       () => mergeProviderIds(metadata?.providerIds, fallbackProviderIds),
@@ -823,6 +834,13 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
                   </div>
                 )}
               <div className="ml-auto flex space-x-3">
+                {canPostpone ? (
+                  <PostponeButton
+                    collection={collection}
+                    mediaServerId={id}
+                    onPostponed={onCollectionItemPostponed}
+                  />
+                ) : null}
                 {canTriggerRuleAction ? (
                   <TriggerRuleButton
                     collection={collection}

--- a/apps/ui/src/components/Common/MediaCard/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/index.tsx
@@ -53,6 +53,7 @@ interface IMediaCard {
   collection?: ICollection
   isManual?: boolean
   onRemove?: (id: string) => void
+  onItemPostponed?: (id: string, addDate: string) => void
 }
 
 const MediaCard: React.FC<IMediaCard> = ({
@@ -72,6 +73,7 @@ const MediaCard: React.FC<IMediaCard> = ({
   collection = undefined,
   isManual = false,
   onRemove = () => {},
+  onItemPostponed,
 }) => {
   const navigate = useNavigate()
   const [showDetail, setShowDetail] = useState(false)
@@ -289,6 +291,9 @@ const MediaCard: React.FC<IMediaCard> = ({
             onRemove(id.toString())
             setShowMediaModal(false)
           }}
+          onCollectionItemPostponed={(addDate) =>
+            onItemPostponed?.(id.toString(), addDate)
+          }
         />
       )}
     </div>

--- a/apps/ui/src/components/Overview/Content/index.tsx
+++ b/apps/ui/src/components/Overview/Content/index.tsx
@@ -19,6 +19,7 @@ interface IOverviewContent {
   extrasLoading?: boolean
   fetchData: () => void
   onRemove?: (id: string) => void
+  onItemPostponed?: (id: string, addDate: string) => void
   libraryId: string
   collectionPage?: boolean
   collectionInfo?: ICollectionMedia[]
@@ -174,6 +175,7 @@ const OverviewContent = (props: IOverviewContent) => {
                   }
                   exclusionType={el.maintainerrExclusionType}
                   onRemove={props.onRemove}
+                  onItemPostponed={props.onItemPostponed}
                   collectionId={props.collectionId}
                   collection={
                     props.collection ??

--- a/apps/ui/src/pages/CollectionMediaPage.tsx
+++ b/apps/ui/src/pages/CollectionMediaPage.tsx
@@ -151,6 +151,17 @@ const CollectionMediaPage = () => {
             currentMedia.filter((item) => item.mediaServerId !== id),
           )
         }}
+        onItemPostponed={(id: string, addDate: string) => {
+          // Patch the local addDate so the "days left" badge reflects the new
+          // deletion date immediately, without refetching the page.
+          updateMedia((currentMedia) =>
+            currentMedia.map((item) =>
+              item.mediaServerId === id
+                ? { ...item, addDate: new Date(addDate) }
+                : item,
+            ),
+          )
+        }}
         collectionInfo={media}
       />
     </div>


### PR DESCRIPTION
## What

Adds a per-item **postpone deletion** capability to collections — an authenticated API endpoint plus an admin-UI control — so operators (and external automation) can keep media a requester asked for without turning off automatic deletion.

Maintainerr stays non-user-facing: this is the machine half of a requester "keep" workflow that external tools (Home Assistant, Ombi, Seerr, …) can drive. Motivated by the "notify requester before automatic deletion / let them keep it" feature request.

## Server

- `POST /api/collections/media/postpone` — moves `collection_media.addDate` forward by `days`, or resets the full window to *now* when `days` is omitted. Returns the new `addDate` and the resulting `deletionDate`.
- Runs under the shared collection/rule **execution lock**, so it can't race a delete run already in flight (409 if busy).
- `addDate` is normalised to date granularity (local midnight) to match the existing insert convention, using DST-safe calendar-day math.
- **No schema change, no worker change** — the worker already deletes on `addDate + deleteAfterDays`.

## UI

- **Postpone** button in the media modal (next to *Trigger Rule Action*), gated to collections that actually have a deletion window (and non-excluded items).
- The "days left" badge updates **instantly** by patching local state from the response — mirrors the existing `onRemove` path, so no refetch and scroll/pagination are preserved.
- `days` upper bound 3650, kept in sync between UI and server.

## Tests

- Service: add-days, reset, not-found.
- Controller: execution-lock (409) and not-found (404).
- Notification timer: a postponed item drops out of the pre-deletion "leaving soon" warning.

Full suite green — **1951 server + 241 UI tests**; typecheck, prettier, and ESLint (zero warnings) all clean.

## Non-goals / notes

- Postpone only defers the **automatic** worker; a manual *Trigger Rule Action* still deletes immediately (verified end-to-end).
- No user-facing surface beyond the operator's own admin console.
