### PR TITLE
perf(rules): memoize metadata id-resolution in the Seerr and Sonarr-fallback getters

### DIFF
--- a/apps/server/src/modules/rules/getter/getter.service.ts
+++ b/apps/server/src/modules/rules/getter/getter.service.ts
@@ -83,7 +83,12 @@ export class ValueGetterService {
         );
       }
       case Application.SEERR: {
-        return await this.seerrGetter.get(val2, libItem, dataType);
+        return await this.seerrGetter.get(
+          val2,
+          libItem,
+          dataType,
+          arrLookupCache,
+        );
       }
       case Application.TAUTULLI: {
         return await this.tautulliGetter.get(

--- a/apps/server/src/modules/rules/getter/seerr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/seerr-getter.service.spec.ts
@@ -10,6 +10,10 @@ import {
 } from '../../api/seerr-api/seerr-api.service';
 import { MetadataService } from '../../metadata/metadata.service';
 import { SeerrGetterService } from './seerr-getter.service';
+import { ArrLookupCache } from '../helpers/arr-lookup-cache';
+
+// Let the memo's eviction callback (chained on the resolved promise) run.
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
 
 describe('SeerrGetterService', () => {
   const ADD_USER_PROP_ID = 0;
@@ -119,6 +123,64 @@ describe('SeerrGetterService', () => {
       })),
       ...overrides,
     }) as unknown as SeerrRequest;
+
+  // The id-resolution (media item -> tmdb) preceding every Seerr query ran once
+  // per rule condition; the run-scoped ArrLookupCache now memoizes it so it runs
+  // once per item (#3285). Mirrors the Radarr/Sonarr candidate memo.
+  describe('id-resolution memoization (#3285)', () => {
+    const call = (
+      service: SeerrGetterService,
+      arrLookupCache?: ArrLookupCache,
+    ) =>
+      service.get(
+        IS_REQUESTED_PROP_ID,
+        movieLibItem,
+        undefined,
+        arrLookupCache,
+      );
+
+    it('resolves ids once per item across conditions sharing a run cache', async () => {
+      const { service, seerrApi, metadataService } = createService();
+      seerrApi.getRequestsForMedia.mockResolvedValue([]);
+      const cache = new ArrLookupCache();
+
+      await call(service, cache);
+      await call(service, cache); // second condition, same item + same run cache
+
+      expect(
+        metadataService.resolveIdsFromMediaItemForService,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-resolves per call when no run cache is provided (unchanged behaviour)', async () => {
+      const { service, seerrApi, metadataService } = createService();
+      seerrApi.getRequestsForMedia.mockResolvedValue([]);
+
+      await call(service);
+      await call(service);
+
+      expect(
+        metadataService.resolveIdsFromMediaItemForService,
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    it('evicts a no-tmdb resolution so a later condition retries (transient safety, #3125)', async () => {
+      const { service, seerrApi, metadataService } = createService();
+      seerrApi.getRequestsForMedia.mockResolvedValue([]);
+      metadataService.resolveIdsFromMediaItemForService
+        .mockResolvedValueOnce(undefined) // transient: nothing resolved
+        .mockResolvedValue({ tmdb: 12345, type: 'movie' });
+      const cache = new ArrLookupCache();
+
+      await call(service, cache); // no tmdb -> evicted from the memo
+      await flushMicrotasks();
+      await call(service, cache); // retries instead of serving the stale result
+
+      expect(
+        metadataService.resolveIdsFromMediaItemForService,
+      ).toHaveBeenCalledTimes(2);
+    });
+  });
 
   describe('addUser (property id=0)', () => {
     it('should return Plex username using plexUsername field from Seerr', async () => {

--- a/apps/server/src/modules/rules/getter/seerr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/seerr-getter.service.ts
@@ -23,6 +23,7 @@ import {
   Property,
   RuleConstants,
 } from '../constants/rules.constants';
+import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 
 @Injectable()
 export class SeerrGetterService {
@@ -41,7 +42,12 @@ export class SeerrGetterService {
     ).props;
   }
 
-  async get(id: number, libItem: MediaItem, dataType?: MediaItemType) {
+  async get(
+    id: number,
+    libItem: MediaItem,
+    dataType?: MediaItemType,
+    arrLookupCache?: ArrLookupCache,
+  ) {
     try {
       let origLibItem: MediaItem = undefined;
 
@@ -55,11 +61,26 @@ export class SeerrGetterService {
       }
 
       const prop = this.appProperties.find((el) => el.id === id);
-      const resolvedIds =
-        await this.metadataService.resolveIdsFromMediaItemForService(
+      // The id-resolution (media item -> tmdb) is identical for an item across
+      // every Seerr condition in a run, yet ran once per condition - redundant
+      // CPU, response cloning and duplicate logs (#3285, the same redundancy the
+      // Radarr/Sonarr candidate memo already dedupes). Route it through the same
+      // run-scoped memo. libItem is already lifted to the parent show for
+      // season/episode above, so the key collapses them onto one entry. Evict a
+      // result with no tmdb so a transient metadata-provider failure retries next
+      // condition instead of sticking for the run.
+      const resolveIds = () =>
+        this.metadataService.resolveIdsFromMediaItemForService(
           libItem,
           'seerr',
         );
+      const resolvedIds = await (arrLookupCache
+        ? arrLookupCache.memoize(
+            `metadata:seerr:${libItem.id}`,
+            resolveIds,
+            (ids) => !ids?.tmdb,
+          )
+        : resolveIds());
       const tmdbId = resolvedIds?.tmdb as number | undefined;
 
       if (!tmdbId) {

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
@@ -1027,6 +1027,71 @@ describe('SonarrGetterService', () => {
         }),
       );
 
+    // The tv-detail resolution behind this fallback ran once per rule condition;
+    // the run-scoped ArrLookupCache now memoizes it per show (#3285), mirroring
+    // the candidate memo. A distinct key ('metadata:sonarr:details:') keeps it
+    // from colliding with the {tvdb}-policy candidate resolution.
+    describe('tv-detail resolution memoization (#3285)', () => {
+      const callEnded = (arrLookupCache?: ArrLookupCache) =>
+        sonarrGetterService.get(
+          7, // 'ended' - reaches tryMetadataFallback's resolveIdsFromMediaItem
+          mediaItem,
+          'show',
+          createRulesDto({
+            collection: collectionMedia.collection,
+            dataType: 'show',
+          }),
+          undefined,
+          arrLookupCache,
+        );
+
+      beforeEach(() => {
+        metadataService.resolveIdsFromMediaItem.mockResolvedValue({
+          type: 'tv',
+          tvdb: 322399,
+        } as any);
+        metadataService.getDetails.mockResolvedValue({
+          type: 'tv',
+          ended: true,
+        } as any);
+      });
+
+      it('resolves tv ids once per show across conditions sharing a run cache', async () => {
+        const cache = new ArrLookupCache();
+
+        await callEnded(cache);
+        await callEnded(cache); // second condition, same show + same run cache
+
+        expect(metadataService.resolveIdsFromMediaItem).toHaveBeenCalledTimes(
+          1,
+        );
+      });
+
+      it('re-resolves per call when no run cache is provided (unchanged behaviour)', async () => {
+        await callEnded();
+        await callEnded();
+
+        expect(metadataService.resolveIdsFromMediaItem).toHaveBeenCalledTimes(
+          2,
+        );
+      });
+
+      it('evicts a non-tv resolution so a later condition retries (transient safety)', async () => {
+        metadataService.resolveIdsFromMediaItem
+          .mockResolvedValueOnce(undefined) // transient: nothing resolved
+          .mockResolvedValue({ type: 'tv', tvdb: 322399 } as any);
+        const cache = new ArrLookupCache();
+
+        await callEnded(cache); // non-tv/undefined -> evicted from the memo
+        await flushMicrotasks();
+        await callEnded(cache); // retries instead of serving the stale result
+
+        expect(metadataService.resolveIdsFromMediaItem).toHaveBeenCalledTimes(
+          2,
+        );
+      });
+    });
+
     it('returns 1 for ended when metadata says the show ended', async () => {
       metadataService.resolveIdsFromMediaItem.mockResolvedValue({
         type: 'tv',

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -157,6 +157,7 @@ export class SonarrGetterService {
           libItem,
           prop?.name,
           dataType,
+          arrLookupCache,
         );
         if (fallback.handled) {
           this.logger.debug(
@@ -773,6 +774,7 @@ export class SonarrGetterService {
     libItem: MediaItem,
     propName: string | undefined,
     dataType: MediaItemType | undefined,
+    arrLookupCache?: ArrLookupCache,
   ): Promise<
     { handled: false } | { handled: true; value: number | string | Date | null }
   > {
@@ -792,7 +794,21 @@ export class SonarrGetterService {
       return { handled: false };
     }
 
-    const ids = await this.metadataService.resolveIdsFromMediaItem(libItem);
+    // Same per-condition redundancy as findLookupCandidatesFromMediaItem
+    // (#3285): dedupe this resolution through the run-scoped memo. A DISTINCT key
+    // from the candidate memo - this fallback resolves under the default
+    // (all-provider) policy, not the Sonarr {tvdb} policy, so it can produce a
+    // different result for the same show id. Evict an unresolved / non-tv result
+    // so a transient metadata-provider failure retries next condition.
+    const resolveTvIds = () =>
+      this.metadataService.resolveIdsFromMediaItem(libItem);
+    const ids = await (arrLookupCache
+      ? arrLookupCache.memoize(
+          `metadata:sonarr:details:${libItem.id}`,
+          resolveTvIds,
+          (resolved) => !resolved || resolved.type !== 'tv',
+        )
+      : resolveTvIds());
     if (!ids || ids.type !== 'tv') {
       return { handled: false };
     }

--- a/apps/server/src/modules/rules/helpers/arr-lookup-cache.ts
+++ b/apps/server/src/modules/rules/helpers/arr-lookup-cache.ts
@@ -14,9 +14,16 @@
  * the collection-sync / action phase, so it is gone before any deletion runs
  * and the cleanup still reads Sonarr/Radarr fresh.
  *
- * It is intentionally NOT used by the Tautulli / Seerr / Plex / Jellyfin / Emby
- * getters - those already cache at the API layer, so routing them through here
- * would just be redundant double-caching.
+ * It also memoizes the MetadataService id/candidate resolution that precedes
+ * those arr lookups (media-server ids -> validated provider ids). That resolution
+ * is identical for an item across every rule condition but otherwise re-runs each
+ * time - redundant CPU, response cloning and duplicate logs (#3285). The Radarr,
+ * Sonarr and Seerr getters route their resolution through here.
+ *
+ * The Plex / Jellyfin / Emby / Tautulli getters do not use it: they don't run the
+ * MetadataService resolution, and their per-item reads are served from their own
+ * API-layer caches. (Seerr's own request lookups are API-cached too - only the
+ * id-resolution that feeds them is deduped here.)
  */
 export class ArrLookupCache {
   private readonly entries = new Map<string, Promise<unknown>>();


### PR DESCRIPTION
Follow-up to #3287.

#3287 memoized the Radarr/Sonarr candidate resolution per item. Two callers of the same MetadataService id-resolution still ran once per rule condition; this routes them through the same run-scoped `ArrLookupCache`:

- **Seerr getter** - `resolveIdsFromMediaItemForService` (media item -> tmdb), run before its already-cached request lookup. Key `metadata:seerr:${libItem.id}` (the parent show for season/episode, so seasons/episodes collapse onto one entry); evicts a no-tmdb result so a transient metadata-provider failure retries next condition.
- **Sonarr tv-detail fallback** - `tryMetadataFallback` -> `resolveIdsFromMediaItem`, for shows not tracked in Sonarr using `ended` / `firstAirDate` / `seasons`. Distinct key `metadata:sonarr:details:${libItem.id}` because it resolves under the default (all-provider) policy, not the Sonarr `{tvdb}` policy the candidate memo uses.

The memo is the eval-only cache the executor creates for the rule loop and never hands to the collection/action phase, so cleanup still resolves fresh (same lifecycle as #2897). Also corrects the `ArrLookupCache` docstring: its "Seerr already caches at the API layer" note refers to Seerr's request lookups - the id-resolution that feeds them is a separate layer and wasn't deduped.

No behaviour change: the memo wraps the same resolve call and returns the same value; evict-on-failure preserves the per-condition retry. Unit tests assert once-per-item with a shared cache, re-resolve without one, and evict-and-retry on a transient failure.
