### PR TITLE
fix(deps): drop orphaned @semantic-release/error@^3.0.0 from lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5061,13 +5061,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@semantic-release/error@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@semantic-release/error@npm:3.0.0"
-  checksum: 10c0/51f06d11186a6efc543b44996ca1c368a77c6ed18dd823f0362188c37b7ef32f3580bd17654f594e6a72b931ebe69b44bbcb1ee16c755a1d3e44dcb652b47275
-  languageName: node
-  linkType: hard
-
 "@semantic-release/error@npm:^4.0.0":
   version: 4.0.0
   resolution: "@semantic-release/error@npm:4.0.0"


### PR DESCRIPTION
Merging the `@semantic-release/changelog` 7 (#3299) and `@semantic-release/git` 11 (#3310) majors separately left an unreferenced `@semantic-release/error@^3.0.0` entry in `yarn.lock`. Both packages moved to `@semantic-release/error@^4.0.0`, so the v3 entry is dead weight and makes `yarn --immutable` fail on development.

Regenerated the lockfile to drop it (7-line deletion, no dependency behavior change).