### PR TITLE
fix(rules): keep collections and exclusions intact when internet-dependent lookups fail transiently

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -332,6 +332,14 @@ describe('EmbyAdapterService', () => {
         service.getLibraryContents('library-1', { offset: 0, limit: 50 }),
       ).rejects.toThrow('boom');
     });
+
+    it('re-throws library count read failures instead of reporting zero', async () => {
+      http.get.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(
+        service.getLibraryContentCount('library-1', 'movie'),
+      ).rejects.toThrow('boom');
+    });
   });
 
   // Collection reads must be user-scoped: Emby resolves the BoxSet query

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -324,6 +324,16 @@ describe('EmbyAdapterService', () => {
     });
   });
 
+  describe('getLibraryContents', () => {
+    it('re-throws page read failures so callers never mistake a failed read for an empty library', async () => {
+      http.get.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(
+        service.getLibraryContents('library-1', { offset: 0, limit: 50 }),
+      ).rejects.toThrow('boom');
+    });
+  });
+
   // Collection reads must be user-scoped: Emby resolves the BoxSet query
   // against a user's library view, so the plain /Items path can miss or 404,
   // which would break the manual-collection bootstrap (incl. the cross-library

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -350,7 +350,10 @@ export class EmbyAdapterService implements IMediaServerService {
       this.logger.warn(
         `Emby getLibraryContents(${libraryId}) failed: ${formatConnectionFailureMessage(error, 'Connection failed')}`,
       );
-      return { items: [], totalSize: 0, offset, limit };
+      // A fabricated empty page reads as end-of-library downstream, which
+      // truncates rule evaluation and mass-removes the unevaluated tail from
+      // collections (#3307). Fail closed like getCollectionChildren.
+      throw error;
     }
   }
 

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -379,7 +379,9 @@ export class EmbyAdapterService implements IMediaServerService {
       this.logger.debug(
         `Emby getLibraryContentCount(${libraryId}) failed: ${formatConnectionFailureMessage(error, 'Connection failed')}`,
       );
-      return 0;
+      // Same contract as getLibraryContents: a fabricated count masks a
+      // failed read from callers that gate work on it.
+      throw error;
     }
   }
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -539,6 +539,14 @@ describe('JellyfinAdapterService', () => {
       expect(jellyfinApiMocks.getItems).toHaveBeenCalledTimes(1);
     });
 
+    it('rethrows library count read failures instead of reporting zero', async () => {
+      jellyfinApiMocks.getItems.mockRejectedValueOnce(createResponseError(500));
+
+      await expect(
+        service.getLibraryContentCount('library-1', 'movie'),
+      ).rejects.toThrow('request failed with status 500');
+    });
+
     it('rethrows when the transient retry is exhausted instead of fabricating an empty page', async () => {
       jellyfinApiMocks.getItems.mockRejectedValue(createResponseError(503));
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -524,18 +524,33 @@ describe('JellyfinAdapterService', () => {
       });
     });
 
-    it('does not retry non-transient library-content failures', async () => {
+    it('does not retry non-transient library-content failures and rethrows', async () => {
       jellyfinApiMocks.getItems.mockRejectedValueOnce(createResponseError(401));
 
-      const result = await service.getLibraryContents('library-1', {
-        offset: 0,
-        limit: 30,
-        type: 'movie',
-      });
+      await expect(
+        service.getLibraryContents('library-1', {
+          offset: 0,
+          limit: 30,
+          type: 'movie',
+        }),
+      ).rejects.toThrow('request failed with status 401');
 
       expect(delay).not.toHaveBeenCalled();
       expect(jellyfinApiMocks.getItems).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({ items: [], totalSize: 0, offset: 0, limit: 50 });
+    });
+
+    it('rethrows when the transient retry is exhausted instead of fabricating an empty page', async () => {
+      jellyfinApiMocks.getItems.mockRejectedValue(createResponseError(503));
+
+      await expect(
+        service.getLibraryContents('library-1', {
+          offset: 0,
+          limit: 30,
+          type: 'movie',
+        }),
+      ).rejects.toThrow('request failed with status 503');
+
+      expect(jellyfinApiMocks.getItems).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -791,7 +791,10 @@ export class JellyfinAdapterService implements IMediaServerService {
       };
     } catch (error) {
       this.logLibraryError(libraryId, 'get library contents', error);
-      return { items: [], totalSize: 0, offset: 0, limit: 50 };
+      // A fabricated empty page reads as end-of-library downstream, which
+      // truncates rule evaluation and mass-removes the unevaluated tail from
+      // collections (#3307). Fail closed like getCollectionChildren.
+      throw error;
     }
   }
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -820,7 +820,9 @@ export class JellyfinAdapterService implements IMediaServerService {
       return response.data.TotalRecordCount || 0;
     } catch (error) {
       this.logLibraryError(libraryId, 'get library count', error);
-      return 0;
+      // Same contract as getLibraryContents: a fabricated count masks a
+      // failed read from callers that gate work on it.
+      throw error;
     }
   }
 

--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -102,6 +102,13 @@ export interface IMediaServerService {
 
   /**
    * Get contents of a specific library with optional pagination and filtering.
+   * An empty page means the server confirmed there are no (more) items -
+   * never "the read failed".
+   *
+   * @throws Error on any failure to read the page (connection, 4xx/5xx).
+   * Like getCollectionChildren: a fabricated empty page would read as
+   * end-of-library and let rule evaluation truncate silently, mass-removing
+   * the unevaluated tail from collections.
    */
   getLibraryContents(
     libraryId: string,

--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -117,6 +117,9 @@ export interface IMediaServerService {
 
   /**
    * Get total count of items in a library, optionally filtered by type.
+   *
+   * @throws Error on a failed read - a fabricated 0 masks the failure from
+   * callers that gate work on the count.
    */
   getLibraryContentCount(
     libraryId: string,

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -429,6 +429,14 @@ describe('PlexAdapterService', () => {
       await service.getLibraryContents('1', { offset: 0, limit: 50 });
       expect(plexApi.getLibraryContents).toHaveBeenCalled();
     });
+
+    it('propagates page read failures so callers never mistake a failed read for an empty library', async () => {
+      plexApi.getLibraryContents.mockRejectedValue(new Error('boom'));
+
+      await expect(
+        service.getLibraryContents('1', { offset: 0, limit: 50 }),
+      ).rejects.toThrow('boom');
+    });
   });
 
   describe('prefetchWatchHistory', () => {

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -144,13 +144,14 @@ export class PlexAdapterService implements IMediaServerService {
       plexType,
     );
 
-    const items = response?.items
-      ? response.items.map(PlexMapper.toMediaItem)
-      : [];
+    // plexApi.getLibraryContents throws on a failed read; a fabricated empty
+    // page here would truncate rule evaluation and mass-remove the
+    // unevaluated tail from collections (#3307).
+    const items = response.items.map(PlexMapper.toMediaItem);
 
     return {
       items,
-      totalSize: response?.totalSize ?? items.length,
+      totalSize: response.totalSize ?? items.length,
       offset: options?.offset ?? 0,
       limit: options?.limit ?? PLEX_PAGE_SIZE.DEFAULT,
     };

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -388,7 +388,7 @@ describe('PlexApiService.getMetadata', () => {
         name: 'owner',
       } as any,
     ]);
-    jest.spyOn(service, 'getUserDataFromPlexTv').mockResolvedValue(undefined);
+    jest.spyOn(service, 'getUserDataFromPlexTv').mockResolvedValue([]);
     jest.spyOn(service, 'getOwnerDataFromPlexTv').mockResolvedValue({
       id: '42',
       username: 'owner',
@@ -404,7 +404,10 @@ describe('PlexApiService.getMetadata', () => {
     ]);
   });
 
-  it('ignores avatar urls that do not match the expected plex shape', async () => {
+  it('throws from getCorrectedUsers when plex.tv user data is unavailable', async () => {
+    // A silent fallback to local account names produced plausible-but-wrong
+    // lists that rules acted on (#3307). Getters catch this and return the
+    // transient `undefined`.
     jest.spyOn(service, 'getUsers').mockResolvedValue([
       {
         id: 1,
@@ -412,6 +415,64 @@ describe('PlexApiService.getMetadata', () => {
       } as any,
     ]);
     jest.spyOn(service, 'getUserDataFromPlexTv').mockResolvedValue(undefined);
+    jest.spyOn(service, 'getOwnerDataFromPlexTv').mockResolvedValue({
+      id: '42',
+      username: 'owner',
+      thumb: 'https://plex.tv/users/abc123/avatar?c=123456',
+    } as any);
+
+    await expect(service.getCorrectedUsers()).rejects.toThrow(
+      'plex.tv user data unavailable',
+    );
+  });
+
+  it('throws from getCorrectedUsers when the plex.tv owner fetch fails', async () => {
+    jest.spyOn(service, 'getUsers').mockResolvedValue([
+      {
+        id: 1,
+        name: 'owner',
+      } as any,
+    ]);
+    jest.spyOn(service, 'getUserDataFromPlexTv').mockResolvedValue([]);
+    jest.spyOn(service, 'getOwnerDataFromPlexTv').mockResolvedValue(undefined);
+
+    await expect(service.getCorrectedUsers()).rejects.toThrow(
+      'plex.tv user data unavailable',
+    );
+  });
+
+  it('returns a confirmed empty list from getUserDataFromPlexTv when the account has no shared users', async () => {
+    (service as any).plexTvClient = {
+      getUsers: jest.fn().mockResolvedValue({ MediaContainer: {} }),
+    };
+
+    await expect(service.getUserDataFromPlexTv()).resolves.toEqual([]);
+  });
+
+  it('returns undefined from getUserDataFromPlexTv when the plex.tv fetch fails', async () => {
+    (service as any).plexTvClient = {
+      getUsers: jest.fn().mockRejectedValue(new Error('boom')),
+    };
+
+    await expect(service.getUserDataFromPlexTv()).resolves.toBeUndefined();
+  });
+
+  it('re-throws library count read failures instead of reporting zero', async () => {
+    const query = jest.fn().mockRejectedValue(new Error('boom'));
+
+    (service as any).plexClient = { query };
+
+    await expect(service.getLibraryContentCount('1')).rejects.toThrow('boom');
+  });
+
+  it('ignores avatar urls that do not match the expected plex shape', async () => {
+    jest.spyOn(service, 'getUsers').mockResolvedValue([
+      {
+        id: 1,
+        name: 'owner',
+      } as any,
+    ]);
+    jest.spyOn(service, 'getUserDataFromPlexTv').mockResolvedValue([]);
     jest.spyOn(service, 'getOwnerDataFromPlexTv').mockResolvedValue({
       id: '42',
       username: 'owner',

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -203,6 +203,37 @@ describe('PlexApiService.getMetadata', () => {
     );
   });
 
+  it('returns a confirmed empty page when a library section has no items', async () => {
+    const query = jest.fn().mockResolvedValue({
+      MediaContainer: { totalSize: 0 },
+    });
+
+    (service as any).plexClient = { query };
+
+    expect(await service.getLibraryContents('1')).toEqual({
+      totalSize: 0,
+      items: [],
+    });
+  });
+
+  it('re-throws library page read failures instead of reporting an empty page', async () => {
+    const query = jest.fn().mockRejectedValue(new Error('boom'));
+
+    (service as any).plexClient = { query };
+
+    await expect(service.getLibraryContents('1')).rejects.toThrow('boom');
+  });
+
+  it('throws on a library page response without a MediaContainer', async () => {
+    const query = jest.fn().mockResolvedValue(undefined);
+
+    (service as any).plexClient = { query };
+
+    await expect(service.getLibraryContents('1')).rejects.toThrow(
+      'no MediaContainer',
+    );
+  });
+
   it('builds a single encoded collection uri when adding multiple children', async () => {
     const putQuery = jest.fn().mockResolvedValue({
       MediaContainer: { Metadata: [{ ratingKey: '123' }] },

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -484,14 +484,17 @@ export class PlexApiService {
       });
 
       if (!response?.MediaContainer) {
-        this.logLibrarySectionError(id);
-        return undefined;
+        throw new Error(
+          `Plex library section ${id} returned no MediaContainer`,
+        );
       }
 
       return response.MediaContainer.totalSize;
     } catch (error) {
       this.logLibrarySectionError(id, error);
-      return undefined;
+      // Same contract as getLibraryContents: a fabricated count masks a
+      // failed read from callers that gate work on it.
+      throw error;
     }
   }
 
@@ -638,7 +641,10 @@ export class PlexApiService {
   public async getUserDataFromPlexTv(): Promise<PlexTvUser[] | undefined> {
     try {
       const response = await this.plexTvClient.getUsers();
-      return response.MediaContainer.User;
+      // xml2js leaves `User` undefined when the account simply has no shared
+      // users - that is a confirmed empty list, not a failure. Reserve
+      // `undefined` for a failed fetch so callers can tell them apart.
+      return response.MediaContainer.User ?? [];
     } catch (error) {
       this.logger.error(
         "Outbound call to plex.tv failed. Couldn't fetch users",
@@ -648,7 +654,7 @@ export class PlexApiService {
     }
   }
 
-  public async getOwnerDataFromPlexTv(): Promise<PlexUser> {
+  public async getOwnerDataFromPlexTv(): Promise<PlexUser | undefined> {
     try {
       return await this.plexTvClient.getUser();
     } catch (error) {
@@ -1671,6 +1677,19 @@ export class PlexApiService {
   ): Promise<SimplePlexUser[]> {
     const plexTvUsers = await this.getUserDataFromPlexTv();
     const owner = await this.getOwnerDataFromPlexTv();
+
+    // The whole point of this method is the plex.tv enrichment: usernames
+    // that match Seerr's (#1240, #1339) and the uuids the watchlist getters
+    // key on. When plex.tv is unreachable a silent fallback to local account
+    // names produced plausible-but-wrong lists that rules then acted on
+    // (#3307). Throw instead - rule getters catch this and return the
+    // transient `undefined`, pausing evaluation for the item. The per-user
+    // local fallback below stays for accounts plex.tv genuinely doesn't know.
+    if (plexTvUsers === undefined || owner === undefined) {
+      throw new Error(
+        'plex.tv user data unavailable; cannot resolve Plex usernames',
+      );
+    }
 
     return (await this.getUsers()).map((el) => {
       const plextv = plexTvUsers?.find((tvEl) => Number(tvEl.$?.id) === el.id);

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -520,8 +520,9 @@ export class PlexApiService {
       );
 
       if (!response?.MediaContainer) {
-        this.logLibrarySectionError(id);
-        return undefined;
+        throw new Error(
+          `Plex library section ${id} returned no MediaContainer`,
+        );
       }
 
       return {
@@ -530,7 +531,10 @@ export class PlexApiService {
       };
     } catch (error) {
       this.logLibrarySectionError(id, error);
-      return undefined;
+      // A swallowed page read looks like the end of the library downstream,
+      // which truncates rule evaluation and mass-removes the unevaluated
+      // tail from collections (#3307). Same contract as getCollectionChildren.
+      throw error;
     }
   }
 

--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -715,6 +715,60 @@ describe('PlexGetterService', () => {
       );
     });
 
+    it('returns undefined for watchlist properties when no user has a plex.tv uuid (ids 28 and 30)', async () => {
+      // plex.tv unreachable: getCorrectedUsers falls back to local accounts
+      // without uuids. Must be transient (undefined), not a confirmed
+      // empty/false answer (#3307).
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({
+          ratingKey: 'movie-1',
+          type: 'movie',
+          guid: 'plex://movie/movieuuid',
+        }),
+      );
+      plexApi.getCorrectedUsers.mockResolvedValue([
+        makePlexUser({ plexId: 1, username: 'alice' }),
+        makePlexUser({ plexId: 2, username: 'bob' }),
+      ]);
+
+      const libItem = createMediaItem({ id: 'movie-1', type: 'movie' });
+      const ruleGroup = createRulesDto({ dataType: 'movie' });
+
+      await expect(
+        service.get(28, libItem, 'movie', ruleGroup),
+      ).resolves.toBeUndefined();
+      await expect(
+        service.get(30, libItem, 'movie', ruleGroup),
+      ).resolves.toBeUndefined();
+      expect(plexApi.getWatchlistIdsForUser).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined for watchlist properties when a watchlist read fails (ids 28 and 30)', async () => {
+      // getWatchlistIdsForUser resolves undefined on a failed community API
+      // fetch; that must not collapse into "not watchlisted" (#3307).
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({
+          ratingKey: 'movie-1',
+          type: 'movie',
+          guid: 'plex://movie/movieuuid',
+        }),
+      );
+      plexApi.getCorrectedUsers.mockResolvedValue([
+        makePlexUser({ plexId: 1, username: 'alice', uuid: 'uuid-a' }),
+      ]);
+      plexApi.getWatchlistIdsForUser.mockResolvedValue(undefined);
+
+      const libItem = createMediaItem({ id: 'movie-1', type: 'movie' });
+      const ruleGroup = createRulesDto({ dataType: 'movie' });
+
+      await expect(
+        service.get(28, libItem, 'movie', ruleGroup),
+      ).resolves.toBeUndefined();
+      await expect(
+        service.get(30, libItem, 'movie', ruleGroup),
+      ).resolves.toBeUndefined();
+    });
+
     it.each([
       { id: 31, name: 'rating_imdb', expected: 7.8 },
       { id: 32, name: 'rating_rottenTomatoesCritic', expected: 6.6 },

--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -1418,6 +1418,23 @@ describe('PlexGetterService', () => {
 
       expect(result).toBeUndefined();
     });
+
+    it('returns undefined when the plex.tv username enrichment fails so degraded names never mis-evaluate rules (#3307)', async () => {
+      plexApi.getMetadata.mockResolvedValue(makeMetadata());
+      plexApi.getCorrectedUsers.mockRejectedValue(
+        new Error('plex.tv user data unavailable'),
+      );
+      plexApi.getWatchHistory.mockResolvedValue([
+        makeWatchEntry({ accountID: 1 }),
+      ]);
+
+      const result = await service.get(
+        SEEN_BY_PROP_ID,
+        createMediaItem({ type: 'movie' }),
+      );
+
+      expect(result).toBeUndefined();
+    });
   });
 
   describe('sw_lastWatched (id 13) - Newest episode view date', () => {

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -516,8 +516,10 @@ export class PlexGetterService {
           const plexUsers: SimplePlexUser[] =
             await this.plexApi.getCorrectedUsers();
 
-          // When plex.tv is unreachable, no users will have UUIDs.
-          // Return null to skip the rule rather than falsely report an empty watchlist.
+          // When plex.tv is unreachable, no users will have UUIDs. This is a
+          // transient transport failure, so return `undefined` - `null` would
+          // read as "confirmed absent" and let the executor remove protected
+          // items (#3307).
           if (
             plexUsers.length > 0 &&
             !plexUsers.some((u) => u.uuid !== undefined)
@@ -525,7 +527,7 @@ export class PlexGetterService {
             this.logger.warn(
               'Unable to check watchlists: no user UUIDs available (plex.tv may be unreachable)',
             );
-            return null;
+            return undefined;
           }
 
           const usernames: string[] = [];
@@ -536,7 +538,12 @@ export class PlexGetterService {
               u.uuid,
               u.username,
             );
-            if (watchlist?.find((i) => i.id === media_uuid[1]) !== undefined) {
+            // A failed fetch would silently understate the list, so surface
+            // it as transient instead of a confirmed answer.
+            if (watchlist === undefined) {
+              return undefined;
+            }
+            if (watchlist.find((i) => i.id === media_uuid[1]) !== undefined) {
               usernames.push(u.username);
             }
           }
@@ -556,8 +563,10 @@ export class PlexGetterService {
           const plexUsers: SimplePlexUser[] =
             await this.plexApi.getCorrectedUsers();
 
-          // When plex.tv is unreachable, no users will have UUIDs.
-          // Return null to skip the rule rather than falsely report an empty watchlist.
+          // When plex.tv is unreachable, no users will have UUIDs. This is a
+          // transient transport failure, so return `undefined` - `null` would
+          // read as "confirmed absent" and let the executor remove protected
+          // items (#3307).
           if (
             plexUsers.length > 0 &&
             !plexUsers.some((u) => u.uuid !== undefined)
@@ -565,7 +574,7 @@ export class PlexGetterService {
             this.logger.warn(
               'Unable to check watchlists: no user UUIDs available (plex.tv may be unreachable)',
             );
-            return null;
+            return undefined;
           }
 
           for (const u of plexUsers.filter(
@@ -575,7 +584,12 @@ export class PlexGetterService {
               u.uuid,
               u.username,
             );
-            if (watchlist?.find((i) => i.id === media_uuid[1]) !== undefined) {
+            // A failed fetch cannot confirm "not watchlisted", so surface it
+            // as transient instead of a false negative.
+            if (watchlist === undefined) {
+              return undefined;
+            }
+            if (watchlist.find((i) => i.id === media_uuid[1]) !== undefined) {
               return true;
             }
           }

--- a/apps/server/src/modules/rules/getter/radarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.spec.ts
@@ -327,6 +327,17 @@ describe('RadarrGetterService', () => {
 
       await expect(callAddDate()).resolves.toBeNull();
     });
+
+    it('returns undefined (fail closed) when no external ids resolve', async () => {
+      // Empty resolution also covers a transient TMDB/TVDB validation
+      // failure, so it must stay transient (#3307).
+      mockRadarrApi();
+      metadataService.resolveLookupCandidatesFromMediaItemForService.mockResolvedValue(
+        [],
+      );
+
+      await expect(callAddDate()).resolves.toBeUndefined();
+    });
   });
 
   // Scope handles mirroring Sonarr's seriesTitle/seriesId (#3220).

--- a/apps/server/src/modules/rules/getter/radarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.ts
@@ -76,7 +76,11 @@ export class RadarrGetterService {
         this.logger.warn(
           `Failed to resolve external IDs for '${libItem.title}' (media server ID '${libItem.id}'). As a result, no Radarr query could be made.`,
         );
-        return null;
+        // An empty resolution cannot distinguish "item has no provider ids"
+        // from a transient TMDB/TVDB failure (validation runs online), so it
+        // must stay `undefined` - `null` would defeat the transient-removal
+        // guard and wipe collections during an internet outage (#3307).
+        return undefined;
       }
 
       const radarrApiClient = await this.servarrService.getRadarrApiClient(

--- a/apps/server/src/modules/rules/getter/seerr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/seerr-getter.service.spec.ts
@@ -887,7 +887,7 @@ describe('SeerrGetterService', () => {
   });
 
   describe('no resolvable tmdb id', () => {
-    it('should return null without querying Seerr', async () => {
+    it('should return undefined (transient) without querying Seerr', async () => {
       const { service, seerrApi, metadataService } = createService();
       (
         metadataService.resolveIdsFromMediaItemForService as jest.Mock
@@ -895,7 +895,7 @@ describe('SeerrGetterService', () => {
 
       await expect(
         service.get(IS_REQUESTED_PROP_ID, movieLibItem, undefined),
-      ).resolves.toBeNull();
+      ).resolves.toBeUndefined();
       expect(seerrApi.getRequestsForMedia).not.toHaveBeenCalled();
       expect(seerrApi.getMovie).not.toHaveBeenCalled();
     });

--- a/apps/server/src/modules/rules/getter/seerr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/seerr-getter.service.ts
@@ -167,7 +167,9 @@ export class SeerrGetterService {
             } catch (error) {
               this.logger.warn("Couldn't get addUser from Seerr");
               this.logger.debug(error);
-              return null;
+              // undefined (transient) per the getter contract - null reads as
+              // a confirmed answer and lifts the removal guard.
+              return undefined;
             }
           }
           case 'amountRequested': {

--- a/apps/server/src/modules/rules/getter/seerr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/seerr-getter.service.ts
@@ -87,7 +87,11 @@ export class SeerrGetterService {
         this.logger.debug(
           `Couldn't find tmdb id for media '${libItem.title}' with id '${libItem.id}'. As a result, no Seerr query could be made.`,
         );
-        return null;
+        // An empty resolution cannot distinguish "item has no tmdb id" from a
+        // transient TMDB failure (validation runs online), so it must stay
+        // `undefined` - `null` would defeat the transient-removal guard and
+        // wipe collections during an internet outage (#3307).
+        return undefined;
       }
 
       // releaseDate (movie releaseDate / tv firstAirDate / season|episode

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
@@ -380,6 +380,16 @@ describe('SonarrGetterService', () => {
         ).toHaveBeenCalledTimes(2);
       });
 
+      it('returns undefined (fail closed) when no external ids resolve', async () => {
+        // Empty resolution also covers a transient TMDB/TVDB validation
+        // failure, so it must stay transient (#3307).
+        metadataService.resolveLookupCandidatesFromMediaItemForService.mockResolvedValue(
+          [],
+        );
+
+        await expect(call()).resolves.toBeUndefined();
+      });
+
       it('evicts an empty resolution so a later condition retries (transient safety, #3125)', async () => {
         metadataService.resolveLookupCandidatesFromMediaItemForService
           .mockResolvedValueOnce([]) // transient: nothing resolved

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -109,7 +109,11 @@ export class SonarrGetterService {
         this.logger.warn(
           `Failed to resolve external IDs for '${libItem.title}' (media server ID '${libItem.id}'). As a result, no Sonarr query could be made.`,
         );
-        return null;
+        // An empty resolution cannot distinguish "item has no provider ids"
+        // from a transient TMDB/TVDB failure (validation runs online), so it
+        // must stay `undefined` - `null` would defeat the transient-removal
+        // guard and wipe collections during an internet outage (#3307).
+        return undefined;
       }
 
       const sonarrApiClient = await this.servarrService.getSonarrApiClient(

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.spec.ts
@@ -11,6 +11,7 @@ import { Collection } from '../../collections/entities/collection.entities';
 import { RulesDto } from '../dtos/rules.dto';
 import { TautulliGetterService } from './tautulli-getter.service';
 
+const SEEN_BY = 0;
 const SW_LAST_WATCHED = 7;
 
 // Tautulli grades watched_status as 0 | 0.25 | 0.5 | 0.75 | 1; only 1 means the
@@ -26,6 +27,7 @@ const historyItem = (props: {
 const createService = (
   history: ReturnType<typeof historyItem>[],
   tautulliWatchedPercentOverride: number | null = null,
+  plexApi: Partial<jest.Mocked<PlexApiService>> = {},
 ) => {
   const tautulliApi = {
     getMetadata: jest
@@ -42,7 +44,7 @@ const createService = (
 
   return new TautulliGetterService(
     tautulliApi,
-    {} as jest.Mocked<PlexApiService>,
+    plexApi as jest.Mocked<PlexApiService>,
     collectionRepository,
     createMockLogger(),
   );
@@ -52,6 +54,42 @@ const showItem: MediaItem = createMediaItem({ type: 'show', id: '1' });
 const ruleGroup = { collection: { id: 1 } } as RulesDto;
 
 describe('TautulliGetterService', () => {
+  describe('seenBy', () => {
+    const watchedPlay = historyItem({
+      watched_status: 1,
+      percent_complete: 100,
+      parent_media_index: 1,
+      media_index: 1,
+      stopped: 1_700_000_000,
+    });
+
+    it('maps Tautulli viewer ids to plex.tv usernames', async () => {
+      const service = createService([watchedPlay], null, {
+        getCorrectedUsers: jest
+          .fn()
+          .mockResolvedValue([{ plexId: 1, username: 'alice' }]),
+      } as Partial<jest.Mocked<PlexApiService>>);
+
+      await expect(
+        service.get(SEEN_BY, showItem, undefined, ruleGroup),
+      ).resolves.toEqual(['alice']);
+    });
+
+    it('returns undefined when the plex.tv username enrichment fails so degraded names never mis-evaluate rules (#3307)', async () => {
+      // Before, a failed plex.tv fetch degraded to local account ids/names,
+      // silently dropping viewers from the list.
+      const service = createService([watchedPlay], null, {
+        getCorrectedUsers: jest
+          .fn()
+          .mockRejectedValue(new Error('plex.tv user data unavailable')),
+      } as Partial<jest.Mocked<PlexApiService>>);
+
+      await expect(
+        service.get(SEEN_BY, showItem, undefined, ruleGroup),
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe('sw_lastWatched', () => {
     it('returns null when no episode crossed the watched threshold', async () => {
       const service = createService([

--- a/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -178,6 +178,11 @@ export class RuleComparatorService {
         `Something went wrong while running rule ${rulegroup.name}`,
         error,
       );
+      // Swallowing here returned `undefined` for the whole chunk: the
+      // executor then saw none of these items as matching or transiently
+      // failed and removed them from the collection. Fail the run instead
+      // (#3307).
+      throw error;
     }
   }
 

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -1749,14 +1749,14 @@ export class RulesService {
     if (mediaResp) {
       group.rules = await this.getRules(group.id);
       const ruleComparator = this.ruleComparatorServiceFactory.create();
-      const result = await ruleComparator.executeRulesWithData(
-        group as RulesDto,
-        [mediaResp],
-      );
-
-      if (result) {
+      try {
+        const result = await ruleComparator.executeRulesWithData(
+          group as RulesDto,
+          [mediaResp],
+        );
         return { code: 1, result: result.stats };
-      } else {
+      } catch (error) {
+        this.logger.debug(error);
         return { code: 0, result: 'An error occurred executing rules' };
       }
     }

--- a/apps/server/src/modules/rules/tasks/exclusion-corrector.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/exclusion-corrector.service.spec.ts
@@ -14,6 +14,7 @@ describe('ExclusionTypeCorrectorService', () => {
     collections?: any[];
     ruleGroups?: any[];
     isSetup?: boolean;
+    mediaServer?: { getMetadata?: jest.Mock; itemExists?: jest.Mock };
   }) => {
     const {
       exclusions = [],
@@ -43,10 +44,14 @@ describe('ExclusionTypeCorrectorService', () => {
       save: jest.fn().mockResolvedValue(undefined),
     };
 
+    const mediaServer = {
+      getMetadata: jest.fn().mockResolvedValue(null),
+      itemExists: jest.fn().mockResolvedValue(true),
+      ...options?.mediaServer,
+    };
+
     const mediaServerFactory = {
-      getService: jest.fn().mockResolvedValue({
-        getMetadata: jest.fn().mockResolvedValue(null),
-      }),
+      getService: jest.fn().mockResolvedValue(mediaServer),
     };
 
     const settings = {
@@ -74,6 +79,7 @@ describe('ExclusionTypeCorrectorService', () => {
       ruleGroupRepo,
       settings,
       mediaServerFactory,
+      mediaServer,
       rulesService,
     };
   };
@@ -193,6 +199,59 @@ describe('ExclusionTypeCorrectorService', () => {
       expect(logger.debug).toHaveBeenCalledWith(
         expect.objectContaining({ message: 'connection refused' }),
       );
+    });
+  });
+
+  describe('correctExclusionTypes - stale vs unreachable media (#3307 follow-up)', () => {
+    it('backfills the type and saves only corrected rows', async () => {
+      const exclusions = [{ id: 1, type: null, mediaServerId: '11' }];
+      const { service, exclusionRepo, rulesService } = createService({
+        exclusions,
+        isSetup: true,
+        mediaServer: {
+          getMetadata: jest.fn().mockResolvedValue({ id: '11', type: 'movie' }),
+        },
+      });
+
+      await service.onModuleInit();
+
+      expect(exclusions[0].type).toBe('movie');
+      expect(rulesService.removeExclusion).not.toHaveBeenCalled();
+      expect(exclusionRepo.save).toHaveBeenLastCalledWith([exclusions[0]]);
+    });
+
+    it('removes an exclusion only on a confirmed 404 and does not re-save the removed row', async () => {
+      const exclusions = [{ id: 1, type: null, mediaServerId: '11' }];
+      const { service, exclusionRepo, rulesService } = createService({
+        exclusions,
+        isSetup: true,
+        mediaServer: {
+          getMetadata: jest.fn().mockResolvedValue(undefined),
+          itemExists: jest.fn().mockResolvedValue(false),
+        },
+      });
+
+      await service.onModuleInit();
+
+      expect(rulesService.removeExclusion).toHaveBeenCalledWith(1);
+      // Saving the full list would re-insert the row removed above.
+      expect(exclusionRepo.save).toHaveBeenLastCalledWith([]);
+    });
+
+    it('keeps the exclusion when the existence check is inconclusive', async () => {
+      const exclusions = [{ id: 1, type: null, mediaServerId: '11' }];
+      const { service, rulesService } = createService({
+        exclusions,
+        isSetup: true,
+        mediaServer: {
+          getMetadata: jest.fn().mockResolvedValue(undefined),
+          itemExists: jest.fn().mockRejectedValue(new Error('unreachable')),
+        },
+      });
+
+      await service.onModuleInit();
+
+      expect(rulesService.removeExclusion).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/modules/rules/tasks/exclusion-corrector.service.ts
+++ b/apps/server/src/modules/rules/tasks/exclusion-corrector.service.ts
@@ -143,20 +143,34 @@ export class ExclusionTypeCorrectorService implements OnModuleInit {
 
     const mediaServer = await this.mediaServerFactory.getService();
 
-    // correct the type
+    const corrected: typeof exclusionsWithoutType = [];
     for (const el of exclusionsWithoutType) {
       const metaData = await mediaServer.getMetadata(el.mediaServerId);
-      if (!metaData) {
-        // remove record if not in media server
+      if (metaData) {
+        el.type = metaData.type;
+        corrected.push(el);
+        continue;
+      }
+
+      // getMetadata is undefined for both a gone item and a failed read.
+      // Only remove on a confirmed 404 via itemExists; on an inconclusive
+      // check leave the row untyped so the next startup retries - a
+      // transient blip must not delete the protection an exclusion provides.
+      let exists = true;
+      try {
+        exists = await mediaServer.itemExists(el.mediaServerId);
+      } catch (error) {
+        this.logger.debug(error);
+      }
+
+      if (!exists) {
         await this.rulesService.removeExclusion(el.id);
-      } else {
-        // Assign MediaItemType string directly
-        el.type = metaData?.type;
       }
     }
 
-    // save edited data
-    await this.exclusionRepo.save(exclusionsWithoutType);
+    // Save only the rows that received a type: saving the full list would
+    // re-insert the exclusions removed above.
+    await this.exclusionRepo.save(corrected);
 
     this.logger.log('Exclusion type backfill complete');
   }

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -313,12 +313,13 @@ export class RuleExecutorService {
             arrLookupCache,
           );
 
-          if (ruleResult) {
-            this.statisticsData.push(...ruleResult.stats);
-            this.resultData.push(...ruleResult.data);
-            for (const id of ruleResult.transientFailureMediaIds) {
-              this.transientFailureMediaIds.add(id);
-            }
+          // executeRulesWithData throws on evaluation failure; a silently
+          // skipped chunk would be removed from the collection as
+          // "no longer matching" (#3307).
+          this.statisticsData.push(...ruleResult.stats);
+          this.resultData.push(...ruleResult.data);
+          for (const id of ruleResult.transientFailureMediaIds) {
+            this.transientFailureMediaIds.add(id);
           }
         }
 

--- a/apps/server/src/modules/rules/tasks/rule-maintenance.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-maintenance.service.spec.ts
@@ -1,0 +1,69 @@
+import { createMockLogger } from '../../../../test/utils/data';
+import { RuleMaintenanceService } from './rule-maintenance.service';
+
+describe('RuleMaintenanceService - removeLeftoverExclusions', () => {
+  const createService = (options?: {
+    exclusions?: any[];
+    itemExists?: jest.Mock;
+  }) => {
+    const { exclusions = [] } = options ?? {};
+
+    const mediaServer = {
+      itemExists: options?.itemExists ?? jest.fn().mockResolvedValue(true),
+    };
+
+    const rulesService = {
+      getAllExclusions: jest.fn().mockResolvedValue(exclusions),
+      getRuleGroups: jest.fn().mockResolvedValue([]),
+      removeExclusion: jest.fn(),
+    };
+
+    const service = new RuleMaintenanceService(
+      { createJob: jest.fn(), updateJob: jest.fn() } as any,
+      createMockLogger() as any,
+      {
+        testMediaServerConnection: jest.fn().mockResolvedValue(true),
+      } as any,
+      rulesService as any,
+      { find: jest.fn().mockResolvedValue([]) } as any,
+      { getService: jest.fn().mockResolvedValue(mediaServer) } as any,
+      { removeStaleCollectionMedia: jest.fn() } as any,
+    );
+
+    return { service, rulesService, mediaServer };
+  };
+
+  it('removes an exclusion only when the media server confirms the item is gone', async () => {
+    const { service, rulesService } = createService({
+      exclusions: [{ id: 1, mediaServerId: '11' }],
+      itemExists: jest.fn().mockResolvedValue(false),
+    });
+
+    await (service as any).executeTask();
+
+    expect(rulesService.removeExclusion).toHaveBeenCalledWith(1);
+  });
+
+  it('keeps the exclusion when the existence check is inconclusive (#3307 follow-up)', async () => {
+    // getMetadata-based checks removed exclusions on a transient blip; the
+    // itemExists contract throws on inconclusive and must not delete.
+    const { service, rulesService } = createService({
+      exclusions: [{ id: 1, mediaServerId: '11' }],
+      itemExists: jest.fn().mockRejectedValue(new Error('unreachable')),
+    });
+
+    await (service as any).executeTask();
+
+    expect(rulesService.removeExclusion).not.toHaveBeenCalled();
+  });
+
+  it('keeps the exclusion when the item still exists', async () => {
+    const { service, rulesService } = createService({
+      exclusions: [{ id: 1, mediaServerId: '11' }],
+    });
+
+    await (service as any).executeTask();
+
+    expect(rulesService.removeExclusion).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/modules/rules/tasks/rule-maintenance.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-maintenance.service.ts
@@ -55,15 +55,22 @@ export class RuleMaintenanceService extends TaskBase {
   }
 
   private async removeLeftoverExclusions() {
-    // get all exclusions
     const exclusions = await this.rulesService.getAllExclusions();
     const mediaServer = await this.mediaServerFactory.getService();
-    // loop through exclusions
     for (const exclusion of exclusions) {
-      // check if media still exists
-      const resp = await mediaServer.getMetadata(exclusion.mediaServerId);
-      // remove when not
-      if (!resp?.id) {
+      // Only drop an exclusion when the media server *confirms* the item is
+      // gone. `itemExists` returns false solely on a 404/empty result and
+      // throws on an inconclusive check, unlike `getMetadata` which returns
+      // undefined for both absent and failed reads - a transient blip must
+      // not delete the protection an exclusion provides.
+      let exists = true;
+      try {
+        exists = await mediaServer.itemExists(exclusion.mediaServerId);
+      } catch (error) {
+        this.logger.debug(error);
+      }
+
+      if (!exists) {
         await this.rulesService.removeExclusion(exclusion.id);
       }
     }

--- a/apps/server/src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts
+++ b/apps/server/src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts
@@ -138,6 +138,31 @@ describe('RuleComparatorService.executeRulesWithData', () => {
     } as never);
   });
 
+  it('rethrows evaluation failures instead of returning undefined for the chunk (#3307)', async () => {
+    // A swallowed chunk error left every item in it unmatched and
+    // unprotected, so the executor removed them as "no longer matching".
+    const mediaItem = createSingleMedia();
+    const rules = [
+      createStoredRule(1, {
+        operator: null,
+        action: RulePossibility.SMALLER,
+        firstVal: [Application.PLEX, 31],
+        customVal: { ruleTypeId: +RuleType.NUMBER, value: '6' },
+        section: 0,
+      }),
+    ];
+
+    valueGetterService.get.mockReset();
+    valueGetterService.get.mockRejectedValue(new Error('boom'));
+
+    await expect(
+      ruleComparatorService.executeRulesWithData(
+        createRulesDto({ dataType: 'movie', rules }),
+        [mediaItem],
+      ),
+    ).rejects.toThrow('boom');
+  });
+
   it('fails closed when the first value is missing for a custom comparison', async () => {
     const mediaItem = createSingleMedia();
     const rules = [


### PR DESCRIPTION
Fixes #3307 (same failure class first reported in #2446).

An internet outage with the media server still reachable on LAN emptied every affected collection - collection_media rows removed and the server-side collection deleted - then recovery re-added everything with a fresh addDate, resetting deletion countdowns and dropping overlays. Reproduced end to end against a real Plex server by blocking plex.tv/TMDB while PMS stayed reachable.

Root cause: several paths collapse a transient internet failure into a definitive value, defeating the #2870 transient-removal guard (which only engages on `undefined`):

- The Plex watchlist getters returned `null` when plex.tv was unreachable (#2445 predates the guard) and collapsed a failed community watchlist read into a confirmed false/[]. Both now return `undefined`.
- The Radarr/Sonarr/Seerr getters collapsed a transiently failed TMDB/TVDB id validation into `null`, un-protecting every arr/Seerr rule property library-wide whenever the metadata cache was cold.
- `getLibraryContents` fabricated an empty page on a failed read on all three adapters, which reads as end-of-library and silently truncated evaluation, mass-removing the unevaluated tail. Adapters now throw (same contract as `getCollectionChildren`, #3248) and the run fails without membership changes. `getLibraryContentCount` follows the same contract.
- The comparator no longer swallows a chunk evaluation error into `undefined` (the executor removed such chunks as no longer matching); the single-item rule test endpoint keeps its graceful error result.
- `getCorrectedUsers` silently fell back to local account names without uuids when plex.tv was unreachable, so seenBy/sw_watchers evaluated on plausible-but-wrong lists and the Tautulli user mapping dropped viewers. It now throws on a failed plex.tv fetch (getters catch it into the transient `undefined`); a confirmed no-shared-users response still resolves as `[]`, and the per-user local fallback keeps working for accounts plex.tv does not know (#1240/#1339 intent preserved).
- The daily maintenance exclusion sweep and the startup exclusion type corrector deleted exclusions on a transient `getMetadata` blip; both now require an `itemExists`-confirmed 404, and the corrector no longer re-inserts rows it just removed.

Behavior note: items whose lookups stay unavailable remain in their collection flagged as evaluation-failed until a healthy run - uncertainty no longer removes or deletes anything.

Verified with the full test suite plus a live outage/recovery cycle on a real Plex server: pre-fix the cycle wipes and re-adds the collection; post-fix items survive flagged and the flags clear on recovery without touching addDate.