### PR TITLE
fix(collections): log media title instead of id when postponing

### DIFF
--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -142,7 +142,33 @@ describe('CollectionsService', () => {
       });
       expect(logSpy).toHaveBeenCalledWith(
         collection,
-        'Postponed deletion of media item-5 by 14 day(s)',
+        'Postponed deletion of "item-5" by 14 day(s)',
+        ECollectionLogType.MEDIA,
+      );
+    });
+
+    it('logs the resolved media title when the media server can supply it', async () => {
+      const collection = createCollection({ id: 1, deleteAfterDays: 30 });
+      const media = createCollectionMedia(collection, {
+        id: 5,
+        mediaServerId: 'item-5',
+        addDate: new Date(2026, 5, 24),
+      });
+      collectionRepo.findOne.mockResolvedValue(collection);
+      collectionMediaRepo.findOne.mockResolvedValue(media);
+      mediaServer.getMetadata.mockResolvedValue({
+        type: 'movie',
+        title: 'Sample Movie',
+      } as never);
+      const logSpy = jest
+        .spyOn(service, 'addLogRecord')
+        .mockResolvedValue(undefined);
+
+      await service.postponeCollectionMedia(1, 'item-5', 7);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        collection,
+        'Postponed deletion of "Sample Movie" by 7 day(s)',
         ECollectionLogType.MEDIA,
       );
     });
@@ -172,7 +198,7 @@ describe('CollectionsService', () => {
         expect(result?.deletionDate).toEqual(new Date(2026, 7, 18));
         expect(logSpy).toHaveBeenCalledWith(
           collection,
-          'Reset deletion timer for media item-5',
+          'Reset deletion timer for "item-5"',
           ECollectionLogType.MEDIA,
         );
       } finally {

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -212,11 +212,26 @@ export class CollectionsService {
 
     await this.CollectionMediaRepo.update(media.id, { addDate: newAddDate });
 
+    // Prefer the item's title in the log; fall back to its id if the media
+    // server can't resolve it (transient error / already gone) - never fail the
+    // postpone over a cosmetic label.
+    let mediaLabel = mediaServerId;
+    try {
+      const mediaData = await (
+        await this.getMediaServer()
+      ).getMetadata(mediaServerId);
+      if (mediaData) {
+        mediaLabel = this.describeMediaForLog(mediaData);
+      }
+    } catch (error) {
+      this.logger.debug(error);
+    }
+
     await this.addLogRecord(
       collection,
       days != null
-        ? `Postponed deletion of media ${mediaServerId} by ${days} day(s)`
-        : `Reset deletion timer for media ${mediaServerId}`,
+        ? `Postponed deletion of "${mediaLabel}" by ${days} day(s)`
+        : `Reset deletion timer for "${mediaLabel}"`,
       ECollectionLogType.MEDIA,
     );
 
@@ -3413,6 +3428,18 @@ export class CollectionsService {
     return { serverRejectedIds: failedItemIds, persistedIds };
   }
 
+  /**
+   * Human-readable name for a media item in collection log messages: the title,
+   * or a "Show - season N - episode M" composite for seasons/episodes.
+   */
+  private describeMediaForLog(mediaData: MediaItem): string {
+    return isMediaType(mediaData.type, 'episode')
+      ? `${mediaData.grandparentTitle} - season ${mediaData.parentIndex} - episode ${mediaData.index}`
+      : isMediaType(mediaData.type, 'season')
+        ? `${mediaData.parentTitle} - season ${mediaData.index}`
+        : mediaData.title;
+  }
+
   public async CollectionLogRecordForChild(
     mediaServerId: string,
     collectionId: number,
@@ -3423,11 +3450,7 @@ export class CollectionsService {
     const mediaData = await mediaServer.getMetadata(mediaServerId);
 
     if (mediaData) {
-      const subject = isMediaType(mediaData.type, 'episode')
-        ? `${mediaData.grandparentTitle} - season ${mediaData.parentIndex} - episode ${mediaData.index}`
-        : isMediaType(mediaData.type, 'season')
-          ? `${mediaData.parentTitle} - season ${mediaData.index}`
-          : mediaData.title;
+      const subject = this.describeMediaForLog(mediaData);
       await this.addLogRecord(
         { id: collectionId } as Collection,
         `${type === 'add' ? 'Added' : type === 'handle' ? 'Successfully handled' : type === 'exclude' ? 'Added a specific exclusion for' : type === 'include' ? 'Removed specific exclusion of' : 'Removed'} "${subject}"`,


### PR DESCRIPTION
Postpone log records showed the raw media-server id (e.g. `Postponed deletion of media 9614097b0492...`) instead of the item's title.

- Resolve and log the item's title, matching how per-item add/remove log records already read.
- Fall back to the id when the media server can't resolve the item (transient error / already gone); never fails the postpone over a cosmetic label.
- Extract the shared subject formatting into a `describeMediaForLog` helper (DRY with `CollectionLogRecordForChild`).