### PR TITLE
fix(collections): mark handler-removed items to prevent re-adoption as manual

### DIFF
--- a/apps/server/src/modules/collections/collection-handler.spec.ts
+++ b/apps/server/src/modules/collections/collection-handler.spec.ts
@@ -195,6 +195,57 @@ describe('CollectionHandler', () => {
     ).not.toHaveBeenCalled();
   });
 
+  it('records a rule-removal marker when handling an item in an automatic collection', async () => {
+    // UNMONITOR leaves the file (and the media-server item) in place, so if the
+    // BoxSet removal silently no-ops the item lingers there. The marker is what
+    // lets the next run self-heal it instead of re-adopting it as manual (#3298,
+    // extended to the handler path).
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR,
+      sonarrSettingsId: 1,
+      type: 'show',
+      manualCollection: false,
+    });
+    const collectionMedia = createCollectionMedia(collection);
+
+    mediaServer.getLibraries.mockResolvedValue(
+      createMediaLibraries({
+        id: collection.libraryId.toString(),
+        type: 'show',
+      }),
+    );
+    sonarrActionHandler.handleAction.mockResolvedValue(true);
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(collectionsService.markRuleRemoved).toHaveBeenCalledWith(
+      collection.id,
+      [collectionMedia.mediaServerId],
+    );
+  });
+
+  it('does not record a rule-removal marker for a manual collection (no rule to reclaim it)', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR,
+      sonarrSettingsId: 1,
+      type: 'show',
+      manualCollection: true,
+    });
+    const collectionMedia = createCollectionMedia(collection);
+
+    mediaServer.getLibraries.mockResolvedValue(
+      createMediaLibraries({
+        id: collection.libraryId.toString(),
+        type: 'show',
+      }),
+    );
+    sonarrActionHandler.handleAction.mockResolvedValue(true);
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(collectionsService.markRuleRemoved).not.toHaveBeenCalled();
+  });
+
   it('should call Radarr action handler', async () => {
     const collection = createCollection({
       arrAction: ServarrAction.DELETE,

--- a/apps/server/src/modules/collections/collection-handler.ts
+++ b/apps/server/src/modules/collections/collection-handler.ts
@@ -228,6 +228,26 @@ export class CollectionHandler {
       collection = updatedCollection;
     }
 
+    // The collection's configured action retired this item, so record a
+    // rule-removal marker - the same protection #3298 gives the rule executor's
+    // own removals, extended to the handler path. For actions that leave the
+    // file in place (UNMONITOR / quality change) the item stays on the media
+    // server, so if the BoxSet removal above silently no-ops it lingers there;
+    // without a marker the next run would re-adopt it as a spurious manual
+    // member. The marker lets that run self-heal it instead. Automatic,
+    // still-linked collections only (a manual collection has no rule to reclaim
+    // it; an emptied collection was unlinked above so nothing can linger).
+    // Best-effort: a marker write must never fail an already-applied action.
+    if (!collection.manualCollection && collection.mediaServerId) {
+      try {
+        await this.collectionService.markRuleRemoved(collection.id, [
+          media.mediaServerId,
+        ]);
+      } catch (error) {
+        this.logger.debug(error);
+      }
+    }
+
     // The file is gone after a disk-freeing action (DELETE, DELETE_SHOW_IF_EMPTY,
     // and the UNMONITOR_DELETE_* variants all delete files), but the item still
     // resolves on the media server until its next library scan. Prune it from


### PR DESCRIPTION
Follow-up to #3298. That fix added a `collection_media_rule_removal` marker so a rule-removed item the media server silently retains in its collection is self-healed on the next run instead of being re-adopted as a spurious manual member. The marker is reason-gated (`media_removed_by_rule`), so it was only written by the rule executor's own removals.

The **collection handler** removes handled items with no such reason ([collection-handler.ts](https://github.com/Maintainerr/Maintainerr/blob/development/apps/server/src/modules/collections/collection-handler.ts)), so its removals write no marker. For actions that leave the item on the server (`UNMONITOR`, `CHANGE_QUALITY_PROFILE`), a silent server no-op leaves the item lingering in the BoxSet with no marker, and the next rule run adopts it as manual - the exact symptom #3298 was reported for, still open on the handler path.

- Write the rule-removal marker for the handler's removals too, for automatic, still-linked collections (a manual collection has no rule to reclaim the item; an emptied collection is unlinked so nothing can linger).
- Best-effort: a marker write never fails an already-applied action.
- Reuses #3298's existing reconcile/self-heal machinery; no behavior change to the removal itself.

Adds regression tests asserting the marker is written for automatic collections and skipped for manual ones.