### PR TITLE
feat(sportarr): follow-up nits + "has upcoming events" rule property

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ spec:
 
 # Features
 
-- Build rules from properties across Plex, Jellyfin, Emby, Radarr, Sonarr, Seerr, Tautulli and Streamystats, combined with AND/OR logic.
+- Build rules from properties across Plex, Jellyfin, Emby, Radarr, Sonarr, Sportarr, Seerr, Tautulli and Streamystats, combined with AND/OR logic.
 - Use Plex, Jellyfin or Emby as your media server.
 - Switch between media server types with rule migration.
 - Deploy separate Maintainerr instances for separate media servers, each with isolated rules, collections and data.
@@ -177,7 +177,7 @@ spec:
 - Run automatic collections, or manual ones you manage; add or exclude individual items even when they match a rule.
 - Delete items from your download client.
 - Manage collection membership from within your media server - Maintainerr syncs manual changes back.
-- On handling: delete files from disk, unmonitor or delete in Radarr/Sonarr, change quality profile, and clear requests in Seerr.
+- On handling: delete files from disk, unmonitor or delete in Radarr/Sonarr/Sportarr, change quality profile, and clear requests in Seerr.
 - Render configurable overlays (text, countdown, shapes, images) onto posters and title cards on your media server(s).
 - Set a custom collection poster that survives recreation.
 - Send notifications via Discord, Slack, Telegram, Pushover, Gotify, ntfy, Pushbullet, LunaSea, email or webhook.
@@ -196,10 +196,11 @@ Maintainerr builds rules from data across these apps:
 [![Seerr](https://img.shields.io/badge/Seerr-5969F8?style=for-the-badge)](https://seerr.dev/)
 [![Radarr](https://img.shields.io/badge/Radarr-FFC230?style=for-the-badge&logo=radarr&logoColor=white)](https://radarr.video/)
 [![Sonarr](https://img.shields.io/badge/Sonarr-2596BE?style=for-the-badge&logo=sonarr&logoColor=white)](https://sonarr.tv/)
+[![Sportarr](https://img.shields.io/badge/Sportarr-E4572E?style=for-the-badge)](https://sportarr.net/)
 [![Tautulli](https://img.shields.io/badge/Tautulli-DBA81A?style=for-the-badge)](https://tautulli.com/)
 [![Streamystats](https://img.shields.io/badge/Streamystats-8A4FBE?style=for-the-badge)](https://github.com/fredrikburmester/streamystats)
 
-<sub>Tautulli is Plex-only; Streamystats is Jellyfin-only.</sub>
+<sub>Tautulli is Plex-only; Streamystats is Jellyfin-only; Sportarr manages sports libraries.</sub>
 
 # API
 

--- a/apps/server/src/modules/actions/sportarr-action-handler.ts
+++ b/apps/server/src/modules/actions/sportarr-action-handler.ts
@@ -383,7 +383,9 @@ export class SportarrActionHandler {
   // the event's seasonNumber; the display label is derived from the matched
   // events where needed.
   private seasonIndex(mediaData: MediaItem | undefined): number | undefined {
-    return mediaData?.grandparentId ? mediaData?.parentIndex : mediaData?.index;
+    // Only ever called on a season item, whose own index is the season number
+    // on every server. Don't infer scope from grandparentId presence (#3065).
+    return mediaData?.index;
   }
 
   private async resolveEvent(

--- a/apps/server/src/modules/api/servarr-api/helpers/sportarr-version.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sportarr-version.ts
@@ -5,12 +5,13 @@ export function isBelowMinimumVersion(
   version: string,
   minimum: string,
 ): boolean {
-  const parse = (v: string) =>
-    v
-      .trim()
-      .replace(/^v/i, '')
-      .split('.')
-      .map((s) => Number.parseInt(s, 10));
+  const parse = (v: string) => {
+    const trimmed = v.trim();
+    // Strip a leading "v"/"V" prefix without a regex (project convention).
+    const digits =
+      trimmed[0] === 'v' || trimmed[0] === 'V' ? trimmed.slice(1) : trimmed;
+    return digits.split('.').map((s) => Number.parseInt(s, 10));
+  };
   const current = parse(version);
   const required = parse(minimum);
   if (current.some(Number.isNaN) || required.some(Number.isNaN)) {

--- a/apps/server/src/modules/rules/constants/rules.constants.ts
+++ b/apps/server/src/modules/rules/constants/rules.constants.ts
@@ -1053,6 +1053,14 @@ export class RuleConstants {
           showType: ['show', 'season'],
         },
         {
+          id: 14,
+          name: 'hasFutureEvents',
+          humanName: 'Has upcoming events',
+          mediaType: MediaType.SHOW,
+          type: RuleType.BOOL,
+          showType: ['show', 'season'],
+        },
+        {
           id: 9,
           name: 'seasonNumber',
           humanName: 'Season number (year)',

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.spec.ts
@@ -145,6 +145,59 @@ describe('SportarrGetterService', () => {
     expect(result).toBe(false);
   });
 
+  describe('hasFutureEvents (property 14)', () => {
+    const trackedLeague = {
+      id: 3,
+      externalId: F1_EXTERNAL_ID,
+      name: 'Formula 1',
+      monitored: true,
+    };
+
+    it('returns true when a scheduled event is still upcoming', async () => {
+      mockClient.getLeagueByExternalId.mockResolvedValue(trackedLeague);
+      mockClient.getLeagueEvents.mockResolvedValue([
+        { id: 10, seasonNumber: 2026, eventDate: '2000-01-01T00:00:00.000Z' },
+        { id: 11, seasonNumber: 2026, eventDate: '2099-01-01T00:00:00.000Z' },
+      ]);
+
+      const result = await service.get(14, showItem(), 'show', ruleGroup());
+      expect(result).toBe(true);
+    });
+
+    it('prefers broadcastDate over eventDate', async () => {
+      mockClient.getLeagueByExternalId.mockResolvedValue(trackedLeague);
+      mockClient.getLeagueEvents.mockResolvedValue([
+        {
+          id: 10,
+          seasonNumber: 2026,
+          eventDate: '2000-01-01T00:00:00.000Z',
+          broadcastDate: '2099-01-01T00:00:00.000Z',
+        },
+      ]);
+
+      const result = await service.get(14, showItem(), 'show', ruleGroup());
+      expect(result).toBe(true);
+    });
+
+    it('returns false when every event is in the past', async () => {
+      mockClient.getLeagueByExternalId.mockResolvedValue(trackedLeague);
+      mockClient.getLeagueEvents.mockResolvedValue([
+        { id: 10, seasonNumber: 2026, eventDate: '2000-01-01T00:00:00.000Z' },
+      ]);
+
+      const result = await service.get(14, showItem(), 'show', ruleGroup());
+      expect(result).toBe(false);
+    });
+
+    it('fails closed (undefined) when the events fetch fails', async () => {
+      mockClient.getLeagueByExternalId.mockResolvedValue(trackedLeague);
+      mockClient.getLeagueEvents.mockResolvedValue(undefined);
+
+      const result = await service.get(14, showItem(), 'show', ruleGroup());
+      expect(result).toBeUndefined();
+    });
+  });
+
   it('returns null when the league is not tracked in Sportarr', async () => {
     mockClient.getLeagueByExternalId.mockResolvedValue(null);
     const result = await service.get(1, showItem(), 'show', ruleGroup());

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
@@ -242,6 +242,23 @@ export class SportarrGetterService {
               : events;
           return scoped.filter((e) => e.hasFile).length;
         }
+        case 'hasFutureEvents': {
+          // True when the league (or scoped season) still has an event dated in
+          // the future - i.e. it is still ongoing rather than a wrapped-up
+          // season. Lets retention rules keep in-progress leagues and only act
+          // on ended ones. Any scheduled event counts, monitored or not.
+          const events = await resolveEvents();
+          if (events === undefined) return undefined;
+          const scoped =
+            dataType === 'season'
+              ? this.seasonEvents(events, seasonNumber)
+              : events;
+          const now = new Date();
+          return scoped.some((e) => {
+            const date = e.broadcastDate ?? e.eventDate;
+            return date != null && new Date(date) > now;
+          });
+        }
         case 'seasonNumber': {
           if (dataType === 'episode') {
             const events = await resolveEvents();

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
@@ -282,9 +282,7 @@ export class SportarrGetterService {
         }
       }
     } catch (e) {
-      this.logger.warn(
-        `Sportarr-Getter - Action failed : ${e instanceof Error ? e.message : e}`,
-      );
+      this.logger.warn('Sportarr-Getter - Action failed');
       this.logger.debug(e);
       return undefined;
     }


### PR DESCRIPTION
Follow-ups from the review of #3306.

- **fix:** `seasonIndex` reads the season item's `index` directly instead of inferring scope from `grandparentId` presence (#3065); the getter's outer-catch keeps `warn` plain with the throwable on `logger.debug`; the version parser strips the `v` prefix without a regex.
- **feat:** adds a `hasFutureEvents` ("Has upcoming events") BOOL rule property at show/season scope, computed from the events already fetched for the count properties. Lets retention rules keep in-progress leagues and only act on ended ones. Fails closed (undefined) when the events fetch fails.
- **docs:** adds Sportarr to the supported-services badges in the README.

Note: `hasFutureEvents` currently counts any scheduled future event, monitored or not. Sportarr's own "continuing" status keys on monitored future events - happy to switch to that if preferred.
