### PR TITLE
fix(logs): show the newest entry in the log viewer

### DIFF
--- a/apps/server/src/modules/logging/logs.controller.spec.ts
+++ b/apps/server/src/modules/logging/logs.controller.spec.ts
@@ -11,6 +11,7 @@ import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import { lstat, realpath } from 'fs/promises';
 import { IncomingMessage } from 'http';
+import readLastLines from 'read-last-lines';
 import { PassThrough } from 'stream';
 import { createMockLogger } from '../../../test/utils/data';
 import { LogSettingsService } from './logs.service';
@@ -35,6 +36,11 @@ jest.mock('fs', () => {
   };
 });
 
+jest.mock('read-last-lines', () => ({
+  __esModule: true,
+  default: { read: jest.fn() },
+}));
+
 jest.mock('fs/promises', () => {
   const actual = jest.requireActual('fs/promises');
   return {
@@ -52,6 +58,8 @@ const createReadStreamMock = fs.createReadStream as jest.MockedFunction<
 
 const lstatMock = jest.mocked(lstat);
 const realpathMock = jest.mocked(realpath);
+const readdirMock = fs.readdir as unknown as jest.Mock;
+const readLastLinesMock = jest.mocked(readLastLines.read);
 
 class MockSocket extends EventEmitter {
   setKeepAlive = jest.fn();
@@ -77,6 +85,16 @@ class MockResponse extends EventEmitter {
     },
   );
 }
+
+// The file replay resolves through promises, so let them settle before asserting.
+const flushAsync = () => new Promise(setImmediate);
+
+const readReplayedEvents = (response: MockResponse) =>
+  response.write.mock.calls
+    .map(([chunk]) => chunk)
+    .filter((chunk) => chunk.startsWith('data: '))
+    .map((chunk) => JSON.parse(chunk.slice('data: '.length)))
+    .map(({ level, message }) => ({ level, message }));
 
 const buildRequest = (): RawBodyRequest<IncomingMessage> =>
   ({
@@ -120,6 +138,33 @@ describe('LogsController', () => {
 
     expect(() => controller.sendDataToClient(clientId, message)).not.toThrow();
     expect(controller.connectedClients.size).toBe(0);
+  });
+
+  it('replays every log file entry, including the newest one', async () => {
+    const controller = createController();
+    const response = new MockResponse();
+    readdirMock.mockImplementationOnce(
+      (_dir: string, callback: (error: null, files: string[]) => void) => {
+        callback(null, ['maintainerr-2026-07-28.log']);
+      },
+    );
+    readLastLinesMock.mockResolvedValue(
+      '[maintainerr]  |  28/07/2026 10:00:00  [INFO] [Server] Startup complete\n' +
+        '[maintainerr]  |  28/07/2026 10:00:01  [WARN] [Rules] Zero items matched\n' +
+        '[maintainerr]  |  28/07/2026 10:00:02  [INFO] [Collections] Handling finished\n',
+    );
+
+    await controller.stream(response as unknown as Response, buildRequest());
+    await flushAsync();
+    // Closes the client so the keep-alive interval does not outlive the test.
+    await controller.beforeApplicationShutdown();
+
+    expect(readReplayedEvents(response)).toEqual([
+      { level: 'INFO', message: 'Startup complete\n' },
+      // A capital "Z" used to terminate the entry early.
+      { level: 'WARN', message: 'Zero items matched\n' },
+      { level: 'INFO', message: 'Handling finished\n' },
+    ]);
   });
 
   it('rejects filenames that only contain a valid log filename as a substring', async () => {

--- a/apps/server/src/modules/logging/logs.controller.ts
+++ b/apps/server/src/modules/logging/logs.controller.ts
@@ -200,7 +200,9 @@ export class LogsController implements BeforeApplicationShutdown {
       from(currentLogFileRecentLines).pipe(
         filter((x) => x !== ''),
         mergeMap((data: string) => {
-          const logFileRegex = /\[maintainerr\].*?(?=\[maintainerr\]|\Z)/gs;
+          // No `m` flag, so `$` is end-of-input. JS has no `\Z` anchor - it
+          // matches a literal "Z", which dropped or truncated the last entry.
+          const logFileRegex = /\[maintainerr\].*?(?=\[maintainerr\]|$)/gs;
           const matches = data.match(logFileRegex) ?? [];
           const events: MessageEvent[] = [];
 


### PR DESCRIPTION
Fixes #3342

The log viewer's history replay split the log file with
`/\[maintainerr\].*?(?=\[maintainerr\]|\Z)/gs`. `\Z` is not an end-of-input
anchor in JavaScript - without the `u` flag it is an identity escape matching a
literal `Z`. The newest entry has no following `[maintainerr]` and usually no
stray `Z`, so its match never completed and the entry was dropped. Live events
only cover what is logged after the page opens, so nothing ever backfilled it.

- Anchor on `$` instead. The regex has no `m` flag, so `$` is end-of-input.
- Also fixes entries being truncated at a capital `Z`. Real logs hit this
  through base64 media server ids.
- Regression test covers both through the SSE stream path.

Checked against the 18 archived log files in this dev environment (~84k
entries): every file now replays exactly as many entries as it contains, and 4
real truncations disappear.

Present since #1545 (v2.11.0).