### PR TITLE
perf(media-server): resolve show watch state in one sweep per user (#3337)

### DIFF
--- a/apps/server/src/modules/api/lib/cache.spec.ts
+++ b/apps/server/src/modules/api/lib/cache.spec.ts
@@ -90,6 +90,24 @@ describe('Cache key-count bound (#3284)', () => {
         cache.data.flushAll();
       }
     });
+
+    // Each entry covers a whole show's episodes across every user, so these
+    // hold far fewer keys than the shared per-item caches and are never cloned.
+    it('bounds the watch-sweep caches well below DEFAULT_MAX_KEYS and skips cloning', () => {
+      for (const id of ['jellyfinwatchsweep', 'embywatchsweep'] as const) {
+        const cache = cacheManager.getCache(id);
+        cache.data.flushAll();
+
+        const value = { 'ep-1': [] };
+        cache.data.set('sweep', value);
+        expect(cache.data.get('sweep')).toBe(value);
+
+        fill(cache, DEFAULT_MAX_KEYS);
+        expect(cache.data.keys().length).toBeLessThan(DEFAULT_MAX_KEYS);
+        expect(cache.persistent).toBe(false);
+        cache.data.flushAll();
+      }
+    });
   });
 
   describe('existing behaviour is preserved', () => {

--- a/apps/server/src/modules/api/lib/cache.ts
+++ b/apps/server/src/modules/api/lib/cache.ts
@@ -13,7 +13,9 @@ type AvailableCacheIds =
   | 'streamystats'
   | 'github'
   | 'jellyfin'
-  | 'emby';
+  | 'jellyfinwatchsweep'
+  | 'emby'
+  | 'embywatchsweep';
 
 type CacheType = AvailableCacheIds | 'radarr' | 'sonarr' | 'sportarr';
 
@@ -29,6 +31,10 @@ const DEFAULT_CHECK_PERIOD = 120; // 2 min
 // window. It stays far above any paginated/working-set flow, so normal use never
 // evicts.
 export const DEFAULT_MAX_KEYS = 1200;
+// Key ceiling for the Jellyfin/Emby per-show watch sweeps. Sized to the rule
+// executor's 50-item chunk (rule evaluation is rule-major, so only the current
+// chunk's sweeps need to survive from one rule to the next) with headroom.
+const WATCH_SWEEP_MAX_KEYS = 100;
 
 type CacheOptions = {
   stdTtl?: number;
@@ -186,7 +192,27 @@ class CacheManager {
       checkPeriod: 60 * 60, // Check every hour
     }),
     jellyfin: new Cache('jellyfin', 'Jellyfin API', 'jellyfin'),
+    // Holds the per-show descendant watch sweeps built by
+    // getDescendantEpisodeWatchHistory - one entry per show/season, each
+    // covering all of its episodes across all users. useClones is off because
+    // those values are large (a 500-episode show across 20 users measured
+    // ~48ms to clone per read) and every consumer only reads them. The key
+    // ceiling is small on purpose: the executor evaluates 50 items per chunk,
+    // so only that chunk's sweeps need to survive between rules, and each
+    // entry is far bigger than a normal cached response.
+    jellyfinwatchsweep: new Cache(
+      'jellyfinwatchsweep',
+      'Jellyfin watch sweep',
+      'jellyfinwatchsweep',
+      { useClones: false, maxKeys: WATCH_SWEEP_MAX_KEYS },
+    ),
     emby: new Cache('emby', 'Emby API', 'emby'),
+    embywatchsweep: new Cache(
+      'embywatchsweep',
+      'Emby watch sweep',
+      'embywatchsweep',
+      { useClones: false, maxKeys: WATCH_SWEEP_MAX_KEYS },
+    ),
   };
 
   public createCache(

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -655,6 +655,116 @@ describe('EmbyAdapterService', () => {
     });
   });
 
+  describe('getDescendantEpisodeWatchHistory', () => {
+    const stubSweep = (
+      itemsByUser: Record<string, unknown[]>,
+      totalRecordCount?: number,
+    ) => {
+      http.get.mockImplementation(
+        async (path: string, config?: { params?: { UserId?: string } }) => {
+          if (path === '/Users/Query') {
+            return {
+              data: Object.keys(itemsByUser).map((id) => ({
+                Id: id,
+                Name: id,
+              })),
+            };
+          }
+          if (path === '/Items') {
+            const userId = config?.params?.UserId ?? '';
+            const items = itemsByUser[userId];
+            if (!items) throw new Error(`Unexpected user ${userId}`);
+            return {
+              data: { Items: items, TotalRecordCount: totalRecordCount },
+            };
+          }
+          throw new Error(`Unexpected path ${path}`);
+        },
+      );
+    };
+
+    it('keys watch records by episode id from one request per user', async () => {
+      stubSweep({
+        'user-1': [
+          {
+            Id: 'ep-1',
+            UserData: { Played: true, LastPlayedDate: '2024-01-01T00:00:00Z' },
+          },
+          { Id: 'ep-2', UserData: { Played: false } },
+        ],
+        'user-2': [
+          { Id: 'ep-1', UserData: { Played: false } },
+          { Id: 'ep-2', UserData: { Played: true } },
+        ],
+      });
+
+      const result = await service.getDescendantEpisodeWatchHistory('show-1');
+
+      expect(result['ep-1'].map((r) => r.userId)).toEqual(['user-1']);
+      expect(result['ep-2'].map((r) => r.userId)).toEqual(['user-2']);
+      expect(result['ep-1'][0].watchedAt).toEqual(
+        new Date('2024-01-01T00:00:00Z'),
+      );
+      // /Users/Query plus one /Items sweep per user.
+      expect(http.get).toHaveBeenCalledTimes(3);
+      expect(http.get).toHaveBeenCalledWith(
+        '/Items',
+        expect.objectContaining({
+          params: expect.objectContaining({
+            ParentId: 'show-1',
+            Recursive: true,
+            IncludeItemTypes: 'Episode',
+            EnableUserData: true,
+          }),
+        }),
+      );
+    });
+
+    it('records an empty history for an episode nobody watched', async () => {
+      stubSweep({
+        'user-1': [{ Id: 'ep-1', UserData: { Played: false } }],
+      });
+
+      await expect(
+        service.getDescendantEpisodeWatchHistory('show-1'),
+      ).resolves.toEqual({ 'ep-1': [] });
+    });
+
+    it('throws instead of answering when a user sweep fails', async () => {
+      http.get.mockImplementation(async (path: string) => {
+        if (path === '/Users/Query') {
+          return { data: [{ Id: 'user-1' }, { Id: 'user-2' }] };
+        }
+        throw new Error('boom');
+      });
+
+      await expect(
+        service.getDescendantEpisodeWatchHistory('show-1'),
+      ).rejects.toThrow('boom');
+      expect(embyCacheMocks.data.set).not.toHaveBeenCalled();
+    });
+
+    it('throws instead of answering when a sweep returns a short page', async () => {
+      stubSweep({ 'user-1': [{ Id: 'ep-1', UserData: { Played: true } }] }, 12);
+
+      await expect(
+        service.getDescendantEpisodeWatchHistory('show-1'),
+      ).rejects.toThrow('1 of 12 episodes');
+      expect(embyCacheMocks.data.set).not.toHaveBeenCalled();
+    });
+
+    it('derives watchers from the sweep and caches it per parent id', async () => {
+      embyCacheMocks.data.get.mockReturnValue({
+        'ep-1': [{ userId: 'user-9', itemId: 'ep-1', progress: 100 }],
+      });
+
+      await expect(
+        service.getDescendantEpisodeWatchers('show-1'),
+      ).resolves.toEqual(['user-9']);
+      expect(http.get).not.toHaveBeenCalled();
+    });
+  });
+
   describe('itemExists', () => {
     it('returns true when Emby returns the item, scoped to the user', async () => {
       http.get.mockResolvedValueOnce({ data: { Id: '42' } });

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -68,6 +68,9 @@ export class EmbyAdapterService implements IMediaServerService {
   private embyUserId: string | undefined;
   private deviceId: string;
   private readonly cache: Cache;
+  // Separate cache: the per-show sweeps are large, read-only values, so they
+  // are held uncloned under their own small key ceiling (see api/lib/cache.ts).
+  private readonly watchSweepCache: Cache;
 
   constructor(
     private readonly settings: SettingsDataService,
@@ -75,6 +78,7 @@ export class EmbyAdapterService implements IMediaServerService {
   ) {
     this.logger.setContext(EmbyAdapterService.name);
     this.cache = cacheManager.getCache('emby');
+    this.watchSweepCache = cacheManager.getCache('embywatchsweep');
     this.deviceId = `${EMBY_DEVICE_INFO.idPrefix}-${this.randomToken(12)}`;
   }
 
@@ -129,6 +133,7 @@ export class EmbyAdapterService implements IMediaServerService {
     this.embyApiKey = undefined;
     this.embyUserId = undefined;
     this.cache.flush();
+    this.watchSweepCache.flush();
   }
 
   isSetup(): boolean {
@@ -543,45 +548,101 @@ export class EmbyAdapterService implements IMediaServerService {
   }
 
   /**
+   * Watch records for every Episode descendant of `parentId` (show or season),
+   * keyed by episode id, with an entry for every episode the sweep saw (an
+   * empty array means confirmed never watched). Mirrors
+   * `JellyfinAdapterService.getDescendantEpisodeWatchHistory`: one /Items
+   * request per user - O(users), not the O(users × episodes) a per-episode
+   * getWatchHistory walk costs (#3337).
+   *
+   * The sweep is unfiltered rather than using `IsPlayed=true`, so the records
+   * are built from the same UserData the per-item path reads.
+   *
+   * All-or-nothing. A user whose sweep failed, or a short page, would read as
+   * "watched nothing" for every episode of the show, so an incomplete sweep
+   * throws rather than answering with a partial map.
+   */
+  async getDescendantEpisodeWatchHistory(
+    parentId: string,
+  ): Promise<Record<string, WatchRecord[]>> {
+    if (!this.http) return {};
+
+    const cacheKey = `${EMBY_CACHE_KEYS.WATCH_HISTORY}:descendants:${parentId}`;
+    const cached =
+      this.watchSweepCache.data.get<Record<string, WatchRecord[]>>(cacheKey);
+    if (cached !== undefined) return cached;
+
+    const users = await this.fetchUsersQuery(this.http);
+    const watchHistory: Record<string, WatchRecord[]> = {};
+
+    for (const user of users) {
+      const { data } = await this.http.get<EmbyItemsQueryResponse>('/Items', {
+        params: {
+          UserId: user.Id,
+          ParentId: parentId,
+          Recursive: true,
+          IncludeItemTypes: 'Episode',
+          ExcludeLocationTypes: 'Virtual',
+          EnableUserData: true,
+          // No Fields: the default set already carries UserData, and this is
+          // the request shape getDescendantEpisodeWatchers already used.
+        },
+      });
+
+      const items = data.Items ?? [];
+      if (
+        typeof data.TotalRecordCount === 'number' &&
+        items.length < data.TotalRecordCount
+      ) {
+        throw new Error(
+          `Emby returned ${items.length} of ${data.TotalRecordCount} episodes under ${parentId}`,
+        );
+      }
+
+      for (const item of items) {
+        watchHistory[item.Id] ??= [];
+        if (!item.UserData?.Played) continue;
+
+        watchHistory[item.Id].push(
+          EmbyMapper.toWatchRecord(
+            user.Id,
+            item.Id,
+            item.UserData.LastPlayedDate
+              ? new Date(item.UserData.LastPlayedDate)
+              : undefined,
+          ),
+        );
+      }
+    }
+
+    this.watchSweepCache.data.set(
+      cacheKey,
+      watchHistory,
+      EMBY_CACHE_TTL.WATCH_HISTORY,
+    );
+    return watchHistory;
+  }
+
+  /**
    * Users who watched at least one episode under `parentId` (season or show).
-   * Mirrors `JellyfinAdapterService.getDescendantEpisodeWatchers`. One
-   * /Items request per user, each scoped to that user with `IsPlayed=true`
-   * + `Limit=1` - we only need to know whether any played episode exists.
+   * Mirrors `JellyfinAdapterService.getDescendantEpisodeWatchers`.
+   *
+   * Errors propagate for the same reason they do in getWatchHistory: an empty
+   * watcher list is indistinguishable from "nobody watched this", which would
+   * make a failed lookup a deletion candidate.
    */
   async getDescendantEpisodeWatchers(parentId: string): Promise<string[]> {
     if (!this.http) return [];
-    try {
-      const users = await this.getUsers();
-      const watchers = new Set<string>();
-      for (const user of users) {
-        try {
-          const { data } = await this.http.get<EmbyItemsQueryResponse>(
-            '/Items',
-            {
-              params: {
-                UserId: user.id,
-                ParentId: parentId,
-                Recursive: true,
-                IncludeItemTypes: 'Episode',
-                ExcludeLocationTypes: 'Virtual',
-                IsPlayed: true,
-                Limit: 1,
-                EnableUserData: true,
-              },
-            },
-          );
-          if ((data.Items ?? []).length > 0) watchers.add(user.id);
-        } catch {
-          // skip users without visibility
-        }
+
+    const watchHistory = await this.getDescendantEpisodeWatchHistory(parentId);
+    const watchers = new Set<string>();
+    for (const records of Object.values(watchHistory)) {
+      for (const record of records) {
+        watchers.add(record.userId);
       }
-      return [...watchers];
-    } catch (error) {
-      this.logger.debug(
-        `Emby getDescendantEpisodeWatchers(${parentId}) failed: ${formatConnectionFailureMessage(error, 'Connection failed')}`,
-      );
-      return [];
     }
+
+    return [...watchers];
   }
 
   /**
@@ -1332,9 +1393,12 @@ export class EmbyAdapterService implements IMediaServerService {
   resetMetadataCache(_itemId?: string): void {
     // The Emby cache only stores server-wide aggregates (users/libraries/status/
     // collections), never per-item watch entries (getWatchHistory hits the API
-    // fresh), so a full flush is the simplest correct reset.
+    // fresh), so a full flush is the simplest correct reset. Descendant sweeps
+    // are keyed by show/season, so an episode-level change has no key of its
+    // own to clear - drop them all.
     void _itemId;
     this.cache.flush();
+    this.watchSweepCache.flush();
   }
 
   // ============================================================================

--- a/apps/server/src/modules/api/media-server/emby/emby.constants.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby.constants.ts
@@ -20,6 +20,7 @@ export const EMBY_BATCH_SIZE = {
 } as const;
 
 export const EMBY_CACHE_KEYS = {
+  WATCH_HISTORY: 'emby:watch',
   USERS: 'emby:users',
   LIBRARIES: 'emby:libraries',
   STATUS: 'emby:status',

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -1057,8 +1057,11 @@ describe('JellyfinAdapterService', () => {
             return Promise.resolve({
               data: {
                 Items: [
-                  { UserData: { Played: true } },
-                  { UserData: { Played: false, PlayedPercentage: 10 } },
+                  { Id: 'ep-1', UserData: { Played: true } },
+                  {
+                    Id: 'ep-2',
+                    UserData: { Played: false, PlayedPercentage: 10 },
+                  },
                 ],
               },
             });
@@ -1067,8 +1070,14 @@ describe('JellyfinAdapterService', () => {
             return Promise.resolve({
               data: {
                 Items: [
-                  { UserData: { Played: false, PlayedPercentage: 0 } },
-                  { UserData: { Played: false, PlayedPercentage: 20 } },
+                  {
+                    Id: 'ep-1',
+                    UserData: { Played: false, PlayedPercentage: 0 },
+                  },
+                  {
+                    Id: 'ep-2',
+                    UserData: { Played: false, PlayedPercentage: 20 },
+                  },
                 ],
               },
             });
@@ -1076,7 +1085,12 @@ describe('JellyfinAdapterService', () => {
           if (userId === 'user-3') {
             return Promise.resolve({
               data: {
-                Items: [{ UserData: { Played: false, PlayedPercentage: 95 } }],
+                Items: [
+                  {
+                    Id: 'ep-1',
+                    UserData: { Played: false, PlayedPercentage: 95 },
+                  },
+                ],
               },
             });
           }
@@ -1109,7 +1123,9 @@ describe('JellyfinAdapterService', () => {
       });
       jellyfinApiMocks.getItems.mockResolvedValue({
         data: {
-          Items: [{ UserData: { Played: false, PlayedPercentage: 0 } }],
+          Items: [
+            { Id: 'ep-1', UserData: { Played: false, PlayedPercentage: 0 } },
+          ],
         },
       });
 
@@ -1124,9 +1140,9 @@ describe('JellyfinAdapterService', () => {
       jellyfinApiMocks.getItems.mockResolvedValue({
         data: {
           Items: [
-            { UserData: { Played: true } },
-            { UserData: { Played: true } },
-            { UserData: { Played: true } },
+            { Id: 'ep-1', UserData: { Played: true } },
+            { Id: 'ep-2', UserData: { Played: true } },
+            { Id: 'ep-3', UserData: { Played: true } },
           ],
         },
       });
@@ -1139,15 +1155,28 @@ describe('JellyfinAdapterService', () => {
       jellyfinApiMocks.getUsers.mockResolvedValue({
         data: [{ Id: 'user-1', Name: 'Alice' }],
       });
-      jellyfinCacheMocks.data.get.mockReturnValue(['user-1']);
+      jellyfinCacheMocks.data.get.mockReturnValue({
+        'ep-1': [{ userId: 'user-1', itemId: 'ep-1', progress: 100 }],
+      });
 
       const result = await service.getDescendantEpisodeWatchers('show-1');
 
       expect(result).toEqual(['user-1']);
       expect(jellyfinApiMocks.getItems).not.toHaveBeenCalled();
     });
+  });
 
-    it('skips users whose per-user query fails without aborting others', async () => {
+  describe('getDescendantEpisodeWatchHistory', () => {
+    beforeEach(async () => {
+      settingsDataService.getSettings.mockResolvedValue(
+        mockSettings as unknown as Awaited<
+          ReturnType<SettingsDataService['getSettings']>
+        >,
+      );
+      await service.initialize();
+    });
+
+    it('keys watch records by episode id and keeps unwatched episodes as empty', async () => {
       jellyfinApiMocks.getUsers.mockResolvedValue({
         data: [
           { Id: 'user-1', Name: 'Alice' },
@@ -1155,18 +1184,110 @@ describe('JellyfinAdapterService', () => {
         ],
       });
       jellyfinApiMocks.getItems.mockImplementation(
-        ({ userId }: { userId: string }) => {
-          if (userId === 'user-1') {
-            return Promise.reject(new Error('boom'));
-          }
-          return Promise.resolve({
-            data: { Items: [{ UserData: { Played: true } }] },
-          });
-        },
+        ({ userId }: { userId: string }) =>
+          Promise.resolve({
+            data: {
+              Items: [
+                {
+                  Id: 'ep-1',
+                  UserData: {
+                    Played: true,
+                    LastPlayedDate: '2024-06-03T00:00:00.000Z',
+                  },
+                },
+                {
+                  Id: 'ep-2',
+                  UserData: { Played: userId === 'user-1' },
+                },
+              ],
+            },
+          }),
       );
 
-      const result = await service.getDescendantEpisodeWatchers('show-1');
-      expect(result).toEqual(['user-2']);
+      const result = await service.getDescendantEpisodeWatchHistory('show-1');
+
+      expect(Object.keys(result).sort()).toEqual(['ep-1', 'ep-2']);
+      expect(result['ep-1'].map((r) => r.userId).sort()).toEqual([
+        'user-1',
+        'user-2',
+      ]);
+      expect(result['ep-1'][0].watchedAt).toEqual(
+        new Date('2024-06-03T00:00:00.000Z'),
+      );
+      expect(result['ep-2'].map((r) => r.userId)).toEqual(['user-1']);
+      // One request per user, not one per (episode, user).
+      expect(jellyfinApiMocks.getItems).toHaveBeenCalledTimes(2);
+    });
+
+    it('records an empty history for an episode nobody watched', async () => {
+      jellyfinApiMocks.getUsers.mockResolvedValue({
+        data: [{ Id: 'user-1', Name: 'Alice' }],
+      });
+      jellyfinApiMocks.getItems.mockResolvedValue({
+        data: { Items: [{ Id: 'ep-1', UserData: { Played: false } }] },
+      });
+
+      const result = await service.getDescendantEpisodeWatchHistory('show-1');
+
+      expect(result).toEqual({ 'ep-1': [] });
+    });
+
+    it('throws instead of answering when a user sweep fails', async () => {
+      jellyfinApiMocks.getUsers.mockResolvedValue({
+        data: [
+          { Id: 'user-1', Name: 'Alice' },
+          { Id: 'user-2', Name: 'Bob' },
+        ],
+      });
+      jellyfinApiMocks.getItems.mockImplementation(
+        ({ userId }: { userId: string }) =>
+          userId === 'user-1'
+            ? Promise.reject(new Error('boom'))
+            : Promise.resolve({
+                data: { Items: [{ Id: 'ep-1', UserData: { Played: true } }] },
+              }),
+      );
+
+      await expect(
+        service.getDescendantEpisodeWatchHistory('show-1'),
+      ).rejects.toThrow('covered 1 of 2 users');
+      expect(jellyfinCacheMocks.data.set).not.toHaveBeenCalledWith(
+        expect.stringContaining('descendants:show-1'),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('throws instead of answering when a sweep returns a short page', async () => {
+      jellyfinApiMocks.getUsers.mockResolvedValue({
+        data: [{ Id: 'user-1', Name: 'Alice' }],
+      });
+      jellyfinApiMocks.getItems.mockResolvedValue({
+        data: {
+          Items: [{ Id: 'ep-1', UserData: { Played: true } }],
+          TotalRecordCount: 12,
+        },
+      });
+
+      await expect(
+        service.getDescendantEpisodeWatchHistory('show-1'),
+      ).rejects.toThrow('covered 0 of 1 users');
+      expect(jellyfinCacheMocks.data.set).not.toHaveBeenCalledWith(
+        expect.stringContaining('descendants:show-1'),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('propagates a failed played-threshold lookup', async () => {
+      jellyfinApiMocks.getUsers.mockResolvedValue({
+        data: [{ Id: 'user-1', Name: 'Alice' }],
+      });
+      jellyfinApiMocks.getConfiguration.mockRejectedValue(new Error('boom'));
+
+      await expect(
+        service.getDescendantEpisodeWatchHistory('show-1'),
+      ).rejects.toThrow('boom');
     });
   });
 
@@ -1332,7 +1453,7 @@ describe('JellyfinAdapterService', () => {
         'jellyfin:watch:90:item123', // this item's watch history
         'jellyfin:watch:95:item123', // ...at another played threshold
         'jellyfin:watch:90:episode-999', // a DESCENDANT episode (#3274) - different id
-        'jellyfin:watch:90:episode-watchers:item123', // descendant-watchers rollup
+        'jellyfin:watch:90:other-item', // another item's watch entry
         'jellyfin:favorited-by:item123',
         'jellyfin:total-play-count:item123',
         'jellyfin:favorited-by:other-item', // unrelated item - must be kept
@@ -1354,7 +1475,7 @@ describe('JellyfinAdapterService', () => {
         'jellyfin:watch:90:episode-999',
       );
       expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
-        'jellyfin:watch:90:episode-watchers:item123',
+        'jellyfin:watch:90:other-item',
       );
       // This item's per-item favorite/play-count entries still cleared as before.
       expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -118,12 +118,16 @@ export class JellyfinAdapterService implements IMediaServerService {
   private initialized = false;
   private jellyfinUserId: string | undefined;
   private readonly cache: Cache;
+  // Separate cache: the per-show sweeps are large, read-only values, so they
+  // are held uncloned under their own small key ceiling (see api/lib/cache.ts).
+  private readonly watchSweepCache: Cache;
 
   constructor(
     private readonly settingsDataService: SettingsDataService,
     private readonly logger: MaintainerrLogger,
   ) {
     this.cache = cacheManager.getCache('jellyfin');
+    this.watchSweepCache = cacheManager.getCache('jellyfinwatchsweep');
     this.logger.setContext(JellyfinAdapterService.name);
   }
 
@@ -245,6 +249,7 @@ export class JellyfinAdapterService implements IMediaServerService {
     this.jellyfinUserId = undefined;
     // Clear the cache when uninitializing
     this.cache.flush();
+    this.watchSweepCache.flush();
   }
 
   isSetup(): boolean {
@@ -1136,62 +1141,121 @@ export class JellyfinAdapterService implements IMediaServerService {
   }
 
   /**
+   * Watch records for every Episode descendant of `parentId` (show or season),
+   * keyed by episode id, with an entry for every episode the sweep saw (an
+   * empty array means confirmed never watched). One getItems call per user
+   * (batched via mapUsersBatched) - O(users), not the O(users × episodes) a
+   * per-episode getWatchHistory walk costs (#3337).
+   *
+   * This reads the same /Items + enableUserData payload the per-item path
+   * reads, so the records it builds are identical; only the request count
+   * changes. The sweep is deliberately unfiltered: Jellyfin's isPlayed filter
+   * tests the Played flag alone, so it would drop episodes that are only
+   * watched by crossing the PlayedPercentage threshold (#2466).
+   *
+   * All-or-nothing. A user whose sweep failed, or a short page, would read as
+   * "watched nothing" for every episode of the show, so an incomplete sweep
+   * throws rather than answering with a partial map (#2744).
+   */
+  async getDescendantEpisodeWatchHistory(
+    parentId: string,
+  ): Promise<Record<string, WatchRecord[]>> {
+    if (!this.api) return {};
+
+    const playedCompletionThreshold =
+      await this.getPlayedCompletionThreshold(true);
+    const cacheKey = `${JELLYFIN_CACHE_KEYS.WATCH_HISTORY}:${playedCompletionThreshold ?? 'played'}:descendants:${parentId}`;
+    const cached =
+      this.watchSweepCache.data.get<Record<string, WatchRecord[]>>(cacheKey);
+    if (cached !== undefined) return cached;
+
+    const users = await this.getUsers(true);
+    const entries = await this.mapUsersBatched(async (user) => {
+      const response = await getItemsApi(this.api!).getItems({
+        userId: user.id,
+        parentId,
+        recursive: true,
+        includeItemTypes: [BaseItemKind.Episode],
+        // Ignore unaired placeholders (mirrors #2624).
+        excludeLocationTypes: [LocationType.Virtual],
+        enableUserData: true,
+        // Minimize payload - we only need UserData per episode.
+        fields: [],
+      });
+
+      const items = response.data.Items ?? [];
+      const total = response.data.TotalRecordCount;
+      if (typeof total === 'number' && items.length < total) {
+        throw new Error(
+          `Jellyfin returned ${items.length} of ${total} episodes under ${parentId}`,
+        );
+      }
+
+      return { userId: user.id, items };
+    }, true);
+
+    // mapUsersBatched drops users whose request failed, which here would read
+    // as "this user watched nothing" for the whole show.
+    if (entries.length !== users.length) {
+      throw new Error(
+        `Jellyfin watch-history sweep for ${parentId} covered ${entries.length} of ${users.length} users`,
+      );
+    }
+
+    const watchHistory: Record<string, WatchRecord[]> = {};
+    for (const { userId, items } of entries) {
+      for (const item of items) {
+        if (!item.Id) continue;
+
+        watchHistory[item.Id] ??= [];
+        const userData = item.UserData ?? undefined;
+        if (!this.isCompletedWatch(userData, playedCompletionThreshold)) {
+          continue;
+        }
+
+        watchHistory[item.Id].push(
+          JellyfinMapper.toWatchRecord(
+            userId,
+            item.Id,
+            userData?.LastPlayedDate
+              ? new Date(userData.LastPlayedDate)
+              : undefined,
+            userData?.PlayedPercentage ?? undefined,
+          ),
+        );
+      }
+    }
+
+    this.watchSweepCache.data.set(
+      cacheKey,
+      watchHistory,
+      JELLYFIN_CACHE_TTL.WATCH_HISTORY,
+    );
+    return watchHistory;
+  }
+
+  /**
    * Users who watched ≥1 Episode descendant of `parentId` (show or season),
    * honouring the configured PlayedPercentage threshold via isCompletedWatch.
    * Jellyfin's Series Played flag is an all-or-nothing aggregate, so the
    * show-level watch history degenerates to sw_allEpisodesSeenBy (#2559).
-   * One getItems call per user (batched via mapUsersBatched, shared with
-   * getAllUserItemData) - O(users), not O(users × episodes).
+   *
+   * Errors propagate for the same reason they do in getWatchHistory: an empty
+   * watcher list is indistinguishable from "nobody watched this", which would
+   * make a failed lookup a deletion candidate.
    */
   async getDescendantEpisodeWatchers(parentId: string): Promise<string[]> {
     if (!this.api) return [];
 
-    try {
-      const playedCompletionThreshold =
-        await this.getPlayedCompletionThreshold();
-      const cacheKey = `${JELLYFIN_CACHE_KEYS.WATCH_HISTORY}:${playedCompletionThreshold ?? 'played'}:episode-watchers:${parentId}`;
-      const cached = this.cache.data.get<string[]>(cacheKey);
-      if (cached !== undefined) return cached;
-
-      const entries = await this.mapUsersBatched(async (user) => ({
-        userId: user.id,
-        items:
-          (
-            await getItemsApi(this.api!).getItems({
-              userId: user.id,
-              parentId,
-              recursive: true,
-              includeItemTypes: [BaseItemKind.Episode],
-              // Ignore unaired placeholders (mirrors #2624).
-              excludeLocationTypes: [LocationType.Virtual],
-              enableUserData: true,
-              // Minimize payload - we only need UserData per episode.
-              fields: [],
-            })
-          ).data.Items ?? [],
-      }));
-
-      const watcherIds = new Set<string>();
-      for (const { userId, items } of entries) {
-        const hasWatched = items.some((item) =>
-          this.isCompletedWatch(
-            item.UserData ?? undefined,
-            playedCompletionThreshold,
-          ),
-        );
-        if (hasWatched) watcherIds.add(userId);
+    const watchHistory = await this.getDescendantEpisodeWatchHistory(parentId);
+    const watcherIds = new Set<string>();
+    for (const records of Object.values(watchHistory)) {
+      for (const record of records) {
+        watcherIds.add(record.userId);
       }
-
-      const watchers = [...watcherIds];
-      this.cache.data.set(cacheKey, watchers, JELLYFIN_CACHE_TTL.WATCH_HISTORY);
-      return watchers;
-    } catch (error) {
-      this.logger.error(
-        `Failed to get descendant episode watchers for ${parentId}`,
-      );
-      this.logger.debug(error);
-      return [];
     }
+
+    return [...watcherIds];
   }
 
   /**
@@ -2071,6 +2135,11 @@ export class JellyfinAdapterService implements IMediaServerService {
   }
 
   resetMetadataCache(itemId?: string): void {
+    // Descendant sweeps are keyed by show/season, so an episode-level change
+    // has no key of its own to clear - drop them all, exactly as the watch
+    // namespace below does (#3274).
+    this.watchSweepCache.flush();
+
     if (itemId) {
       // Watch-history entries are keyed per item. Season/show getters
       // (e.g. sw_allEpisodesSeenBy) aggregate their DESCENDANT episodes' entries,

--- a/apps/server/src/modules/rules/getter/emby-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/emby-getter.service.spec.ts
@@ -49,6 +49,18 @@ const createWatchRecord = (
   ...overrides,
 });
 
+// Helper to build the per-show descendant watch map the adapter returns:
+// one entry per episode found, empty array = confirmed never watched.
+const createDescendantWatchHistory = (
+  watchedBy: Record<string, Array<Partial<WatchRecord>>>,
+): Record<string, WatchRecord[]> =>
+  Object.fromEntries(
+    Object.entries(watchedBy).map(([itemId, records]) => [
+      itemId,
+      records.map((record) => createWatchRecord({ itemId, ...record })),
+    ]),
+  );
+
 describe('EmbyGetterService', () => {
   let embyGetterService: EmbyGetterService;
   let embyAdapter: Mocked<EmbyAdapterService>;
@@ -90,6 +102,166 @@ describe('EmbyGetterService', () => {
       );
 
       expect(response).toEqual(['blank-user', 'missing-user', 'Alice']);
+    });
+  });
+
+  // Show/season watch rules resolve every descendant episode from one sweep
+  // (getDescendantEpisodeWatchHistory), not one lookup per episode (#3337).
+  describe('show and season watch rules', () => {
+    const showItem = createMediaItem({
+      id: 'show-1',
+      type: 'show' as MediaItemType,
+    });
+
+    const stubShowTree = () => {
+      embyAdapter.getMetadata.mockResolvedValue(showItem);
+      embyAdapter.getChildrenMetadata.mockImplementation(
+        async (parentId: string, childType?: MediaItemType) => {
+          if (parentId === 'show-1' && childType === 'season') {
+            return [
+              createMediaItem({
+                id: 'season-1',
+                type: 'season' as MediaItemType,
+                index: 1,
+              }),
+            ];
+          }
+          if (parentId === 'season-1' && childType === 'episode') {
+            return [
+              createMediaItem({
+                id: 'ep-1',
+                type: 'episode' as MediaItemType,
+                index: 1,
+                parentIndex: 1,
+              }),
+              createMediaItem({
+                id: 'ep-2',
+                type: 'episode' as MediaItemType,
+                index: 2,
+                parentIndex: 1,
+              }),
+            ];
+          }
+          return [];
+        },
+      );
+    };
+
+    it('sw_lastWatched (id: 13) takes the newest watched episode from the sweep', async () => {
+      stubShowTree();
+      embyAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          // ep-1 was rewatched later, but ep-2 is the newest episode watched
+          'ep-1': [{ watchedAt: new Date('2026-04-20') }],
+          'ep-2': [{ watchedAt: new Date('2026-03-06') }],
+        }),
+      );
+
+      const response = await embyGetterService.get(
+        13,
+        showItem,
+        'show',
+        createRulesDto({ dataType: 'show' }),
+      );
+
+      expect(response).toEqual(new Date('2026-03-06'));
+      expect(embyAdapter.getWatchHistory).not.toHaveBeenCalled();
+    });
+
+    it('sw_viewedEpisodes (id: 15) counts only episodes with a watcher', async () => {
+      stubShowTree();
+      embyAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'ep-1': [{ userId: 'user-1' }],
+          'ep-2': [],
+        }),
+      );
+
+      const response = await embyGetterService.get(
+        15,
+        showItem,
+        'show',
+        createRulesDto({ dataType: 'show' }),
+      );
+
+      expect(response).toBe(1);
+    });
+
+    it('sw_amountOfViews (id: 17) sums every watch record under the show', async () => {
+      stubShowTree();
+      embyAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'ep-1': [{ userId: 'user-1' }, { userId: 'user-2' }],
+          'ep-2': [{ userId: 'user-1' }],
+        }),
+      );
+
+      const response = await embyGetterService.get(
+        17,
+        showItem,
+        'show',
+        createRulesDto({ dataType: 'show' }),
+      );
+
+      expect(response).toBe(3);
+    });
+
+    it('sw_allEpisodesSeenBy (id: 12) returns only users present on every episode', async () => {
+      stubShowTree();
+      embyAdapter.getUsers.mockResolvedValue([
+        createMediaUser({ id: 'user-1', name: 'Alice' }),
+        createMediaUser({ id: 'user-2', name: 'Bob' }),
+      ]);
+      embyAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'ep-1': [{ userId: 'user-1' }, { userId: 'user-2' }],
+          'ep-2': [{ userId: 'user-2' }],
+        }),
+      );
+
+      const response = await embyGetterService.get(
+        12,
+        showItem,
+        'show',
+        createRulesDto({ dataType: 'show' }),
+      );
+
+      expect(response).toEqual(['Bob']);
+    });
+
+    it('lastViewedAt (id: 7) aggregates the newest descendant watch date', async () => {
+      stubShowTree();
+      embyAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'ep-1': [{ watchedAt: new Date('2026-03-01') }],
+          'ep-2': [{ watchedAt: new Date('2026-03-06') }],
+        }),
+      );
+
+      const response = await embyGetterService.get(
+        7,
+        showItem,
+        'show',
+        createRulesDto({ dataType: 'show' }),
+      );
+
+      expect(response).toEqual(new Date('2026-03-06'));
+    });
+
+    it('skips the item when the sweep fails rather than reporting never watched', async () => {
+      stubShowTree();
+      embyAdapter.getDescendantEpisodeWatchHistory.mockRejectedValue(
+        new Error('sweep failed'),
+      );
+
+      const response = await embyGetterService.get(
+        15,
+        showItem,
+        'show',
+        createRulesDto({ dataType: 'show' }),
+      );
+
+      expect(response).toBeUndefined();
     });
   });
 

--- a/apps/server/src/modules/rules/getter/emby-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/emby-getter.service.ts
@@ -3,6 +3,7 @@ import {
   MediaItem,
   MediaItemType,
   RuleValueType,
+  WatchRecord,
 } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import cacheManager, { Cache } from '../../api/lib/cache';
@@ -194,10 +195,7 @@ export class EmbyGetterService {
             isMediaType(metadata.type, 'show') ||
             isMediaType(metadata.type, 'season')
           ) {
-            return await this.getLastWatchedShowDate(
-              metadata.id,
-              metadata.type,
-            );
+            return await this.getLastWatchedShowDate(metadata.id);
           }
           return await this.getLastViewedAt(metadata.id);
         }
@@ -228,7 +226,7 @@ export class EmbyGetterService {
         }
 
         case 'sw_allEpisodesSeenBy': {
-          return await this.getAllEpisodesSeenBy(metadata.id, metadata.type);
+          return await this.getAllEpisodesSeenBy(metadata.id);
         }
 
         case 'sw_lastWatched': {
@@ -243,7 +241,7 @@ export class EmbyGetterService {
         }
 
         case 'sw_viewedEpisodes': {
-          return await this.getViewedEpisodeCount(metadata.id, metadata.type);
+          return await this.getViewedEpisodeCount(metadata.id);
         }
 
         case 'sw_lastEpisodeAddedAt': {
@@ -480,63 +478,35 @@ export class EmbyGetterService {
     }
   }
 
-  private async getLastViewedAt(itemId: string): Promise<Date | null> {
-    const watchHistory = await this.embyAdapter.getWatchHistory(itemId);
-    if (!watchHistory.length) {
-      return null;
-    }
-
-    const dates = watchHistory
+  private newestWatchedAt(records: WatchRecord[]): Date | null {
+    const times = records
       .map((r) => r.watchedAt)
-      .filter((d): d is Date => d !== undefined);
+      .filter((d): d is Date => d !== undefined)
+      .map((d) => d.getTime());
 
-    return dates.length > 0
-      ? new Date(Math.max(...dates.map((d) => d.getTime())))
-      : null;
+    return times.length > 0 ? new Date(Math.max(...times)) : null;
   }
 
-  private async getAllEpisodesSeenBy(
-    itemId: string,
-    type: MediaItemType,
-  ): Promise<string[]> {
+  private async getLastViewedAt(itemId: string): Promise<Date | null> {
+    return this.newestWatchedAt(await this.embyAdapter.getWatchHistory(itemId));
+  }
+
+  private async getAllEpisodesSeenBy(itemId: string): Promise<string[]> {
     const users = await this.embyAdapter.getUsers();
-
-    // Get all episodes - handle both shows and seasons
-    const allEpisodes: string[] = [];
-    if (type === 'season') {
-      // For seasons, get episodes directly (children of season)
-      const episodes = await this.embyAdapter.getChildrenMetadata(
-        itemId,
-        'episode',
-      );
-      allEpisodes.push(...episodes.map((e) => e.id));
-    } else {
-      // For shows, get seasons first, then episodes from each season
-      const seasons = await this.embyAdapter.getChildrenMetadata(
-        itemId,
-        'season',
-      );
-      for (const season of seasons) {
-        const episodes = await this.embyAdapter.getChildrenMetadata(
-          season.id,
-          'episode',
-        );
-        allEpisodes.push(...episodes.map((e) => e.id));
-      }
-    }
-
-    if (allEpisodes.length === 0) return [];
-
-    // Get watch status for each episode
-    const episodeWatchers = await Promise.all(
-      allEpisodes.map((epId) => this.embyAdapter.getItemSeenBy(epId)),
+    const episodeWatchers = Object.values(
+      await this.embyAdapter.getDescendantEpisodeWatchHistory(itemId),
     );
 
-    // Find users who appear in ALL episode watch lists
-    const allUserIds = new Set(users.map((u) => u.id));
-    const usersWhoWatchedAll = [...allUserIds].filter((userId) =>
-      episodeWatchers.every((watchers) => watchers.includes(userId)),
-    );
+    if (episodeWatchers.length === 0) return [];
+
+    // Users who appear in EVERY episode's watch list
+    const usersWhoWatchedAll = users
+      .map((user) => user.id)
+      .filter((userId) =>
+        episodeWatchers.every((records) =>
+          records.some((record) => record.userId === userId),
+        ),
+      );
 
     return mapRuleUserIdsToNames(
       usersWhoWatchedAll,
@@ -567,6 +537,9 @@ export class EmbyGetterService {
       viewedAt: Date;
     }> = [];
 
+    const watchHistory =
+      await this.embyAdapter.getDescendantEpisodeWatchHistory(itemId);
+
     for (const season of seasons) {
       const episodes = await this.embyAdapter.getChildrenMetadata(
         season.id,
@@ -578,7 +551,7 @@ export class EmbyGetterService {
         if (episodeOrder === undefined || episode.parentIndex === undefined) {
           continue;
         }
-        const viewedAt = await this.getLastViewedAt(episode.id);
+        const viewedAt = this.newestWatchedAt(watchHistory[episode.id] ?? []);
         if (!viewedAt) continue;
         watched.push({
           parentIndex: episode.parentIndex,
@@ -608,45 +581,11 @@ export class EmbyGetterService {
    * highest-numbered episode, the way the Plex/Tautulli `sw_lastWatched`
    * getters compute it. Used by the `lastViewedAt` rule only.
    */
-  private async getLastWatchedShowDate(
-    itemId: string,
-    type: MediaItemType,
-  ): Promise<Date | null> {
-    let latestDate: Date | null = null;
+  private async getLastWatchedShowDate(itemId: string): Promise<Date | null> {
+    const watchHistory =
+      await this.embyAdapter.getDescendantEpisodeWatchHistory(itemId);
 
-    if (type === 'season') {
-      // For seasons, get episodes directly
-      const episodes = await this.embyAdapter.getChildrenMetadata(
-        itemId,
-        'episode',
-      );
-      for (const episode of episodes) {
-        const lastViewed = await this.getLastViewedAt(episode.id);
-        if (lastViewed && (!latestDate || lastViewed > latestDate)) {
-          latestDate = lastViewed;
-        }
-      }
-    } else {
-      // For shows, iterate through seasons first
-      const seasons = await this.embyAdapter.getChildrenMetadata(
-        itemId,
-        'season',
-      );
-      for (const season of seasons) {
-        const episodes = await this.embyAdapter.getChildrenMetadata(
-          season.id,
-          'episode',
-        );
-        for (const episode of episodes) {
-          const lastViewed = await this.getLastViewedAt(episode.id);
-          if (lastViewed && (!latestDate || lastViewed > latestDate)) {
-            latestDate = lastViewed;
-          }
-        }
-      }
-    }
-
-    return latestDate;
+    return this.newestWatchedAt(Object.values(watchHistory).flat());
   }
 
   private async getEpisodeCount(
@@ -677,27 +616,12 @@ export class EmbyGetterService {
     return count;
   }
 
-  private async getViewedEpisodeCount(
-    itemId: string,
-    type: MediaItemType,
-  ): Promise<number> {
-    const seasons =
-      type === 'season'
-        ? [{ id: itemId }]
-        : await this.embyAdapter.getChildrenMetadata(itemId, 'season');
+  private async getViewedEpisodeCount(itemId: string): Promise<number> {
+    const watchHistory =
+      await this.embyAdapter.getDescendantEpisodeWatchHistory(itemId);
 
-    let viewedCount = 0;
-    for (const season of seasons) {
-      const episodes = await this.embyAdapter.getChildrenMetadata(
-        season.id,
-        'episode',
-      );
-      for (const episode of episodes) {
-        const seenBy = await this.embyAdapter.getItemSeenBy(episode.id);
-        if (seenBy.length > 0) viewedCount++;
-      }
-    }
-    return viewedCount;
+    return Object.values(watchHistory).filter((records) => records.length > 0)
+      .length;
   }
 
   private async getLastEpisodeAddedAt(
@@ -738,23 +662,13 @@ export class EmbyGetterService {
       return history.length;
     }
 
-    const seasons =
-      type === 'season'
-        ? [{ id: itemId }]
-        : await this.embyAdapter.getChildrenMetadata(itemId, 'season');
+    const watchHistory =
+      await this.embyAdapter.getDescendantEpisodeWatchHistory(itemId);
 
-    let totalViews = 0;
-    for (const season of seasons) {
-      const episodes = await this.embyAdapter.getChildrenMetadata(
-        season.id,
-        'episode',
-      );
-      for (const episode of episodes) {
-        const history = await this.embyAdapter.getWatchHistory(episode.id);
-        totalViews += history.length;
-      }
-    }
-    return totalViews;
+    return Object.values(watchHistory).reduce(
+      (total, records) => total + records.length,
+      0,
+    );
   }
 
   private async getSwWatchers(

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
@@ -63,6 +63,18 @@ const createWatchRecord = (
   ...overrides,
 });
 
+// Helper to build the per-show descendant watch map the adapter returns:
+// one entry per episode found, empty array = confirmed never watched.
+const createDescendantWatchHistory = (
+  watchedBy: Record<string, Array<Partial<WatchRecord>>>,
+): Record<string, WatchRecord[]> =>
+  Object.fromEntries(
+    Object.entries(watchedBy).map(([itemId, records]) => [
+      itemId,
+      records.map((record) => createWatchRecord({ itemId, ...record })),
+    ]),
+  );
+
 const createMediaCollection = (
   overrides: Partial<MediaCollection> = {},
 ): MediaCollection => ({
@@ -896,20 +908,11 @@ describe('JellyfinGetterService', () => {
           return [];
         },
       );
-      jellyfinAdapter.getWatchHistory.mockImplementation(
-        async (itemId: string) => {
-          if (itemId === 'ep-1') {
-            return [
-              createWatchRecord({ itemId, watchedAt: new Date('2026-03-01') }),
-            ];
-          }
-          if (itemId === 'ep-2') {
-            return [
-              createWatchRecord({ itemId, watchedAt: new Date('2026-03-06') }),
-            ];
-          }
-          return [];
-        },
+      jellyfinAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'ep-1': [{ watchedAt: new Date('2026-03-01') }],
+          'ep-2': [{ watchedAt: new Date('2026-03-06') }],
+        }),
       );
 
       const response = await jellyfinGetterService.get(
@@ -945,20 +948,11 @@ describe('JellyfinGetterService', () => {
           return [];
         },
       );
-      jellyfinAdapter.getWatchHistory.mockImplementation(
-        async (itemId: string) => {
-          if (itemId === 'ep-1') {
-            return [
-              createWatchRecord({ itemId, watchedAt: new Date('2026-03-01') }),
-            ];
-          }
-          if (itemId === 'ep-2') {
-            return [
-              createWatchRecord({ itemId, watchedAt: new Date('2026-03-04') }),
-            ];
-          }
-          return [];
-        },
+      jellyfinAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'ep-1': [{ watchedAt: new Date('2026-03-01') }],
+          'ep-2': [{ watchedAt: new Date('2026-03-04') }],
+        }),
       );
 
       const response = await jellyfinGetterService.get(
@@ -1008,12 +1002,11 @@ describe('JellyfinGetterService', () => {
           return [];
         },
       );
-      jellyfinAdapter.getItemSeenBy.mockImplementation(
-        async (itemId: string) => {
-          if (itemId === 'episode-all-seen-1') return ['user-1', 'user-2'];
-          if (itemId === 'episode-all-seen-2') return ['user-2', 'user-3'];
-          return [];
-        },
+      jellyfinAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'episode-all-seen-1': [{ userId: 'user-1' }, { userId: 'user-2' }],
+          'episode-all-seen-2': [{ userId: 'user-2' }, { userId: 'user-3' }],
+        }),
       );
 
       const response = await jellyfinGetterService.get(
@@ -1025,6 +1018,40 @@ describe('JellyfinGetterService', () => {
 
       expect(response).toEqual(['Bob']);
     });
+
+    // A failed sweep must never read as "never watched" - the item is skipped
+    // (undefined) so a transient Jellyfin failure can't drive a deletion.
+    it.each([
+      [12, 'sw_allEpisodesSeenBy'],
+      [13, 'sw_lastWatched'],
+      [15, 'sw_viewedEpisodes'],
+      [17, 'sw_amountOfViews'],
+      [7, 'lastViewedAt'],
+    ])(
+      'skips the item when the descendant watch sweep fails (%i - %s)',
+      async (propertyId) => {
+        const showItem = createMediaItem({
+          id: 'show-sweep-failure',
+          type: 'show' as MediaItemType,
+        });
+
+        jellyfinAdapter.getMetadata.mockResolvedValue(showItem);
+        jellyfinAdapter.getUsers.mockResolvedValue([createMediaUser()]);
+        jellyfinAdapter.getChildrenMetadata.mockResolvedValue([]);
+        jellyfinAdapter.getDescendantEpisodeWatchHistory.mockRejectedValue(
+          new Error('sweep failed'),
+        );
+
+        const response = await jellyfinGetterService.get(
+          propertyId,
+          showItem,
+          'show',
+          createRulesDto({ dataType: 'show' }),
+        );
+
+        expect(response).toBeUndefined();
+      },
+    );
 
     it('sw_episodes (id: 14) counts all episodes under a show', async () => {
       const showItem = createMediaItem({
@@ -1241,26 +1268,13 @@ describe('JellyfinGetterService', () => {
           return [];
         },
       );
-      jellyfinAdapter.getWatchHistory.mockImplementation(
-        async (itemId: string) => {
-          // S1E1 rewatched most recently, but we should still prefer S2E2
-          if (itemId === 'ep-s1e1') {
-            return [
-              createWatchRecord({ itemId, watchedAt: new Date('2026-04-20') }),
-            ];
-          }
-          if (itemId === 'ep-s2e1') {
-            return [
-              createWatchRecord({ itemId, watchedAt: new Date('2026-03-01') }),
-            ];
-          }
-          if (itemId === 'ep-s2e2') {
-            return [
-              createWatchRecord({ itemId, watchedAt: new Date('2026-03-06') }),
-            ];
-          }
-          return [];
-        },
+      // S1E1 rewatched most recently, but we should still prefer S2E2
+      jellyfinAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'ep-s1e1': [{ watchedAt: new Date('2026-04-20') }],
+          'ep-s2e1': [{ watchedAt: new Date('2026-03-01') }],
+          'ep-s2e2': [{ watchedAt: new Date('2026-03-06') }],
+        }),
       );
 
       const response = await jellyfinGetterService.get(
@@ -1307,21 +1321,13 @@ describe('JellyfinGetterService', () => {
           return [];
         },
       );
-      jellyfinAdapter.getWatchHistory.mockImplementation(
-        async (itemId: string) => {
-          if (itemId === 'ep-1') {
-            return [
-              createWatchRecord({ itemId, watchedAt: new Date('2026-04-10') }),
-            ];
-          }
-          if (itemId === 'ep-2') {
-            return [
-              createWatchRecord({ itemId, watchedAt: new Date('2026-03-01') }),
-            ];
-          }
+      jellyfinAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'ep-1': [{ watchedAt: new Date('2026-04-10') }],
+          'ep-2': [{ watchedAt: new Date('2026-03-01') }],
           // ep-3 (the latest episode) has never been watched
-          return [];
-        },
+          'ep-3': [],
+        }),
       );
 
       const response = await jellyfinGetterService.get(
@@ -1357,7 +1363,9 @@ describe('JellyfinGetterService', () => {
           return [];
         },
       );
-      jellyfinAdapter.getWatchHistory.mockResolvedValue([]);
+      jellyfinAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({ 'ep-1': [] }),
+      );
 
       const response = await jellyfinGetterService.get(
         13,
@@ -1391,12 +1399,11 @@ describe('JellyfinGetterService', () => {
           return [];
         },
       );
-      jellyfinAdapter.getWatchHistory.mockResolvedValue([
-        createWatchRecord({
-          itemId: 'ep-special-1',
-          watchedAt: new Date('2026-02-01'),
+      jellyfinAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'ep-special-1': [{ watchedAt: new Date('2026-02-01') }],
         }),
-      ]);
+      );
 
       const response = await jellyfinGetterService.get(
         13,
@@ -1437,20 +1444,11 @@ describe('JellyfinGetterService', () => {
           return [];
         },
       );
-      jellyfinAdapter.getWatchHistory.mockImplementation(
-        async (itemId: string) => {
-          if (itemId === 'ep-1') {
-            return [
-              createWatchRecord({ itemId, watchedAt: new Date('2026-04-10') }),
-            ];
-          }
-          if (itemId === 'ep-1-2') {
-            return [
-              createWatchRecord({ itemId, watchedAt: new Date('2026-03-01') }),
-            ];
-          }
-          return [];
-        },
+      jellyfinAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'ep-1': [{ watchedAt: new Date('2026-04-10') }],
+          'ep-1-2': [{ watchedAt: new Date('2026-03-01') }],
+        }),
       );
 
       const response = await jellyfinGetterService.get(
@@ -1499,12 +1497,12 @@ describe('JellyfinGetterService', () => {
         },
       );
       // ep-1 and ep-3 are watched, ep-2 is not
-      jellyfinAdapter.getItemSeenBy.mockImplementation(
-        async (itemId: string) => {
-          if (itemId === 'ep-1') return ['user-1'];
-          if (itemId === 'ep-3') return ['user-2', 'user-3'];
-          return [];
-        },
+      jellyfinAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'ep-1': [{ userId: 'user-1' }],
+          'ep-2': [],
+          'ep-3': [{ userId: 'user-2' }, { userId: 'user-3' }],
+        }),
       );
 
       const response = await jellyfinGetterService.get(
@@ -1536,7 +1534,9 @@ describe('JellyfinGetterService', () => {
           return [];
         },
       );
-      jellyfinAdapter.getItemSeenBy.mockResolvedValue([]);
+      jellyfinAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({ 'ep-1': [] }),
+      );
 
       const response = await jellyfinGetterService.get(
         15,
@@ -1574,21 +1574,15 @@ describe('JellyfinGetterService', () => {
         },
       );
       // ep-1 watched 3 times, ep-2 watched 2 times
-      jellyfinAdapter.getWatchHistory.mockImplementation(
-        async (itemId: string) => {
-          if (itemId === 'ep-1')
-            return [
-              createWatchRecord({ userId: 'user-1', itemId: 'ep-1' }),
-              createWatchRecord({ userId: 'user-2', itemId: 'ep-1' }),
-              createWatchRecord({ userId: 'user-1', itemId: 'ep-1' }), // re-watch
-            ];
-          if (itemId === 'ep-2')
-            return [
-              createWatchRecord({ userId: 'user-1', itemId: 'ep-2' }),
-              createWatchRecord({ userId: 'user-3', itemId: 'ep-2' }),
-            ];
-          return [];
-        },
+      jellyfinAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({
+          'ep-1': [
+            { userId: 'user-1' },
+            { userId: 'user-2' },
+            { userId: 'user-1' }, // re-watch
+          ],
+          'ep-2': [{ userId: 'user-1' }, { userId: 'user-3' }],
+        }),
       );
 
       const response = await jellyfinGetterService.get(
@@ -1620,7 +1614,9 @@ describe('JellyfinGetterService', () => {
           return [];
         },
       );
-      jellyfinAdapter.getWatchHistory.mockResolvedValue([]);
+      jellyfinAdapter.getDescendantEpisodeWatchHistory.mockResolvedValue(
+        createDescendantWatchHistory({ 'ep-1': [] }),
+      );
 
       const response = await jellyfinGetterService.get(
         17,

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
@@ -3,6 +3,7 @@ import {
   MediaItem,
   MediaItemType,
   RuleValueType,
+  WatchRecord,
 } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import cacheManager, { Cache } from '../../api/lib/cache';
@@ -197,10 +198,7 @@ export class JellyfinGetterService {
             isMediaType(metadata.type, 'show') ||
             isMediaType(metadata.type, 'season')
           ) {
-            return await this.getLastWatchedShowDate(
-              metadata.id,
-              metadata.type,
-            );
+            return await this.getLastWatchedShowDate(metadata.id);
           }
           return await this.getLastViewedAt(metadata.id);
         }
@@ -230,7 +228,7 @@ export class JellyfinGetterService {
         }
 
         case 'sw_allEpisodesSeenBy': {
-          return await this.getAllEpisodesSeenBy(metadata.id, metadata.type);
+          return await this.getAllEpisodesSeenBy(metadata.id);
         }
 
         case 'sw_lastWatched': {
@@ -245,7 +243,7 @@ export class JellyfinGetterService {
         }
 
         case 'sw_viewedEpisodes': {
-          return await this.getViewedEpisodeCount(metadata.id, metadata.type);
+          return await this.getViewedEpisodeCount(metadata.id);
         }
 
         case 'sw_lastEpisodeAddedAt': {
@@ -479,63 +477,37 @@ export class JellyfinGetterService {
     }
   }
 
-  private async getLastViewedAt(itemId: string): Promise<Date | null> {
-    const watchHistory = await this.jellyfinAdapter.getWatchHistory(itemId);
-    if (!watchHistory.length) {
-      return null;
-    }
-
-    const dates = watchHistory
+  private newestWatchedAt(records: WatchRecord[]): Date | null {
+    const times = records
       .map((r) => r.watchedAt)
-      .filter((d): d is Date => d !== undefined);
+      .filter((d): d is Date => d !== undefined)
+      .map((d) => d.getTime());
 
-    return dates.length > 0
-      ? new Date(Math.max(...dates.map((d) => d.getTime())))
-      : null;
+    return times.length > 0 ? new Date(Math.max(...times)) : null;
   }
 
-  private async getAllEpisodesSeenBy(
-    itemId: string,
-    type: MediaItemType,
-  ): Promise<string[]> {
+  private async getLastViewedAt(itemId: string): Promise<Date | null> {
+    return this.newestWatchedAt(
+      await this.jellyfinAdapter.getWatchHistory(itemId),
+    );
+  }
+
+  private async getAllEpisodesSeenBy(itemId: string): Promise<string[]> {
     const users = await this.jellyfinAdapter.getUsers();
-
-    // Get all episodes - handle both shows and seasons
-    const allEpisodes: string[] = [];
-    if (type === 'season') {
-      // For seasons, get episodes directly (children of season)
-      const episodes = await this.jellyfinAdapter.getChildrenMetadata(
-        itemId,
-        'episode',
-      );
-      allEpisodes.push(...episodes.map((e) => e.id));
-    } else {
-      // For shows, get seasons first, then episodes from each season
-      const seasons = await this.jellyfinAdapter.getChildrenMetadata(
-        itemId,
-        'season',
-      );
-      for (const season of seasons) {
-        const episodes = await this.jellyfinAdapter.getChildrenMetadata(
-          season.id,
-          'episode',
-        );
-        allEpisodes.push(...episodes.map((e) => e.id));
-      }
-    }
-
-    if (allEpisodes.length === 0) return [];
-
-    // Get watch status for each episode
-    const episodeWatchers = await Promise.all(
-      allEpisodes.map((epId) => this.jellyfinAdapter.getItemSeenBy(epId)),
+    const episodeWatchers = Object.values(
+      await this.jellyfinAdapter.getDescendantEpisodeWatchHistory(itemId),
     );
 
-    // Find users who appear in ALL episode watch lists
-    const allUserIds = new Set(users.map((u) => u.id));
-    const usersWhoWatchedAll = [...allUserIds].filter((userId) =>
-      episodeWatchers.every((watchers) => watchers.includes(userId)),
-    );
+    if (episodeWatchers.length === 0) return [];
+
+    // Users who appear in EVERY episode's watch list
+    const usersWhoWatchedAll = users
+      .map((user) => user.id)
+      .filter((userId) =>
+        episodeWatchers.every((records) =>
+          records.some((record) => record.userId === userId),
+        ),
+      );
 
     return mapRuleUserIdsToNames(
       usersWhoWatchedAll,
@@ -566,6 +538,9 @@ export class JellyfinGetterService {
       viewedAt: Date;
     }> = [];
 
+    const watchHistory =
+      await this.jellyfinAdapter.getDescendantEpisodeWatchHistory(itemId);
+
     for (const season of seasons) {
       const episodes = await this.jellyfinAdapter.getChildrenMetadata(
         season.id,
@@ -577,7 +552,7 @@ export class JellyfinGetterService {
         if (episodeOrder === undefined || episode.parentIndex === undefined) {
           continue;
         }
-        const viewedAt = await this.getLastViewedAt(episode.id);
+        const viewedAt = this.newestWatchedAt(watchHistory[episode.id] ?? []);
         if (!viewedAt) continue;
         watched.push({
           parentIndex: episode.parentIndex,
@@ -607,45 +582,11 @@ export class JellyfinGetterService {
    * highest-numbered episode, the way the Plex/Tautulli `sw_lastWatched`
    * getters compute it. Used by the `lastViewedAt` rule only.
    */
-  private async getLastWatchedShowDate(
-    itemId: string,
-    type: MediaItemType,
-  ): Promise<Date | null> {
-    let latestDate: Date | null = null;
+  private async getLastWatchedShowDate(itemId: string): Promise<Date | null> {
+    const watchHistory =
+      await this.jellyfinAdapter.getDescendantEpisodeWatchHistory(itemId);
 
-    if (type === 'season') {
-      // For seasons, get episodes directly
-      const episodes = await this.jellyfinAdapter.getChildrenMetadata(
-        itemId,
-        'episode',
-      );
-      for (const episode of episodes) {
-        const lastViewed = await this.getLastViewedAt(episode.id);
-        if (lastViewed && (!latestDate || lastViewed > latestDate)) {
-          latestDate = lastViewed;
-        }
-      }
-    } else {
-      // For shows, iterate through seasons first
-      const seasons = await this.jellyfinAdapter.getChildrenMetadata(
-        itemId,
-        'season',
-      );
-      for (const season of seasons) {
-        const episodes = await this.jellyfinAdapter.getChildrenMetadata(
-          season.id,
-          'episode',
-        );
-        for (const episode of episodes) {
-          const lastViewed = await this.getLastViewedAt(episode.id);
-          if (lastViewed && (!latestDate || lastViewed > latestDate)) {
-            latestDate = lastViewed;
-          }
-        }
-      }
-    }
-
-    return latestDate;
+    return this.newestWatchedAt(Object.values(watchHistory).flat());
   }
 
   private async getEpisodeCount(
@@ -676,27 +617,12 @@ export class JellyfinGetterService {
     return count;
   }
 
-  private async getViewedEpisodeCount(
-    itemId: string,
-    type: MediaItemType,
-  ): Promise<number> {
-    const seasons =
-      type === 'season'
-        ? [{ id: itemId }]
-        : await this.jellyfinAdapter.getChildrenMetadata(itemId, 'season');
+  private async getViewedEpisodeCount(itemId: string): Promise<number> {
+    const watchHistory =
+      await this.jellyfinAdapter.getDescendantEpisodeWatchHistory(itemId);
 
-    let viewedCount = 0;
-    for (const season of seasons) {
-      const episodes = await this.jellyfinAdapter.getChildrenMetadata(
-        season.id,
-        'episode',
-      );
-      for (const episode of episodes) {
-        const seenBy = await this.jellyfinAdapter.getItemSeenBy(episode.id);
-        if (seenBy.length > 0) viewedCount++;
-      }
-    }
-    return viewedCount;
+    return Object.values(watchHistory).filter((records) => records.length > 0)
+      .length;
   }
 
   private async getLastEpisodeAddedAt(
@@ -737,23 +663,13 @@ export class JellyfinGetterService {
       return history.length;
     }
 
-    const seasons =
-      type === 'season'
-        ? [{ id: itemId }]
-        : await this.jellyfinAdapter.getChildrenMetadata(itemId, 'season');
+    const watchHistory =
+      await this.jellyfinAdapter.getDescendantEpisodeWatchHistory(itemId);
 
-    let totalViews = 0;
-    for (const season of seasons) {
-      const episodes = await this.jellyfinAdapter.getChildrenMetadata(
-        season.id,
-        'episode',
-      );
-      for (const episode of episodes) {
-        const history = await this.jellyfinAdapter.getWatchHistory(episode.id);
-        totalViews += history.length;
-      }
-    }
-    return totalViews;
+    return Object.values(watchHistory).reduce(
+      (total, records) => total + records.length,
+      0,
+    );
   }
 
   private async getSwWatchers(


### PR DESCRIPTION
Closes #3337.

Every show-level watch property walked seasons then episodes and called `getWatchHistory` per episode, and each of those issues one `/Items` request **per Jellyfin/Emby user**. A Shows rule group therefore cost `O(episodes x users)` requests.

`getDescendantEpisodeWatchers` already had the cheap shape - one recursive `/Items` per user, scoped to the show. This generalises it into `getDescendantEpisodeWatchHistory`, which returns watch records keyed by episode id, and serves `sw_lastWatched`, `sw_viewedEpisodes`, `sw_amountOfViews`, `sw_allEpisodesSeenBy` and show/season `lastViewedAt` from it. Cost becomes `O(users)` per show.

- **No semantic change.** The sweep hits the same endpoint with the same `enableUserData` payload the per-item path reads; I verified the `UserData` objects are byte-identical between the bulk and single-id forms on Jellyfin 10.11.11 (unplayed, played, and mid-progress).
- **No `isPlayed` filter.** It tests the `Played` flag alone, so it would silently drop episodes watched only by crossing the `PlayedPercentage` threshold (#2466) - a false "never watched" on a tool that deletes media.
- **All-or-nothing.** A failed user sweep or a short page throws instead of caching a partial map, so a transient failure skips the item rather than reading as never watched (#2744, #3318). `getDescendantEpisodeWatchers` no longer swallows errors into an empty watcher list for the same reason.
- **Sweeps get their own small uncloned cache.** They are much larger than a normal cached response (cloning one measured ~48ms per read) and every consumer only reads them; the key ceiling is sized to the executor's 50-item chunk so #3284's memory bound still holds.
- Emby mirrors Jellyfin throughout - it has the identical per-user model and had the identical defect.

Measured against a real Jellyfin (Blender Open Movies, 5 episodes, 5 users), before vs after: all six property values identical, **154 requests -> 46**. Per property the watch cost drops from `episodes x users` to `users`, so the ratio grows with episode count.

Not addressed here: movie and episode-level rule groups still pay `O(users)` per item, which is inherent to Jellyfin's per-user watch model without a library-wide prefetch.