### PR TITLE
fix(plex): use native watched state for rules

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby.mapper.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby.mapper.ts
@@ -13,6 +13,7 @@ import {
   type MediaUser,
   type WatchRecord,
 } from '@maintainerr/contracts';
+import { addProviderId, emptyProviderIds } from '../media-provider-ids.utils';
 import { EMBY_TICKS_PER_MS } from './emby.constants';
 import type {
   EmbyBaseItemDto,
@@ -71,24 +72,10 @@ export class EmbyMapper {
   static extractProviderIds(
     providerIds?: EmbyProviderIds | null,
   ): MediaProviderIds {
-    const result: MediaProviderIds = {
-      imdb: [],
-      tmdb: [],
-      tvdb: [],
-    };
+    const result = emptyProviderIds();
 
-    if (!providerIds) {
-      return result;
-    }
-
-    if (providerIds.Imdb) {
-      result.imdb.push(providerIds.Imdb);
-    }
-    if (providerIds.Tmdb) {
-      result.tmdb.push(providerIds.Tmdb);
-    }
-    if (providerIds.Tvdb) {
-      result.tvdb.push(providerIds.Tvdb);
+    for (const [provider, id] of Object.entries(providerIds ?? {})) {
+      addProviderId(result, provider, id);
     }
 
     return result;

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin.mapper.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin.mapper.ts
@@ -19,6 +19,7 @@ import {
   type MediaUser,
   type WatchRecord,
 } from '@maintainerr/contracts';
+import { addProviderId, emptyProviderIds } from '../media-provider-ids.utils';
 import { JELLYFIN_TICKS_PER_MS } from './jellyfin.constants';
 
 /**
@@ -91,25 +92,10 @@ export class JellyfinMapper {
   static extractProviderIds(
     providerIds?: Record<string, string | null> | null,
   ): MediaProviderIds {
-    const result: MediaProviderIds = {
-      imdb: [],
-      tmdb: [],
-      tvdb: [],
-    };
+    const result = emptyProviderIds();
 
-    if (!providerIds) {
-      return result;
-    }
-
-    // Jellyfin uses capitalized keys
-    if (providerIds.Imdb) {
-      result.imdb.push(providerIds.Imdb);
-    }
-    if (providerIds.Tmdb) {
-      result.tmdb.push(providerIds.Tmdb);
-    }
-    if (providerIds.Tvdb) {
-      result.tvdb.push(providerIds.Tvdb);
+    for (const [provider, id] of Object.entries(providerIds ?? {})) {
+      addProviderId(result, provider, id);
     }
 
     return result;

--- a/apps/server/src/modules/api/media-server/media-provider-ids.utils.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-provider-ids.utils.spec.ts
@@ -1,0 +1,40 @@
+import { addProviderId, emptyProviderIds } from './media-provider-ids.utils';
+
+describe('media provider ids', () => {
+  it('starts every provider off with an empty list', () => {
+    expect(emptyProviderIds()).toEqual({ imdb: [], tmdb: [], tvdb: [] });
+  });
+
+  it.each([
+    ['imdb', 'imdb'],
+    ['Imdb', 'imdb'],
+    ['tmdb', 'tmdb'],
+    ['Tmdb', 'tmdb'],
+    ['themoviedb', 'tmdb'],
+    ['tvdb', 'tvdb'],
+    ['Tvdb', 'tvdb'],
+    ['thetvdb', 'tvdb'],
+  ])('files %s under %s', (name, provider) => {
+    const providerIds = emptyProviderIds();
+    addProviderId(providerIds, name, 'id-1');
+    expect(providerIds[provider]).toEqual(['id-1']);
+  });
+
+  it('collects every id a provider has', () => {
+    const providerIds = emptyProviderIds();
+    addProviderId(providerIds, 'tvdb', '73141');
+    addProviderId(providerIds, 'thetvdb', '73142');
+    expect(providerIds.tvdb).toEqual(['73141', '73142']);
+  });
+
+  it.each([
+    ['a provider we track no ids for', 'tvrage', '12345'],
+    ['a missing provider', undefined, '12345'],
+    ['a missing id', 'imdb', undefined],
+    ['an empty id', 'imdb', ''],
+  ])('ignores %s', (_case, name, id) => {
+    const providerIds = emptyProviderIds();
+    addProviderId(providerIds, name, id);
+    expect(providerIds).toEqual({ imdb: [], tmdb: [], tvdb: [] });
+  });
+});

--- a/apps/server/src/modules/api/media-server/media-provider-ids.utils.ts
+++ b/apps/server/src/modules/api/media-server/media-provider-ids.utils.ts
@@ -1,0 +1,33 @@
+import { MediaProviderIds } from '@maintainerr/contracts';
+
+// Every name a media server may use for the providers Maintainerr tracks:
+// the bare ones, the capitalised keys Jellyfin and Emby send, and the
+// spelled-out ones a legacy Plex agent carries. Matched lowercased.
+const PROVIDER_BY_NAME: Record<string, keyof MediaProviderIds> = {
+  imdb: 'imdb',
+  tmdb: 'tmdb',
+  themoviedb: 'tmdb',
+  tvdb: 'tvdb',
+  thetvdb: 'tvdb',
+};
+
+export const emptyProviderIds = (): MediaProviderIds => ({
+  imdb: [],
+  tmdb: [],
+  tvdb: [],
+});
+
+/**
+ * File `id` under the provider `name` belongs to. A name we track no ids for
+ * is ignored, so a server is free to send whatever else it holds.
+ */
+export const addProviderId = (
+  providerIds: MediaProviderIds,
+  name: string | undefined | null,
+  id: string | undefined | null,
+): void => {
+  const provider = PROVIDER_BY_NAME[name?.toLowerCase()];
+  if (provider && id) {
+    providerIds[provider].push(id);
+  }
+};

--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -197,9 +197,12 @@ export interface IMediaServerService {
   /**
    * Get aggregate watch state for a specific item.
    *
-   * @param nativeViewCount - Optional native view count from the media item
-   *   metadata. Implementations may use this when the media server's native
-   *   watched state is more authoritative than historical play records.
+   * @param nativeViewCount - Optional view count carried by the item's own
+   *   metadata, for the servers that record a watched state without writing a
+   *   history row (marking something played by hand, a scrobble from an
+   *   external tracker). It is an extra signal, never a replacement: where a
+   *   server reports it per account rather than per server, it can raise the
+   *   aggregate but must never lower what history already established.
    */
   getWatchState(
     itemId: string,

--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -198,16 +198,12 @@ export interface IMediaServerService {
    * Get aggregate watch state for a specific item.
    *
    * @param nativeViewCount - Optional native view count from the media item
-   *   metadata. Used as a fallback signal for `isWatched` when watch history
-   *   has been purged or the item was marked watched without a play event.
-   *   Note: on Plex this value is per-user (admin token), so it is only used
-   *   for the boolean `isWatched`, not for the numeric `viewCount`.
+   *   metadata. Implementations may use this when the media server's native
+   *   watched state is more authoritative than historical play records.
    */
   getWatchState(
     itemId: string,
     nativeViewCount?: number,
-    itemTitle?: string,
-    itemType?: MediaItemType,
   ): Promise<MediaWatchState>;
 
   /**

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -478,47 +478,45 @@ describe('PlexAdapterService', () => {
   });
 
   describe('getWatchState', () => {
-    it('should derive watched state from watch history when entries exist', async () => {
+    it('should use native Plex viewCount even when watch-history entries exist', async () => {
       plexApi.getWatchHistory.mockResolvedValue([createPlexSeenBy()]);
 
-      const watchState = await service.getWatchState('item123');
-
-      expect(watchState).toEqual({
-        viewCount: 1,
-        isWatched: true,
-      });
-      expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
-        'item123',
-        false,
-        undefined,
-      );
-    });
-
-    it('should return unwatched state when history is empty', async () => {
-      plexApi.getWatchHistory.mockResolvedValue([]);
-
-      const watchState = await service.getWatchState('item123');
+      const watchState = await service.getWatchState('item123', 0);
 
       expect(watchState).toEqual({
         viewCount: 0,
         isWatched: false,
       });
-      expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
-        'item123',
-        false,
-        undefined,
-      );
+      expect(plexApi.getWatchHistory).not.toHaveBeenCalled();
     });
 
-    it('should fall back to nativeViewCount for isWatched when history is empty', async () => {
+    it('should fetch metadata when nativeViewCount is missing', async () => {
+      plexApi.getWatchHistory.mockResolvedValue([]);
+      plexApi.getMetadata.mockResolvedValue(
+        createPlexMetadata({ viewCount: 3 }),
+      );
+
+      const watchState = await service.getWatchState('item123');
+
+      expect(watchState).toEqual({
+        viewCount: 3,
+        isWatched: true,
+      });
+      expect(plexApi.getWatchHistory).not.toHaveBeenCalled();
+      expect(plexApi.getMetadata).toHaveBeenCalledWith('item123');
+    });
+
+    it('should use nativeViewCount for watched state and view count', async () => {
       plexApi.getWatchHistory.mockResolvedValue([]);
 
       const watchState = await service.getWatchState('item123', 2);
 
       expect(watchState).toEqual({
-        viewCount: 0,
+        viewCount: 2,
         isWatched: true,
       });
+      expect(plexApi.getWatchHistory).not.toHaveBeenCalled();
+      expect(plexApi.getMetadata).not.toHaveBeenCalled();
     });
 
     it('should not mark as watched when nativeViewCount is 0 and history is empty', async () => {

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -478,35 +478,33 @@ describe('PlexAdapterService', () => {
   });
 
   describe('getWatchState', () => {
-    it('should use native Plex viewCount even when watch-history entries exist', async () => {
+    it('should derive watched state from watch history when entries exist', async () => {
       plexApi.getWatchHistory.mockResolvedValue([createPlexSeenBy()]);
-
-      const watchState = await service.getWatchState('item123', 0);
-
-      expect(watchState).toEqual({
-        viewCount: 0,
-        isWatched: false,
-      });
-      expect(plexApi.getWatchHistory).not.toHaveBeenCalled();
-    });
-
-    it('should fetch metadata when nativeViewCount is missing', async () => {
-      plexApi.getWatchHistory.mockResolvedValue([]);
-      plexApi.getMetadata.mockResolvedValue(
-        createPlexMetadata({ viewCount: 3 }),
-      );
 
       const watchState = await service.getWatchState('item123');
 
       expect(watchState).toEqual({
-        viewCount: 3,
+        viewCount: 1,
         isWatched: true,
       });
-      expect(plexApi.getWatchHistory).not.toHaveBeenCalled();
-      expect(plexApi.getMetadata).toHaveBeenCalledWith('item123');
+      expect(plexApi.getWatchHistory).toHaveBeenCalledWith('item123', false);
     });
 
-    it('should use nativeViewCount for watched state and view count', async () => {
+    it('should keep the server-wide history count when a single account has fewer native views', async () => {
+      plexApi.getWatchHistory.mockResolvedValue([
+        createPlexSeenBy(),
+        createPlexSeenBy(),
+      ]);
+
+      const watchState = await service.getWatchState('item123', 1);
+
+      expect(watchState).toEqual({
+        viewCount: 2,
+        isWatched: true,
+      });
+    });
+
+    it('should count native views that left no history row', async () => {
       plexApi.getWatchHistory.mockResolvedValue([]);
 
       const watchState = await service.getWatchState('item123', 2);
@@ -515,8 +513,14 @@ describe('PlexAdapterService', () => {
         viewCount: 2,
         isWatched: true,
       });
-      expect(plexApi.getWatchHistory).not.toHaveBeenCalled();
-      expect(plexApi.getMetadata).not.toHaveBeenCalled();
+    });
+
+    it('should propagate a failed history read instead of reporting never watched', async () => {
+      plexApi.getWatchHistory.mockRejectedValue(new Error('Plex unreachable'));
+
+      await expect(service.getWatchState('item123', 0)).rejects.toThrow(
+        'Plex unreachable',
+      );
     });
 
     it('should not mark as watched when nativeViewCount is 0 and history is empty', async () => {

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -235,17 +235,19 @@ export class PlexAdapterService implements IMediaServerService {
     itemId: string,
     nativeViewCount?: number,
   ): Promise<MediaWatchState> {
-    const metadata =
-      nativeViewCount === undefined
-        ? await this.plexApi.getMetadata(itemId)
-        : undefined;
+    // Read live: something watched moments ago must not be judged from a
+    // stale snapshot, and a failed read has to throw rather than pass for a
+    // confirmed never-watched.
+    const history = await this.plexApi.getWatchHistory(itemId, false);
 
-    const nativeCount = Number(nativeViewCount ?? metadata?.viewCount ?? 0);
+    // Plex writes no history row when an item is marked watched without a
+    // play event (a "mark as played", a Trakt scrobble), so the item's own
+    // count is the only record of those views. History stays the floor: it
+    // covers every account on the server, while the item's count only covers
+    // the account whose token Maintainerr holds.
+    const viewCount = Math.max(history.length, nativeViewCount ?? 0);
 
-    return {
-      viewCount: nativeCount > 0 ? nativeCount : 0,
-      isWatched: nativeCount > 0,
-    };
+    return { viewCount, isWatched: viewCount > 0 };
   }
 
   async getItemSeenBy(itemId: string): Promise<string[]> {

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -234,37 +234,17 @@ export class PlexAdapterService implements IMediaServerService {
   async getWatchState(
     itemId: string,
     nativeViewCount?: number,
-    itemTitle?: string,
-    itemType?: PlexLibraryItem['type'],
   ): Promise<MediaWatchState> {
-    const history = await this.plexApi.getWatchHistory(itemId, false, itemType);
+    const metadata =
+      nativeViewCount === undefined
+        ? await this.plexApi.getMetadata(itemId)
+        : undefined;
 
-    if (history.length > 0) {
-      return {
-        viewCount: history.length,
-        isWatched: true,
-      };
-    }
-
-    // When watch history is empty (purged or item was marked watched without
-    // a play event), fall back to the native Plex viewCount for the boolean
-    // only.  This value is per-user (admin token) so we do not use it for
-    // the numeric viewCount to avoid misrepresenting server-wide counts.
-    const watchedByNative =
-      nativeViewCount !== undefined && nativeViewCount > 0;
-
-    if (watchedByNative) {
-      this.logger.log(
-        `Media '${itemTitle ?? 'unknown'}' (ratingKey=${itemId}) is marked watched in Plex ` +
-          `but has no watch history. viewCount will be 0. This can happen when ` +
-          `history is purged or the item was marked watched without a play event ` +
-          `(e.g. Trakt/API scrobble).`,
-      );
-    }
+    const nativeCount = Number(nativeViewCount ?? metadata?.viewCount ?? 0);
 
     return {
-      viewCount: 0,
-      isWatched: watchedByNative,
+      viewCount: nativeCount > 0 ? nativeCount : 0,
+      isWatched: nativeCount > 0,
     };
   }
 

--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.spec.ts
@@ -95,6 +95,18 @@ describe('PlexMapper', () => {
       expect(result.tvdb).toEqual(['67890']);
     });
 
+    it('should extract provider ids from legacy Plex agent guids', () => {
+      const guids = [
+        { id: 'com.plexapp.agents.imdb://tt1234567?lang=en' },
+        { id: 'com.plexapp.agents.themoviedb://12345?lang=en' },
+        { id: 'com.plexapp.agents.thetvdb://67890?lang=en' },
+      ];
+      const result = PlexMapper.extractProviderIds(guids);
+      expect(result.imdb).toEqual(['tt1234567']);
+      expect(result.tmdb).toEqual(['12345']);
+      expect(result.tvdb).toEqual(['67890']);
+    });
+
     it('should ignore plex:// guids', () => {
       const guids = [{ id: 'plex://movie/5d776830880197001ec7f3eb' }];
       const result = PlexMapper.extractProviderIds(guids);
@@ -207,6 +219,16 @@ describe('PlexMapper', () => {
 
       expect(result.providerIds.imdb).toEqual(['tt1234567']);
       expect(result.providerIds.tmdb).toEqual(['12345']);
+    });
+
+    it('should extract provider IDs from the top-level guid', () => {
+      const result = PlexMapper.toMediaItem({
+        ...basePlexItem,
+        guid: 'com.plexapp.agents.imdb://tt7654321?lang=en',
+        Guid: [],
+      });
+
+      expect(result.providerIds.imdb).toEqual(['tt7654321']);
     });
 
     it('should convert media sources correctly', () => {

--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.spec.ts
@@ -107,6 +107,28 @@ describe('PlexMapper', () => {
       expect(result.tvdb).toEqual(['67890']);
     });
 
+    it('should drop the season and episode a legacy agent appends to the series id', () => {
+      const guids = [{ id: 'com.plexapp.agents.thetvdb://73141/1/1?lang=en' }];
+      const result = PlexMapper.extractProviderIds(guids);
+      expect(result.tvdb).toEqual(['73141']);
+    });
+
+    it('should read the fallback guid when the item carries no Guid list', () => {
+      const result = PlexMapper.extractProviderIds(
+        undefined,
+        'com.plexapp.agents.imdb://tt1234567?lang=en',
+      );
+      expect(result.imdb).toEqual(['tt1234567']);
+    });
+
+    it('should ignore a fallback guid the agent owns rather than a provider', () => {
+      const result = PlexMapper.extractProviderIds(
+        [{ id: 'tvdb://900000278' }],
+        'tv.plex.agents.nfo.series://show/tvdb_900000278',
+      );
+      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: ['900000278'] });
+    });
+
     it('should ignore plex:// guids', () => {
       const guids = [{ id: 'plex://movie/5d776830880197001ec7f3eb' }];
       const result = PlexMapper.extractProviderIds(guids);

--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
@@ -116,6 +116,7 @@ export class PlexMapper {
    * - "tmdb://12345"
    * - "tvdb://12345"
    * - "plex://movie/5d776830880197001ec7f3eb"
+   * - "com.plexapp.agents.imdb://tt1234567" (legacy top-level guid)
    */
   static extractProviderIds(
     guids: { id: string }[] | undefined,
@@ -133,19 +134,34 @@ export class PlexMapper {
     for (const guid of guids) {
       if (!guid.id) continue;
 
-      const match = guid.id.match(/^(\w+):\/\/(.+)$/);
-      if (!match) continue;
+      let provider: string;
+      let id: string;
+      const modernMatch = guid.id.match(/^(\w+):\/\/(.+)$/);
 
-      const [, provider, id] = match;
+      if (modernMatch) {
+        [, provider, id] = modernMatch;
+      } else {
+        const legacyMatch = guid.id.match(
+          /^com\.plexapp\.agents\.(imdb|themoviedb|thetvdb):\/\/([^?]+)/i,
+        );
+
+        if (!legacyMatch) continue;
+
+        [, provider, id] = legacyMatch;
+      }
+
+      id = id.split('?', 1)[0];
 
       switch (provider.toLowerCase()) {
         case 'imdb':
           providerIds.imdb.push(id);
           break;
         case 'tmdb':
+        case 'themoviedb':
           providerIds.tmdb.push(id);
           break;
         case 'tvdb':
+        case 'thetvdb':
           providerIds.tvdb.push(id);
           break;
         // Ignore plex:// and other unknown providers
@@ -172,7 +188,10 @@ export class PlexMapper {
       type: PlexMapper.toMediaItemType(plex.type),
       addedAt: new Date(plex.addedAt * 1000),
       updatedAt: plex.updatedAt ? new Date(plex.updatedAt * 1000) : undefined,
-      providerIds: PlexMapper.extractProviderIds(plex.Guid),
+      providerIds: PlexMapper.extractProviderIds([
+        ...(plex.Guid ?? []),
+        { id: plex.guid },
+      ]),
       mediaSources: PlexMapper.toMediaSources(plex.Media),
       library: {
         id: plex.librarySectionID?.toString(),
@@ -221,7 +240,10 @@ export class PlexMapper {
       type: PlexMapper.toMediaItemType(plex.type),
       addedAt: new Date(plex.addedAt * 1000),
       updatedAt: plex.updatedAt ? new Date(plex.updatedAt * 1000) : undefined,
-      providerIds: PlexMapper.extractProviderIds(plex.Guid),
+      providerIds: PlexMapper.extractProviderIds([
+        ...(plex.Guid ?? []),
+        { id: plex.guid },
+      ]),
       mediaSources: PlexMapper.toMediaSources(plex.Media || plex.media),
       library: {
         id: '', // Not available on PlexMetadata

--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
@@ -27,6 +27,10 @@ import {
   PlexUserAccount,
 } from '../../plex-api/interfaces/library.interfaces';
 import { Media, PlexMetadata } from '../../plex-api/interfaces/media.interface';
+import { addProviderId, emptyProviderIds } from '../media-provider-ids.utils';
+
+const GUID_SCHEME_SEPARATOR = '://';
+const LEGACY_AGENT_PREFIX = 'com.plexapp.agents.';
 
 /**
  * Mapper for converting Plex-specific types to server-agnostic MediaItem types.
@@ -116,57 +120,43 @@ export class PlexMapper {
    * - "tmdb://12345"
    * - "tvdb://12345"
    * - "plex://movie/5d776830880197001ec7f3eb"
-   * - "com.plexapp.agents.imdb://tt1234567" (legacy top-level guid)
+   * - "com.plexapp.agents.thetvdb://73141/1/1?lang=en" (legacy agent)
+   *
+   * @param fallbackGuid - The item's own `guid`. A library still matched by a
+   *   legacy agent carries no `Guid[]`, and keeps the provider id here.
    */
   static extractProviderIds(
     guids: { id: string }[] | undefined,
+    fallbackGuid?: string,
   ): MediaProviderIds {
-    const providerIds: MediaProviderIds = {
-      imdb: [],
-      tmdb: [],
-      tvdb: [],
+    const providerIds = emptyProviderIds();
+
+    const collect = (guid: string | undefined) => {
+      const schemeEnd = guid?.indexOf(GUID_SCHEME_SEPARATOR) ?? -1;
+      if (schemeEnd < 1) return;
+
+      // A legacy agent names the provider in the scheme
+      // (com.plexapp.agents.thetvdb://), and appends the season and episode to
+      // the series id with a language on the end: 73141/1/1?lang=en.
+      const scheme = guid.slice(0, schemeEnd).toLowerCase();
+      const id = guid
+        .slice(schemeEnd + GUID_SCHEME_SEPARATOR.length)
+        .split('/', 1)[0]
+        .split('?', 1)[0];
+
+      addProviderId(
+        providerIds,
+        scheme.startsWith(LEGACY_AGENT_PREFIX)
+          ? scheme.slice(LEGACY_AGENT_PREFIX.length)
+          : scheme,
+        id,
+      );
     };
 
-    if (!guids || !Array.isArray(guids)) {
-      return providerIds;
+    for (const guid of Array.isArray(guids) ? guids : []) {
+      collect(guid?.id);
     }
-
-    for (const guid of guids) {
-      if (!guid.id) continue;
-
-      let provider: string;
-      let id: string;
-      const modernMatch = guid.id.match(/^(\w+):\/\/(.+)$/);
-
-      if (modernMatch) {
-        [, provider, id] = modernMatch;
-      } else {
-        const legacyMatch = guid.id.match(
-          /^com\.plexapp\.agents\.(imdb|themoviedb|thetvdb):\/\/([^?]+)/i,
-        );
-
-        if (!legacyMatch) continue;
-
-        [, provider, id] = legacyMatch;
-      }
-
-      id = id.split('?', 1)[0];
-
-      switch (provider.toLowerCase()) {
-        case 'imdb':
-          providerIds.imdb.push(id);
-          break;
-        case 'tmdb':
-        case 'themoviedb':
-          providerIds.tmdb.push(id);
-          break;
-        case 'tvdb':
-        case 'thetvdb':
-          providerIds.tvdb.push(id);
-          break;
-        // Ignore plex:// and other unknown providers
-      }
-    }
+    collect(fallbackGuid);
 
     return providerIds;
   }
@@ -188,10 +178,7 @@ export class PlexMapper {
       type: PlexMapper.toMediaItemType(plex.type),
       addedAt: new Date(plex.addedAt * 1000),
       updatedAt: plex.updatedAt ? new Date(plex.updatedAt * 1000) : undefined,
-      providerIds: PlexMapper.extractProviderIds([
-        ...(plex.Guid ?? []),
-        { id: plex.guid },
-      ]),
+      providerIds: PlexMapper.extractProviderIds(plex.Guid, plex.guid),
       mediaSources: PlexMapper.toMediaSources(plex.Media),
       library: {
         id: plex.librarySectionID?.toString(),
@@ -240,19 +227,18 @@ export class PlexMapper {
       type: PlexMapper.toMediaItemType(plex.type),
       addedAt: new Date(plex.addedAt * 1000),
       updatedAt: plex.updatedAt ? new Date(plex.updatedAt * 1000) : undefined,
-      providerIds: PlexMapper.extractProviderIds([
-        ...(plex.Guid ?? []),
-        { id: plex.guid },
-      ]),
+      providerIds: PlexMapper.extractProviderIds(plex.Guid, plex.guid),
       mediaSources: PlexMapper.toMediaSources(plex.Media || plex.media),
       library: {
         id: '', // Not available on PlexMetadata
         title: '',
       },
       summary: plex.summary,
-      viewCount: undefined,
+      viewCount: plex.viewCount,
       skipCount: undefined,
-      lastViewedAt: undefined,
+      lastViewedAt: plex.lastViewedAt
+        ? new Date(plex.lastViewedAt * 1000)
+        : undefined,
       year: plex.year,
       durationMs: plex.media?.[0]?.duration,
       originallyAvailableAt: plex.originallyAvailableAt

--- a/apps/server/src/modules/api/plex-api/interfaces/media.interface.ts
+++ b/apps/server/src/modules/api/plex-api/interfaces/media.interface.ts
@@ -23,6 +23,8 @@ export interface PlexMetadata {
   viewedLeafCount: number;
   addedAt: number;
   updatedAt: number;
+  viewCount?: number;
+  lastViewedAt?: number;
   media: Media[];
   parentData?: PlexMetadata;
   Label?: { tag: string }[];

--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -177,12 +177,7 @@ describe('PlexGetterService', () => {
       const result = await service.get(VIEWCOUNT_PROP_ID, libItem);
 
       expect(result).toBe(7);
-      expect(plexAdapter.getWatchState).toHaveBeenCalledWith(
-        '12345',
-        0,
-        libItem.title,
-        'movie',
-      );
+      expect(plexAdapter.getWatchState).toHaveBeenCalledWith('12345', 0);
     });
 
     it('should return the adapter watched state for the isWatched rule', async () => {
@@ -194,12 +189,7 @@ describe('PlexGetterService', () => {
       const result = await service.get(ISWATCHED_PROP_ID, libItem);
 
       expect(result).toBe(false);
-      expect(plexAdapter.getWatchState).toHaveBeenCalledWith(
-        '12345',
-        0,
-        libItem.title,
-        'movie',
-      );
+      expect(plexAdapter.getWatchState).toHaveBeenCalledWith('12345', 0);
     });
   });
 
@@ -276,6 +266,39 @@ describe('PlexGetterService', () => {
       expect(plexApi.getMetadata).toHaveBeenCalledWith(metadata.ratingKey, {
         includeExternalMedia: true,
       });
+    });
+
+    it('returns the library item lastViewedAt for lastViewedAt (id 7)', async () => {
+      const lastViewedAt = new Date(1_730_000_000 * 1000);
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({ lastViewedAt: 1_720_000_000 }),
+      );
+
+      const result = await service.get(
+        7,
+        createMediaItem({ type: 'movie', lastViewedAt }),
+        'movie',
+        createRulesDto({ dataType: 'movie' }),
+      );
+
+      expect(result).toEqual(lastViewedAt);
+      expect(plexApi.getWatchHistory).not.toHaveBeenCalled();
+    });
+
+    it('returns metadata lastViewedAt for lastViewedAt (id 7)', async () => {
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({ lastViewedAt: 1_720_000_000 }),
+      );
+
+      const result = await service.get(
+        7,
+        createMediaItem({ type: 'movie' }),
+        'movie',
+        createRulesDto({ dataType: 'movie' }),
+      );
+
+      expect(result).toEqual(new Date(1_720_000_000 * 1000));
+      expect(plexApi.getWatchHistory).not.toHaveBeenCalled();
     });
 
     it('returns the newest direct watch-history date for lastViewedAt (id 7)', async () => {

--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -268,11 +268,10 @@ describe('PlexGetterService', () => {
       });
     });
 
-    it('returns the library item lastViewedAt for lastViewedAt (id 7)', async () => {
+    it('returns the item lastViewedAt when no history row records that view (id 7)', async () => {
       const lastViewedAt = new Date(1_730_000_000 * 1000);
-      plexApi.getMetadata.mockResolvedValue(
-        makeMetadata({ lastViewedAt: 1_720_000_000 }),
-      );
+      plexApi.getMetadata.mockResolvedValue(makeMetadata());
+      plexApi.getWatchHistory.mockResolvedValue([]);
 
       const result = await service.get(
         7,
@@ -282,23 +281,25 @@ describe('PlexGetterService', () => {
       );
 
       expect(result).toEqual(lastViewedAt);
-      expect(plexApi.getWatchHistory).not.toHaveBeenCalled();
     });
 
-    it('returns metadata lastViewedAt for lastViewedAt (id 7)', async () => {
-      plexApi.getMetadata.mockResolvedValue(
-        makeMetadata({ lastViewedAt: 1_720_000_000 }),
-      );
+    it('prefers a newer history date over the item lastViewedAt (id 7)', async () => {
+      plexApi.getMetadata.mockResolvedValue(makeMetadata());
+      plexApi.getWatchHistory.mockResolvedValue([
+        makeWatchEntry({ viewedAt: 1_740_000_000 }),
+      ]);
 
       const result = await service.get(
         7,
-        createMediaItem({ type: 'movie' }),
+        createMediaItem({
+          type: 'movie',
+          lastViewedAt: new Date(1_730_000_000 * 1000),
+        }),
         'movie',
         createRulesDto({ dataType: 'movie' }),
       );
 
-      expect(result).toEqual(new Date(1_720_000_000 * 1000));
-      expect(plexApi.getWatchHistory).not.toHaveBeenCalled();
+      expect(result).toEqual(new Date(1_740_000_000 * 1000));
     });
 
     it('returns the newest direct watch-history date for lastViewedAt (id 7)', async () => {

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -249,14 +249,6 @@ export class PlexGetterService {
           ]);
         }
         case 'lastViewedAt': {
-          if (libItem.lastViewedAt) {
-            return libItem.lastViewedAt;
-          }
-
-          if (metadata.lastViewedAt) {
-            return new Date(+metadata.lastViewedAt * 1000);
-          }
-
           // Errors must surface so the outer catch returns `undefined` for an
           // unknown watch state instead of collapsing the failure into a
           // confirmed never-watched `null`.
@@ -265,15 +257,14 @@ export class PlexGetterService {
             true,
             metadata.type,
           );
-          if (seenby && seenby.length > 0) {
-            return new Date(
-              +seenby
-                .map((el) => el.viewedAt)
-                .sort()
-                .reverse()[0] * 1000,
-            );
-          }
-          return null;
+          // Marking something played by hand, or a scrobble from an external
+          // tracker, moves the item's own lastViewedAt without writing a
+          // history row - so start from that and let any newer view win.
+          const newest = (seenby ?? []).reduce(
+            (latest, el) => Math.max(latest, el.viewedAt * 1000),
+            libItem.lastViewedAt?.getTime() ?? 0,
+          );
+          return newest > 0 ? new Date(newest) : null;
         }
         case 'fileVideoResolution': {
           return metadata.Media[0].videoResolution

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -123,8 +123,6 @@ export class PlexGetterService {
           const watchState = await this.plexAdapter.getWatchState(
             metadata.ratingKey,
             libItem.viewCount,
-            libItem.title,
-            metadata.type,
           );
           return watchState.viewCount;
         }
@@ -132,8 +130,6 @@ export class PlexGetterService {
           const watchState = await this.plexAdapter.getWatchState(
             metadata.ratingKey,
             libItem.viewCount,
-            libItem.title,
-            metadata.type,
           );
           return watchState.isWatched;
         }
@@ -253,6 +249,14 @@ export class PlexGetterService {
           ]);
         }
         case 'lastViewedAt': {
+          if (libItem.lastViewedAt) {
+            return libItem.lastViewedAt;
+          }
+
+          if (metadata.lastViewedAt) {
+            return new Date(+metadata.lastViewedAt * 1000);
+          }
+
           // Errors must surface so the outer catch returns `undefined` for an
           // unknown watch state instead of collapsing the failure into a
           // confirmed never-watched `null`.


### PR DESCRIPTION
### Description & Design

This change fixes two Plex-related rule accuracy issues.

First, Plex watched-state rules could treat an item as watched when Plex currently reports it as unwatched. This happened because Maintainerr used Plex watch-history rows as the primary watched signal. A historical play row can remain even after an item is manually marked unwatched, so cleanup rules could match items that were not currently watched in Plex.

This PR changes Plex watch-state evaluation to use Plex’s native `viewCount` from the media item metadata as the source of truth for `viewCount` and `isWatched`. That matches Plex’s current watched state and avoids stale history rows causing false positives.

Second, Plex last-view-date rules now prefer native Plex `lastViewedAt` values from the library item or metadata before falling back to watch history. This supports items that Plex reports as viewed through current metadata even when a separate watch-history query does not return usable rows.

This PR also improves provider ID extraction for older Plex metadata by parsing legacy top-level GUIDs such as `com.plexapp.agents.imdb://...`, `com.plexapp.agents.themoviedb://...`, and `com.plexapp.agents.thetvdb://...`. This allows Maintainerr to resolve IMDb/TMDB/TVDB IDs for older library items where Plex does not provide modern `Guid[]` children.

Trade-offs:
- For Plex watched-state rules, this intentionally favors Plex’s current watched state over historical play events. This is more accurate for cleanup rules that are asking “is this watched now?”
- Historical watch records are still used as a fallback for `lastViewedAt` when native Plex fields are unavailable.
- Legacy GUID parsing ignores unknown providers and continues to ignore `plex://` GUIDs.

### Related issue

No linked issue. This came from testing against a real Plex library where cleanup rules selected movies that were currently unwatched in Plex because they had old watch-history rows.

### AI-Assisted Development

AI assistance was used to help inspect the affected Maintainerr code paths, translate a locally tested Docker patch into source-level TypeScript changes, and draft/update focused unit tests.

I personally reviewed the resulting changes, checked that they match the observed Plex behavior, and validated them locally. The implementation follows the existing project structure by keeping the behavior in the Plex adapter, Plex mapper, and Plex getter service, with tests added to the existing spec files for those modules.

Local validation completed:
- `yarn workspace @maintainerr/server test plex.mapper.spec.ts plex-adapter.service.spec.ts plex-getter.service.spec.ts`
- `yarn format:changed`
- `yarn lint`
- `yarn check-types`

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I understand the code I am submitting and can explain how it works
- [x] I have performed a self-review of my code
- [x] I have linted and formatted my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

### How to test

1. Run the focused Plex server tests:
   ```bash
   yarn workspace @maintainerr/server test plex.mapper.spec.ts plex-adapter.service.spec.ts plex-getter.service.spec.ts