### PR TITLE
perf(jellyfin): serve container favourites from the watch snapshot (#3356)

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -164,6 +164,42 @@ describe('EmbyAdapterService', () => {
     });
   });
 
+  describe('getMetadata in-flight dedupe (#3356)', () => {
+    it('shares one request between concurrent reads of the same id', async () => {
+      let resolveItem: (value: unknown) => void = () => {};
+      http.get.mockReturnValue(
+        new Promise((resolve) => {
+          resolveItem = resolve;
+        }),
+      );
+
+      // Concurrently evaluated siblings all miss the cold cache key together,
+      // so the cache alone cannot stop the first read fanning out.
+      const reads = Promise.all([
+        service.getMetadata('series-1'),
+        service.getMetadata('series-1'),
+      ]);
+      resolveItem({ data: { Id: 'series-1', Type: 'Series' } });
+
+      const results = await reads;
+      expect(results.map((item) => item?.id)).toEqual(['series-1', 'series-1']);
+      expect(http.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops the in-flight entry once the request settles', async () => {
+      http.get.mockResolvedValue({ data: { Id: 'series-1', Type: 'Series' } });
+
+      await service.getMetadata('series-1');
+      await service.getMetadata('series-1');
+
+      // The map only ever holds an unsettled request - a later read is served
+      // by the cache above it, never by a retained promise. The cache is
+      // mocked to always miss here, so the second read reaching the API is
+      // what proves the entry was released.
+      expect(http.get).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('getActiveSessions', () => {
     it('collects the playing item plus its season and series ids', async () => {
       http.get.mockResolvedValue({

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -69,6 +69,11 @@ export class EmbyAdapterService implements IMediaServerService {
   private embyUserId: string | undefined;
   private deviceId: string;
   private readonly cache: Cache;
+  // Shared in-flight metadata reads, keyed by item id. See getMetadata.
+  private readonly metadataRequests = new Map<
+    string,
+    Promise<MediaItem | undefined>
+  >();
 
   constructor(
     private readonly settings: SettingsDataService,
@@ -421,9 +426,11 @@ export class EmbyAdapterService implements IMediaServerService {
   /**
    * Cached for the same reason as the Jellyfin adapter's: every rule condition
    * re-reads the evaluated item and its parents through here, so an uncached
-   * read costs one wide request per condition per item (#3355). See there for
-   * why only a resolved item is stored, and why a MediaItem's UserData-derived
-   * fields must not feed a watch or deletion decision.
+   * read costs one wide request per condition per item (#3355), and
+   * concurrently evaluated siblings all miss the cold key together so they
+   * share the in-flight read. See there for why only a resolved item is
+   * stored, and why a MediaItem's UserData-derived fields must not feed a
+   * watch or deletion decision.
    */
   async getMetadata(itemId: string): Promise<MediaItem | undefined> {
     if (!this.http) return undefined;
@@ -432,6 +439,21 @@ export class EmbyAdapterService implements IMediaServerService {
     const cached = this.cache.data.get<MediaItem>(cacheKey);
     if (cached !== undefined) return cached;
 
+    const inFlight = this.metadataRequests.get(itemId);
+    if (inFlight !== undefined) return inFlight;
+
+    const pending = this.fetchMetadata(itemId, cacheKey).finally(() => {
+      this.metadataRequests.delete(itemId);
+    });
+    this.metadataRequests.set(itemId, pending);
+
+    return pending;
+  }
+
+  private async fetchMetadata(
+    itemId: string,
+    cacheKey: string,
+  ): Promise<MediaItem | undefined> {
     try {
       // Emby's /Users/{userId}/Items/{itemId} returns user-specific data.
       // When no user context, fall back to /Items/{itemId}.

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -984,6 +984,59 @@ describe('JellyfinAdapterService', () => {
     });
   });
 
+  describe('getMetadata in-flight dedupe (#3356)', () => {
+    beforeEach(async () => {
+      settingsDataService.getSettings.mockResolvedValue(
+        mockSettings as unknown as Awaited<
+          ReturnType<SettingsDataService['getSettings']>
+        >,
+      );
+      await service.initialize();
+    });
+
+    it('shares one request between concurrent reads of the same id', async () => {
+      let resolvePage: (value: unknown) => void = () => {};
+      jellyfinApiMocks.getItems.mockReturnValue(
+        new Promise((resolve) => {
+          resolvePage = resolve;
+        }),
+      );
+
+      // Sibling items are evaluated in parallel and each resolves the same
+      // parent, and they all miss the cold cache key together - so without
+      // this the cache cannot stop the first read fanning out per child.
+      const reads = Promise.all([
+        service.getMetadata('series-1'),
+        service.getMetadata('series-1'),
+        service.getMetadata('series-1'),
+      ]);
+      resolvePage({ data: { Items: [{ Id: 'series-1', Type: 'Series' }] } });
+
+      const results = await reads;
+      expect(results.map((item) => item?.id)).toEqual([
+        'series-1',
+        'series-1',
+        'series-1',
+      ]);
+      expect(jellyfinApiMocks.getItems).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops the in-flight entry once the request settles', async () => {
+      jellyfinApiMocks.getItems.mockResolvedValue({
+        data: { Items: [{ Id: 'series-1', Type: 'Series' }] },
+      });
+
+      await service.getMetadata('series-1');
+      await service.getMetadata('series-1');
+
+      // The map only ever holds an unsettled request - a later read is served
+      // by the cache above it, never by a retained promise. The cache is
+      // mocked to always miss here, so the second read reaching the API is
+      // what proves the entry was released.
+      expect(jellyfinApiMocks.getItems).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('uninitialized state', () => {
     it.each([
       ['getStatus', undefined, () => service.getStatus()],

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -1277,12 +1277,23 @@ describe('JellyfinAdapterService', () => {
             UserData: { Played: userId === 'user-1' },
           },
           { Id: 'movie-1', Type: 'Movie', UserData: { Played: false } },
+          {
+            Id: 'season-1',
+            Type: 'Season',
+            SeriesId: 'show-1',
+            UserData: { Played: false, IsFavorite: userId === 'user-2' },
+          },
+          {
+            Id: 'show-1',
+            Type: 'Series',
+            UserData: { Played: false, IsFavorite: userId === 'user-1' },
+          },
         ],
-        TotalRecordCount: 3,
+        TotalRecordCount: 5,
       },
     });
 
-    it('indexes leaf watch records and the show/season tree from one sweep per user', async () => {
+    it('indexes watch records and the show/season tree from one sweep per user', async () => {
       jellyfinApiMocks.getUsers.mockResolvedValue({
         data: [
           { Id: 'user-1', Name: 'Alice' },
@@ -1301,12 +1312,46 @@ describe('JellyfinAdapterService', () => {
         'ep-1',
         'ep-2',
         'movie-1',
+        'season-1',
+        'show-1',
       ]);
-      // Both parents index the same episodes, each exactly once.
+      // Both parents index the same episodes, each exactly once. A season
+      // carries SeriesId too, so it must not land here as an episode.
       expect(cached!.descendants.get('show-1')).toEqual(['ep-1', 'ep-2']);
       expect(cached!.descendants.get('season-1')).toEqual(['ep-1', 'ep-2']);
       // One request per user, not one per item.
       expect(jellyfinApiMocks.getItems).toHaveBeenCalledTimes(2);
+      expect(jellyfinApiMocks.getItems).toHaveBeenCalledWith(
+        expect.objectContaining({
+          includeItemTypes: ['Movie', 'Episode', 'Series', 'Season'],
+        }),
+      );
+    });
+
+    it('answers container favourites from the snapshot without a per-user fan-out (#3356)', async () => {
+      jellyfinApiMocks.getUsers.mockResolvedValue({
+        data: [
+          { Id: 'user-1', Name: 'Alice' },
+          { Id: 'user-2', Name: 'Bob' },
+        ],
+      });
+      jellyfinApiMocks.getItems.mockImplementation(
+        ({ userId }: { userId: string }) => Promise.resolve(leafPage(userId)),
+      );
+      await service.prefetchWatchHistory();
+      jellyfinApiMocks.getItems.mockClear();
+
+      // A season's IsFavorite is independent of its episodes', so this can
+      // only come from the container's own swept UserData.
+      await expect(service.getItemFavoritedBy('season-1')).resolves.toEqual([
+        'user-2',
+      ]);
+      await expect(service.getItemFavoritedBy('show-1')).resolves.toEqual([
+        'user-1',
+      ]);
+      // A swept container nobody favourited is a confirmed empty list.
+      await expect(service.getItemFavoritedBy('movie-1')).resolves.toEqual([]);
+      expect(jellyfinApiMocks.getItems).not.toHaveBeenCalled();
     });
 
     it('serves getDescendantEpisodeWatchHistory from the snapshot without new requests', async () => {

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -130,6 +130,11 @@ export class JellyfinAdapterService implements IMediaServerService {
   private readonly cache: Cache;
   // Shared in-flight prefetch, so concurrent rule groups sweep once.
   private watchHistoryPrefetch: Promise<void> | undefined;
+  // Shared in-flight metadata reads, keyed by item id. See getMetadata.
+  private readonly metadataRequests = new Map<
+    string,
+    Promise<MediaItem | undefined>
+  >();
 
   constructor(
     private readonly settingsDataService: SettingsDataService,
@@ -884,6 +889,13 @@ export class JellyfinAdapterService implements IMediaServerService {
    * API-layer cache - the whole-cache flush at the start of each rule group
    * bounds staleness to a single group run.
    *
+   * The cache cannot collapse the first read of an id, though: sibling items
+   * are evaluated concurrently (RULE_EVALUATION_CONCURRENCY) and each resolves
+   * the same parent and grandparent, so they all miss together and all fetch.
+   * Concurrent callers therefore share one in-flight request, whose entry is
+   * dropped the moment it settles - every later read goes through the cache
+   * above. No caller mutates what it gets back, so sharing is safe.
+   *
    * A MediaItem carries UserData-derived fields (viewCount, lastViewedAt,
    * userRating), so anything that feeds a watch or deletion decision must read
    * the library page's own item rather than this - see how PlexGetterService
@@ -898,6 +910,21 @@ export class JellyfinAdapterService implements IMediaServerService {
     const cached = this.cache.data.get<MediaItem>(cacheKey);
     if (cached !== undefined) return cached;
 
+    const inFlight = this.metadataRequests.get(itemId);
+    if (inFlight !== undefined) return inFlight;
+
+    const pending = this.fetchMetadata(itemId, cacheKey).finally(() => {
+      this.metadataRequests.delete(itemId);
+    });
+    this.metadataRequests.set(itemId, pending);
+
+    return pending;
+  }
+
+  private async fetchMetadata(
+    itemId: string,
+    cacheKey: string,
+  ): Promise<MediaItem | undefined> {
     try {
       const userId = await this.getUserId();
       const response = await getItemsApi(this.api).getItems({

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -1135,8 +1135,16 @@ export class JellyfinAdapterService implements IMediaServerService {
    * Capture every user's watch state for the whole server in one paginated
    * sweep per user, so rule evaluation reads it from memory instead of asking
    * per item (#3337). Jellyfin has no central history endpoint, but /Items
-   * answers "all leaf items with this user's UserData" in bulk, and that is the
+   * answers "all items with this user's UserData" in bulk, and that is the
    * same payload the per-item path reads.
+   *
+   * Series and seasons are swept alongside movies and episodes: their
+   * favourite state is independent of their episodes' - a favourited season
+   * says nothing about the episodes under it - so it can only come from the
+   * container's own UserData (#3356). Jellyfin answers a container id from
+   * that same UserData live, so a swept container is identical to a live read.
+   * Plex's map stays leaf-only for the opposite reason: there a container id
+   * means a server-side rollup its bulk rows cannot reproduce.
    *
    * Episode rows carry SeriesId and SeasonId, so the show/season -> episode
    * index comes free from the same response. Plex could not do this - its
@@ -1187,7 +1195,7 @@ export class JellyfinAdapterService implements IMediaServerService {
         // Pages are folded in as they arrive rather than collected first, so
         // the transient cost is one page, not one copy of the library.
         const seenThisUser = new Set<string>();
-        await this.sweepUserLeafItems(user.id, abortSignal, (items) => {
+        await this.sweepUserItems(user.id, abortSignal, (items) => {
           for (const item of items) {
             if (!item.Id) continue;
             // Paging is not transactional, so a library changing under the sweep
@@ -1201,11 +1209,15 @@ export class JellyfinAdapterService implements IMediaServerService {
               itemRecords = [];
               watchHistory.set(item.Id, itemRecords);
               // Index each episode under its season and series exactly once.
-              for (const parentId of [item.SeriesId, item.SeasonId]) {
-                if (!parentId) continue;
-                const siblings = descendants.get(parentId);
-                if (siblings) siblings.push(item.Id);
-                else descendants.set(parentId, [item.Id]);
+              // Seasons also carry SeriesId, so this is gated on the type -
+              // indexing one would list seasons as episodes of their series.
+              if (item.Type === BaseItemKind.Episode) {
+                for (const parentId of [item.SeriesId, item.SeasonId]) {
+                  if (!parentId) continue;
+                  const siblings = descendants.get(parentId);
+                  if (siblings) siblings.push(item.Id);
+                  else descendants.set(parentId, [item.Id]);
+                }
               }
             }
 
@@ -1296,11 +1308,11 @@ export class JellyfinAdapterService implements IMediaServerService {
   }
 
   /**
-   * Hands each page of one user's movies and episodes to `onPage` as it
-   * arrives. Throws on a short or uncountable page so a truncated sweep is
-   * never mistaken for a small library.
+   * Hands each page of one user's movies, episodes, series and seasons to
+   * `onPage` as it arrives. Throws on a short or uncountable page so a
+   * truncated sweep is never mistaken for a small library.
    */
-  private async sweepUserLeafItems(
+  private async sweepUserItems(
     userId: string,
     abortSignal: AbortSignal | undefined,
     onPage: (items: BaseItemDto[]) => void,
@@ -1318,7 +1330,15 @@ export class JellyfinAdapterService implements IMediaServerService {
         ...JELLYFIN_LIBRARY_QUERY_DEFAULTS,
         userId,
         recursive: true,
-        includeItemTypes: [BaseItemKind.Movie, BaseItemKind.Episode],
+        // Series and Season carry their own UserData (IsFavorite, Played), so
+        // sweeping them costs a couple of extra pages per user and spares
+        // container properties a per-user fan-out each (#3356).
+        includeItemTypes: [
+          BaseItemKind.Movie,
+          BaseItemKind.Episode,
+          BaseItemKind.Series,
+          BaseItemKind.Season,
+        ],
         // Ignore unaired placeholders (mirrors #2624).
         excludeLocationTypes: [LocationType.Virtual],
         enableUserData: true,
@@ -1386,8 +1406,8 @@ export class JellyfinAdapterService implements IMediaServerService {
 
     if (useSnapshot) {
       // Only a present key is authoritative - an absent one means the item was
-      // not swept (a show/season id, a new item), so fall through to a live
-      // read rather than answering "never watched".
+      // not swept (an item added since), so fall through to a live read rather
+      // than answering "never watched".
       const records = this.getWatchSnapshot(
         playedCompletionThreshold,
       )?.watchHistory.get(itemId);
@@ -1583,8 +1603,8 @@ export class JellyfinAdapterService implements IMediaServerService {
     if (!this.api) return [];
 
     try {
-      // The prefetch indexes every leaf item, so a swept id answers from
-      // memory; an unswept one (a show/season, or an item added since) falls
+      // The prefetch indexes movies, episodes, series and seasons, so a swept
+      // id answers from memory; an unswept one (an item added since) falls
       // through to the per-user read below.
       const snapshot = this.getWatchSnapshot(
         await this.getPlayedCompletionThreshold(),

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin.types.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin.types.ts
@@ -16,17 +16,17 @@ import type {
  */
 export interface JellyfinWatchSnapshot {
   /**
-   * Leaf item id (movie or episode) -> completed-watch records. The sweep is
-   * unfiltered, so an entry exists for every item it saw: a present-but-empty
-   * array is a confirmed "never watched", while an absent key means "not
-   * swept" and must fall back to a live read.
+   * Item id (movie, episode, series or season) -> completed-watch records. The
+   * sweep is unfiltered, so an entry exists for every item it saw: a
+   * present-but-empty array is a confirmed "never watched", while an absent key
+   * means "not swept" and must fall back to a live read.
    */
   watchHistory: Map<string, WatchRecord[]>;
   /** Series and season id -> the episode ids beneath it, from the same sweep. */
   descendants: Map<string, string[]>;
-  /** Leaf item id -> ids of the users who favourited it. */
+  /** Item id -> ids of the users who favourited it. */
   favoritedBy: Map<string, string[]>;
-  /** Leaf item id -> PlayCount summed across users (includes partial plays). */
+  /** Item id -> PlayCount summed across users (includes partial plays). */
   playCount: Map<string, number>;
   /**
    * PlayedPercentage threshold the records were built with. isCompletedWatch


### PR DESCRIPTION
Fixes #3356.

The run-scoped sweep collected movies and episodes only, so a show or season id
could never satisfy the snapshot gate in `getItemFavoritedBy` and always fell
back to one request per user. `sw_favoritedBy` on a show or season cost U
requests per item, and `sw_favoritedBy_including_parent` cost 2U because it also
checks the parent and grandparent. This cannot be derived from the episode
index: `IsFavorite` on a season is independent of `IsFavorite` on its episodes.

Series and Season now ride the same sweep, so the fix is one `includeItemTypes`
array rather than a second query plus a widened guard. Jellyfin returns
container `UserData` in a bulk listing byte-identical to the per-item read the
live path uses (verified on 10.11.11), so a swept container answers exactly what
a live read would and the existing `watchHistory.has()` gate starts matching with
no change. The same gate moves `getTotalPlayCount` for containers onto the snapshot
too; the value is identical either way, since the sweep records the container's own
`PlayCount`. Containers carry no `PlayedPercentage`, `LastPlayedDate` or
`PlayCount`, so their watch records and play counts are unchanged too.

Plex keeps its leaf-only map for the opposite reason: there a container id means
a server-side rollup its bulk history rows cannot reproduce. On Jellyfin there is
no rollup, so the leaf boundary carried no meaning. A code comment records this.

Seasons also carry `SeriesId`, so the show/season to episode index is now gated on
the row being an Episode. Without that gate a season is indexed as an episode of
its series and `sw_viewedEpisodes` over-counts, which a real rule run confirmed.

Measured against a real Jellyfin with 5 users and one season rule group: 35 to 25
requests, per-user fan-out 10 to 0. Saved is 2 x U per season item. The sweep
itself costs the same, since containers fit in the pages it already fetches.

Two related points from the issue, both deliberately left alone:

- The all-or-nothing user coverage guard stays. A disabled account does not break
  the sweep (verified: it is still listed by `/Users` and both the bulk and
  per-item reads return 200 with full data), the Jellyfin client already retries
  transient failures three times with exponential backoff, and Plex discards an
  incomplete sweep the same way. Keeping a partial snapshot would drop a user's
  favourites and make a protected item deletable.
- Emby is untouched. It does return `IsFavorite` in bulk, but it has no snapshot
  infrastructure at all, so a favourites sweep there is a separate change.
---

**Second commit: share the in-flight metadata read between sibling items.**

Sibling items are evaluated concurrently (`RULE_EVALUATION_CONCURRENCY = 8`) and each
resolves the same parent and grandparent through `getMetadata`, which has no cache, so
an episode-level rule reads the same season and the same series once per episode.
Concurrent reads of one id now share a single request.

This sits in front of the per-item cache from #3363, which cannot help here: the
concurrent siblings all miss the cold key together, so they all fetch. The in-flight
entry is dropped the moment the request settles - every later read is served by the
cache above it, never by a retained promise. No caller mutates the item it gets back,
so sharing the reference is safe. Same shape on Emby.

Measured on a real Jellyfin, one rule group over 9 seasons across 3 series: 18 per-item
reads to 13, duplicate reads 6 to 1. This is the residual of the cache stampede reported
on the issue; the fan-out half of it is removed by the first commit.


