### PR TITLE
perf(media-server): cache per-item metadata reads on Jellyfin and Emby (#3355)

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -126,6 +126,44 @@ describe('EmbyAdapterService', () => {
     });
   });
 
+  describe('getChildrenMetadata caching (#3355)', () => {
+    it('keys seasons and episodes of one parent separately', async () => {
+      http.get.mockResolvedValue({ data: { Items: [{ Id: 'child-1' }] } });
+
+      await service.getChildrenMetadata('show-1', 'season');
+      await service.getChildrenMetadata('show-1', 'episode');
+
+      expect(embyCacheMocks.data.set).toHaveBeenCalledWith(
+        'emby:children:show-1:season',
+        [expect.objectContaining({ id: 'child-1' })],
+        EMBY_CACHE_TTL.METADATA,
+      );
+      expect(embyCacheMocks.data.set).toHaveBeenCalledWith(
+        'emby:children:show-1:episode',
+        [expect.objectContaining({ id: 'child-1' })],
+        EMBY_CACHE_TTL.METADATA,
+      );
+    });
+
+    it('serves a cached list without touching the API', async () => {
+      embyCacheMocks.data.get.mockReturnValueOnce([{ id: 'ep-1' }]);
+
+      await expect(
+        service.getChildrenMetadata('season-1', 'episode'),
+      ).resolves.toEqual([{ id: 'ep-1' }]);
+      expect(http.get).not.toHaveBeenCalled();
+    });
+
+    it('does not cache a failed read', async () => {
+      http.get.mockRejectedValue(new Error('boom'));
+
+      await expect(
+        service.getChildrenMetadata('season-1', 'episode'),
+      ).resolves.toEqual([]);
+      expect(embyCacheMocks.data.set).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getActiveSessions', () => {
     it('collects the playing item plus its season and series ids', async () => {
       http.get.mockResolvedValue({

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -93,6 +93,39 @@ describe('EmbyAdapterService', () => {
     setHttp();
   });
 
+  describe('getMetadata caching (#3355)', () => {
+    it('caches a resolved item so repeat conditions do not re-read it', async () => {
+      http.get.mockResolvedValue({
+        data: { Id: 'series-1', Type: 'Series', Name: 'A Show' },
+      });
+
+      const item = await service.getMetadata('series-1');
+
+      expect(item?.id).toBe('series-1');
+      expect(embyCacheMocks.data.set).toHaveBeenCalledWith(
+        'emby:metadata:series-1',
+        expect.objectContaining({ id: 'series-1' }),
+        EMBY_CACHE_TTL.METADATA,
+      );
+    });
+
+    it('serves a cached item without touching the API', async () => {
+      embyCacheMocks.data.get.mockReturnValueOnce({ id: 'series-1' });
+
+      await expect(service.getMetadata('series-1')).resolves.toEqual({
+        id: 'series-1',
+      });
+      expect(http.get).not.toHaveBeenCalled();
+    });
+
+    it('does not cache a failed read', async () => {
+      http.get.mockRejectedValue(new Error('boom'));
+
+      await expect(service.getMetadata('item-1')).resolves.toBeUndefined();
+      expect(embyCacheMocks.data.set).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getActiveSessions', () => {
     it('collects the playing item plus its season and series ids', async () => {
       http.get.mockResolvedValue({

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -455,11 +455,20 @@ export class EmbyAdapterService implements IMediaServerService {
     }
   }
 
+  /**
+   * Cached like the Jellyfin adapter's (#3355) - see there for why only a
+   * completed read is stored.
+   */
   async getChildrenMetadata(
     parentId: string,
     childType?: MediaItemType,
   ): Promise<MediaItem[]> {
     if (!this.http) return [];
+
+    const cacheKey = `${EMBY_CACHE_KEYS.CHILDREN}:${parentId}:${childType ?? 'any'}`;
+    const cached = this.cache.data.get<MediaItem[]>(cacheKey);
+    if (cached !== undefined) return cached;
+
     try {
       // Seasons of a series live under /Shows/{seriesId}/Seasons, not under
       // /Items?ParentId= (ParentId of a season points to the library folder,
@@ -475,7 +484,10 @@ export class EmbyAdapterService implements IMediaServerService {
             },
           },
         );
-        return (data.Items ?? []).map(EmbyMapper.toMediaItem);
+        return this.cacheChildren(
+          cacheKey,
+          (data.Items ?? []).map(EmbyMapper.toMediaItem),
+        );
       }
 
       const { data } = await this.http.get<EmbyItemsQueryResponse>('/Items', {
@@ -491,13 +503,21 @@ export class EmbyAdapterService implements IMediaServerService {
           Limit: EMBY_BATCH_SIZE.MAX_PAGE_SIZE,
         },
       });
-      return (data.Items ?? []).map(EmbyMapper.toMediaItem);
+      return this.cacheChildren(
+        cacheKey,
+        (data.Items ?? []).map(EmbyMapper.toMediaItem),
+      );
     } catch (error) {
       this.logger.debug(
         `Emby getChildrenMetadata(${parentId}) failed: ${formatConnectionFailureMessage(error, 'Connection failed')}`,
       );
       return [];
     }
+  }
+
+  private cacheChildren(cacheKey: string, children: MediaItem[]): MediaItem[] {
+    this.cache.data.set(cacheKey, children, EMBY_CACHE_TTL.METADATA);
+    return children;
   }
 
   /**

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -418,8 +418,20 @@ export class EmbyAdapterService implements IMediaServerService {
   // Metadata
   // ============================================================================
 
+  /**
+   * Cached for the same reason as the Jellyfin adapter's: every rule condition
+   * re-reads the evaluated item and its parents through here, so an uncached
+   * read costs one wide request per condition per item (#3355). See there for
+   * why only a resolved item is stored, and why a MediaItem's UserData-derived
+   * fields must not feed a watch or deletion decision.
+   */
   async getMetadata(itemId: string): Promise<MediaItem | undefined> {
     if (!this.http) return undefined;
+
+    const cacheKey = `${EMBY_CACHE_KEYS.METADATA}:${itemId}`;
+    const cached = this.cache.data.get<MediaItem>(cacheKey);
+    if (cached !== undefined) return cached;
+
     try {
       // Emby's /Users/{userId}/Items/{itemId} returns user-specific data.
       // When no user context, fall back to /Items/{itemId}.
@@ -432,7 +444,9 @@ export class EmbyAdapterService implements IMediaServerService {
             'ProviderIds,DateCreated,Overview,Tags,MediaSources,Genres,People',
         },
       });
-      return EmbyMapper.toMediaItem(data);
+      const mediaItem = EmbyMapper.toMediaItem(data);
+      this.cache.data.set(cacheKey, mediaItem, EMBY_CACHE_TTL.METADATA);
+      return mediaItem;
     } catch (error) {
       this.logger.debug(
         `Emby getMetadata(${itemId}) failed: ${formatConnectionFailureMessage(error, 'Connection failed')}`,
@@ -1397,9 +1411,9 @@ export class EmbyAdapterService implements IMediaServerService {
   // ============================================================================
 
   resetMetadataCache(_itemId?: string): void {
-    // The Emby cache only stores server-wide aggregates (users/libraries/status/
-    // collections), never per-item watch entries (getWatchHistory hits the API
-    // fresh), so a full flush is the simplest correct reset.
+    // Besides the server-wide aggregates (users/libraries/status/collections)
+    // the only per-item entries are getMetadata's; watch reads still hit the
+    // API fresh. A full flush is the simplest correct reset.
     void _itemId;
     this.cache.flush();
   }

--- a/apps/server/src/modules/api/media-server/emby/emby.constants.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby.constants.ts
@@ -22,6 +22,7 @@ export const EMBY_BATCH_SIZE = {
 
 export const EMBY_CACHE_KEYS = {
   METADATA: 'emby:metadata',
+  CHILDREN: 'emby:children',
   USERS: 'emby:users',
   LIBRARIES: 'emby:libraries',
   STATUS: 'emby:status',

--- a/apps/server/src/modules/api/media-server/emby/emby.constants.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby.constants.ts
@@ -6,6 +6,7 @@ export const EMBY_CACHE_TTL = {
   WATCH_HISTORY: 300, // 5 min
   USER_DATA: 300, // 5 min
   PLAYED_THRESHOLD: 300, // 5 min
+  METADATA: 300, // 5 min
   USERS: 1800, // 30 min
   LIBRARIES: 1800, // 30 min
   STATUS: 60, // 1 min
@@ -20,6 +21,7 @@ export const EMBY_BATCH_SIZE = {
 } as const;
 
 export const EMBY_CACHE_KEYS = {
+  METADATA: 'emby:metadata',
   USERS: 'emby:users',
   LIBRARIES: 'emby:libraries',
   STATUS: 'emby:status',

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -30,6 +30,7 @@ const jellyfinApiMocks = {
   getItemImage: jest.fn(),
   setItemImage: jest.fn(),
   getSessions: jest.fn(),
+  getSeasons: jest.fn(),
 };
 
 const collectionApiMocks = {
@@ -137,6 +138,9 @@ jest.mock('@jellyfin/sdk/lib/utils/api/index.js', () => ({
     getItems: (...args: unknown[]) => jellyfinApiMocks.getItems(...args),
     getItemUserData: (...args: unknown[]) =>
       jellyfinApiMocks.getItemUserData(...args),
+  })),
+  getTvShowsApi: jest.fn().mockImplementation(() => ({
+    getSeasons: (...args: unknown[]) => jellyfinApiMocks.getSeasons(...args),
   })),
   getLibraryApi: jest.fn().mockImplementation(() => ({
     getMediaFolders: (...args: unknown[]) =>
@@ -898,6 +902,84 @@ describe('JellyfinAdapterService', () => {
       );
       expect(jellyfinCacheMocks.data.del).not.toHaveBeenCalledWith(
         'jellyfin:metadata:other',
+      );
+    });
+  });
+
+  describe('getChildrenMetadata caching (#3355)', () => {
+    beforeEach(async () => {
+      settingsDataService.getSettings.mockResolvedValue(
+        mockSettings as unknown as Awaited<
+          ReturnType<SettingsDataService['getSettings']>
+        >,
+      );
+      await service.initialize();
+    });
+
+    it('caches episodes and seasons under separate keys', async () => {
+      jellyfinApiMocks.getItems.mockResolvedValue({
+        data: { Items: [{ Id: 'ep-1', Type: 'Episode' }] },
+      });
+      jellyfinApiMocks.getSeasons.mockResolvedValue({
+        data: { Items: [{ Id: 'season-1', Type: 'Season' }] },
+      });
+
+      await service.getChildrenMetadata('show-1', 'episode');
+      await service.getChildrenMetadata('show-1', 'season');
+
+      // Same parent, different child type - one key each, or the season walk
+      // would answer with episodes.
+      expect(jellyfinCacheMocks.data.set).toHaveBeenCalledWith(
+        'jellyfin:children:show-1:episode',
+        [expect.objectContaining({ id: 'ep-1' })],
+        JELLYFIN_CACHE_TTL.METADATA,
+      );
+      expect(jellyfinCacheMocks.data.set).toHaveBeenCalledWith(
+        'jellyfin:children:show-1:season',
+        [expect.objectContaining({ id: 'season-1' })],
+        JELLYFIN_CACHE_TTL.METADATA,
+      );
+    });
+
+    it('serves a cached list without touching the API', async () => {
+      jellyfinCacheMocks.data.get.mockReturnValueOnce([{ id: 'ep-1' }]);
+
+      await expect(
+        service.getChildrenMetadata('season-1', 'episode'),
+      ).resolves.toEqual([{ id: 'ep-1' }]);
+      expect(jellyfinApiMocks.getItems).not.toHaveBeenCalled();
+    });
+
+    it('does not cache a failed read', async () => {
+      // The catch answers [], which is indistinguishable from "no episodes" -
+      // persisting it would read as an empty show for the whole TTL.
+      jellyfinApiMocks.getItems.mockRejectedValue(new Error('boom'));
+
+      await expect(
+        service.getChildrenMetadata('season-1', 'episode'),
+      ).resolves.toEqual([]);
+      expect(jellyfinCacheMocks.data.set).not.toHaveBeenCalled();
+    });
+
+    it('drops the whole children namespace on resetMetadataCache', async () => {
+      // A show's episode lists hang off its season ids, not the id passed in,
+      // so scoping the delete to that id would leave them stale (#3274).
+      jellyfinCacheMocks.data.keys.mockReturnValue([
+        'jellyfin:children:show-1:season',
+        'jellyfin:children:season-9:episode',
+        'jellyfin:users',
+      ]);
+
+      service.resetMetadataCache('show-1');
+
+      expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
+        'jellyfin:children:show-1:season',
+      );
+      expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
+        'jellyfin:children:season-9:episode',
+      );
+      expect(jellyfinCacheMocks.data.del).not.toHaveBeenCalledWith(
+        'jellyfin:users',
       );
     });
   });

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -836,6 +836,72 @@ describe('JellyfinAdapterService', () => {
     });
   });
 
+  describe('getMetadata caching (#3355)', () => {
+    beforeEach(async () => {
+      settingsDataService.getSettings.mockResolvedValue(
+        mockSettings as unknown as Awaited<
+          ReturnType<SettingsDataService['getSettings']>
+        >,
+      );
+      await service.initialize();
+      jellyfinApiMocks.getItems.mockResolvedValue({
+        data: { Items: [{ Id: 'series-1', Type: 'Series', Name: 'A Show' }] },
+      });
+    });
+
+    it('caches a resolved item so repeat conditions do not re-read it', async () => {
+      const item = await service.getMetadata('series-1');
+
+      expect(item?.id).toBe('series-1');
+      expect(jellyfinCacheMocks.data.set).toHaveBeenCalledWith(
+        'jellyfin:metadata:series-1',
+        expect.objectContaining({ id: 'series-1' }),
+        JELLYFIN_CACHE_TTL.METADATA,
+      );
+    });
+
+    it('serves a cached item without touching the API', async () => {
+      jellyfinCacheMocks.data.get.mockReturnValueOnce({ id: 'series-1' });
+
+      await expect(service.getMetadata('series-1')).resolves.toEqual({
+        id: 'series-1',
+      });
+      expect(jellyfinApiMocks.getItems).not.toHaveBeenCalled();
+    });
+
+    it('does not cache a missing item', async () => {
+      jellyfinApiMocks.getItems.mockResolvedValue({ data: { Items: [] } });
+
+      await expect(service.getMetadata('gone')).resolves.toBeUndefined();
+      expect(jellyfinCacheMocks.data.set).not.toHaveBeenCalled();
+    });
+
+    it('does not cache a failed read', async () => {
+      // undefined means both "missing" and "could not read", so persisting it
+      // would turn a blip into "item is gone" for the whole TTL (#3307).
+      jellyfinApiMocks.getItems.mockRejectedValue(new Error('boom'));
+
+      await expect(service.getMetadata('item-1')).resolves.toBeUndefined();
+      expect(jellyfinCacheMocks.data.set).not.toHaveBeenCalled();
+    });
+
+    it('drops the item entry on resetMetadataCache', async () => {
+      jellyfinCacheMocks.data.keys.mockReturnValue([
+        'jellyfin:metadata:item-1',
+        'jellyfin:metadata:other',
+      ]);
+
+      service.resetMetadataCache('item-1');
+
+      expect(jellyfinCacheMocks.data.del).toHaveBeenCalledWith(
+        'jellyfin:metadata:item-1',
+      );
+      expect(jellyfinCacheMocks.data.del).not.toHaveBeenCalledWith(
+        'jellyfin:metadata:other',
+      );
+    });
+  });
+
   describe('uninitialized state', () => {
     it.each([
       ['getStatus', undefined, () => service.getStatus()],

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -877,8 +877,26 @@ export class JellyfinAdapterService implements IMediaServerService {
     }
   }
 
+  /**
+   * Every rule condition re-reads the evaluated item (and its parents) through
+   * here, so an uncached read costs one wide request per condition per item
+   * (#3355). Cached like the Plex path, which has always served these from its
+   * API-layer cache - the whole-cache flush at the start of each rule group
+   * bounds staleness to a single group run.
+   *
+   * A MediaItem carries UserData-derived fields (viewCount, lastViewedAt,
+   * userRating), so anything that feeds a watch or deletion decision must read
+   * the library page's own item rather than this - see how PlexGetterService
+   * passes `libItem.viewCount` into getWatchState (#3352), not `metadata`.
+   */
   async getMetadata(itemId: string): Promise<MediaItem | undefined> {
     if (!this.api) return undefined;
+
+    const cacheKey = `${JELLYFIN_CACHE_KEYS.METADATA}:${itemId}`;
+    // Read once rather than has()-then-get(): an entry expiring between the two
+    // would return undefined, which callers read as "item is gone".
+    const cached = this.cache.data.get<MediaItem>(cacheKey);
+    if (cached !== undefined) return cached;
 
     try {
       const userId = await this.getUserId();
@@ -899,7 +917,14 @@ export class JellyfinAdapterService implements IMediaServerService {
       });
 
       const item = response.data.Items?.[0];
-      return item ? JellyfinMapper.toMediaItem(item) : undefined;
+      if (!item) return undefined;
+
+      // Only a resolved item is cached. This method answers undefined for both
+      // a missing item and a failed read, so persisting that would turn a
+      // transient blip into "item is gone" for the whole TTL (#3307).
+      const mediaItem = JellyfinMapper.toMediaItem(item);
+      this.cache.data.set(cacheKey, mediaItem, JELLYFIN_CACHE_TTL.METADATA);
+      return mediaItem;
     } catch (error) {
       this.logger.warn(`Failed to get metadata for ${itemId}`);
       this.logger.debug(error);
@@ -2392,7 +2417,8 @@ export class JellyfinAdapterService implements IMediaServerService {
           (key) =>
             key.startsWith(`${JELLYFIN_CACHE_KEYS.WATCH_HISTORY}:`) ||
             key === `${JELLYFIN_CACHE_KEYS.FAVORITED_BY}:${itemId}` ||
-            key === `${JELLYFIN_CACHE_KEYS.TOTAL_PLAY_COUNT}:${itemId}`,
+            key === `${JELLYFIN_CACHE_KEYS.TOTAL_PLAY_COUNT}:${itemId}` ||
+            key === `${JELLYFIN_CACHE_KEYS.METADATA}:${itemId}`,
         )
         .forEach((key) => this.cache.data.del(key));
     } else {

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -887,7 +887,7 @@ export class JellyfinAdapterService implements IMediaServerService {
    * A MediaItem carries UserData-derived fields (viewCount, lastViewedAt,
    * userRating), so anything that feeds a watch or deletion decision must read
    * the library page's own item rather than this - see how PlexGetterService
-   * passes `libItem.viewCount` into getWatchState (#3352), not `metadata`.
+   * passes `libItem.viewCount` into getWatchState (#2570), not `metadata`.
    */
   async getMetadata(itemId: string): Promise<MediaItem | undefined> {
     if (!this.api) return undefined;

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -962,11 +962,22 @@ export class JellyfinAdapterService implements IMediaServerService {
     }
   }
 
+  /**
+   * Cached for the same reason as getMetadata (#3355): the show and season
+   * getters walk the tree on every condition, so an uncached read costs
+   * 1 + seasons requests per condition per item. Plex has always served these
+   * from its API-layer cache. Only a completed read is stored - the catch below
+   * answers [] for a failed one, and caching that would read as "no episodes".
+   */
   async getChildrenMetadata(
     parentId: string,
     childType?: MediaItemType,
   ): Promise<MediaItem[]> {
     if (!this.api) return [];
+
+    const cacheKey = `${JELLYFIN_CACHE_KEYS.CHILDREN}:${parentId}:${childType ?? 'any'}`;
+    const cached = this.cache.data.get<MediaItem[]>(cacheKey);
+    if (cached !== undefined) return cached;
 
     try {
       const userId = await this.getUserId();
@@ -987,7 +998,10 @@ export class JellyfinAdapterService implements IMediaServerService {
           enableUserData: true,
         });
 
-        return (response.data.Items || []).map(JellyfinMapper.toMediaItem);
+        return this.cacheChildren(
+          cacheKey,
+          (response.data.Items || []).map(JellyfinMapper.toMediaItem),
+        );
       }
 
       // For episodes and other types, parentId works correctly
@@ -1014,12 +1028,20 @@ export class JellyfinAdapterService implements IMediaServerService {
           childType === 'episode' ? [LocationType.Virtual] : undefined,
       });
 
-      return (response.data.Items || []).map(JellyfinMapper.toMediaItem);
+      return this.cacheChildren(
+        cacheKey,
+        (response.data.Items || []).map(JellyfinMapper.toMediaItem),
+      );
     } catch (error) {
       this.logger.error(`Failed to get children for ${parentId}`);
       this.logger.debug(error);
       return [];
     }
+  }
+
+  private cacheChildren(cacheKey: string, children: MediaItem[]): MediaItem[] {
+    this.cache.data.set(cacheKey, children, JELLYFIN_CACHE_TTL.METADATA);
+    return children;
   }
 
   async getRecentlyAdded(
@@ -2408,14 +2430,17 @@ export class JellyfinAdapterService implements IMediaServerService {
       // scoping the watch invalidation to `:${itemId}` left them stale: a season
       // stayed "not watched by everyone" for hours after a manual mark in
       // Jellyfin (#3274). Clear the whole watch-history namespace instead (cheap,
-      // and flushed each run anyway). The item's favourite/play-count entries and
-      // the server-wide aggregate caches (users/libraries/status/collections) are
-      // invalidated exactly as before.
+      // and flushed each run anyway). Children entries are keyed the same way -
+      // a show's episode lists hang off its season ids, not the id passed here -
+      // so that namespace goes wholesale too. The item's favourite/play-count
+      // entries and the server-wide aggregate caches (users/libraries/status/
+      // collections) are invalidated exactly as before.
       this.cache.data
         .keys()
         .filter(
           (key) =>
             key.startsWith(`${JELLYFIN_CACHE_KEYS.WATCH_HISTORY}:`) ||
+            key.startsWith(`${JELLYFIN_CACHE_KEYS.CHILDREN}:`) ||
             key === `${JELLYFIN_CACHE_KEYS.FAVORITED_BY}:${itemId}` ||
             key === `${JELLYFIN_CACHE_KEYS.TOTAL_PLAY_COUNT}:${itemId}` ||
             key === `${JELLYFIN_CACHE_KEYS.METADATA}:${itemId}`,

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin.constants.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin.constants.ts
@@ -5,6 +5,7 @@
 export const JELLYFIN_CACHE_TTL = {
   WATCH_HISTORY: 300, // 5 min
   USER_DATA: 300, // 5 min
+  METADATA: 300, // 5 min
   PLAYED_THRESHOLD: 300, // 5 min
   USERS: 1800, // 30 min
   LIBRARIES: 1800, // 30 min
@@ -62,6 +63,7 @@ export const JELLYFIN_WATCH_SNAPSHOT_MAX_RECORDS = 500_000;
 
 export const JELLYFIN_CACHE_KEYS = {
   WATCH_HISTORY: 'jellyfin:watch',
+  METADATA: 'jellyfin:metadata',
   FAVORITED_BY: 'jellyfin:favorited-by',
   TOTAL_PLAY_COUNT: 'jellyfin:total-play-count',
   PLAYED_THRESHOLD: 'jellyfin:played-threshold',

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin.constants.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin.constants.ts
@@ -64,6 +64,7 @@ export const JELLYFIN_WATCH_SNAPSHOT_MAX_RECORDS = 500_000;
 export const JELLYFIN_CACHE_KEYS = {
   WATCH_HISTORY: 'jellyfin:watch',
   METADATA: 'jellyfin:metadata',
+  CHILDREN: 'jellyfin:children',
   FAVORITED_BY: 'jellyfin:favorited-by',
   TOTAL_PLAY_COUNT: 'jellyfin:total-play-count',
   PLAYED_THRESHOLD: 'jellyfin:played-threshold',

--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -416,7 +416,10 @@ export interface IMediaServerService {
 
   /**
    * Reset metadata cache.
-   * @param itemId - If provided, only reset cache for this item. Otherwise reset all.
+   * @param itemId - If provided, invalidate at least this item's cached
+   * metadata; implementations may drop more (Jellyfin also clears its
+   * children and watch namespaces, Emby flushes everything). Otherwise
+   * reset all.
    */
   resetMetadataCache(itemId?: string): void;
 

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -1446,3 +1446,49 @@ describe('PlexApiService overlay helpers', () => {
     await expect(service.getOverlayLibrarySections()).resolves.toEqual([]);
   });
 });
+
+describe('PlexApiService.resetMetadataCache', () => {
+  let service: PlexApiService;
+  let cache: { set: (k: string, v: unknown) => void; keys: () => string[] };
+
+  const key = (uri: string) => JSON.stringify({ uri });
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(PlexApiService).compile();
+    service = unit;
+
+    unitRef.get(MaintainerrLoggerFactory).createLogger.mockReturnValue({
+      setContext: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as any);
+
+    const cacheManager = (await import('../lib/cache')).default;
+    cache = cacheManager.getCache('plexguid').data as unknown as typeof cache;
+    (cache as unknown as { flushAll: () => void }).flushAll();
+  });
+
+  // The rule getter always passes includeExternalMedia, so its entries land
+  // under a query-string uri. Deleting only the bare uri invalidated nothing on
+  // the one path that caches, and rules testing kept serving stale metadata.
+  it('drops every option variant for the item, and nothing else', () => {
+    const withOptions = key(
+      '/library/metadata/12?includeExternalMedia=1&asyncAugmentMetadata=1',
+    );
+    cache.set(key('/library/metadata/12'), 'bare');
+    cache.set(withOptions, 'from the rule getter');
+    cache.set(key('/library/metadata/12/children'), 'children');
+    cache.set(key('/library/metadata/123'), 'a different item');
+
+    service.resetMetadataCache('12');
+
+    expect(cache.keys().sort()).toEqual(
+      [
+        key('/library/metadata/12/children'),
+        key('/library/metadata/123'),
+      ].sort(),
+    );
+  });
+});

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -1491,4 +1491,28 @@ describe('PlexApiService.resetMetadataCache', () => {
       ].sort(),
     );
   });
+
+  // Jellyfin and Emby both drop watch state on reset; Plex did not, so a
+  // just-watched item kept testing stale. History entries are keyed by leaf
+  // ratingKey - not the id passed in - so the whole namespace goes.
+  it('drops watch history entries and the bulk snapshot too', async () => {
+    const cacheManager = (await import('../lib/cache')).default;
+    const watchCache = cacheManager.getCache('plexwatchhistory').data;
+
+    cache.set(
+      key('/status/sessions/history/all?sort=viewedAt:desc&metadataItemID=99'),
+      'another item',
+    );
+    cache.set(
+      key('/status/sessions/history/all?sort=viewedAt:desc'),
+      'bulk page',
+    );
+    cache.set(key('/library/sections'), 'sections listing');
+    watchCache.set('watch-history-bulk', 'snapshot');
+
+    service.resetMetadataCache('12');
+
+    expect(cache.keys()).toEqual([key('/library/sections')]);
+    expect(watchCache.keys()).toEqual([]);
+  });
 });

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -632,11 +632,30 @@ export class PlexApiService {
   }
 
   public resetMetadataCache(mediaId: string) {
-    cacheManager.getCache('plexguid').data.del(
-      JSON.stringify({
-        uri: `/library/metadata/${mediaId}`,
-      }),
-    );
+    // getMetadata appends the caller's options to the uri, and the rule getter
+    // always passes includeExternalMedia - so its entries are cached under
+    // `?includeExternalMedia=1&asyncAugmentMetadata=1`, which the bare-uri
+    // delete this used to do never matched. Rules testing flushed nothing on
+    // the one path that caches, and served pre-change metadata for the TTL.
+    // Drop every option variant for this id instead.
+    const cache = cacheManager.getCache('plexguid').data;
+    const uri = `/library/metadata/${mediaId}`;
+
+    for (const key of cache.keys()) {
+      // Keys are the serialized request options, so read the uri back out
+      // rather than matching on the raw key - options other than the uri end up
+      // in there too. The `?` boundary keeps id 12 from matching id 123.
+      let cachedUri: string | undefined;
+      try {
+        cachedUri = (JSON.parse(key) as { uri?: string }).uri;
+      } catch {
+        continue;
+      }
+
+      if (cachedUri === uri || cachedUri?.startsWith(`${uri}?`)) {
+        cache.del(key);
+      }
+    }
   }
 
   public async getUserDataFromPlexTv(): Promise<PlexTvUser[] | undefined> {

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -640,6 +640,11 @@ export class PlexApiService {
     // Drop every option variant for this id instead.
     const cache = cacheManager.getCache('plexguid').data;
     const uri = `/library/metadata/${mediaId}`;
+    // Watch state goes too, like the Jellyfin and Emby resets already do.
+    // History entries are keyed by leaf ratingKey - a show or season test
+    // reads its episodes' entries, not the id passed here - so the whole
+    // history namespace is dropped rather than one id's key.
+    const historyUri = '/status/sessions/history/all';
 
     for (const key of cache.keys()) {
       // Keys are the serialized request options, so read the uri back out
@@ -652,10 +657,19 @@ export class PlexApiService {
         continue;
       }
 
-      if (cachedUri === uri || cachedUri?.startsWith(`${uri}?`)) {
+      if (
+        cachedUri === uri ||
+        cachedUri?.startsWith(`${uri}?`) ||
+        cachedUri?.startsWith(historyUri)
+      ) {
         cache.del(key);
       }
     }
+
+    // The prefetched snapshot is a point-in-time copy of every item's watch
+    // state, so a just-watched change would stay invisible to a rules test
+    // for up to its TTL.
+    cacheManager.getCache('plexwatchhistory').data.flushAll();
   }
 
   public async getUserDataFromPlexTv(): Promise<PlexTvUser[] | undefined> {


### PR DESCRIPTION
Fixes #3355.

Both media-server getters open every property read with `getMetadata(libItem.id)`,
and that method had no cache, so a rule group cost one wide eight-field request per
condition per item. Measured against a real Jellyfin: **6 conditions over 9 seasons
made 98 metadata requests**, byte-identical apart from the id. A rule whose second
value is also a media-server property doubles it, because `getSecondValue` re-enters
the getter.

Plex has the same getter shape and never pays for it, because `plexApi.query` caches
by default. So this closes a gap rather than adding a cache: the same store, the same
5 minute TTL, the same key-count bound (#3284), and the same whole-cache flush at the
start of every rule group that already bounds every other Jellyfin and Emby entry.
The same run now makes **12 requests, one per item**; total requests 121 to 32.

Deliberate details:

- **Only a resolved item is stored.** `getMetadata` answers `undefined` for both a
  missing item and a failed read, so caching that would turn a transient blip into
  "item is gone" for the whole TTL (#3307).
- **The Jellyfin per-item reset drops the entry.** Verified end to end: change a tag
  in Jellyfin, hit Test Media, the new value shows immediately. With that line
  removed the stale value persists, so it is load-bearing.
- **A `MediaItem` is not static metadata.** It carries `viewCount`, `lastViewedAt`
  and `userRating` from `UserData`. Nothing feeds those into a watch or deletion
  decision today, and a comment records that anything which does must read the
  library page's item instead - which is what `PlexGetterService` already does when
  it passes `libItem.viewCount` into `getWatchState` (#3352). Deletion truth still
  goes through `itemExists`, which is uncached everywhere.
- Cost check: cloning a 3.2 KB item out of the cache measures 0.022 ms against a
  9-13 ms request, and the existing key bound caps this at a few MB.

**Also fixes a real Plex bug found while establishing that baseline.**
`PlexApiService.resetMetadataCache` invalidated nothing on the path that actually
caches. `getMetadata` appends the caller's options to the uri and the rule getter
always passes `includeExternalMedia`, so its entries are stored under
`?includeExternalMedia=1&asyncAugmentMetadata=1` while the delete only ever targeted
the bare uri - the two never matched. Testing a rule on Plex flushed caches and still
served pre-change metadata for up to five minutes. Now every option variant for the
id is dropped. Covered by a test that fails against the old code.

`getChildrenMetadata` gets the same treatment, in the second commit. The show and
season getters walk the tree on every condition, so it cost `1 + seasons` requests per
condition per item on top of the metadata read. Same real Jellyfin, 3 conditions over 3
shows: **40 child requests during evaluation for 14 distinct lookups, now 16** (the
remainder being library and collection listings, not child lookups). Total requests for
that run 81 to 40.

It is keyed on the child type as well as the parent, since one show answers a different
list for seasons than for episodes. The per-item reset drops the whole children
namespace rather than the acted-on id, for the reason the watch-history reset beside it
already does - a show's episode lists hang off its season ids. Verified live: three
consecutive rule tests each re-read the tree from the server. The collection size walk
in the action phase asks without a child type, so it keeps its own keys - its first
walk per parent in a run reads fresh; only a repeat within the same group run is served
from cache.

The same reset now drops Plex watch state as well - the per-item history entries and the
bulk prefetched snapshot - which the Jellyfin and Emby resets have always done. Without it
a just-watched item still tested stale on `seenBy`, `lastViewedAt`, `sw_watchers` and the
rest. History entries are keyed by leaf ratingKey, so a show or season test reads its
episodes' entries rather than the id passed in, and the whole namespace goes.

One thing left out on purpose: the Plex fix does not touch `/children` entries, which
the original never targeted either. Show-level rule testing on Plex can still read
cached children.

Touches `getMetadata` in the Jellyfin adapter, so expect a small conflict with #3357
depending on merge order.



