### PR TITLE
fix(rules): fail closed when Jellyfin or Emby metadata cannot be read

### DIFF
--- a/apps/server/src/modules/rules/getter/emby-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/emby-getter.service.spec.ts
@@ -93,6 +93,24 @@ describe('EmbyGetterService', () => {
     });
   });
 
+  describe('error handling', () => {
+    it('returns undefined when metadata cannot be read', async () => {
+      // getMetadata answers undefined for a failed read as well as a missing
+      // item, so this must stay the transient signal - null would let
+      // NOT_EXISTS match on a blip.
+      embyAdapter.getMetadata.mockResolvedValue(undefined);
+
+      const response = await embyGetterService.get(
+        0,
+        createMediaItem(),
+        'movie',
+        createRulesDto({ dataType: 'movie' }),
+      );
+
+      expect(response).toBeUndefined();
+    });
+  });
+
   describe('collection rules', () => {
     it('trims collection names and excludes the rule and manual collections', async () => {
       const mediaItem = createMediaItem({

--- a/apps/server/src/modules/rules/getter/emby-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/emby-getter.service.ts
@@ -75,7 +75,11 @@ export class EmbyGetterService {
 
       if (!metadata) {
         this.logger.warn(`Failed to get Emby metadata for item ${libItem.id}`);
-        return null;
+        // undefined, not null: getMetadata answers undefined for both a
+        // missing item and a failed read, and null is the comparator's
+        // "confirmed absent" signal - it would let NOT_EXISTS match on a
+        // transient blip. Mirrors the arr getter contract (#3125).
+        return undefined;
       }
 
       // Get parent/grandparent metadata lazily (like Plex getter)

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
@@ -2017,7 +2017,10 @@ describe('JellyfinGetterService', () => {
       expect(response).toBeUndefined();
     });
 
-    it('should return null when metadata is not found', async () => {
+    it('should return undefined when metadata cannot be read', async () => {
+      // getMetadata answers undefined for a failed read as well as a missing
+      // item, so this must stay the transient signal - null would let
+      // NOT_EXISTS match on a blip.
       const mediaItem = createMediaItem({ type: 'movie' });
       jellyfinAdapter.getMetadata.mockResolvedValue(undefined);
 
@@ -2028,7 +2031,7 @@ describe('JellyfinGetterService', () => {
         createRulesDto({ dataType: 'movie' }),
       );
 
-      expect(response).toBeNull();
+      expect(response).toBeUndefined();
     });
   });
 

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
@@ -76,7 +76,11 @@ export class JellyfinGetterService {
         this.logger.warn(
           `Failed to get Jellyfin metadata for item ${libItem.id}`,
         );
-        return null;
+        // undefined, not null: getMetadata answers undefined for both a
+        // missing item and a failed read, and null is the comparator's
+        // "confirmed absent" signal - it would let NOT_EXISTS match on a
+        // transient blip. Mirrors the arr getter contract (#3125).
+        return undefined;
       }
 
       // Get parent/grandparent metadata lazily (like Plex getter)


### PR DESCRIPTION
The Jellyfin and Emby getters open every property read with `getMetadata(libItem.id)` and
answer `null` when it comes back empty. But `getMetadata` returns `undefined` for a failed
read as well as a genuinely missing item, and `null` is the comparator's "confirmed absent"
signal - so a transient blip satisfies `NOT_EXISTS` and adds the item. Plex already returns
`undefined` here, which the comparator skips (#1446), and the arr getters were moved to the
same contract in #3125.

Both getters now return `undefined` on an unreadable item, so the rule is skipped and the
executor's transient guard preserves the item for the next pass. A genuinely absent value
still reaches the comparator as `null` from the property branches themselves - only the
"could not read the item at all" path changes.

Verified against a real Jellyfin with a fault-injecting proxy that 500s every per-item
metadata read, on a `[list] Tags NOT_EXISTS` movie group: before the change the run added
**5 items** to the collection purely from the injected failures; after it, **0**, with the
same 5 warnings logged.
