### PR TITLE
feat(metadata): number season and episode posters and resolve their metadata

### DIFF
--- a/apps/server/src/modules/api/tmdb-api/interfaces/tmdb.interface.ts
+++ b/apps/server/src/modules/api/tmdb-api/interfaces/tmdb.interface.ts
@@ -177,6 +177,20 @@ export interface TmdbTvSeasonResult {
   season_number: number;
 }
 
+/**
+ * `/tv/{id}/season/{n}`. Unlike the season entries embedded in the show record,
+ * this carries every episode of the season, so one request covers them all.
+ */
+export interface TmdbTvSeasonDetails {
+  id: number;
+  air_date: string;
+  name: string;
+  overview: string;
+  poster_path?: string;
+  season_number: number;
+  episodes: TmdbTvEpisodeResult[];
+}
+
 export interface TmdbTvDetails {
   id: number;
   backdrop_path?: string;

--- a/apps/server/src/modules/api/tmdb-api/tmdb.service.ts
+++ b/apps/server/src/modules/api/tmdb-api/tmdb.service.ts
@@ -14,6 +14,7 @@ import {
   TmdbMovieDetails,
   TmdbPersonDetail,
   TmdbTvDetails,
+  TmdbTvSeasonDetails,
 } from './interfaces/tmdb.interface';
 
 const TMDB_DEFAULT_API_KEY = 'db55323b8d3e4154498498a75642b381';
@@ -168,6 +169,29 @@ export class TmdbApiService extends ExternalApiService {
       return data;
     } catch (error) {
       this.logger.warn('Failed to fetch TV show details');
+      this.logger.debug(error);
+    }
+  };
+
+  public getTvSeason = async ({
+    tvId,
+    seasonNumber,
+    language = 'en',
+  }: {
+    tvId: number;
+    seasonNumber: number;
+    language?: string;
+  }): Promise<TmdbTvSeasonDetails> => {
+    try {
+      const data = await this.get<TmdbTvSeasonDetails>(
+        `/tv/${tvId}/season/${seasonNumber}`,
+        { params: { language } },
+        43200,
+      );
+
+      return data;
+    } catch (error) {
+      this.logger.warn('Failed to fetch TV season details');
       this.logger.debug(error);
     }
   };

--- a/apps/server/src/modules/api/tvdb-api/interfaces/tvdb.interface.ts
+++ b/apps/server/src/modules/api/tvdb-api/interfaces/tvdb.interface.ts
@@ -38,6 +38,7 @@ export interface TvdbSeason {
   type: TvdbSeasonType;
   number: number;
   name: string | null;
+  image?: string;
 }
 
 export interface TvdbSeriesBase {

--- a/apps/server/src/modules/metadata/interfaces/metadata-provider.interface.ts
+++ b/apps/server/src/modules/metadata/interfaces/metadata-provider.interface.ts
@@ -1,8 +1,10 @@
 import {
   ExternalIdSearchResult,
   MetadataDetails,
+  MetadataImageOptions,
   PersonDetails,
   ProviderIds,
+  TvHierarchyRef,
 } from './metadata.types';
 
 export const MetadataProviders = Symbol('MetadataProviders');
@@ -22,16 +24,35 @@ export interface IMetadataProvider {
     type: 'movie' | 'tv',
   ): Promise<MetadataDetails | undefined>;
 
+  /**
+   * `ref` asks for that season's poster; episodes get their season's poster
+   * because neither provider holds a portrait image per episode. Providers fall
+   * back to the show poster when they have no artwork for the season.
+   */
   getPosterUrl(
     id: number,
     type: 'movie' | 'tv',
-    sizeHint?: string,
+    options?: MetadataImageOptions,
   ): Promise<string | undefined>;
 
+  /**
+   * `ref` asks for the episode's still. Providers with no landscape image for
+   * what `ref` addresses - a season, or an episode they don't hold a still for
+   * - fall back to the show backdrop.
+   */
   getBackdropUrl(
     id: number,
     type: 'movie' | 'tv',
-    sizeHint?: string,
+    options?: MetadataImageOptions,
+  ): Promise<string | undefined>;
+
+  /**
+   * Description of the episode `ref` addresses, or of the season when it
+   * addresses a whole season. Undefined when the provider has none.
+   */
+  getHierarchyOverview(
+    id: number,
+    ref: TvHierarchyRef,
   ): Promise<string | undefined>;
 
   getPersonDetails(id: number): Promise<PersonDetails | undefined>;

--- a/apps/server/src/modules/metadata/interfaces/metadata.types.ts
+++ b/apps/server/src/modules/metadata/interfaces/metadata.types.ts
@@ -7,6 +7,21 @@ export interface ExternalIdSearchResult {
   tvShowId?: number;
 }
 
+/**
+ * Addresses a season, or one episode inside it, within a tv lookup. Providers
+ * answer for the most specific thing they hold and fall back to the show.
+ */
+export interface TvHierarchyRef {
+  seasonNumber: number;
+  episodeNumber?: number;
+}
+
+export interface MetadataImageOptions {
+  /** Preferred image width. Providers serving fixed URLs ignore it. */
+  sizeHint?: string;
+  ref?: TvHierarchyRef;
+}
+
 export interface PersonDetails {
   id: number;
   name: string;

--- a/apps/server/src/modules/metadata/metadata.controller.ts
+++ b/apps/server/src/modules/metadata/metadata.controller.ts
@@ -57,6 +57,25 @@ export class MetadataController {
     );
   }
 
+  @Get('/overview/:type')
+  async getOverview(
+    @Param('type') type: MediaLibrary['type'],
+    @Query() query: Record<string, string>,
+  ): Promise<{ overview: string } | undefined> {
+    const ids = this.parseIds(query);
+    if (!ids) {
+      return undefined;
+    }
+
+    const overview = await this.metadata.getOverview(
+      ids,
+      this.resolveMetadataType(type),
+      query.itemId,
+    );
+
+    return overview ? { overview } : undefined;
+  }
+
   @Get('/image/:type')
   async getImage(
     @Param('type') type: MediaLibrary['type'],

--- a/apps/server/src/modules/metadata/metadata.service.spec.ts
+++ b/apps/server/src/modules/metadata/metadata.service.spec.ts
@@ -142,18 +142,20 @@ describe('MetadataService', () => {
       'tt0099785',
       'imdb',
     );
-    expect(tvdbProvider.getPosterUrl).toHaveBeenCalledWith(
-      202,
-      'movie',
-      'w500',
-    );
+    expect(tvdbProvider.getPosterUrl).toHaveBeenCalledWith(202, 'movie', {
+      sizeHint: 'w500',
+      ref: undefined,
+    });
     expect(tmdbProvider.getPosterUrl).not.toHaveBeenCalled();
   });
 
-  it('resolves parent show IDs when a season mediaServerItemId is provided', async () => {
+  // Season 3 of a show, where the season carries provider IDs of its own that
+  // must not be used for the lookup (#2649).
+  const createSeasonMediaServerMock = () => {
     const seasonItem = createMediaItem({
       id: 'season-42',
       type: 'season',
+      index: 3,
       parentId: 'show-1',
       providerIds: { tmdb: ['9999'], tvdb: ['8888'] },
     });
@@ -162,13 +164,18 @@ describe('MetadataService', () => {
       type: 'show',
       providerIds: { tmdb: ['100'], tvdb: ['200'] },
     });
-    const mediaServer = {
+
+    return {
       getMetadata: jest
         .fn()
         .mockImplementation((id: string) =>
           Promise.resolve(id === 'season-42' ? seasonItem : showItem),
         ),
     };
+  };
+
+  it('resolves parent show IDs and the season number for a season poster', async () => {
+    const mediaServer = createSeasonMediaServerMock();
     const { service, tvdbProvider } = createService({ mediaServer });
 
     const result = await service.getPosterUrl(
@@ -181,13 +188,115 @@ describe('MetadataService', () => {
     expect(mediaServer.getMetadata).toHaveBeenCalledWith('season-42');
     expect(mediaServer.getMetadata).toHaveBeenCalledWith('show-1');
     expect(result).toBeDefined();
-    expect(tvdbProvider.getPosterUrl).toHaveBeenCalledWith(200, 'tv', 'w500');
+    expect(tvdbProvider.getPosterUrl).toHaveBeenCalledWith(200, 'tv', {
+      sizeHint: 'w500',
+      ref: { seasonNumber: 3 },
+    });
+  });
+
+  it('addresses a season, never an episode, on a season backdrop', async () => {
+    const { service, tvdbProvider } = createService({
+      mediaServer: createSeasonMediaServerMock(),
+    });
+
+    const result = await service.getBackdropUrl(
+      { tmdb: 9999, tvdb: 8888 },
+      'tv',
+      'w1280',
+      'season-42',
+    );
+
+    expect(result).toBeDefined();
+    // No episodeNumber, so providers have nothing below the show to offer.
+    expect(tvdbProvider.getBackdropUrl).toHaveBeenCalledWith(200, 'tv', {
+      sizeHint: 'w1280',
+      ref: { seasonNumber: 3 },
+    });
+  });
+
+  it('reads a season description from the metadata provider', async () => {
+    const { service, tvdbProvider, tmdbProvider } = createService({
+      mediaServer: createSeasonMediaServerMock(),
+      providerMocks: [
+        { name: 'TVDB', idKey: 'tvdb' },
+        { name: 'TMDB', idKey: 'tmdb', hierarchyOverview: 'The third season.' },
+      ],
+    });
+
+    const overview = await service.getOverview(
+      { tmdb: 9999, tvdb: 8888 },
+      'tv',
+      'season-42',
+    );
+
+    expect(overview).toBe('The third season.');
+    // The show's IDs, not the season's, and only for the season it addresses.
+    expect(tvdbProvider.getHierarchyOverview).toHaveBeenCalledWith(200, {
+      seasonNumber: 3,
+    });
+    expect(tmdbProvider.getHierarchyOverview).toHaveBeenCalledWith(100, {
+      seasonNumber: 3,
+    });
+  });
+
+  it('falls back to the show description when no provider describes the season', async () => {
+    const { service } = createService({
+      mediaServer: createSeasonMediaServerMock(),
+      providerMocks: [
+        {
+          name: 'TVDB',
+          idKey: 'tvdb',
+          detailsId: 200,
+          details: {
+            type: 'tv',
+            overview: 'The whole series.',
+            externalIds: { tvdb: 200, type: 'tv' },
+          },
+        },
+        { name: 'TMDB', idKey: 'tmdb' },
+      ],
+    });
+
+    const overview = await service.getOverview(
+      { tmdb: 9999, tvdb: 8888 },
+      'tv',
+      'season-42',
+    );
+
+    expect(overview).toBe('The whole series.');
+  });
+
+  it('does not consult the media server for a movie description', async () => {
+    const mediaServer = { getMetadata: jest.fn() };
+    const { service, tvdbProvider } = createService({
+      mediaServer,
+      providerMocks: [
+        {
+          name: 'TVDB',
+          idKey: 'tvdb',
+          detailsId: 200,
+          details: {
+            type: 'movie',
+            overview: 'The movie.',
+            externalIds: { tvdb: 200, type: 'movie' },
+          },
+        },
+      ],
+    });
+
+    const overview = await service.getOverview({ tvdb: 200 }, 'movie');
+
+    expect(overview).toBe('The movie.');
+    expect(mediaServer.getMetadata).not.toHaveBeenCalled();
+    expect(tvdbProvider.getHierarchyOverview).not.toHaveBeenCalled();
   });
 
   it('resolves parent show IDs when an episode mediaServerItemId is provided', async () => {
     const episodeItem = createMediaItem({
       id: 'episode-7',
       type: 'episode',
+      index: 7,
+      parentIndex: 3,
       parentId: 'season-3',
       grandparentId: 'show-1',
       providerIds: { tmdb: ['5555'] },
@@ -216,11 +325,89 @@ describe('MetadataService', () => {
     expect(mediaServer.getMetadata).toHaveBeenCalledWith('episode-7');
     expect(mediaServer.getMetadata).toHaveBeenCalledWith('show-1');
     expect(result).toBeDefined();
-    expect(tvdbProvider.getBackdropUrl).toHaveBeenCalledWith(
-      200,
+    expect(tvdbProvider.getBackdropUrl).toHaveBeenCalledWith(200, 'tv', {
+      sizeHint: 'w1280',
+      ref: { seasonNumber: 3, episodeNumber: 7 },
+    });
+  });
+
+  it('gives an episode its season poster and asks for its own description', async () => {
+    const episodeItem = createMediaItem({
+      id: 'episode-7',
+      type: 'episode',
+      index: 7,
+      parentIndex: 3,
+      parentId: 'season-3',
+      grandparentId: 'show-1',
+      providerIds: { tmdb: ['5555'] },
+    });
+    const showItem = createMediaItem({
+      id: 'show-1',
+      type: 'show',
+      providerIds: { tmdb: ['100'], tvdb: ['200'] },
+    });
+    const mediaServer = {
+      getMetadata: jest
+        .fn()
+        .mockImplementation((id: string) =>
+          Promise.resolve(id === 'episode-7' ? episodeItem : showItem),
+        ),
+    };
+    const { service, tvdbProvider, tmdbProvider } = createService({
+      mediaServer,
+      providerMocks: [
+        { name: 'TVDB', idKey: 'tvdb' },
+        { name: 'TMDB', idKey: 'tmdb', hierarchyOverview: 'The seventh one.' },
+      ],
+    });
+
+    await service.getPosterUrl({ tmdb: 5555 }, 'tv', 'w500', 'episode-7');
+    const overview = await service.getOverview(
+      { tmdb: 5555 },
       'tv',
-      'w1280',
+      'episode-7',
     );
+
+    expect(tvdbProvider.getPosterUrl).toHaveBeenCalledWith(200, 'tv', {
+      sizeHint: 'w500',
+      ref: { seasonNumber: 3, episodeNumber: 7 },
+    });
+    expect(overview).toBe('The seventh one.');
+    expect(tmdbProvider.getHierarchyOverview).toHaveBeenCalledWith(100, {
+      seasonNumber: 3,
+      episodeNumber: 7,
+    });
+  });
+
+  it('leaves an episode with no season number on the show artwork', async () => {
+    const episodeItem = createMediaItem({
+      id: 'episode-8',
+      type: 'episode',
+      index: 8,
+      parentIndex: undefined,
+      grandparentId: 'show-1',
+      providerIds: { tmdb: ['5555'] },
+    });
+    const showItem = createMediaItem({
+      id: 'show-1',
+      type: 'show',
+      providerIds: { tmdb: ['100'], tvdb: ['200'] },
+    });
+    const mediaServer = {
+      getMetadata: jest
+        .fn()
+        .mockImplementation((id: string) =>
+          Promise.resolve(id === 'episode-8' ? episodeItem : showItem),
+        ),
+    };
+    const { service, tvdbProvider } = createService({ mediaServer });
+
+    await service.getPosterUrl({ tmdb: 5555 }, 'tv', 'w500', 'episode-8');
+
+    expect(tvdbProvider.getPosterUrl).toHaveBeenCalledWith(200, 'tv', {
+      sizeHint: 'w500',
+      ref: undefined,
+    });
   });
 
   it('falls back to original IDs when mediaServer lookup fails', async () => {
@@ -237,7 +424,10 @@ describe('MetadataService', () => {
     );
 
     expect(result).toBeDefined();
-    expect(tvdbProvider.getPosterUrl).toHaveBeenCalledWith(200, 'tv', 'w500');
+    expect(tvdbProvider.getPosterUrl).toHaveBeenCalledWith(200, 'tv', {
+      sizeHint: 'w500',
+      ref: undefined,
+    });
   });
 
   it('skips show ID resolution for movies even when mediaServerItemId is provided', async () => {
@@ -249,11 +439,10 @@ describe('MetadataService', () => {
     await service.getPosterUrl({ tvdb: 200 }, 'movie', 'w500', 'movie-1');
 
     expect(mediaServer.getMetadata).not.toHaveBeenCalled();
-    expect(tvdbProvider.getPosterUrl).toHaveBeenCalledWith(
-      200,
-      'movie',
-      'w500',
-    );
+    expect(tvdbProvider.getPosterUrl).toHaveBeenCalledWith(200, 'movie', {
+      sizeHint: 'w500',
+      ref: undefined,
+    });
   });
 
   it.each(metadataLookupServiceTestCases)(

--- a/apps/server/src/modules/metadata/metadata.service.ts
+++ b/apps/server/src/modules/metadata/metadata.service.ts
@@ -21,6 +21,7 @@ import {
   PersonDetails,
   ProviderIds,
   ResolvedMediaIds,
+  TvHierarchyRef,
 } from './interfaces/metadata.types';
 import { MetadataLookupCandidate } from './metadata-lookup.util';
 
@@ -703,43 +704,86 @@ export class MetadataService {
     size = 'w500',
     mediaServerItemId?: string,
   ): Promise<{ url: string; provider: string; id: number } | undefined> {
-    const resolvedIds = await this.resolveShowIdsForImage(
+    const { ids: resolvedIds, hierarchy } = await this.resolveShowLookup(
       ids,
       type,
       mediaServerItemId,
     );
     return this.resolveImageUrl(resolvedIds, type, (provider, id) =>
-      provider.getPosterUrl(id, type, size),
+      provider.getPosterUrl(id, type, { sizeHint: size, ref: hierarchy }),
     );
   }
 
+  /**
+   * Episodes resolve to their own still. Seasons keep the show's backdrop -
+   * TMDB's season image set is posters-only, and TVDB's series record carries
+   * a single image per season, so neither offers a season background to use.
+   */
   async getBackdropUrl(
     ids: ProviderIds,
     type: 'movie' | 'tv',
     size = 'w1280',
     mediaServerItemId?: string,
   ): Promise<{ url: string; provider: string; id: number } | undefined> {
-    const resolvedIds = await this.resolveShowIdsForImage(
+    const { ids: resolvedIds, hierarchy } = await this.resolveShowLookup(
       ids,
       type,
       mediaServerItemId,
     );
     return this.resolveImageUrl(resolvedIds, type, (provider, id) =>
-      provider.getBackdropUrl(id, type, size),
+      provider.getBackdropUrl(id, type, { sizeHint: size, ref: hierarchy }),
     );
   }
 
   /**
-   * For season/episode items, resolve the parent show's provider IDs so that
-   * image lookups use show-level IDs instead of season-specific ones.
+   * Provider description for an item, used where the media server has none of
+   * its own. Seasons and episodes resolve to their own description and fall
+   * back to the show's when the provider only describes the series.
    */
-  private async resolveShowIdsForImage(
+  async getOverview(
     ids: ProviderIds,
     type: 'movie' | 'tv',
     mediaServerItemId?: string,
-  ): Promise<ProviderIds> {
+  ): Promise<string | undefined> {
+    const { ids: resolvedIds, hierarchy } = await this.resolveShowLookup(
+      ids,
+      type,
+      mediaServerItemId,
+    );
+
+    // Same ID resolution the image lookups run, so an item the media server
+    // only tagged with one provider's ID still reaches a configured provider.
+    const providerIds: ResolvedMediaIds = { ...resolvedIds, type };
+    await this.resolveAllIds(providerIds, this.getOrderedProviderKeys());
+
+    if (hierarchy) {
+      const hierarchyOverview = await this.withProviderFallback(
+        providerIds,
+        (provider, id) => provider.getHierarchyOverview(id, hierarchy),
+      );
+
+      if (hierarchyOverview) {
+        return hierarchyOverview;
+      }
+    }
+
+    const details = await this.getDetails(providerIds, type);
+    return details?.overview || undefined;
+  }
+
+  /**
+   * For season/episode items, resolve the parent show's provider IDs so that
+   * lookups use show-level IDs instead of season-specific ones, and report
+   * which season/episode the item is so providers can answer for it rather
+   * than for the show.
+   */
+  private async resolveShowLookup(
+    ids: ProviderIds,
+    type: 'movie' | 'tv',
+    mediaServerItemId?: string,
+  ): Promise<{ ids: ProviderIds; hierarchy?: TvHierarchyRef }> {
     if (!mediaServerItemId || type !== 'tv') {
-      return ids;
+      return { ids };
     }
 
     try {
@@ -747,20 +791,21 @@ export class MetadataService {
       const item = await mediaServer.getMetadata(mediaServerItemId);
 
       if (!item || (item.type !== 'season' && item.type !== 'episode')) {
-        return ids;
+        return { ids };
       }
 
+      const hierarchy = this.readHierarchyRef(item);
       const showId =
         item.type === 'episode' ? item.grandparentId : item.parentId;
 
       if (!showId) {
-        return ids;
+        return { ids, hierarchy };
       }
 
       const show = await mediaServer.getMetadata(showId);
 
       if (!show) {
-        return ids;
+        return { ids, hierarchy };
       }
 
       const showIds = this.extractDirectIds(show);
@@ -772,13 +817,31 @@ export class MetadataService {
         }
       }
 
-      return merged;
+      return { ids: merged, hierarchy };
     } catch (err) {
       this.logger.warn(
         `Failed to resolve show IDs for item ${mediaServerItemId}: ${err}`,
       );
-      return ids;
+      return { ids };
     }
+  }
+
+  /**
+   * A season is its own `index`; an episode is its `index` inside `parentIndex`.
+   * Season 0 (specials) is a real season, so guard on null, not truthiness.
+   */
+  private readHierarchyRef(item: MediaItem): TvHierarchyRef | undefined {
+    if (item.type === 'season') {
+      return item.index != null ? { seasonNumber: item.index } : undefined;
+    }
+
+    if (item.type === 'episode') {
+      return item.parentIndex != null
+        ? { seasonNumber: item.parentIndex, episodeNumber: item.index }
+        : undefined;
+    }
+
+    return undefined;
   }
 
   private hasRequiredIds(

--- a/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.spec.ts
+++ b/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.spec.ts
@@ -73,6 +73,145 @@ describe('TmdbMetadataProvider', () => {
     expect(details?.ended).toBe(false);
   });
 
+  it('returns the requested season poster instead of the show poster', async () => {
+    tmdbApi.getTvShow.mockResolvedValue({
+      ...baseTvRecord,
+      seasons: [
+        { season_number: 1, poster_path: '/s1.jpg' },
+        { season_number: 2, poster_path: '/s2.jpg' },
+      ],
+    } as any);
+
+    await expect(
+      provider.getPosterUrl(1, 'tv', {
+        sizeHint: 'w300',
+        ref: { seasonNumber: 2 },
+      }),
+    ).resolves.toBe('https://image.tmdb.org/t/p/w300/s2.jpg');
+  });
+
+  it('falls back to the show poster when the season has no artwork', async () => {
+    tmdbApi.getTvShow.mockResolvedValue({
+      ...baseTvRecord,
+      seasons: [{ season_number: 1 }],
+    } as any);
+
+    await expect(
+      provider.getPosterUrl(1, 'tv', {
+        sizeHint: 'w300',
+        ref: { seasonNumber: 1 },
+      }),
+    ).resolves.toBe('https://image.tmdb.org/t/p/w300/p.jpg');
+    await expect(
+      provider.getPosterUrl(1, 'tv', {
+        sizeHint: 'w300',
+        ref: { seasonNumber: 9 },
+      }),
+    ).resolves.toBe('https://image.tmdb.org/t/p/w300/p.jpg');
+  });
+
+  it('reads the season overview from the show record', async () => {
+    tmdbApi.getTvShow.mockResolvedValue({
+      ...baseTvRecord,
+      seasons: [
+        { season_number: 1, overview: 'First season.' },
+        { season_number: 2, overview: '' },
+      ],
+    } as any);
+
+    await expect(
+      provider.getHierarchyOverview(1, { seasonNumber: 1 }),
+    ).resolves.toBe('First season.');
+    // An empty provider overview is no overview at all.
+    await expect(
+      provider.getHierarchyOverview(1, { seasonNumber: 2 }),
+    ).resolves.toBeUndefined();
+    await expect(
+      provider.getHierarchyOverview(1, { seasonNumber: 9 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('gives an episode its season poster, since TMDB has no episode poster', async () => {
+    tmdbApi.getTvShow.mockResolvedValue({
+      ...baseTvRecord,
+      seasons: [{ season_number: 2, poster_path: '/s2.jpg' }],
+    } as any);
+
+    await expect(
+      provider.getPosterUrl(1, 'tv', {
+        sizeHint: 'w300',
+        ref: { seasonNumber: 2, episodeNumber: 4 },
+      }),
+    ).resolves.toBe('https://image.tmdb.org/t/p/w300/s2.jpg');
+    expect(tmdbApi.getTvSeason).not.toHaveBeenCalled();
+  });
+
+  it("uses the episode still as the episode's backdrop", async () => {
+    tmdbApi.getTvSeason.mockResolvedValue({
+      season_number: 2,
+      episodes: [
+        { episode_number: 3, still_path: '/e3.jpg', overview: 'Third.' },
+        { episode_number: 4, still_path: '/e4.jpg', overview: '' },
+      ],
+    } as any);
+
+    // Stills are not published in backdrop sizes, so the hint is ignored.
+    await expect(
+      provider.getBackdropUrl(1, 'tv', {
+        sizeHint: 'w1280',
+        ref: { seasonNumber: 2, episodeNumber: 3 },
+      }),
+    ).resolves.toBe('https://image.tmdb.org/t/p/original/e3.jpg');
+    expect(tmdbApi.getTvSeason).toHaveBeenCalledWith({
+      tvId: 1,
+      seasonNumber: 2,
+    });
+  });
+
+  it('falls back to the show backdrop for a season, and for an episode with no still', async () => {
+    tmdbApi.getTvShow.mockResolvedValue(baseTvRecord as any);
+    tmdbApi.getTvSeason.mockResolvedValue({
+      season_number: 2,
+      episodes: [{ episode_number: 3 }],
+    } as any);
+
+    await expect(
+      provider.getBackdropUrl(1, 'tv', {
+        sizeHint: 'w1280',
+        ref: { seasonNumber: 2 },
+      }),
+    ).resolves.toBe('https://image.tmdb.org/t/p/w1280/b.jpg');
+    // A season alone never needs the season request - only episodes do.
+    expect(tmdbApi.getTvSeason).not.toHaveBeenCalled();
+
+    await expect(
+      provider.getBackdropUrl(1, 'tv', {
+        sizeHint: 'w1280',
+        ref: { seasonNumber: 2, episodeNumber: 3 },
+      }),
+    ).resolves.toBe('https://image.tmdb.org/t/p/w1280/b.jpg');
+  });
+
+  it('reads the episode overview from the season record', async () => {
+    tmdbApi.getTvSeason.mockResolvedValue({
+      season_number: 2,
+      episodes: [
+        { episode_number: 3, overview: 'Third episode.' },
+        { episode_number: 4, overview: '' },
+      ],
+    } as any);
+
+    await expect(
+      provider.getHierarchyOverview(1, { seasonNumber: 2, episodeNumber: 3 }),
+    ).resolves.toBe('Third episode.');
+    await expect(
+      provider.getHierarchyOverview(1, { seasonNumber: 2, episodeNumber: 4 }),
+    ).resolves.toBeUndefined();
+    await expect(
+      provider.getHierarchyOverview(1, { seasonNumber: 2, episodeNumber: 9 }),
+    ).resolves.toBeUndefined();
+  });
+
   it('does not set show-only fields for movie details', async () => {
     tmdbApi.getMovie.mockResolvedValue({
       id: 1,

--- a/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.ts
+++ b/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.ts
@@ -1,11 +1,19 @@
 import { Injectable } from '@nestjs/common';
+import {
+  TmdbMovieDetails,
+  TmdbTvDetails,
+  TmdbTvEpisodeResult,
+  TmdbTvSeasonResult,
+} from '../../api/tmdb-api/interfaces/tmdb.interface';
 import { TmdbApiService } from '../../api/tmdb-api/tmdb.service';
 import { IMetadataProvider } from '../interfaces/metadata-provider.interface';
 import {
   ExternalIdSearchResult,
   MetadataDetails,
+  MetadataImageOptions,
   PersonDetails,
   ProviderIds,
+  TvHierarchyRef,
 } from '../interfaces/metadata.types';
 
 const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p';
@@ -120,20 +128,96 @@ export class TmdbMetadataProvider implements IMetadataProvider {
     return undefined;
   }
 
+  /** The show record already carries every season, so this costs no extra call. */
+  private findSeason(
+    record: TmdbMovieDetails | TmdbTvDetails | undefined,
+    seasonNumber: number,
+  ): TmdbTvSeasonResult | undefined {
+    if (!record || !('seasons' in record) || !Array.isArray(record.seasons)) {
+      return undefined;
+    }
+
+    return record.seasons.find(
+      (season) => season.season_number === seasonNumber,
+    );
+  }
+
+  /**
+   * Episode records are not part of the show record, so this is one extra
+   * request - but it returns the whole season, and it is cached like every
+   * other TMDB read, so the season's other episodes come for free.
+   */
+  private async findEpisode(
+    tmdbId: number,
+    ref: TvHierarchyRef,
+  ): Promise<TmdbTvEpisodeResult | undefined> {
+    if (ref.episodeNumber === undefined) {
+      return undefined;
+    }
+
+    const season = await this.tmdbApi.getTvSeason({
+      tvId: tmdbId,
+      seasonNumber: ref.seasonNumber,
+    });
+
+    return season?.episodes?.find(
+      (episode) => episode.episode_number === ref.episodeNumber,
+    );
+  }
+
   async getPosterUrl(
     tmdbId: number,
     type: 'movie' | 'tv',
-    sizeHint = 'w500',
+    options: MetadataImageOptions = {},
   ): Promise<string | undefined> {
+    const { sizeHint = 'w500', ref } = options;
     const record = await this.getRecord(tmdbId, type);
+
+    if (ref) {
+      const seasonPosterUrl = this.buildImageUrl(
+        this.findSeason(record, ref.seasonNumber)?.poster_path,
+        sizeHint,
+      );
+
+      if (seasonPosterUrl) {
+        return seasonPosterUrl;
+      }
+    }
+
     return this.buildImageUrl(record?.poster_path, sizeHint);
+  }
+
+  async getHierarchyOverview(
+    tmdbId: number,
+    ref: TvHierarchyRef,
+  ): Promise<string | undefined> {
+    if (ref.episodeNumber !== undefined) {
+      const episode = await this.findEpisode(tmdbId, ref);
+      return episode?.overview || undefined;
+    }
+
+    const record = await this.getRecord(tmdbId, 'tv');
+    return this.findSeason(record, ref.seasonNumber)?.overview || undefined;
   }
 
   async getBackdropUrl(
     tmdbId: number,
     type: 'movie' | 'tv',
-    sizeHint = 'w1280',
+    options: MetadataImageOptions = {},
   ): Promise<string | undefined> {
+    const { sizeHint = 'w1280', ref } = options;
+
+    if (ref?.episodeNumber !== undefined) {
+      const episode = await this.findEpisode(tmdbId, ref);
+      // Stills are only published in w92/w185/w300/original, so a backdrop
+      // size hint would not apply; `original` is the only one large enough.
+      const stillUrl = this.buildImageUrl(episode?.still_path, 'original');
+
+      if (stillUrl) {
+        return stillUrl;
+      }
+    }
+
     const record = await this.getRecord(tmdbId, type);
     return this.buildImageUrl(record?.backdrop_path, sizeHint);
   }

--- a/apps/server/src/modules/metadata/providers/tvdb-metadata.provider.spec.ts
+++ b/apps/server/src/modules/metadata/providers/tvdb-metadata.provider.spec.ts
@@ -68,6 +68,35 @@ describe('TvdbMetadataProvider', () => {
     expect(details?.seasonCount).toBe(2);
   });
 
+  it('returns the season image from the default ordering', async () => {
+    tvdbApi.getSeries.mockResolvedValue({
+      ...baseSeriesRecord,
+      seasons: [
+        { number: 2, type: { id: 1 }, image: 'https://tvdb/aired-s2.jpg' },
+        { number: 2, type: { id: 2 }, image: 'https://tvdb/dvd-s2.jpg' },
+      ],
+    } as any);
+
+    await expect(
+      provider.getPosterUrl(322399, 'tv', { ref: { seasonNumber: 2 } }),
+    ).resolves.toBe('https://tvdb/aired-s2.jpg');
+  });
+
+  it('falls back to the series poster when the season has no image', async () => {
+    tvdbApi.getPosterUrl.mockReturnValue('https://tvdb/series.jpg');
+    tvdbApi.getSeries.mockResolvedValue({
+      ...baseSeriesRecord,
+      seasons: [{ number: 2, type: { id: 1 } }],
+    } as any);
+
+    await expect(
+      provider.getPosterUrl(322399, 'tv', { ref: { seasonNumber: 2 } }),
+    ).resolves.toBe('https://tvdb/series.jpg');
+    await expect(
+      provider.getPosterUrl(322399, 'tv', { ref: { seasonNumber: 9 } }),
+    ).resolves.toBe('https://tvdb/series.jpg');
+  });
+
   it('does not derive ended or season count for movie details', async () => {
     tvdbApi.getMovie.mockResolvedValue({
       id: 1,

--- a/apps/server/src/modules/metadata/providers/tvdb-metadata.provider.ts
+++ b/apps/server/src/modules/metadata/providers/tvdb-metadata.provider.ts
@@ -1,9 +1,14 @@
 import { Injectable } from '@nestjs/common';
+import {
+  TvdbMovieBase,
+  TvdbSeriesBase,
+} from '../../api/tvdb-api/interfaces/tvdb.interface';
 import { TvdbApiService } from '../../api/tvdb-api/tvdb.service';
 import { IMetadataProvider } from '../interfaces/metadata-provider.interface';
 import {
   ExternalIdSearchResult,
   MetadataDetails,
+  MetadataImageOptions,
   PersonDetails,
   ProviderIds,
 } from '../interfaces/metadata.types';
@@ -103,12 +108,55 @@ export class TvdbMetadataProvider implements IMetadataProvider {
     return count;
   }
 
+  /**
+   * The series record lists a season per alternative ordering (Aired / DVD /
+   * ...), so the series' default ordering decides which entry is "season N".
+   * `season.image` is the one image TVDB attaches to the season itself.
+   */
+  private findSeasonImage(
+    record: TvdbSeriesBase | TvdbMovieBase | undefined,
+    seasonNumber: number,
+  ): string | undefined {
+    if (!record || !('seasons' in record) || !Array.isArray(record.seasons)) {
+      return undefined;
+    }
+
+    return record.seasons.find(
+      (season) =>
+        season.type?.id === record.defaultSeasonType &&
+        season.number === seasonNumber,
+    )?.image;
+  }
+
+  // TVDB serves one fixed artwork URL per image, so there is no size to apply.
   async getPosterUrl(
     tvdbId: number,
     type: 'movie' | 'tv',
+    options: MetadataImageOptions = {},
   ): Promise<string | undefined> {
     const record = await this.getRecord(tvdbId, type);
+
+    if (options.ref) {
+      const seasonImage = this.findSeasonImage(
+        record,
+        options.ref.seasonNumber,
+      );
+
+      if (seasonImage) {
+        return seasonImage;
+      }
+    }
+
     return this.tvdbApi.getPosterUrl(record, type);
+  }
+
+  /**
+   * The series record holds no episode entries and only reports which languages
+   * a season overview is translated into, never the text, so TVDB has no
+   * description below show level to read without per-episode requests.
+   */
+  async getHierarchyOverview(): Promise<string | undefined> {
+    return undefined;
   }
 
   async getBackdropUrl(

--- a/apps/server/test/utils/data.ts
+++ b/apps/server/test/utils/data.ts
@@ -670,6 +670,7 @@ export interface MetadataProviderMockConfig {
   detailsId?: number;
   posterUrl?: string;
   backdropUrl?: string;
+  hierarchyOverview?: string;
   findByExternalId?: (
     externalId: string | number,
     type: string,
@@ -710,6 +711,7 @@ export const createMetadataProviderMock = ({
   detailsId,
   posterUrl,
   backdropUrl,
+  hierarchyOverview,
   findByExternalId,
 }: MetadataProviderMockConfig): jest.Mocked<IMetadataProvider> => {
   const resolvedDetails = details
@@ -736,6 +738,7 @@ export const createMetadataProviderMock = ({
     getBackdropUrl: jest
       .fn()
       .mockResolvedValue(backdropUrl ?? `https://${idKey}/backdrop.jpg`),
+    getHierarchyOverview: jest.fn().mockResolvedValue(hierarchyOverview),
     getPersonDetails: jest.fn(),
     findByExternalId: jest
       .fn()

--- a/apps/ui/src/api/metadata.ts
+++ b/apps/ui/src/api/metadata.ts
@@ -1,0 +1,55 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import GetApiHandler from '../utils/ApiHandler'
+
+export const metadataKeys = {
+  all: ['metadata'] as const,
+  overview: (path: string) => [...metadataKeys.all, 'overview', path] as const,
+}
+
+type UseMetadataOverviewQueryKey = ReturnType<typeof metadataKeys.overview>
+type UseMetadataOverviewOptions = Omit<
+  UseQueryOptions<
+    string | null,
+    Error,
+    string | null,
+    UseMetadataOverviewQueryKey
+  >,
+  'queryKey' | 'queryFn'
+>
+
+/**
+ * Hook to fetch an item's description from the configured metadata provider,
+ * for items the media server does not describe itself. Takes the path built by
+ * `buildMetadataPath('overview', ...)` and stays idle without one, so callers
+ * can request it only when they need the fallback.
+ */
+export const useMetadataOverview = (
+  path: string | undefined,
+  options?: UseMetadataOverviewOptions,
+) => {
+  return useQuery<
+    string | null,
+    Error,
+    string | null,
+    UseMetadataOverviewQueryKey
+  >({
+    queryKey: metadataKeys.overview(path ?? ''),
+    queryFn: async () => {
+      if (!path) {
+        return null
+      }
+
+      const response = await GetApiHandler<{ overview: string } | undefined>(
+        path,
+      )
+
+      return response?.overview ?? null
+    },
+    // Provider descriptions barely change, and the server caches them too.
+    staleTime: 300000, // 5 minutes
+    enabled: !!path,
+    ...options,
+  })
+}
+
+export type UseMetadataOverviewResult = ReturnType<typeof useMetadataOverview>

--- a/apps/ui/src/components/Collection/CollectionItem/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionItem/index.tsx
@@ -5,7 +5,7 @@ import { useLibraryDisplay } from '../../../hooks/useLibraryDisplay'
 import GetApiHandler from '../../../utils/ApiHandler'
 import { formatSizeCompact } from '../../../utils/formatBytes'
 import {
-  buildMetadataImagePath,
+  buildMetadataPath,
   isAbsoluteUrl,
   toProviderIds,
 } from '../../../utils/mediaTypeUtils'
@@ -47,7 +47,7 @@ const CollectionItem = (props: ICollectionItem) => {
 
           // Pass 'season' for TV collections so the backend can resolve
           // parent show IDs when the preview item's own IDs differ.
-          const imageRequestPath = buildMetadataImagePath(
+          const imageRequestPath = buildMetadataPath(
             'image',
             props.collection.type === 'movie' ? 'movie' : 'season',
             toProviderIds({

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.spec.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.spec.tsx
@@ -1,17 +1,35 @@
 import { MediaServerType, type MediaItem } from '@maintainerr/contracts'
+import { QueryClientProvider } from '@tanstack/react-query'
 import {
   cleanup,
   fireEvent,
-  render,
+  render as renderComponent,
   screen,
   waitFor,
 } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useMediaServerType } from '../../../../hooks/useMediaServerType'
 import { createDeferred } from '../../../../test-utils/createDeferred'
+import { createTestQueryClient } from '../../../../test-utils/queryClient'
 import GetApiHandler from '../../../../utils/ApiHandler'
 import { clearMaintainerrStatusDetailsCache } from '../maintainerrStatus'
 import MediaModal from './index'
+
+// The modal reads a metadata-provider description through TanStack Query, so
+// every render (including rerenders) needs a client in context.
+const render = (ui: ReactNode) => {
+  const queryClient = createTestQueryClient()
+  const withClient = (node: ReactNode) => (
+    <QueryClientProvider client={queryClient}>{node}</QueryClientProvider>
+  )
+  const result = renderComponent(withClient(ui))
+
+  return {
+    ...result,
+    rerender: (node: ReactNode) => result.rerender(withClient(node)),
+  }
+}
 
 vi.mock('../../../Collection/CollectionDetail/TriggerRuleActionButton', () => ({
   default: () => <div>trigger-rule-action</div>,
@@ -678,6 +696,93 @@ describe('MediaModal', () => {
     await screen.findByText('Movie summary')
 
     expect(getApiHandlerMock).not.toHaveBeenCalledWith('/streamystats/info')
+  })
+
+  it('names the season and falls back to the provider description when the media server has none', async () => {
+    getApiHandlerMock.mockImplementation((path: string) => {
+      if (path === '/media-server') {
+        return Promise.resolve({})
+      }
+
+      if (path === '/settings') {
+        return Promise.resolve({})
+      }
+
+      if (path === '/media-server/meta/55') {
+        return Promise.resolve({ summary: '' } as MediaItem)
+      }
+
+      if (path.startsWith('/metadata/backdrop/show?')) {
+        return Promise.resolve(undefined)
+      }
+
+      if (path === '/metadata/overview/show?tmdbId=101&itemId=55') {
+        return Promise.resolve({ overview: 'What happens in season two.' })
+      }
+
+      if (path === '/streamystats/info') {
+        return Promise.reject(new Error('404 Streamystats not configured'))
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    render(
+      <MediaModal
+        onClose={() => {}}
+        id={55}
+        mediaType="season"
+        seasonNumber={2}
+        title="Sample Series"
+        providerIds={{ tmdb: ['101'] }}
+      />,
+    )
+
+    expect(await screen.findByText('season 2')).toBeTruthy()
+    expect(await screen.findByText('What happens in season two.')).toBeTruthy()
+    expect(screen.queryByText('No summary available.')).toBeNull()
+  })
+
+  it('does not ask the provider for a description the media server already has', async () => {
+    getApiHandlerMock.mockImplementation((path: string) => {
+      if (path === '/media-server') {
+        return Promise.resolve({})
+      }
+
+      if (path === '/settings') {
+        return Promise.resolve({})
+      }
+
+      if (path === '/media-server/meta/56') {
+        return Promise.resolve({ summary: 'Season summary.' } as MediaItem)
+      }
+
+      if (path.startsWith('/metadata/backdrop/show?')) {
+        return Promise.resolve(undefined)
+      }
+
+      if (path === '/streamystats/info') {
+        return Promise.reject(new Error('404 Streamystats not configured'))
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    render(
+      <MediaModal
+        onClose={() => {}}
+        id={56}
+        mediaType="season"
+        seasonNumber={1}
+        title="Sample Series"
+        providerIds={{ tmdb: ['101'] }}
+      />,
+    )
+
+    expect(await screen.findByText('Season summary.')).toBeTruthy()
+    expect(getApiHandlerMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('/metadata/overview/'),
+    )
   })
 
   it('hides the trigger rule action control for excluded collection items', async () => {

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
@@ -5,15 +5,18 @@ import {
   SPORTARR_TVDB_ALIAS_RANGE,
   type MaintainerrMediaStatusDetails,
   type MaintainerrMediaStatusEntry,
+  type MediaItemType,
   type MediaProviderIds,
 } from '@maintainerr/contracts'
 import React, { memo, useEffect, useMemo, useState } from 'react'
+import { useMetadataOverview } from '../../../../api/metadata'
 import { useLockBodyScroll } from '../../../../hooks/useLockBodyScroll'
 import { useMediaServerType } from '../../../../hooks/useMediaServerType'
 import GetApiHandler from '../../../../utils/ApiHandler'
 import { logClientError } from '../../../../utils/ClientLogger'
 import {
-  buildMetadataImagePath,
+  buildMetadataPath,
+  mediaTypeLabel,
   toApiMediaType,
 } from '../../../../utils/mediaTypeUtils'
 import Button from '../../Button'
@@ -34,8 +37,10 @@ interface ModalContentProps {
   id: number | string
   summary?: string
   year?: string
-  mediaType: 'movie' | 'show' | 'season' | 'episode'
+  mediaType: MediaItemType
   title: string
+  seasonNumber?: number
+  episodeNumber?: number
   providerIds?: MediaProviderIds
   exclusionType?: 'global' | 'specific'
   collection?: ICollection
@@ -145,6 +150,8 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
     summary,
     year,
     title,
+    seasonNumber,
+    episodeNumber,
     providerIds: fallbackProviderIds,
     exclusionType,
     collection,
@@ -251,7 +258,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
       return season != null ? `${base}?season=${season}` : base
     }, [seerrConfigured, providerIds, metadata])
 
-    const backdropRequestPath = buildMetadataImagePath(
+    const backdropRequestPath = buildMetadataPath(
       'backdrop',
       mediaType,
       providerIds,
@@ -259,6 +266,22 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
     )
     const isCurrentBackdrop = backdropResult.requestKey === backdropRequestPath
     const resolvedBackdrop = isCurrentBackdrop ? backdropResult.url : null
+    const mediaServerSummary = metadata?.summary || summary
+    // Media servers rarely fill in a season description, so ask the metadata
+    // provider for one instead of leaving the season with no text at all.
+    const overviewRequestPath =
+      loading || mediaServerSummary
+        ? undefined
+        : buildMetadataPath('overview', mediaType, providerIds, id)
+    const { data: providerOverview, isPending: overviewRequestPending } =
+      useMetadataOverview(overviewRequestPath)
+    const isOverviewPending = !!overviewRequestPath && overviewRequestPending
+    // Nothing rather than a placeholder while a description is still in flight,
+    // so the text does not swap out from under the reader.
+    const summaryText =
+      mediaServerSummary ||
+      providerOverview ||
+      (loading || isOverviewPending ? '' : 'No summary available.')
     const providerLogo = useMemo(() => {
       if (!isCurrentBackdrop || !backdropResult.provider) return null
       const cfg = metadataProviderLogos[backdropResult.provider]
@@ -549,7 +572,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
                             : 'bg-rose-900/70'
                     }`}
                   >
-                    {mediaType}
+                    {mediaTypeLabel(mediaType, { seasonNumber, episodeNumber })}
                   </div>
                   {metadata?.contentRating && (
                     <div className="pointer-events-none mt-1 rounded-lg bg-black/70 p-2 text-xs font-medium text-zinc-200 uppercase">
@@ -725,7 +748,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
             </div>
 
             <div className="mt-2 text-gray-300">
-              <p>{metadata?.summary || summary || 'No summary available.'}</p>
+              <p>{summaryText}</p>
             </div>
 
             {requestedBy.length > 0 ? (

--- a/apps/ui/src/components/Common/MediaCard/index.spec.tsx
+++ b/apps/ui/src/components/Common/MediaCard/index.spec.tsx
@@ -67,6 +67,51 @@ describe('MediaCard', () => {
     expect(screen.queryByText('EXCL')).toBeNull()
   })
 
+  it('numbers the season badge so seasons of one show stay distinguishable', () => {
+    render(
+      <MediaCard
+        id="season-1"
+        title="Sample Series"
+        mediaType="season"
+        seasonNumber={2}
+        collectionPage={true}
+      />,
+    )
+
+    expect(screen.getByText('season 2')).toBeTruthy()
+  })
+
+  it('falls back to the plain type badge when the season number is unknown', () => {
+    render(
+      <MediaCard
+        id="season-1"
+        title="Sample Series"
+        mediaType="season"
+        collectionPage={true}
+      />,
+    )
+
+    expect(screen.getByText('season')).toBeTruthy()
+  })
+
+  it('numbers the episode badge and shows the episode title', () => {
+    render(
+      <MediaCard
+        id="episode-1"
+        title="Sample Series"
+        mediaType="episode"
+        seasonNumber={2}
+        episodeNumber={4}
+        episodeTitle="A Quiet Arrival"
+        summary="What happens in the fourth episode."
+        collectionPage={true}
+      />,
+    )
+
+    expect(screen.getByText('episode 4')).toBeTruthy()
+    expect(screen.getByText('A Quiet Arrival')).toBeTruthy()
+  })
+
   it('keeps the collection page manual badge without an overview include badge', () => {
     render(
       <MediaCard

--- a/apps/ui/src/components/Common/MediaCard/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/index.tsx
@@ -3,6 +3,7 @@ import { DocumentAddIcon, DocumentRemoveIcon } from '@heroicons/react/solid'
 import { MediaItemType, type MediaProviderIds } from '@maintainerr/contracts'
 import React, { memo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { mediaTypeLabel } from '../../../utils/mediaTypeUtils'
 import AddModal from '../../AddModal'
 import type { ICollection } from '../../Collection'
 import RemoveFromCollectionButton from '../../Collection/CollectionDetail/RemoveFromCollectionButton'
@@ -40,8 +41,11 @@ interface IMediaCard {
   id: number | string
   summary?: string
   year?: string
-  mediaType: 'movie' | 'show' | 'season' | 'episode'
+  mediaType: MediaItemType
   title: string
+  seasonNumber?: number
+  episodeNumber?: number
+  episodeTitle?: string
   providerIds?: MediaProviderIds
   libraryId?: string
   type?: MediaItemType
@@ -62,6 +66,9 @@ const MediaCard: React.FC<IMediaCard> = ({
   year,
   mediaType,
   title,
+  seasonNumber,
+  episodeNumber,
+  episodeTitle,
   libraryId,
   type,
   collectionId = 0,
@@ -143,7 +150,10 @@ const MediaCard: React.FC<IMediaCard> = ({
         {(image) => (
           <>
             <div className="absolute right-0 left-0 flex items-center justify-between p-2">
-              {renderBadge(mediaType, mediaType)}
+              {renderBadge(
+                mediaTypeLabel(mediaType, { seasonNumber, episodeNumber }),
+                mediaType,
+              )}
               {!collectionPage && exclusionType === 'global'
                 ? renderBadge('EXCL', mediaType)
                 : undefined}
@@ -211,7 +221,7 @@ const MediaCard: React.FC<IMediaCard> = ({
                     >
                       {title}
                     </h1>
-                    {mediaType == 'episode' && (
+                    {mediaType == 'episode' && episodeTitle && (
                       <div
                         className="text-xs whitespace-normal text-shadow-sm"
                         style={{
@@ -222,7 +232,7 @@ const MediaCard: React.FC<IMediaCard> = ({
                           wordBreak: 'break-word',
                         }}
                       >
-                        {summary}
+                        {episodeTitle}
                       </div>
                     )}
 
@@ -278,8 +288,10 @@ const MediaCard: React.FC<IMediaCard> = ({
           id={id}
           onClose={() => setShowMediaModal(false)}
           title={title}
-          summary={summary || 'No description available.'}
+          summary={summary}
           mediaType={mediaType}
+          seasonNumber={seasonNumber}
+          episodeNumber={episodeNumber}
           providerIds={providerIds}
           year={displayYear}
           exclusionType={exclusionType}

--- a/apps/ui/src/components/Common/Poster/PosterCard.tsx
+++ b/apps/ui/src/components/Common/Poster/PosterCard.tsx
@@ -1,11 +1,11 @@
-import { type MediaProviderIds } from '@maintainerr/contracts'
+import {
+  type MediaItemType,
+  type MediaProviderIds,
+} from '@maintainerr/contracts'
 import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import GetApiHandler from '../../../utils/ApiHandler'
-import {
-  buildMetadataImagePath,
-  isAbsoluteUrl,
-} from '../../../utils/mediaTypeUtils'
+import { buildMetadataPath, isAbsoluteUrl } from '../../../utils/mediaTypeUtils'
 
 // Each entry is a request path key + resolved URL string (~200 bytes).
 // 500 entries ≈ 100KB - covers several pages of browsing before eviction.
@@ -15,7 +15,7 @@ const pendingPosterImageRequests = new Map<string, Promise<string | null>>()
 
 type PosterCardProps = Omit<ComponentPropsWithoutRef<'div'>, 'children'> & {
   imagePath?: string | null
-  mediaType: 'movie' | 'show' | 'season' | 'episode'
+  mediaType: MediaItemType
   providerIds?: MediaProviderIds
   itemId?: string | number
   imageClassName?: string
@@ -81,7 +81,7 @@ const PosterCard = ({
 }: PosterCardProps) => {
   const cardRef = useRef<HTMLDivElement | null>(null)
   const isDirectImage = isAbsoluteUrl(imagePath)
-  const imageRequestPath = buildMetadataImagePath(
+  const imageRequestPath = buildMetadataPath(
     'image',
     mediaType,
     providerIds,

--- a/apps/ui/src/components/Overview/Content/index.spec.tsx
+++ b/apps/ui/src/components/Overview/Content/index.spec.tsx
@@ -18,15 +18,29 @@ vi.mock('../../Common/MediaCard', () => ({
   default: ({
     title,
     exclusionId,
+    seasonNumber,
+    episodeNumber,
+    episodeTitle,
+    summary,
   }: {
     title: string
     exclusionId?: number
+    seasonNumber?: number
+    episodeNumber?: number
+    episodeTitle?: string
+    summary?: string
   }) => (
     <div>
       <span>{title}</span>
       {exclusionId ? (
         <span data-testid={`excluded-${title}`}>excluded</span>
       ) : null}
+      <span data-testid={`season-${title}`}>{seasonNumber ?? 'none'}</span>
+      <span data-testid={`episode-${title}`}>{episodeNumber ?? 'none'}</span>
+      <span data-testid={`episode-title-${title}`}>
+        {episodeTitle ?? 'none'}
+      </span>
+      <span data-testid={`summary-${title}`}>{summary ?? 'none'}</span>
     </div>
   ),
 }))
@@ -153,5 +167,89 @@ describe('OverviewContent', () => {
     )
 
     expect(screen.getByTestId('excluded-Item One')).toBeTruthy()
+  })
+
+  it('gives season cards their season number and the season description', () => {
+    render(
+      <OverviewContent
+        data={[
+          {
+            id: '1',
+            title: 'Season 2',
+            parentTitle: 'Sample Series',
+            type: 'season',
+            index: 2,
+            summary: 'What happens in the second season.',
+          } as any,
+        ]}
+        dataFinished={true}
+        loading={false}
+        extrasLoading={false}
+        fetchData={vi.fn()}
+        libraryId="library-1"
+      />,
+    )
+
+    expect(screen.getByTestId('season-Sample Series').textContent).toBe('2')
+    expect(screen.getByTestId('summary-Sample Series').textContent).toBe(
+      'What happens in the second season.',
+    )
+  })
+
+  it('gives episode cards their episode number, title and description', () => {
+    render(
+      <OverviewContent
+        data={[
+          {
+            id: '1',
+            title: 'A Quiet Arrival',
+            grandparentTitle: 'Sample Series',
+            type: 'episode',
+            index: 4,
+            parentIndex: 2,
+            summary: 'What happens in the fourth episode.',
+          } as any,
+        ]}
+        dataFinished={true}
+        loading={false}
+        extrasLoading={false}
+        fetchData={vi.fn()}
+        libraryId="library-1"
+      />,
+    )
+
+    expect(screen.getByTestId('episode-Sample Series').textContent).toBe('4')
+    // The episode's season, so its poster and still resolve to the right one.
+    expect(screen.getByTestId('season-Sample Series').textContent).toBe('2')
+    expect(screen.getByTestId('episode-title-Sample Series').textContent).toBe(
+      'A Quiet Arrival',
+    )
+    expect(screen.getByTestId('summary-Sample Series').textContent).toBe(
+      'What happens in the fourth episode.',
+    )
+  })
+
+  it('does not number movie cards', () => {
+    render(
+      <OverviewContent
+        data={[
+          {
+            id: '1',
+            title: 'Item One',
+            type: 'movie',
+            index: 4,
+            summary: 'Movie description.',
+          } as any,
+        ]}
+        dataFinished={true}
+        loading={false}
+        extrasLoading={false}
+        fetchData={vi.fn()}
+        libraryId="library-1"
+      />,
+    )
+
+    expect(screen.getByTestId('season-Item One').textContent).toBe('none')
+    expect(screen.getByTestId('episode-Item One').textContent).toBe('none')
   })
 })

--- a/apps/ui/src/components/Overview/Content/index.tsx
+++ b/apps/ui/src/components/Overview/Content/index.tsx
@@ -140,15 +140,7 @@ const OverviewContent = (props: IOverviewContent) => {
                   id={el.id}
                   libraryId={props.libraryId}
                   type={el.type}
-                  summary={
-                    el.type === 'movie' || el.type === 'show'
-                      ? el.summary
-                      : el.type === 'season'
-                        ? el.title
-                        : el.type === 'episode'
-                          ? 'Episode ' + el.index + ' - ' + el.title
-                          : ''
-                  }
+                  summary={el.summary}
                   year={
                     el.type === 'episode'
                       ? el.parentTitle
@@ -157,6 +149,15 @@ const OverviewContent = (props: IOverviewContent) => {
                         : el.year?.toString()
                   }
                   mediaType={el.type}
+                  seasonNumber={
+                    el.type === 'season'
+                      ? el.index
+                      : el.type === 'episode'
+                        ? el.parentIndex
+                        : undefined
+                  }
+                  episodeNumber={el.type === 'episode' ? el.index : undefined}
+                  episodeTitle={el.type === 'episode' ? el.title : undefined}
                   title={
                     el.grandparentTitle
                       ? el.grandparentTitle

--- a/apps/ui/src/utils/mediaTypeUtils.ts
+++ b/apps/ui/src/utils/mediaTypeUtils.ts
@@ -1,4 +1,7 @@
-import { type MediaProviderIds } from '@maintainerr/contracts'
+import {
+  type MediaItemType,
+  type MediaProviderIds,
+} from '@maintainerr/contracts'
 
 const mediaTypeBadgeColors: Record<string, string> = {
   movie: 'bg-zinc-900',
@@ -12,16 +15,14 @@ export function mediaTypeBgColor(mediaType: string): string {
 }
 
 export function toImageEndpointType(
-  mediaType: 'movie' | 'show' | 'season' | 'episode',
+  mediaType: MediaItemType,
 ): 'movie' | 'show' {
   return ['season', 'episode'].includes(mediaType)
     ? 'show'
     : (mediaType as 'movie' | 'show')
 }
 
-export function toApiMediaType(
-  mediaType: 'movie' | 'show' | 'season' | 'episode',
-): 'movie' | 'tv' {
+export function toApiMediaType(mediaType: MediaItemType): 'movie' | 'tv' {
   return ['show', 'season', 'episode'].includes(mediaType) ? 'tv' : 'movie'
 }
 
@@ -43,9 +44,27 @@ export function buildProviderIdParams(
   return params
 }
 
-export function buildMetadataImagePath(
-  kind: 'image' | 'backdrop',
-  mediaType: 'movie' | 'show' | 'season' | 'episode',
+/**
+ * Badge/chip label for a media type. Seasons and episodes carry their number so
+ * items of the same show stay distinguishable on the poster.
+ */
+export function mediaTypeLabel(
+  mediaType: MediaItemType,
+  numbers: { seasonNumber?: number; episodeNumber?: number } = {},
+): string {
+  const itemNumber =
+    mediaType === 'season'
+      ? numbers.seasonNumber
+      : mediaType === 'episode'
+        ? numbers.episodeNumber
+        : undefined
+
+  return itemNumber != null ? `${mediaType} ${itemNumber}` : mediaType
+}
+
+export function buildMetadataPath(
+  kind: 'image' | 'backdrop' | 'overview',
+  mediaType: MediaItemType,
   providerIds: MediaProviderIds | undefined,
   itemId?: string | number,
 ): string | undefined {


### PR DESCRIPTION
Seasons of one show were indistinguishable on the collection page: every poster showed the show's artwork under a plain "SEASON" badge, and the only place a season number appeared was the modal description, which was the literal text "Season 1". Requested in [features.maintainerr.info/posts/98](https://features.maintainerr.info/posts/98/add-season-number-to-the-posters-on-the-collection-page).

- Badges read "SEASON 2" / "EPISODE 3", taken from the item's own index.
- Seasons resolve their own poster; episodes resolve their season's poster and their own still as the modal backdrop. Seasons keep the show backdrop, since TMDB's season image set is posters-only.
- Descriptions come from the metadata provider only when the media server has none, through a new `GET /api/metadata/overview/:type`. That applies to every media type, not just seasons.
- TMDB serves season posters and descriptions out of the already cached show record, so seasons cost no extra request; episodes need one extra season request, itself cached and covering the whole season. TVDB supplies season posters only, as its series record exposes no episode entries and no season description text.
- UI side: one shared `mediaTypeLabel()` for the card badge and modal chip, the provider description fetched through a TanStack Query hook, and the duplicated `'movie' | 'show' | 'season' | 'episode'` unions replaced with `MediaItemType` from contracts.