### PR TITLE
refactor: drop underscore-prefixed identifiers

### DIFF
--- a/apps/server/src/modules/actions/radarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/radarr-action-handler.spec.ts
@@ -41,7 +41,7 @@ describe('RadarrActionHandler', () => {
     logger = unitRef.get(MaintainerrLogger);
 
     metadataService.resolveLookupCandidatesForService.mockImplementation(
-      async (_mediaServerId, _service, fallbackIds) => {
+      async (mediaServerId, service, fallbackIds) => {
         const tmdbId =
           typeof fallbackIds?.tmdb === 'number' ? fallbackIds.tmdb : undefined;
 

--- a/apps/server/src/modules/actions/servarr-tag.service.spec.ts
+++ b/apps/server/src/modules/actions/servarr-tag.service.spec.ts
@@ -33,7 +33,7 @@ describe('ServarrTagService', () => {
     // *arr lookup (mocked per test) decides whether it matches an entity. The
     // candidate id is irrelevant here - the lookup mock ignores it.
     metadataService.resolveLookupCandidatesForService.mockImplementation(
-      async (_mediaServerId, service) => [
+      async (mediaServerId, service) => [
         { providerKey: service === 'radarr' ? 'tmdb' : 'tvdb', id: 100 },
       ],
     );

--- a/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -53,7 +53,7 @@ describe('SonarrActionHandler', () => {
     };
 
     metadataService.resolveLookupCandidatesForService.mockImplementation(
-      async (_mediaServerId, _service, fallbackIds) => {
+      async (mediaServerId, service, fallbackIds) => {
         const tvdbId = await mediaIdFinder.findTvdbId();
         const resolvedTvdbId =
           tvdbId ??

--- a/apps/server/src/modules/api/lib/plexApi.spec.ts
+++ b/apps/server/src/modules/api/lib/plexApi.spec.ts
@@ -75,7 +75,7 @@ describe('PlexApi', () => {
       data: {
         MediaContainer: {
           totalSize,
-          Metadata: Array.from({ length: count }, (_v, i) => ({
+          Metadata: Array.from({ length: count }, (v, i) => ({
             ratingKey: String(start + i),
           })),
         },

--- a/apps/server/src/modules/api/lib/plexApi.ts
+++ b/apps/server/src/modules/api/lib/plexApi.ts
@@ -130,19 +130,19 @@ class PlexApi {
   }
 
   private getQuery<T>(options: RequestOptions) {
-    return this._request<T>('GET', options);
+    return this.request<T>('GET', options);
   }
 
   deleteQuery(options: RequestOptions) {
-    return this._request('DELETE', options);
+    return this.request('DELETE', options);
   }
 
   postQuery<T>(options: RequestOptions) {
-    return this._request<T>('POST', options);
+    return this.request<T>('POST', options);
   }
 
   putQuery<T>(options: RequestOptions) {
-    return this._request<T>('PUT', options);
+    return this.request<T>('PUT', options);
   }
 
   private getServerScheme() {
@@ -152,7 +152,7 @@ class PlexApi {
     return this.options.port === 443 ? 'https://' : 'http://';
   }
 
-  private async _request<T>(method: string, options: RequestOptions) {
+  private async request<T>(method: string, options: RequestOptions) {
     const requestConfig: AxiosRequestConfig = {
       url: options.uri,
       method,

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -1452,11 +1452,11 @@ export class EmbyAdapterService implements IMediaServerService {
   // Cache management
   // ============================================================================
 
-  resetMetadataCache(_itemId?: string): void {
-    // Besides the server-wide aggregates (users/libraries/status/collections)
-    // the only per-item entries are getMetadata's; watch reads still hit the
-    // API fresh. A full flush is the simplest correct reset.
-    void _itemId;
+  // The item id is ignored: besides the server-wide aggregates
+  // (users/libraries/status/collections) the only per-item entries are
+  // getMetadata's, and watch reads still hit the API fresh, so a full flush is
+  // the simplest correct reset.
+  resetMetadataCache(): void {
     this.cache.flush();
   }
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -1047,7 +1047,7 @@ describe('JellyfinAdapterService', () => {
       ['searchContent', [], () => service.searchContent('test')],
     ] as [string, unknown, () => Promise<unknown>][])(
       '%s returns %j when not initialized',
-      async (_method, expected, call) => {
+      async (method, expected, call) => {
         const result = await call();
         if (expected === undefined) {
           expect(result).toBeUndefined();

--- a/apps/server/src/modules/api/media-server/media-provider-ids.utils.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-provider-ids.utils.spec.ts
@@ -32,7 +32,7 @@ describe('media provider ids', () => {
     ['a missing provider', undefined, '12345'],
     ['a missing id', 'imdb', undefined],
     ['an empty id', 'imdb', ''],
-  ])('ignores %s', (_case, name, id) => {
+  ])('ignores %s', (scenario, name, id) => {
     const providerIds = emptyProviderIds();
     addProviderId(providerIds, name, id);
     expect(providerIds).toEqual({ imdb: [], tmdb: [], tvdb: [] });

--- a/apps/server/src/modules/api/media-server/media-server-id.utils.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-server-id.utils.spec.ts
@@ -16,7 +16,7 @@ describe('media-server-id.utils', () => {
     it.each([
       ['blank', ''],
       ['Jellyfin id', 'a852a27afe324084ae66db579ee3ee18'],
-    ])('returns false for %s', (_label, value) => {
+    ])('returns false for %s', (label, value) => {
       expect(isLikelyPlexId(value)).toBe(false);
     });
   });
@@ -33,7 +33,7 @@ describe('media-server-id.utils', () => {
       ['blank', ''],
       ['wrong length', 'a852a27afe324084ae66db579ee3ee1'],
       ['dash at wrong position', 'e9b2dcaa529c-426e-9433-5e9981f27f2e'],
-    ])('returns false for %s', (_label, value) => {
+    ])('returns false for %s', (label, value) => {
       expect(isLikelyJellyfinId(value)).toBe(false);
     });
   });

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -885,7 +885,7 @@ describe('PlexAdapterService', () => {
         message: 'batch failed',
       } as any);
       plexApi.addChildToCollection.mockImplementation(
-        async (_collectionId, itemId) => {
+        async (collectionId, itemId) => {
           if (itemId === 'bad') {
             throw new Error('boom');
           }
@@ -930,7 +930,7 @@ describe('PlexAdapterService', () => {
 
     it('should treat 404 removes as successful in batch remove', async () => {
       plexApi.deleteChildFromCollection.mockImplementation(
-        async (_collectionId, itemId) => {
+        async (collectionId, itemId) => {
           if (itemId === 'missing') {
             throw new Error('404 Not Found');
           }
@@ -1028,7 +1028,7 @@ describe('PlexAdapterService', () => {
       ]);
       plexApi.setCollectionCustomSort.mockResolvedValue(undefined);
       plexApi.moveCollectionItem.mockImplementation(
-        async (_collectionId, itemId) => {
+        async (collectionId, itemId) => {
           if (itemId === 'b') {
             throw new Error('plex move 409');
           }

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -722,7 +722,7 @@ describe('PlexApiService.getCollection (missing vs unreachable)', () => {
     ['a 500 response', { response: { status: 500 } }],
     ['an auth failure', { response: { status: 401 } }],
     ['a transport failure', undefined],
-  ])('rethrows on %s', async (_label, cause) => {
+  ])('rethrows on %s', async (label, cause) => {
     const wrapped = new Error('GET /library/collections/7 failed', {
       cause: cause as any,
     });
@@ -927,9 +927,9 @@ describe('PlexApiService.prefetchWatchHistory', () => {
       .fn()
       .mockImplementation(
         async (
-          _query: unknown,
-          _useCache: unknown,
-          _signal: unknown,
+          query: unknown,
+          useCache: unknown,
+          signal: unknown,
           onProgress?: (p: { fetched: number; totalSize: number }) => void,
         ) => {
           // Drive the callback the way queryAll does, one page at a time.
@@ -938,7 +938,7 @@ describe('PlexApiService.prefetchWatchHistory', () => {
           }
           return {
             MediaContainer: {
-              Metadata: Array.from({ length: totalSize }, (_v, i) => ({
+              Metadata: Array.from({ length: totalSize }, (v, i) => ({
                 ratingKey: String(i % 3),
                 type: 'movie',
                 accountID: 1,
@@ -982,15 +982,15 @@ describe('PlexApiService.prefetchWatchHistory', () => {
       .fn()
       .mockImplementation(
         async (
-          _query: unknown,
-          _useCache: unknown,
-          _signal: unknown,
+          query: unknown,
+          useCache: unknown,
+          signal: unknown,
           onProgress?: (p: { fetched: number; totalSize: number }) => void,
         ) => {
           onProgress?.({ fetched: totalSize, totalSize });
           return {
             MediaContainer: {
-              Metadata: Array.from({ length: totalSize }, (_v, i) => ({
+              Metadata: Array.from({ length: totalSize }, (v, i) => ({
                 ratingKey: String(i),
                 type: 'movie',
                 accountID: 1,
@@ -1113,7 +1113,7 @@ describe('PlexApiService.prefetchWatchHistory', () => {
     const requestStarted = createDeferred();
     const queryAll = jest.fn().mockImplementation(async () => {
       requestStarted.resolve();
-      await new Promise((_resolve, reject) => {
+      await new Promise((resolve, reject) => {
         abortController.signal.addEventListener(
           'abort',
           () => reject(abortController.signal.reason),

--- a/apps/server/src/modules/collections/collections.controller.spec.ts
+++ b/apps/server/src/modules/collections/collections.controller.spec.ts
@@ -208,7 +208,7 @@ describe('CollectionsController', () => {
         action: 0,
       },
     ],
-  ])('rejects invalid %s payloads', (_name, schema, payload) => {
+  ])('rejects invalid %s payloads', (name, schema, payload) => {
     const pipe = new ZodValidationPipe(schema);
 
     expect(() =>

--- a/apps/server/src/modules/events/events.controller.spec.ts
+++ b/apps/server/src/modules/events/events.controller.spec.ts
@@ -27,7 +27,7 @@ class MockResponse extends EventEmitter {
   flushHeaders = jest.fn();
   set = jest.fn();
   write = jest.fn(
-    (_chunk: string, callback?: (error?: Error | null) => void) => {
+    (chunk: string, callback?: (error?: Error | null) => void) => {
       callback?.(null);
       return true;
     },

--- a/apps/server/src/modules/logging/logs.controller.spec.ts
+++ b/apps/server/src/modules/logging/logs.controller.spec.ts
@@ -24,7 +24,7 @@ jest.mock('fs', () => {
     createReadStream: jest.fn(),
     readdir: jest.fn(
       (
-        _dir: string,
+        dir: string,
         callback: (
           error: NodeJS.ErrnoException | null,
           files: string[],
@@ -79,7 +79,7 @@ class MockResponse extends EventEmitter {
   flushHeaders = jest.fn();
   set = jest.fn();
   write = jest.fn(
-    (_chunk: string, callback?: (error?: Error | null) => void) => {
+    (chunk: string, callback?: (error?: Error | null) => void) => {
       callback?.(null);
       return true;
     },
@@ -144,7 +144,7 @@ describe('LogsController', () => {
     const controller = createController();
     const response = new MockResponse();
     readdirMock.mockImplementationOnce(
-      (_dir: string, callback: (error: null, files: string[]) => void) => {
+      (dir: string, callback: (error: null, files: string[]) => void) => {
         callback(null, ['maintainerr-2026-07-28.log']);
       },
     );

--- a/apps/server/src/modules/logging/winston/stdioPipeGuard.spec.ts
+++ b/apps/server/src/modules/logging/winston/stdioPipeGuard.spec.ts
@@ -30,7 +30,7 @@ describe('stdioPipeGuard', () => {
       ['no code', new Error('boom')],
       ['null', null],
       ['string', 'EPIPE'],
-    ])('rejects %s as a non-broken-pipe error', (_label, value) => {
+    ])('rejects %s as a non-broken-pipe error', (label, value) => {
       expect(__testing.isBrokenPipeError(value)).toBe(false);
     });
   });

--- a/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.spec.ts
+++ b/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.spec.ts
@@ -35,7 +35,7 @@ describe('TmdbMetadataProvider', () => {
     ['Pilot', undefined, 'status Pilot (unknown)', undefined],
   ])(
     'maps %s to ended=%s (%s)',
-    async (status, inProduction, _label, expected) => {
+    async (status, inProduction, label, expected) => {
       tmdbApi.getTvShow.mockResolvedValue({
         ...baseTvRecord,
         status,

--- a/apps/server/src/modules/notifications/agents/webhook.ts
+++ b/apps/server/src/modules/notifications/agents/webhook.ts
@@ -18,7 +18,7 @@ type KeyMapFunction = (
 ) => string;
 
 const KeyMap: Record<string, string | KeyMapFunction> = {
-  notification_type: (_payload, type) => NotificationType[type],
+  notification_type: (payload, type) => NotificationType[type],
   event: 'event',
   subject: 'subject',
   message: 'message',

--- a/apps/server/src/modules/notifications/email/openPgpEncrypt.ts
+++ b/apps/server/src/modules/notifications/email/openPgpEncrypt.ts
@@ -13,40 +13,43 @@ interface EncryptorOptions {
 class PGPEncryptor extends Transform {
   private readonly logger = new Logger(PGPEncryptor.name);
 
-  private _messageChunks: Uint8Array[] = [];
-  private _messageLength = 0;
-  private _signingKey?: string;
-  private _password?: string;
+  private messageChunks: Uint8Array[] = [];
+  private messageLength = 0;
+  private signingKey?: string;
+  private password?: string;
 
-  private _encryptionKeys: string[];
+  private encryptionKeys: string[];
 
   constructor(options: EncryptorOptions) {
     super();
-    this._signingKey = options.signingKey;
-    this._password = options.password;
-    this._encryptionKeys = options.encryptionKeys;
+    this.signingKey = options.signingKey;
+    this.password = options.password;
+    this.encryptionKeys = options.encryptionKeys;
   }
+
+  // `_transform` and `_flush` are Node's Transform contract, not a private
+  // naming choice: the stream machinery calls them by these exact names.
 
   // just save the whole message
   _transform = (
     chunk: Uint8Array,
-    _encoding: BufferEncoding,
+    encoding: BufferEncoding,
     callback: TransformCallback,
   ): void => {
-    this._messageChunks.push(chunk);
-    this._messageLength += chunk.length;
+    this.messageChunks.push(chunk);
+    this.messageLength += chunk.length;
     callback();
   };
 
   // Actually do stuff
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   _flush = async (callback: TransformCallback): Promise<void> => {
-    const message = Buffer.concat(this._messageChunks, this._messageLength);
+    const message = Buffer.concat(this.messageChunks, this.messageLength);
 
     try {
       // Reconstruct message as buffer
       const validPublicKeys = await Promise.all(
-        this._encryptionKeys.map((armoredKey) =>
+        this.encryptionKeys.map((armoredKey) =>
           openpgp.readKey({ armoredKey }),
         ),
       );
@@ -59,12 +62,12 @@ class PGPEncryptor extends Transform {
       }
 
       // Only sign the message if private key and password exist
-      if (this._signingKey && this._password) {
+      if (this.signingKey && this.password) {
         privateKey = await openpgp.decryptKey({
           privateKey: await openpgp.readPrivateKey({
-            armoredKey: this._signingKey,
+            armoredKey: this.signingKey,
           }),
-          passphrase: this._password,
+          passphrase: this.password,
         });
       }
 

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
@@ -2195,7 +2195,7 @@ describe('JellyfinGetterService', () => {
       [17, 'sw_amountOfViews', 0],
     ])(
       'answers empty for an episode item without sweeping (%i - %s)',
-      async (propertyId, _name, expected) => {
+      async (propertyId, name, expected) => {
         const episodeItem = createMediaItem({
           id: 'episode-not-a-container',
           type: 'episode' as MediaItemType,

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
@@ -44,7 +44,7 @@ export class SportarrGetterService {
     libItem: MediaItem,
     dataType?: MediaItemType,
     ruleGroup?: RulesDto,
-    _rule?: RuleDto,
+    rule?: RuleDto,
     arrLookupCache?: ArrLookupCache,
   ) {
     if (!ruleGroup.collection?.sportarrSettingsId) {

--- a/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -669,7 +669,7 @@ export class RuleComparatorService {
             return false;
           }
         }
-      } catch (_err) {
+      } catch {
         return null;
       }
     }
@@ -709,7 +709,7 @@ export class RuleComparatorService {
             return false;
           }
         }
-      } catch (_err) {
+      } catch {
         return null;
       }
     }
@@ -727,7 +727,7 @@ export class RuleComparatorService {
             return false;
           }
         }
-      } catch (_err) {
+      } catch {
         return null;
       }
     }

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -77,7 +77,7 @@ describe('RuleExecutorService', () => {
       setCollectionMediaRuleEvaluationFailed: jest
         .fn()
         .mockResolvedValue(undefined),
-      addToCollection: jest.fn().mockImplementation(async (_id, items) => {
+      addToCollection: jest.fn().mockImplementation(async (id, items) => {
         return {
           id: 1,
           mediaServerId: 'coll-1',
@@ -87,7 +87,7 @@ describe('RuleExecutorService', () => {
       }),
       addToCollectionWithResolvedLink: jest
         .fn()
-        .mockImplementation(async (_collection, items) => {
+        .mockImplementation(async (collection, items) => {
           return {
             id: 1,
             mediaServerId: 'coll-1',
@@ -97,7 +97,7 @@ describe('RuleExecutorService', () => {
         }),
       syncMediaServerChildrenToCollection: jest
         .fn()
-        .mockImplementation(async (_collection, items) => {
+        .mockImplementation(async (collection, items) => {
           return {
             id: 1,
             mediaServerId: 'coll-1',

--- a/apps/server/src/utils/sse-stream.spec.ts
+++ b/apps/server/src/utils/sse-stream.spec.ts
@@ -15,7 +15,7 @@ class MockResponse extends EventEmitter {
     this.writableEnded = true;
   });
 
-  write = jest.fn((_chunk: string, callback?: WriteCallback) => {
+  write = jest.fn((chunk: string, callback?: WriteCallback) => {
     callback?.(null);
     return true;
   });
@@ -42,7 +42,7 @@ describe('createSseStreamClient', () => {
     const epipeError = makeEpipeError();
 
     response.write.mockImplementation(
-      (_chunk: string, callback?: WriteCallback) => {
+      (chunk: string, callback?: WriteCallback) => {
         setImmediate(() => callback?.(epipeError));
         return true;
       },

--- a/apps/ui/src/components/OverlayEditor/ElementToolbox.tsx
+++ b/apps/ui/src/components/OverlayEditor/ElementToolbox.tsx
@@ -16,8 +16,8 @@ interface ElementToolboxProps {
   nextLayerOrder: number
 }
 
-let _uid = 0
-const uid = () => `el-${Date.now()}-${++_uid}`
+let uidCounter = 0
+const uid = () => `el-${Date.now()}-${++uidCounter}`
 
 export function ElementToolbox({ onAdd, nextLayerOrder }: ElementToolboxProps) {
   const addText = () => {

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.spec.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.spec.tsx
@@ -164,7 +164,7 @@ describe('RuleInput', () => {
     })
 
     await waitFor(() => {
-      const committedRule = onCommit.mock.calls.at(-1)?.[1]
+      const committedRule = onCommit.mock.calls.at(-1)?.[0]
       expect(committedRule).toMatchObject({
         firstVal: [Application.RADARR, listPropertyId],
         action: RulePossibility.EXISTS,
@@ -309,7 +309,7 @@ describe('RuleInput', () => {
     })
 
     await waitFor(() => {
-      const committedRule = onCommit.mock.calls.at(-1)?.[1]
+      const committedRule = onCommit.mock.calls.at(-1)?.[0]
       expect(committedRule).toMatchObject({
         firstVal: [Application.RADARR, listPropertyId],
         action: RulePossibility.EXISTS,

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
@@ -54,7 +54,7 @@ interface IRuleInput {
   dataType?: MediaItemType
   section?: number
   editData?: { rule: IRule }
-  onCommit: (id: number, rule: IRule) => void
+  onCommit: (rule: IRule) => void
   onIncomplete: (id: number) => void
   onDelete: (section: number, id: number) => void
   allowDelete?: boolean
@@ -566,9 +566,9 @@ const RuleInput = (props: IRuleInput) => {
         ...(isSelectedArrDiskspaceRule && arrDiskPath ? { arrDiskPath } : {}),
       }
       if (!requiresSecondValue) {
-        props.onCommit(props.id ? props.id : 0, ruleValues)
+        props.onCommit(ruleValues)
       } else if (customVal) {
-        props.onCommit(props.id ? props.id : 0, {
+        props.onCommit({
           customVal: {
             ruleTypeId: customValActive
               ? customValType === RuleType.DATE
@@ -591,7 +591,7 @@ const RuleInput = (props: IRuleInput) => {
           ...ruleValues,
         })
       } else {
-        props.onCommit(props.id ? props.id : 0, {
+        props.onCommit({
           lastVal: JSON.parse(secondVal!),
           ...ruleValues,
         })

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/index.spec.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/index.spec.tsx
@@ -78,7 +78,7 @@ vi.mock('./RuleInput', () => ({
       <button
         type="button"
         onClick={() =>
-          onCommit(0, {
+          onCommit({
             operator: null,
             firstVal: ['1', String(tagId)],
             action: 1,

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
@@ -113,7 +113,7 @@ const RuleCreator = (props: iRuleCreator) => {
     emitUpdate()
   }, [sections])
 
-  const handleCommit = (uid: string) => (_id: number, rule: IRule) => {
+  const handleCommit = (uid: string) => (rule: IRule) => {
     setSections((prev) => {
       let changed = false
       const next = prev.map((section) => ({
@@ -227,7 +227,7 @@ const RuleCreator = (props: iRuleCreator) => {
         )}
         renderItem={({ value: section, props: itemProps, index }) => {
           const sectionNumber = (index ?? 0) + 1
-          const { key: _itemKey, style: itemStyle, ...itemRest } = itemProps
+          const { key: itemKey, style: itemStyle, ...itemRest } = itemProps
           return (
             <div
               key={section.uid}
@@ -273,7 +273,7 @@ const RuleCreator = (props: iRuleCreator) => {
                     const tagId = (ruleIndex ?? 0) + 1
                     const absoluteId = ++absoluteCounter
                     const {
-                      key: _ruleKey,
+                      key: ruleKey,
                       style: ruleStyle,
                       onKeyDown: ruleOnKeyDown,
                       ...ruleRest

--- a/apps/ui/src/components/Settings/Servarr/ServarrSettingsModal.tsx
+++ b/apps/ui/src/components/Settings/Servarr/ServarrSettingsModal.tsx
@@ -304,7 +304,7 @@ const ServarrSettingsModal = <TSetting extends ServarrSettingShape>({
 
     const values = getValues()
     const { payload, port } = buildServarrPayload(values, settings)
-    const { id: _ignoredId, ...testPayload } = payload
+    const { id: ignoredId, ...testPayload } = payload
 
     setTesting(true)
 

--- a/apps/ui/src/contexts/search-context.tsx
+++ b/apps/ui/src/contexts/search-context.tsx
@@ -12,7 +12,7 @@ interface SearchContextType {
 
 const SearchContext = createContext<SearchContextType>({
   search: {} as ISearch,
-  addText: (_input: string) => {},
+  addText: () => {},
   removeText: () => {},
 })
 SearchContext.displayName = 'SearchContext'


### PR DESCRIPTION
`_name` is not a convention here, so this removes the underscores by removing the need for them rather than renaming around them.

- Trailing unused parameters dropped outright: `EmbyAdapterService.resetMetadataCache` took an item id it never read (it flushes the whole cache), and `RuleInput.onCommit` passed a rule id no consumer used, since `RuleCreator` already curries the slot uid.
- `catch (_err)` becomes `catch`, using the optional catch binding.
- The rest are renames: `plexApi`'s `_request`, the `PGPEncryptor` fields, the overlay editor's uid counter, and unused parameters across specs.
- `_transform` and `_flush` in `openPgpEncrypt` keep their underscore. Those are Node's `Transform` contract, not a naming choice, and a comment now says so.

Two things worth knowing for anyone applying this rule later. `apps/ui/tsconfig.json` sets `noUnusedParameters`, whose documented escape hatch *is* the leading underscore, so a UI parameter cannot simply be renamed. And on the server ESLint will not flag these either, since `no-unused-vars` runs with the default `args: 'after-used'` plus `caughtErrors: 'none'`.

Behaviour is unchanged: compiled server output before and after differs only by these identifier names, one removed `void _itemId;` no-op, and the catch bindings.