### PR TITLE
perf(media-server): scope the watch-history prefetch to the library being evaluated

### DIFF
--- a/apps/server/src/modules/api/lib/cache.ts
+++ b/apps/server/src/modules/api/lib/cache.ts
@@ -138,10 +138,11 @@ class CacheManager {
       persistent: true,
     }),
     plexguid: new Cache('plexguid', 'Plex GUID', 'plexguid'),
-    // Holds the leaf watch-history map built by PlexApiService.prefetchWatchHistory.
-    // Persistent so the map survives flushAll() between rule groups in the same
-    // cron window; useClones is off because the value is a large Map -
-    // getWatchHistory returns copies of the per-item arrays instead.
+    // Holds the per-library watch-history snapshots built by
+    // PlexApiService.prefetchWatchHistory. Persistent so a snapshot survives
+    // flushAll() between rule groups in the same cron window; useClones is off
+    // because the values are large Maps - getWatchHistory returns copies of the
+    // per-item arrays instead.
     plexwatchhistory: new Cache(
       'plexwatchhistory',
       'Plex watch history',
@@ -150,8 +151,8 @@ class CacheManager {
         stdTtl: 3600, // 1 hour
         persistent: true,
         useClones: false,
-        // Holds a single prefetched Map, not one entry per item - exempt from
-        // the key-count bound so it is never evicted mid-run.
+        // One entry per library swept, not one per item - exempt from the
+        // key-count bound so a snapshot is never evicted mid-run.
         maxKeys: 0,
       },
     ),

--- a/apps/server/src/modules/api/lib/plexApi.pagination.spec.ts
+++ b/apps/server/src/modules/api/lib/plexApi.pagination.spec.ts
@@ -1,0 +1,108 @@
+import axios from 'axios';
+import PlexApi from './plexApi';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { create: jest.fn() },
+}));
+
+jest.mock('axios-retry', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  exponentialDelay: jest.fn(),
+}));
+
+// A Plex that never returns more than `serverCap` rows per page, whatever
+// X-Plex-Container-Size asks for.
+const cappedServer = (totalSize: number, serverCap: number) => {
+  const calls: Array<{ start: number; asked: number }> = [];
+  const request = jest.fn(async (config: any) => {
+    const start = Number(config.headers['X-Plex-Container-Start']);
+    const asked = Number(config.headers['X-Plex-Container-Size']);
+    calls.push({ start, asked });
+    const returned = Math.max(
+      0,
+      Math.min(Math.min(asked, serverCap), totalSize - start),
+    );
+    return {
+      data: {
+        MediaContainer: {
+          totalSize,
+          size: returned,
+          Metadata: Array.from({ length: returned }, (v, i) => ({
+            ratingKey: String(start + i),
+          })),
+        },
+      },
+    };
+  });
+  return { request, calls };
+};
+
+const api = () =>
+  new PlexApi({ hostname: 'plex.local', port: 32400, token: 'token' });
+
+describe('PlexApi.queryAll pagination', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('fetches every row when Plex returns a shorter page than requested', async () => {
+    // Plex caps pages at 50 while we ask for the default 120. Stepping the
+    // offset by the requested size would skip 70 rows per page.
+    const { request, calls } = cappedServer(500, 50);
+    (axios.create as jest.Mock).mockReturnValue({ request });
+
+    const result = await api().queryAll<any>(
+      { uri: '/status/sessions/history/all' },
+      false,
+    );
+
+    const keys = result.MediaContainer.Metadata.map((r: any) => r.ratingKey);
+    expect(keys).toHaveLength(500);
+    expect(new Set(keys).size).toBe(500);
+    expect(calls.map((c) => c.start)).toEqual([
+      0, 50, 100, 150, 200, 250, 300, 350, 400, 450,
+    ]);
+  });
+
+  it('honours a caller-supplied page size', async () => {
+    const { request, calls } = cappedServer(2500, 1000);
+    (axios.create as jest.Mock).mockReturnValue({ request });
+
+    const result = await api().queryAll<any>(
+      { uri: '/status/sessions/history/all' },
+      false,
+      undefined,
+      undefined,
+      1000,
+    );
+
+    expect(result.MediaContainer.Metadata).toHaveLength(2500);
+    expect(calls.map((c) => c.asked)).toEqual([1000, 1000, 1000]);
+    expect(calls.map((c) => c.start)).toEqual([0, 1000, 2000]);
+  });
+
+  it('stops instead of looping when a page comes back empty', async () => {
+    // totalSize claims more rows than the server will hand over.
+    const request = jest.fn(async () => ({
+      data: { MediaContainer: { totalSize: 5000, size: 0, Metadata: [] } },
+    }));
+    (axios.create as jest.Mock).mockReturnValue({ request });
+
+    const result = await api().queryAll<any>({ uri: '/library/all' }, false);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(result.MediaContainer.Metadata).toEqual([]);
+  });
+
+  it('stops after one page when Plex reports no totalSize', async () => {
+    const request = jest.fn(async () => ({
+      data: { MediaContainer: { Metadata: [{ ratingKey: '1' }] } },
+    }));
+    (axios.create as jest.Mock).mockReturnValue({ request });
+
+    const result = await api().queryAll<any>({ uri: '/library/all' }, false);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(result.MediaContainer.Metadata).toHaveLength(1);
+  });
+});

--- a/apps/server/src/modules/api/lib/plexApi.ts
+++ b/apps/server/src/modules/api/lib/plexApi.ts
@@ -129,7 +129,11 @@ class PlexApi {
       // silent truncation for callers that have no totalSize check of their
       // own. Stepping by `received` also makes an empty page terminate the
       // sweep instead of looping to the end of totalSize.
-      if (received > 0 && typeof totalSize === 'number' && fetched < totalSize) {
+      if (
+        received > 0 &&
+        typeof totalSize === 'number' &&
+        fetched < totalSize
+      ) {
         offset += received;
         options.extraHeaders['X-Plex-Container-Start'] = `${offset}`;
       } else {

--- a/apps/server/src/modules/api/lib/plexApi.ts
+++ b/apps/server/src/modules/api/lib/plexApi.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
 import { PlexLibraryResponse } from '../plex-api/interfaces/library.interfaces';
+import { PLEX_PAGE_SIZE } from '../plex-api/plex-api.constants';
 import cacheManager, { Cache } from './cache';
 import { applyHttpRetry } from './httpRetry';
 import { describeRequestTarget } from './requestLogging';
@@ -71,6 +72,9 @@ class PlexApi {
    * @param {function} [onProgress] - Called after each page with the running
    *   count of items fetched so far and Plex's reported totalSize, so callers
    *   can surface progress on long sweeps. Not invoked when totalSize is absent.
+   * @param {number} [pageSize] - Rows to request per page. Raise it on long
+   *   sweeps to cut round trips; Plex is free to return fewer and the loop
+   *   corrects for that.
    * @return {Promise<T[]>} - A promise that resolves to an array of T.
    */
   async queryAll<T>(
@@ -78,20 +82,20 @@ class PlexApi {
     useCache: boolean = true,
     signal?: AbortSignal,
     onProgress?: (progress: { fetched: number; totalSize: number }) => void,
+    pageSize: number = PLEX_PAGE_SIZE.QUERY_ALL,
   ): Promise<T> {
     // vars
     let result = undefined;
     let next = true;
-    let page = 0;
+    let offset = 0;
     let fetched = 0;
-    const size = 120;
     const requestSignal = signal ?? options.signal;
     options = {
       ...options,
       extraHeaders: {
         ...options.extraHeaders,
-        'X-Plex-Container-Start': `${page}`,
-        'X-Plex-Container-Size': `${size}`,
+        'X-Plex-Container-Start': `${offset}`,
+        'X-Plex-Container-Size': `${pageSize}`,
       },
       signal: requestSignal,
     };
@@ -112,16 +116,22 @@ class PlexApi {
         this.appendToData(result.MediaContainer, items as any[]);
       }
 
-      fetched += Array.isArray(items) ? items.length : 0;
+      const received = Array.isArray(items) ? items.length : 0;
+      fetched += received;
       const totalSize = query?.MediaContainer?.totalSize;
       if (onProgress && typeof totalSize === 'number') {
         onProgress({ fetched, totalSize });
       }
 
-      // fetch all if more than 120
-      if (query?.MediaContainer?.totalSize > size * (page + 1)) {
-        options.extraHeaders['X-Plex-Container-Start'] = `${size * (page + 1)}`;
-        page++;
+      // Advance by what Plex actually returned, never by what we asked for.
+      // Plex may hand back a shorter page than X-Plex-Container-Size, and
+      // stepping by the requested size would skip every row it withheld - a
+      // silent truncation for callers that have no totalSize check of their
+      // own. Stepping by `received` also makes an empty page terminate the
+      // sweep instead of looping to the end of totalSize.
+      if (received > 0 && typeof totalSize === 'number' && fetched < totalSize) {
+        offset += received;
+        options.extraHeaders['X-Plex-Container-Start'] = `${offset}`;
       } else {
         next = false;
       }

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -9,7 +9,10 @@ import type { AxiosError } from 'axios';
 import { delay } from '../../../../utils/delay';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { SettingsDataService } from '../../../settings/settings-data.service';
-import { JELLYFIN_WATCH_SNAPSHOT_MAX_RECORDS } from './jellyfin.constants';
+import {
+  JELLYFIN_WATCH_SNAPSHOT_MAX_RECORDS,
+  jellyfinWatchSnapshotCacheKey,
+} from './jellyfin.constants';
 import { JellyfinAdapterService } from './jellyfin-adapter.service';
 import { JELLYFIN_BATCH_SIZE, JELLYFIN_CACHE_TTL } from './jellyfin.constants';
 
@@ -423,7 +426,7 @@ describe('JellyfinAdapterService', () => {
     });
 
     it('prefetchWatchHistory is a no-op when the adapter is not initialised', async () => {
-      await expect(service.prefetchWatchHistory()).resolves.toBeUndefined();
+      await expect(service.prefetchWatchHistory({ libraryId: 'lib-1' })).resolves.toBeUndefined();
     });
   });
 
@@ -1302,7 +1305,7 @@ describe('JellyfinAdapterService', () => {
     });
 
     const snapshot = () =>
-      mockSnapshotStore.get('watch-snapshot') as
+      mockSnapshotStore.get(jellyfinWatchSnapshotCacheKey('lib-1')) as
         | {
             watchHistory: Map<string, unknown[]>;
             descendants: Map<string, string[]>;
@@ -1357,7 +1360,7 @@ describe('JellyfinAdapterService', () => {
         ({ userId }: { userId: string }) => Promise.resolve(leafPage(userId)),
       );
 
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
 
       const cached = snapshot();
       expect(cached).toBeDefined();
@@ -1391,19 +1394,21 @@ describe('JellyfinAdapterService', () => {
       jellyfinApiMocks.getItems.mockImplementation(
         ({ userId }: { userId: string }) => Promise.resolve(leafPage(userId)),
       );
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
       jellyfinApiMocks.getItems.mockClear();
 
       // A season's IsFavorite is independent of its episodes', so this can
       // only come from the container's own swept UserData.
-      await expect(service.getItemFavoritedBy('season-1')).resolves.toEqual([
-        'user-2',
-      ]);
-      await expect(service.getItemFavoritedBy('show-1')).resolves.toEqual([
-        'user-1',
-      ]);
+      await expect(
+        service.getItemFavoritedBy('season-1', 'lib-1'),
+      ).resolves.toEqual(['user-2']);
+      await expect(
+        service.getItemFavoritedBy('show-1', 'lib-1'),
+      ).resolves.toEqual(['user-1']);
       // A swept container nobody favourited is a confirmed empty list.
-      await expect(service.getItemFavoritedBy('movie-1')).resolves.toEqual([]);
+      await expect(
+        service.getItemFavoritedBy('movie-1', 'lib-1'),
+      ).resolves.toEqual([]);
       expect(jellyfinApiMocks.getItems).not.toHaveBeenCalled();
     });
 
@@ -1414,10 +1419,13 @@ describe('JellyfinAdapterService', () => {
       jellyfinApiMocks.getItems.mockImplementation(
         ({ userId }: { userId: string }) => Promise.resolve(leafPage(userId)),
       );
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
       jellyfinApiMocks.getItems.mockClear();
 
-      const result = await service.getDescendantEpisodeWatchHistory('show-1');
+      const result = await service.getDescendantEpisodeWatchHistory(
+        'show-1',
+        'lib-1',
+      );
 
       expect(Object.keys(result).sort()).toEqual(['ep-1', 'ep-2']);
       expect(result['ep-1'].map((r) => r.userId)).toEqual(['user-1']);
@@ -1431,7 +1439,7 @@ describe('JellyfinAdapterService', () => {
       jellyfinApiMocks.getItems.mockImplementation(
         ({ userId }: { userId: string }) => Promise.resolve(leafPage(userId)),
       );
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
       jellyfinApiMocks.getItems.mockClear();
       jellyfinApiMocks.getItems.mockResolvedValue({
         data: { Items: [{ Id: 'ep-9', UserData: { Played: true } }] },
@@ -1450,7 +1458,7 @@ describe('JellyfinAdapterService', () => {
       jellyfinApiMocks.getItems.mockImplementation(
         ({ userId }: { userId: string }) => Promise.resolve(leafPage(userId)),
       );
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
       jellyfinApiMocks.getItems.mockClear();
       // The snapshot says ep-2 is unwatched for this user; Jellyfin now says otherwise.
       jellyfinApiMocks.getItems.mockResolvedValue({
@@ -1478,7 +1486,7 @@ describe('JellyfinAdapterService', () => {
             : Promise.resolve(leafPage(userId)),
       );
 
-      await expect(service.prefetchWatchHistory()).resolves.toBeUndefined();
+      await expect(service.prefetchWatchHistory({ libraryId: 'lib-1' })).resolves.toBeUndefined();
       expect(snapshot()).toBeUndefined();
     });
 
@@ -1493,7 +1501,7 @@ describe('JellyfinAdapterService', () => {
         },
       });
 
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
       expect(snapshot()).toBeUndefined();
     });
 
@@ -1505,7 +1513,7 @@ describe('JellyfinAdapterService', () => {
         data: { Items: [{ Id: 'ep-1', UserData: { Played: true } }] },
       });
 
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
       expect(snapshot()).toBeUndefined();
     });
 
@@ -1519,7 +1527,7 @@ describe('JellyfinAdapterService', () => {
       jellyfinApiMocks.getItems.mockImplementation(
         ({ userId }: { userId: string }) => Promise.resolve(leafPage(userId)),
       );
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
 
       // Server threshold changes; the cached records were decided by the old one.
       jellyfinCacheMocks.data.has.mockReturnValue(false);
@@ -1551,7 +1559,7 @@ describe('JellyfinAdapterService', () => {
         data: { Items: many, TotalRecordCount: many.length },
       });
 
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
 
       // Nothing cached, so every caller reads live rather than trusting a
       // snapshot that would have kept growing.
@@ -1566,7 +1574,7 @@ describe('JellyfinAdapterService', () => {
         ({ userId }: { userId: string }) => Promise.resolve(leafPage(userId)),
       );
 
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
 
       // Libraries with "Group films into collections" hide BoxSet members by
       // default, which would silently drop those items from the snapshot.
@@ -1591,7 +1599,7 @@ describe('JellyfinAdapterService', () => {
         data: { Items: [row, row], TotalRecordCount: 2 },
       });
 
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
 
       const cached = snapshot() as unknown as {
         watchHistory: Map<string, unknown[]>;
@@ -1611,9 +1619,9 @@ describe('JellyfinAdapterService', () => {
         ({ userId }: { userId: string }) => Promise.resolve(leafPage(userId)),
       );
 
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
       jellyfinApiMocks.getItems.mockClear();
-      await service.prefetchWatchHistory();
+      await service.prefetchWatchHistory({ libraryId: 'lib-1' });
 
       expect(jellyfinApiMocks.getItems).not.toHaveBeenCalled();
     });

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -426,7 +426,9 @@ describe('JellyfinAdapterService', () => {
     });
 
     it('prefetchWatchHistory is a no-op when the adapter is not initialised', async () => {
-      await expect(service.prefetchWatchHistory({ libraryId: 'lib-1' })).resolves.toBeUndefined();
+      await expect(
+        service.prefetchWatchHistory({ libraryId: 'lib-1' }),
+      ).resolves.toBeUndefined();
     });
   });
 
@@ -1486,7 +1488,9 @@ describe('JellyfinAdapterService', () => {
             : Promise.resolve(leafPage(userId)),
       );
 
-      await expect(service.prefetchWatchHistory({ libraryId: 'lib-1' })).resolves.toBeUndefined();
+      await expect(
+        service.prefetchWatchHistory({ libraryId: 'lib-1' }),
+      ).resolves.toBeUndefined();
       expect(snapshot()).toBeUndefined();
     });
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -1442,7 +1442,9 @@ export class JellyfinAdapterService implements IMediaServerService {
 
     const snapshot = cacheManager
       .getCache('jellyfinwatchhistory')
-      .data.get<JellyfinWatchSnapshot>(jellyfinWatchSnapshotCacheKey(libraryId));
+      .data.get<JellyfinWatchSnapshot>(
+        jellyfinWatchSnapshotCacheKey(libraryId),
+      );
 
     return snapshot?.playedCompletionThreshold === playedCompletionThreshold
       ? snapshot

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -72,7 +72,7 @@ import {
   JELLYFIN_BATCH_SIZE,
   JELLYFIN_CACHE_KEYS,
   JELLYFIN_CACHE_TTL,
-  JELLYFIN_WATCH_SNAPSHOT_CACHE_KEY,
+  jellyfinWatchSnapshotCacheKey,
   JELLYFIN_WATCH_SNAPSHOT_MAX_RECORDS,
   JELLYFIN_CLIENT_INFO,
   JELLYFIN_DEVICE_INFO,
@@ -129,7 +129,7 @@ export class JellyfinAdapterService implements IMediaServerService {
   private jellyfinUserId: string | undefined;
   private readonly cache: Cache;
   // Shared in-flight prefetch, so concurrent rule groups sweep once.
-  private watchHistoryPrefetch: Promise<void> | undefined;
+  private watchHistoryPrefetches = new Map<string, Promise<void>>();
   // Shared in-flight metadata reads, keyed by item id. See getMetadata.
   private readonly metadataRequests = new Map<
     string,
@@ -1138,24 +1138,36 @@ export class JellyfinAdapterService implements IMediaServerService {
     }
   }
 
-  async prefetchWatchHistory(abortSignal?: AbortSignal): Promise<void> {
+  async prefetchWatchHistory({
+    libraryId,
+    abortSignal,
+  }: {
+    libraryId: string;
+    abortSignal?: AbortSignal;
+  }): Promise<void> {
     if (!this.api) return;
 
     if (
       cacheManager
         .getCache('jellyfinwatchhistory')
-        .data.has(JELLYFIN_WATCH_SNAPSHOT_CACHE_KEY)
+        .data.has(jellyfinWatchSnapshotCacheKey(libraryId))
     ) {
       return;
     }
 
-    // Deduplicate concurrent callers onto one in-flight sweep.
-    this.watchHistoryPrefetch ??= this.buildWatchSnapshot(abortSignal).finally(
+    // Deduplicate concurrent callers onto one in-flight sweep per library.
+    const existing = this.watchHistoryPrefetches.get(libraryId);
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const inFlight = this.buildWatchSnapshot(libraryId, abortSignal).finally(
       () => {
-        this.watchHistoryPrefetch = undefined;
+        this.watchHistoryPrefetches.delete(libraryId);
       },
     );
-    return this.watchHistoryPrefetch;
+    this.watchHistoryPrefetches.set(libraryId, inFlight);
+    return inFlight;
   }
 
   /**
@@ -1182,17 +1194,22 @@ export class JellyfinAdapterService implements IMediaServerService {
    * and every caller falls back to a live read, so a failed prefetch can never
    * be mistaken for "nobody watched anything".
    */
-  private async buildWatchSnapshot(abortSignal?: AbortSignal): Promise<void> {
+  private async buildWatchSnapshot(
+    libraryId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<void> {
     try {
       abortSignal?.throwIfAborted();
-      this.logger.log('Prefetching Jellyfin watch history for all users...');
+      this.logger.log(
+        'Prefetching watch state (history, play counts, favourites) for all users...',
+      );
 
       const playedCompletionThreshold =
         await this.getPlayedCompletionThreshold(true);
       const users = await this.getUsers(true);
       if (users.length === 0) {
         this.logger.warn(
-          'Watch history prefetch found no Jellyfin users - falling back to per-item reads.',
+          'Watch state prefetch found no Jellyfin users - falling back to per-item reads.',
         );
         return;
       }
@@ -1210,7 +1227,7 @@ export class JellyfinAdapterService implements IMediaServerService {
       let sweptUsers = 0;
       const reportProgress = createPrefetchProgressReporter(
         (message) => this.logger.log(message),
-        'Prefetching Jellyfin watch history',
+        'Prefetching watch state',
         'users',
       );
 
@@ -1222,7 +1239,7 @@ export class JellyfinAdapterService implements IMediaServerService {
         // Pages are folded in as they arrive rather than collected first, so
         // the transient cost is one page, not one copy of the library.
         const seenThisUser = new Set<string>();
-        await this.sweepUserItems(user.id, abortSignal, (items) => {
+        await this.sweepUserItems(user.id, libraryId, abortSignal, (items) => {
           for (const item of items) {
             if (!item.Id) continue;
             // Paging is not transactional, so a library changing under the sweep
@@ -1295,7 +1312,7 @@ export class JellyfinAdapterService implements IMediaServerService {
 
       if (exceededCeiling) {
         this.logger.warn(
-          `Watch history prefetch passed ${JELLYFIN_WATCH_SNAPSHOT_MAX_RECORDS} watch records - falling back to per-item reads.`,
+          `Watch state prefetch passed ${JELLYFIN_WATCH_SNAPSHOT_MAX_RECORDS} watch records - falling back to per-item reads.`,
         );
         return;
       }
@@ -1304,14 +1321,14 @@ export class JellyfinAdapterService implements IMediaServerService {
       // the whole library, so an incomplete snapshot is discarded outright.
       if (entries.length !== users.length) {
         this.logger.warn(
-          `Watch history prefetch covered ${entries.length} of ${users.length} users - falling back to per-item reads.`,
+          `Watch state prefetch covered ${entries.length} of ${users.length} users - falling back to per-item reads.`,
         );
         return;
       }
 
       cacheManager
         .getCache('jellyfinwatchhistory')
-        .data.set(JELLYFIN_WATCH_SNAPSHOT_CACHE_KEY, {
+        .data.set(jellyfinWatchSnapshotCacheKey(libraryId), {
           watchHistory,
           descendants,
           favoritedBy,
@@ -1320,7 +1337,7 @@ export class JellyfinAdapterService implements IMediaServerService {
         } satisfies JellyfinWatchSnapshot);
 
       this.logger.log(
-        `Watch history prefetch complete: ${watchHistory.size} items across ${users.length} users - ${records} watch records.`,
+        `Watch state prefetch complete: ${watchHistory.size} items across ${users.length} users - ${records} watch records.`,
       );
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {
@@ -1328,7 +1345,7 @@ export class JellyfinAdapterService implements IMediaServerService {
       }
 
       this.logger.warn(
-        'Watch history prefetch failed - falling back to per-item reads.',
+        'Watch state prefetch failed - falling back to per-item reads.',
       );
       this.logger.debug(error);
     }
@@ -1341,6 +1358,7 @@ export class JellyfinAdapterService implements IMediaServerService {
    */
   private async sweepUserItems(
     userId: string,
+    libraryId: string,
     abortSignal: AbortSignal | undefined,
     onPage: (items: BaseItemDto[]) => void,
   ): Promise<void> {
@@ -1356,6 +1374,11 @@ export class JellyfinAdapterService implements IMediaServerService {
         // out of the snapshot entirely (#2554).
         ...JELLYFIN_LIBRARY_QUERY_DEFAULTS,
         userId,
+        // Scoped to the library being evaluated. Unscoped, the (item x user)
+        // matrix is the whole server's and trips
+        // JELLYFIN_WATCH_SNAPSHOT_MAX_RECORDS on large installs, which
+        // abandons the snapshot outright and puts every read back per item.
+        parentId: libraryId,
         recursive: true,
         // Series and Season carry their own UserData (IsFavorite, Played), so
         // sweeping them costs a couple of extra pages per user and spares
@@ -1406,12 +1429,20 @@ export class JellyfinAdapterService implements IMediaServerService {
    * under a different PlayedPercentage threshold is ignored: that threshold is
    * what decided which plays count as watched.
    */
+  /**
+   * The snapshot for `libraryId`, or undefined when there is none to use.
+   * Without a library there is nothing to look up, so every read goes live -
+   * the same outcome as a miss, since a miss here is never an answer.
+   */
   private getWatchSnapshot(
+    libraryId: string | undefined,
     playedCompletionThreshold: number | undefined,
   ): JellyfinWatchSnapshot | undefined {
+    if (!libraryId) return undefined;
+
     const snapshot = cacheManager
       .getCache('jellyfinwatchhistory')
-      .data.get<JellyfinWatchSnapshot>(JELLYFIN_WATCH_SNAPSHOT_CACHE_KEY);
+      .data.get<JellyfinWatchSnapshot>(jellyfinWatchSnapshotCacheKey(libraryId));
 
     return snapshot?.playedCompletionThreshold === playedCompletionThreshold
       ? snapshot
@@ -1421,6 +1452,7 @@ export class JellyfinAdapterService implements IMediaServerService {
   async getWatchHistory(
     itemId: string,
     useSnapshot = true,
+    libraryId?: string,
   ): Promise<WatchRecord[]> {
     if (!this.api) return [];
 
@@ -1436,6 +1468,7 @@ export class JellyfinAdapterService implements IMediaServerService {
       // not swept (an item added since), so fall through to a live read rather
       // than answering "never watched".
       const records = this.getWatchSnapshot(
+        libraryId,
         playedCompletionThreshold,
       )?.watchHistory.get(itemId);
       // The snapshot cache stores by reference, so hand callers a copy.
@@ -1486,8 +1519,8 @@ export class JellyfinAdapterService implements IMediaServerService {
     };
   }
 
-  async getItemSeenBy(itemId: string): Promise<string[]> {
-    const history = await this.getWatchHistory(itemId);
+  async getItemSeenBy(itemId: string, libraryId?: string): Promise<string[]> {
+    const history = await this.getWatchHistory(itemId, true, libraryId);
     return history.map((record) => record.userId);
   }
 
@@ -1534,6 +1567,7 @@ export class JellyfinAdapterService implements IMediaServerService {
    */
   async getDescendantEpisodeWatchHistory(
     parentId: string,
+    libraryId?: string,
   ): Promise<Record<string, WatchRecord[]>> {
     if (!this.api) return {};
 
@@ -1543,7 +1577,10 @@ export class JellyfinAdapterService implements IMediaServerService {
     // A parent the prefetch indexed is answered from memory. An unindexed one
     // (no snapshot, or a show added since) falls through to the per-show sweep
     // below, which is still one request per user rather than per episode.
-    const snapshot = this.getWatchSnapshot(playedCompletionThreshold);
+    const snapshot = this.getWatchSnapshot(
+      libraryId,
+      playedCompletionThreshold,
+    );
     const sweptEpisodeIds = snapshot?.descendants.get(parentId);
     if (sweptEpisodeIds) {
       const fromSnapshot: Record<string, WatchRecord[]> = {};
@@ -1626,7 +1663,10 @@ export class JellyfinAdapterService implements IMediaServerService {
    * Get user IDs of all users who have favorited an item.
    * Iterates over all users and checks UserData.IsFavorite.
    */
-  async getItemFavoritedBy(itemId: string): Promise<string[]> {
+  async getItemFavoritedBy(
+    itemId: string,
+    libraryId?: string,
+  ): Promise<string[]> {
     if (!this.api) return [];
 
     try {
@@ -1634,6 +1674,7 @@ export class JellyfinAdapterService implements IMediaServerService {
       // id answers from memory; an unswept one (an item added since) falls
       // through to the per-user read below.
       const snapshot = this.getWatchSnapshot(
+        libraryId,
         await this.getPlayedCompletionThreshold(),
       );
       if (snapshot?.watchHistory.has(itemId)) {
@@ -1665,11 +1706,12 @@ export class JellyfinAdapterService implements IMediaServerService {
    * This includes partial/unfinished plays (PlayCount > 0 but Played = false).
    * Only meaningful for Movies and Episodes (Series/Seasons always return 0).
    */
-  async getTotalPlayCount(itemId: string): Promise<number> {
+  async getTotalPlayCount(itemId: string, libraryId?: string): Promise<number> {
     if (!this.api) return 0;
 
     try {
       const snapshot = this.getWatchSnapshot(
+        libraryId,
         await this.getPlayedCompletionThreshold(),
       );
       if (snapshot?.watchHistory.has(itemId)) {

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin.constants.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin.constants.ts
@@ -49,16 +49,23 @@ export const JELLYFIN_RETRYABLE_LIBRARY_ERROR_CODES = new Set([
 
 export const JELLYFIN_RETRYABLE_LIBRARY_STATUS_CODES = new Set([502, 503, 504]);
 
-// Key in the 'jellyfinwatchhistory' cache for the library-wide snapshot built
-// by prefetchWatchHistory(). TTL and flush behaviour live on the cache
+// Key prefix in the 'jellyfinwatchhistory' cache for the per-library snapshots
+// built by prefetchWatchHistory(). TTL and flush behaviour live on the cache
 // definition in lib/cache.ts.
-export const JELLYFIN_WATCH_SNAPSHOT_CACHE_KEY = 'watch-snapshot';
+//
+// Keyed per library so each rule group's library gets its own sweep. A single
+// shared key would let the first group's snapshot satisfy the cache check for
+// every later group, leaving their items to miss it and read live one by one.
+const JELLYFIN_WATCH_SNAPSHOT_KEY_PREFIX = 'watch-snapshot';
+export const jellyfinWatchSnapshotCacheKey = (libraryId: string): string =>
+  `${JELLYFIN_WATCH_SNAPSHOT_KEY_PREFIX}:${libraryId}`;
 
-// Ceiling on watch records held in that snapshot. The snapshot lives for a
-// whole run, and a (item x user) matrix grows with both; 500k records measured
-// ~60MB, which stays clear of the 512MB heap the key-count bound protects
-// (#3284). Above it the prefetch is abandoned and callers fall back to the
-// per-show sweep, which is bounded by one show at a time.
+// Ceiling on watch records held in one library's snapshot. The snapshot lives
+// for a whole run, and a (item x user) matrix grows with both; 500k records
+// measured ~60MB, which stays clear of the 512MB heap the key-count bound
+// protects (#3284). Above it the prefetch is abandoned and callers fall back to
+// the per-show sweep, which is bounded by one show at a time. Sweeping per
+// library rather than per server keeps large multi-library servers under it.
 export const JELLYFIN_WATCH_SNAPSHOT_MAX_RECORDS = 500_000;
 
 export const JELLYFIN_CACHE_KEYS = {

--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -170,10 +170,13 @@ export interface IMediaServerService {
   searchContent(query: string): Promise<MediaItem[]>;
 
   /**
-   * Prefetch watch history for all library items in a single bulk request,
-   * caching the result so that subsequent per-item getWatchHistory /
-   * getWatchState calls can be served from memory instead of making individual
-   * HTTP requests.
+   * Prefetch watch history in bulk, caching the result so that subsequent
+   * per-item getWatchHistory / getWatchState calls can be served from memory
+   * instead of making individual HTTP requests.
+   *
+   * @param libraryId - The library about to be evaluated. Sweeps are scoped to
+   *   it and cached per library: a rule group only ever evaluates its own
+   *   library, and an unscoped sweep pays for every other one on the server.
    *
    * Gated by MediaServerFeature.CENTRAL_WATCH_HISTORY (watch history is
    * fetchable in bulk, whether from one central endpoint or one sweep per
@@ -184,7 +187,10 @@ export interface IMediaServerService {
    * cached result, so getWatchHistory falls back to live per-item reads. A
    * failed prefetch must never surface as "nothing was watched".
    */
-  prefetchWatchHistory(abortSignal?: AbortSignal): Promise<void>;
+  prefetchWatchHistory(options: {
+    libraryId: string;
+    abortSignal?: AbortSignal;
+  }): Promise<void>;
 
   /**
    * Get watch history for a specific item.

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -442,8 +442,12 @@ describe('PlexAdapterService', () => {
   describe('prefetchWatchHistory', () => {
     it('delegates to plexApi.prefetchWatchHistory', async () => {
       plexApi.prefetchWatchHistory = jest.fn().mockResolvedValue(undefined);
-      await service.prefetchWatchHistory();
-      expect(plexApi.prefetchWatchHistory).toHaveBeenCalledTimes(1);
+      const abortSignal = new AbortController().signal;
+      await service.prefetchWatchHistory({ libraryId: '7', abortSignal });
+      expect(plexApi.prefetchWatchHistory).toHaveBeenCalledWith(
+        '7',
+        abortSignal,
+      );
     });
   });
 
@@ -487,7 +491,18 @@ describe('PlexAdapterService', () => {
         viewCount: 1,
         isWatched: true,
       });
+      // Never served from the run snapshot (#3352): this is the current-state
+      // read that feeds deletions.
       expect(plexApi.getWatchHistory).toHaveBeenCalledWith('item123', false);
+    });
+
+    it('keeps the native view count as a floor when history is empty', async () => {
+      // Plex writes no history row for a manual "mark as played" or a scrobble.
+      plexApi.getWatchHistory.mockResolvedValue([]);
+
+      const watchState = await service.getWatchState('item123', 3);
+
+      expect(watchState).toEqual({ viewCount: 3, isWatched: true });
     });
 
     it('should keep the server-wide history count when a single account has fewer native views', async () => {

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -223,8 +223,14 @@ export class PlexAdapterService implements IMediaServerService {
     return results.map(PlexMapper.metadataToMediaItem);
   }
 
-  async prefetchWatchHistory(abortSignal?: AbortSignal): Promise<void> {
-    await this.plexApi.prefetchWatchHistory(abortSignal);
+  async prefetchWatchHistory({
+    libraryId,
+    abortSignal,
+  }: {
+    libraryId: string;
+    abortSignal?: AbortSignal;
+  }): Promise<void> {
+    await this.plexApi.prefetchWatchHistory(libraryId, abortSignal);
   }
 
   async getWatchHistory(itemId: string): Promise<WatchRecord[]> {
@@ -238,7 +244,9 @@ export class PlexAdapterService implements IMediaServerService {
   ): Promise<MediaWatchState> {
     // Read live: something watched moments ago must not be judged from a
     // stale snapshot, and a failed read has to throw rather than pass for a
-    // confirmed never-watched.
+    // confirmed never-watched. Deliberately not served from the run's
+    // watch-history snapshot (#3352) - this is the current-state read that
+    // feeds deletions, and stale watched state was the defect that PR fixed.
     const history = await this.plexApi.getWatchHistory(itemId, false);
 
     // Plex writes no history row when an item is marked watched without a

--- a/apps/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
+++ b/apps/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
@@ -130,4 +130,11 @@ export interface PlexSeenBy extends PlexLibraryItem {
   viewedAt: number;
   accountID: number;
   deviceID: number;
+  // Path form (`/library/metadata/<ratingKey>`) of an episode row's season and
+  // show. Undocumented on the history endpoint - the OpenAPI spec documents
+  // `grandparentRatingKey`, which real servers do not send - and absent
+  // entirely over some connections (#3082), so both are optional and the
+  // show/season rollup stands down when either is missing.
+  parentKey?: string;
+  grandparentKey?: string;
 }

--- a/apps/server/src/modules/api/plex-api/plex-api.constants.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.constants.ts
@@ -1,6 +1,15 @@
 export const PLEX_PAGE_SIZE = {
   DEFAULT: 50,
   WATCHLIST: 100,
+  // X-Plex-Container-Size for queryAll's paginated sweeps. Plex may return a
+  // shorter page than asked; queryAll advances by what actually arrived, so an
+  // unknown server-side cap costs round trips, never records.
+  QUERY_ALL: 120,
+  // Ceiling for bulk sweeps that page through a whole library. Matches
+  // JELLYFIN_BATCH_SIZE/EMBY_BATCH_SIZE.MAX_PAGE_SIZE - the sweeps cost per
+  // record, not per request, so paging past this buys almost nothing: on an
+  // 88k-entry history, 1000 instead of 500 saves ~36s of the ~16min sweep.
+  MAX_PAGE_SIZE: 500,
 } as const;
 
 // Bounds runtime Plex socket reads so a wedged request can't stall the rule
@@ -8,8 +17,47 @@ export const PLEX_PAGE_SIZE = {
 // CONNECTION_TEST_TIMEOUT_MS; this applies to the long-lived runtime client.
 export const PLEX_REQUEST_TIMEOUT_MS = 30_000;
 
-// Key in the 'plexwatchhistory' cache for the leaf watch-history map built by
-// prefetchWatchHistory() - leaf items (movies + episodes) keyed by own
-// ratingKey. TTL and flush behaviour live on the cache definition in
-// lib/cache.ts.
-export const WATCH_HISTORY_BULK_CACHE_KEY = 'watch-history-bulk';
+// Key prefix in the 'plexwatchhistory' cache for the watch-history snapshots
+// built by prefetchWatchHistory(). TTL and flush behaviour live on the cache
+// definition in lib/cache.ts.
+//
+// Keyed per library, never globally: a snapshot is authoritative for "never
+// watched" only inside the library it swept. Under one shared key, an item from
+// a library we never swept would miss the map and read as a confirmed empty
+// history - a false never-watched on a tool that deletes media. A miss on an
+// unswept library has to fall through to a per-item read instead.
+const WATCH_HISTORY_CACHE_KEY_PREFIX = 'watch-history-bulk';
+export const watchHistoryCacheKey = (libraryId: string): string =>
+  `${WATCH_HISTORY_CACHE_KEY_PREFIX}:${libraryId}`;
+
+// Ceiling on entries held in one library's snapshot. Mirrors
+// JELLYFIN_WATCH_SNAPSHOT_MAX_RECORDS: 500k trimmed rows measured ~74MB
+// retained, which stays clear of the 512MB heap the key-count bound protects
+// (#3284), and nothing else bounds this map. Plex reports totalSize on the
+// first page, so an oversized history is abandoned after one request rather
+// than paged through in full; callers fall back to per-item reads.
+export const WATCH_HISTORY_MAX_ENTRIES = 500_000;
+
+// A history row is only ever read for its identity, its timing and the account
+// that watched it. Plex sends artwork, titles and summaries by default;
+// dropping them measured 405 -> 148 bytes per row on PMS 1.43.3, and the
+// sweep's cost is per record. `index`/`parentIndex` stay - sw_lastWatched sorts
+// on them.
+export const WATCH_HISTORY_EXCLUDE_FIELDS = [
+  'art',
+  'banner',
+  'deviceID',
+  'grandparentArt',
+  'grandparentThumb',
+  'grandparentTitle',
+  'guid',
+  'historyKey',
+  'key',
+  'originallyAvailableAt',
+  'parentThumb',
+  'parentTitle',
+  'summary',
+  'theme',
+  'thumb',
+  'title',
+].join(',');

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -5,7 +5,12 @@ import {
 } from '../../logging/logs.service';
 import { Settings } from '../../settings/entities/settings.entities';
 import { SettingsDataService } from '../../settings/settings-data.service';
-import { WATCH_HISTORY_BULK_CACHE_KEY } from './plex-api.constants';
+import {
+  PLEX_PAGE_SIZE,
+  WATCH_HISTORY_EXCLUDE_FIELDS,
+  WATCH_HISTORY_MAX_ENTRIES,
+  watchHistoryCacheKey,
+} from './plex-api.constants';
 import { PlexConnection } from './interfaces/server.interface';
 import { PlexApiService } from './plex-api.service';
 
@@ -774,12 +779,12 @@ describe('PlexApiService.initialize', () => {
   it('flushes the watch-history snapshot on uninitialize (server/token switch)', async () => {
     const cacheManager = (await import('../lib/cache')).default;
     const bulkCache = cacheManager.getCache('plexwatchhistory').data;
-    bulkCache.set(WATCH_HISTORY_BULK_CACHE_KEY, new Map([['1', [{}]]]));
+    bulkCache.set(watchHistoryCacheKey('1'), { leaf: new Map([['1', [{}]]]) });
 
     service.uninitialize();
 
-    expect(bulkCache.has(WATCH_HISTORY_BULK_CACHE_KEY)).toBe(false);
-    expect((service as any).watchHistoryPrefetch).toBeUndefined();
+    expect(bulkCache.has(watchHistoryCacheKey('1'))).toBe(false);
+    expect((service as any).watchHistoryPrefetches.size).toBe(0);
   });
 
   it('clears plexClient when primary connection and rediscovery both fail', async () => {
@@ -846,11 +851,44 @@ describe('PlexApiService.initialize', () => {
     expect(status).toEqual({ machineIdentifier: 'm1', version: '1.43.2' });
   });
 });
-
 describe('PlexApiService.prefetchWatchHistory', () => {
   let service: PlexApiService;
   let logger: Mocked<MaintainerrLogger>;
   let loggerFactory: Mocked<MaintainerrLoggerFactory>;
+
+  const LIBRARY = '3';
+
+  const historyRow = (over: Record<string, unknown> = {}) => ({
+    ratingKey: '1',
+    type: 'movie',
+    accountID: 1,
+    viewedAt: 1700000000,
+    ...over,
+  });
+
+  const episodeRow = (over: Record<string, unknown> = {}) =>
+    historyRow({
+      type: 'episode',
+      parentKey: '/library/metadata/900',
+      grandparentKey: '/library/metadata/800',
+      ...over,
+    });
+
+  // The sweep proves its rollup with one live per-item read; unless a test says
+  // otherwise, have that read agree with what the rollup claims.
+  const agreeingVerification = (rows: Record<string, unknown>[]) =>
+    jest.fn().mockImplementation(async (query: { uri: string }) =>
+      query.uri.includes('metadataItemID')
+        ? { MediaContainer: { Metadata: rows } }
+        : { MediaContainer: { Metadata: rows, totalSize: rows.length } },
+    );
+
+  const snapshotFor = async (libraryId: string) => {
+    const cacheManager = (await import('../lib/cache')).default;
+    return cacheManager
+      .getCache('plexwatchhistory')
+      .data.get<any>(watchHistoryCacheKey(libraryId));
+  };
 
   beforeEach(async () => {
     const { unit, unitRef } = await TestBed.solitary(PlexApiService).compile();
@@ -867,58 +905,188 @@ describe('PlexApiService.prefetchWatchHistory', () => {
       debug: jest.fn(),
     } as any);
 
-    // Clear the bulk watch-history cache entries between tests
     const cacheManager = (await import('../lib/cache')).default;
-    const bulkCache = cacheManager.getCache('plexwatchhistory')?.data;
-    bulkCache?.del(WATCH_HISTORY_BULK_CACHE_KEY);
+    cacheManager.getCache('plexwatchhistory')?.data.flushAll();
   });
 
-  it('indexes movie records in the leaf map by ratingKey', async () => {
+  it('sweeps only the requested library, trimmed and paged for a long sweep', async () => {
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: { Metadata: [historyRow()], totalSize: 1 },
+    });
+    (service as any).plexClient = { queryAll };
+
+    await service.prefetchWatchHistory(LIBRARY);
+
+    const [request, useCache, signal, onProgress, pageSize] =
+      queryAll.mock.calls[0];
+    expect(request.uri).toContain(`librarySectionID=${LIBRARY}`);
+    expect(request.uri).toContain(
+      `excludeFields=${WATCH_HISTORY_EXCLUDE_FIELDS}`,
+    );
+    // Fields the getters read must never be excluded.
+    for (const kept of ['ratingKey', 'viewedAt', 'accountID', 'parentIndex']) {
+      expect(WATCH_HISTORY_EXCLUDE_FIELDS.split(',')).not.toContain(kept);
+    }
+    expect(useCache).toBe(false);
+    expect(signal).toBeUndefined();
+    expect(onProgress).toEqual(expect.any(Function));
+    expect(pageSize).toBe(PLEX_PAGE_SIZE.MAX_PAGE_SIZE);
+  });
+
+  it('rolls episodes up to their show and season once Plex confirms the rollup', async () => {
+    const rows = [
+      episodeRow({ ratingKey: '101', viewedAt: 1 }),
+      episodeRow({ ratingKey: '102', viewedAt: 2 }),
+      episodeRow({
+        ratingKey: '201',
+        viewedAt: 3,
+        parentKey: '/library/metadata/901',
+      }),
+    ];
+    const queryAll = agreeingVerification(rows);
+    (service as any).plexClient = { queryAll };
+
+    await service.prefetchWatchHistory(LIBRARY);
+
+    const snapshot = await snapshotFor(LIBRARY);
+    expect(snapshot?.rollup?.show.get('800')).toHaveLength(3);
+    expect(snapshot?.rollup?.season.get('900')).toHaveLength(2);
+    expect(snapshot?.rollup?.season.get('901')).toHaveLength(1);
+  });
+
+  it('drops the rollup when Plex disagrees with what it claims for a show', async () => {
+    // A connection whose parent keys parse to the wrong id would build a
+    // plausible-looking rollup that under-reports the show. The sweep asks
+    // Plex the same question and throws the rollup away when it differs.
+    const rows = [episodeRow({ ratingKey: '101', viewedAt: 1 })];
+    const queryAll = jest.fn().mockImplementation(async (query: { uri: string }) =>
+      query.uri.includes('metadataItemID')
+        ? { MediaContainer: { Metadata: [...rows, episodeRow({ ratingKey: '102', viewedAt: 2 })] } }
+        : { MediaContainer: { Metadata: rows, totalSize: rows.length } },
+    );
+    (service as any).plexClient = { queryAll };
+
+    await service.prefetchWatchHistory(LIBRARY);
+
+    const snapshot = await snapshotFor(LIBRARY);
+    expect(snapshot?.leaf.get('101')).toHaveLength(1);
+    expect(snapshot?.rollup).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('disagreed with Plex'),
+    );
+  });
+
+  it('drops the rollup when the verification read fails', async () => {
+    const rows = [episodeRow({ ratingKey: '101', viewedAt: 1 })];
+    const queryAll = jest.fn().mockImplementation(async (query: { uri: string }) => {
+      if (query.uri.includes('metadataItemID')) throw new Error('network');
+      return { MediaContainer: { Metadata: rows, totalSize: rows.length } };
+    });
+    (service as any).plexClient = { queryAll };
+
+    await service.prefetchWatchHistory(LIBRARY);
+
+    const snapshot = await snapshotFor(LIBRARY);
+    expect(snapshot?.leaf.get('101')).toHaveLength(1);
+    expect(snapshot?.rollup).toBeUndefined();
+  });
+
+  it('stands the rollup down when any episode row lacks its parent keys', async () => {
+    const rows = [
+      episodeRow({ ratingKey: '101', viewedAt: 1 }),
+      episodeRow({ ratingKey: '102', viewedAt: 2, grandparentKey: undefined }),
+    ];
+    const queryAll = agreeingVerification(rows);
+    (service as any).plexClient = { queryAll };
+
+    await service.prefetchWatchHistory(LIBRARY);
+
+    const snapshot = await snapshotFor(LIBRARY);
+    expect(snapshot?.leaf.get('101')).toHaveLength(1);
+    expect(snapshot?.rollup).toBeUndefined();
+    // No rollup to prove, so no verification request was spent on it.
+    expect(
+      queryAll.mock.calls.filter((c: any[]) => c[0].uri.includes('metadataItemID')),
+    ).toHaveLength(0);
+  });
+
+  it('never verifies a movie-only library', async () => {
+    const rows = [historyRow({ ratingKey: '5' })];
+    const queryAll = agreeingVerification(rows);
+    (service as any).plexClient = { queryAll };
+
+    await service.prefetchWatchHistory(LIBRARY);
+
+    expect(
+      queryAll.mock.calls.filter((c: any[]) => c[0].uri.includes('metadataItemID')),
+    ).toHaveLength(0);
+    expect((await snapshotFor(LIBRARY))?.rollup?.show.size ?? 0).toBe(0);
+  });
+
+  it('abandons an oversized history after one request instead of paging it all', async () => {
+    // Nothing else bounds this map, and queryAll materialises every row before
+    // returning, so the only place to stop is the totalSize on page one.
+    const queryAll = jest
+      .fn()
+      .mockImplementation(
+        async (
+          query: unknown,
+          useCache: unknown,
+          signal: unknown,
+          onProgress?: (p: { fetched: number; totalSize: number }) => void,
+        ) => {
+          onProgress?.({
+            fetched: 500,
+            totalSize: WATCH_HISTORY_MAX_ENTRIES + 1,
+          });
+          return { MediaContainer: { Metadata: [], totalSize: 0 } };
+        },
+      );
+    (service as any).plexClient = { queryAll };
+
+    await service.prefetchWatchHistory(LIBRARY);
+
+    expect(queryAll).toHaveBeenCalledTimes(1);
+    expect(await snapshotFor(LIBRARY)).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`passed ${WATCH_HISTORY_MAX_ENTRIES} entries`),
+    );
+  });
+
+  it('indexes movie records in the snapshot by ratingKey', async () => {
     const queryAll = jest.fn().mockResolvedValue({
       MediaContainer: {
         Metadata: [
-          {
-            ratingKey: '1',
-            type: 'movie',
-            accountID: 10,
-            viewedAt: 1700000000,
-          },
-          {
-            ratingKey: '2',
-            type: 'movie',
-            accountID: 11,
-            viewedAt: 1710000000,
-          },
-          {
-            ratingKey: '1',
-            type: 'movie',
-            accountID: 12,
-            viewedAt: 1720000000,
-          },
+          historyRow({ ratingKey: '1', accountID: 10 }),
+          historyRow({ ratingKey: '2', accountID: 11 }),
+          historyRow({ ratingKey: '1', accountID: 12 }),
         ],
         totalSize: 3,
       },
     });
-
     (service as any).plexClient = { queryAll };
 
-    await service.prefetchWatchHistory();
+    await service.prefetchWatchHistory(LIBRARY);
 
-    expect(queryAll).toHaveBeenCalledWith(
-      { uri: '/status/sessions/history/all?sort=viewedAt:desc' },
-      false,
-      undefined,
-      expect.any(Function),
-    );
+    const snapshot = await snapshotFor(LIBRARY);
+    expect(snapshot?.leaf.get('1')).toHaveLength(2);
+    expect(snapshot?.leaf.get('2')).toHaveLength(1);
+  });
 
-    const cacheManager = (await import('../lib/cache')).default;
-    const leafMap = cacheManager
-      .getCache('plexwatchhistory')
-      .data.get<Map<string, unknown[]>>(WATCH_HISTORY_BULK_CACHE_KEY);
+  it('caches per library, so one library does not answer for another', async () => {
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: { Metadata: [historyRow()], totalSize: 1 },
+    });
+    (service as any).plexClient = { queryAll };
 
-    expect(leafMap).toBeDefined();
-    expect(leafMap?.get('1')).toHaveLength(2);
-    expect(leafMap?.get('2')).toHaveLength(1);
+    await service.prefetchWatchHistory('1');
+
+    expect(await snapshotFor('1')).toBeDefined();
+    expect(await snapshotFor('2')).toBeUndefined();
+
+    await service.prefetchWatchHistory('2');
+    expect(queryAll).toHaveBeenCalledTimes(2);
+    expect(queryAll.mock.calls[1][0].uri).toContain('librarySectionID=2');
   });
 
   it('logs watch-history prefetch progress in 10% steps as pages arrive', async () => {
@@ -938,12 +1106,9 @@ describe('PlexApiService.prefetchWatchHistory', () => {
           }
           return {
             MediaContainer: {
-              Metadata: Array.from({ length: totalSize }, (v, i) => ({
-                ratingKey: String(i % 3),
-                type: 'movie',
-                accountID: 1,
-                viewedAt: i,
-              })),
+              Metadata: Array.from({ length: totalSize }, (v, i) =>
+                historyRow({ ratingKey: String(i % 3), viewedAt: i }),
+              ),
               totalSize,
             },
           };
@@ -952,24 +1117,34 @@ describe('PlexApiService.prefetchWatchHistory', () => {
 
     (service as any).plexClient = { queryAll };
 
-    await service.prefetchWatchHistory();
+    await service.prefetchWatchHistory(LIBRARY);
 
+    const prefix = `Prefetching watch history for library ${LIBRARY}:`;
     const progressLogs = (logger.log as jest.Mock).mock.calls
       .map((call) => call[0])
       .filter(
-        (message) =>
-          typeof message === 'string' &&
-          message.startsWith('Prefetching watch history:'),
+        (message) => typeof message === 'string' && message.startsWith(prefix),
       );
 
     // Deciles 10..90 each logged once; the terminal 100% is left to the
     // "prefetch complete" line, so it is never emitted as progress.
     expect(progressLogs).toHaveLength(9);
-    expect(progressLogs[0]).toBe(
-      'Prefetching watch history: 100 of 1000 records (10%)...',
-    );
-    expect(progressLogs[8]).toBe(
-      'Prefetching watch history: 900 of 1000 records (90%)...',
+    expect(progressLogs[0]).toBe(`${prefix} 100 of 1000 entries (10%)...`);
+    expect(progressLogs[8]).toBe(`${prefix} 900 of 1000 entries (90%)...`);
+  });
+
+  it('says what the entry count means on the opening line', async () => {
+    // A user compared an 88k entry count against a 6.5k-episode library and
+    // read it as a bug; the line has to say it counts view events.
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: { Metadata: [historyRow()], totalSize: 1 },
+    });
+    (service as any).plexClient = { queryAll };
+
+    await service.prefetchWatchHistory(LIBRARY);
+
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('one entry per view event, across all users'),
     );
   });
 
@@ -990,12 +1165,9 @@ describe('PlexApiService.prefetchWatchHistory', () => {
           onProgress?.({ fetched: totalSize, totalSize });
           return {
             MediaContainer: {
-              Metadata: Array.from({ length: totalSize }, (v, i) => ({
-                ratingKey: String(i),
-                type: 'movie',
-                accountID: 1,
-                viewedAt: i,
-              })),
+              Metadata: Array.from({ length: totalSize }, (v, i) =>
+                historyRow({ ratingKey: String(i), viewedAt: i }),
+              ),
               totalSize,
             },
           };
@@ -1004,59 +1176,22 @@ describe('PlexApiService.prefetchWatchHistory', () => {
 
     (service as any).plexClient = { queryAll };
 
-    await service.prefetchWatchHistory();
+    await service.prefetchWatchHistory(LIBRARY);
 
     const progressLogs = (logger.log as jest.Mock).mock.calls
       .map((call) => call[0])
       .filter(
         (message) =>
           typeof message === 'string' &&
-          message.startsWith('Prefetching watch history:'),
+          message.startsWith(
+            `Prefetching watch history for library ${LIBRARY}:`,
+          ),
       );
 
     expect(progressLogs).toEqual([]);
   });
 
-  it('indexes episode records in the leaf map by ratingKey', async () => {
-    const queryAll = jest.fn().mockResolvedValue({
-      MediaContainer: {
-        Metadata: [
-          {
-            ratingKey: '101',
-            type: 'episode',
-            accountID: 1,
-            viewedAt: 1700000001,
-          },
-          {
-            ratingKey: '101',
-            type: 'episode',
-            accountID: 2,
-            viewedAt: 1700000002,
-          },
-          {
-            ratingKey: '103',
-            type: 'episode',
-            accountID: 2,
-            viewedAt: 1700000003,
-          },
-        ],
-        totalSize: 3,
-      },
-    });
-
-    (service as any).plexClient = { queryAll };
-    await service.prefetchWatchHistory();
-
-    const cacheManager = (await import('../lib/cache')).default;
-    const leafMap = cacheManager
-      .getCache('plexwatchhistory')
-      .data.get<Map<string, unknown[]>>(WATCH_HISTORY_BULK_CACHE_KEY);
-
-    expect(leafMap?.get('101')).toHaveLength(2);
-    expect(leafMap?.get('103')).toHaveLength(1);
-  });
-
-  it('skips the fetch when the bulk map is already cached', async () => {
+  it('skips the fetch when the library is already cached', async () => {
     const queryAll = jest.fn().mockResolvedValue({
       MediaContainer: { Metadata: [], totalSize: 0 },
     });
@@ -1064,34 +1199,24 @@ describe('PlexApiService.prefetchWatchHistory', () => {
     (service as any).plexClient = { queryAll };
 
     // First call populates the cache
-    await service.prefetchWatchHistory();
+    await service.prefetchWatchHistory(LIBRARY);
     // Second call should not hit the API again
-    await service.prefetchWatchHistory();
+    await service.prefetchWatchHistory(LIBRARY);
 
     expect(queryAll).toHaveBeenCalledTimes(1);
   });
 
-  it('does not cache the map when the sweep is unverifiable (missing/short totalSize)', async () => {
-    const cacheManager = (await import('../lib/cache')).default;
-
+  it('does not cache the snapshot when the sweep is unverifiable (missing/short totalSize)', async () => {
     // A full-looking page with no totalSize: queryAll may have truncated, so the
-    // map must NOT be cached - callers fall back to the per-item query instead.
+    // snapshot must NOT be cached - callers fall back to the per-item query.
     const queryAll = jest.fn().mockResolvedValue({
-      MediaContainer: {
-        Metadata: [
-          { ratingKey: '1', type: 'movie', accountID: 1, viewedAt: 1 },
-        ],
-      },
+      MediaContainer: { Metadata: [historyRow()] },
     });
     (service as any).plexClient = { queryAll };
 
-    await service.prefetchWatchHistory();
+    await service.prefetchWatchHistory(LIBRARY);
 
-    expect(
-      cacheManager
-        .getCache('plexwatchhistory')
-        .data.has(WATCH_HISTORY_BULK_CACHE_KEY),
-    ).toBe(false);
+    expect(await snapshotFor(LIBRARY)).toBeUndefined();
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('unverifiable result'),
     );
@@ -1102,13 +1227,15 @@ describe('PlexApiService.prefetchWatchHistory', () => {
 
     (service as any).plexClient = { queryAll };
 
-    await expect(service.prefetchWatchHistory()).resolves.toBeUndefined();
+    await expect(
+      service.prefetchWatchHistory(LIBRARY),
+    ).resolves.toBeUndefined();
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Watch history prefetch failed'),
+      expect.stringContaining('Watch history prefetch'),
     );
   });
 
-  it('propagates aborts while the bulk watch-history fetch is in flight', async () => {
+  it('propagates aborts while the watch-history sweep is in flight', async () => {
     const abortController = new AbortController();
     const requestStarted = createDeferred();
     const queryAll = jest.fn().mockImplementation(async () => {
@@ -1124,31 +1251,32 @@ describe('PlexApiService.prefetchWatchHistory', () => {
 
     (service as any).plexClient = { queryAll };
 
-    const prefetch = service.prefetchWatchHistory(abortController.signal);
+    const prefetch = service.prefetchWatchHistory(
+      LIBRARY,
+      abortController.signal,
+    );
     await requestStarted.promise;
     abortController.abort();
 
     await expect(prefetch).rejects.toMatchObject({ name: 'AbortError' });
-    expect(queryAll).toHaveBeenCalledWith(
-      { uri: '/status/sessions/history/all?sort=viewedAt:desc' },
-      false,
-      abortController.signal,
-      expect.any(Function),
-    );
+    expect(queryAll.mock.calls[0][2]).toBe(abortController.signal);
     expect(logger.warn).not.toHaveBeenCalled();
-
-    const cacheManager = (await import('../lib/cache')).default;
-    expect(
-      cacheManager
-        .getCache('plexwatchhistory')
-        .data.has(WATCH_HISTORY_BULK_CACHE_KEY),
-    ).toBe(false);
+    expect(await snapshotFor(LIBRARY)).toBeUndefined();
   });
 });
 
-describe('PlexApiService.getWatchHistory bulk map', () => {
+describe('PlexApiService.getWatchHistory snapshot', () => {
   let service: PlexApiService;
   let loggerFactory: Mocked<MaintainerrLoggerFactory>;
+
+  const LIBRARY = '3';
+
+  const setSnapshot = async (libraryId: string, snapshot: unknown) => {
+    const cacheManager = (await import('../lib/cache')).default;
+    cacheManager
+      .getCache('plexwatchhistory')
+      .data.set(watchHistoryCacheKey(libraryId), snapshot);
+  };
 
   beforeEach(async () => {
     const { unit, unitRef } = await TestBed.solitary(PlexApiService).compile();
@@ -1164,58 +1292,124 @@ describe('PlexApiService.getWatchHistory bulk map', () => {
       debug: jest.fn(),
     } as any);
 
-    // Clear the bulk watch-history cache entries between tests
     const cacheManager = (await import('../lib/cache')).default;
-    const bulkCache = cacheManager.getCache('plexwatchhistory')?.data;
-    bulkCache?.del(WATCH_HISTORY_BULK_CACHE_KEY);
+    cacheManager.getCache('plexwatchhistory')?.data.flushAll();
   });
 
-  it('returns results from the bulk map for movie items when the map is populated', async () => {
-    const cacheManager = (await import('../lib/cache')).default;
-    const bulkMap = new Map([
-      ['42', [{ ratingKey: '42', accountID: 10, viewedAt: 1700000000 }]],
-    ]);
-    cacheManager
-      .getCache('plexwatchhistory')
-      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, bulkMap);
+  it('returns results from the snapshot for movie items', async () => {
+    await setSnapshot(LIBRARY, {
+      leaf: new Map([
+        ['42', [{ ratingKey: '42', accountID: 10, viewedAt: 1700000000 }]],
+      ]),
+    });
 
     const queryAll = jest.fn();
     (service as any).plexClient = { queryAll };
 
-    const result = await service.getWatchHistory('42', true, 'movie');
+    const result = await service.getWatchHistory('42', true, 'movie', LIBRARY);
 
     expect(result).toHaveLength(1);
     expect((result[0] as any).ratingKey).toBe('42');
-    // Should NOT have hit the network
     expect(queryAll).not.toHaveBeenCalled();
   });
 
-  it('returns an empty array for a movie not in the bulk map', async () => {
-    const cacheManager = (await import('../lib/cache')).default;
-    const bulkMap = new Map<string, unknown[]>();
-    cacheManager
-      .getCache('plexwatchhistory')
-      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, bulkMap);
+  it('returns an empty array for a movie missing from a swept library', async () => {
+    await setSnapshot(LIBRARY, { leaf: new Map<string, unknown[]>() });
 
     const queryAll = jest.fn();
     (service as any).plexClient = { queryAll };
 
-    const result = await service.getWatchHistory('99', true, 'movie');
+    const result = await service.getWatchHistory('99', true, 'movie', LIBRARY);
 
     expect(result).toEqual([]);
     expect(queryAll).not.toHaveBeenCalled();
   });
 
-  it('always rolls up show queries server-side via the per-item query, even when the leaf map is populated', async () => {
-    // Show/season history is not in the bulk (leaf) map; it must come from the
-    // per-item metadataItemID query so Plex rolls up descendant episodes.
-    const cacheManager = (await import('../lib/cache')).default;
-    cacheManager
-      .getCache('plexwatchhistory')
-      .data.set(
-        WATCH_HISTORY_BULK_CACHE_KEY,
-        new Map([['10', [{ ratingKey: '10' }]]]),
-      );
+  it('reads live when the item belongs to a library we never swept', async () => {
+    // The snapshot is authoritative for "never watched" only inside its own
+    // library. Answering library 4 from library 3's snapshot would report a
+    // false never-watched and delete a watched item.
+    await setSnapshot('3', {
+      leaf: new Map<string, unknown[]>(),
+    });
+
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: {
+        Metadata: [{ ratingKey: '99', accountID: 7, viewedAt: 1700000000 }],
+      },
+    });
+    (service as any).plexClient = { queryAll };
+
+    const result = await service.getWatchHistory('99', true, 'movie', '4');
+
+    expect(result).toHaveLength(1);
+    expect(queryAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uri: expect.stringContaining('metadataItemID=99'),
+      }),
+      true,
+    );
+  });
+
+  it('reads live when the caller names no library at all', async () => {
+    await setSnapshot(LIBRARY, {
+      leaf: new Map([['42', [{ ratingKey: '42' }]]]),
+    });
+
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: { Metadata: [] },
+    });
+    (service as any).plexClient = { queryAll };
+
+    await service.getWatchHistory('42', true, 'movie');
+
+    expect(queryAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uri: expect.stringContaining('metadataItemID=42'),
+      }),
+      true,
+    );
+  });
+
+  it('serves show and season queries from a proven rollup', async () => {
+    await setSnapshot(LIBRARY, {
+      leaf: new Map(),
+      rollup: {
+        show: new Map([['10', [{ ratingKey: '101', viewedAt: 1 }]]]),
+        season: new Map([['20', [{ ratingKey: '201', viewedAt: 2 }]]]),
+      },
+    });
+
+    const queryAll = jest.fn();
+    (service as any).plexClient = { queryAll };
+
+    expect(
+      await service.getWatchHistory('10', true, 'show', LIBRARY),
+    ).toHaveLength(1);
+    expect(
+      await service.getWatchHistory('20', true, 'season', LIBRARY),
+    ).toHaveLength(1);
+    expect(queryAll).not.toHaveBeenCalled();
+  });
+
+  it('returns a copy of rollup entries so in-place sorts cannot corrupt them', async () => {
+    const records = [
+      { ratingKey: '101', viewedAt: 2 },
+      { ratingKey: '102', viewedAt: 1 },
+    ];
+    await setSnapshot(LIBRARY, {
+      leaf: new Map(),
+      rollup: { show: new Map([['10', records]]), season: new Map() },
+    });
+    (service as any).plexClient = { queryAll: jest.fn() };
+
+    (await service.getWatchHistory('10', true, 'show', LIBRARY)).pop();
+
+    expect(await service.getWatchHistory('10', true, 'show', LIBRARY)).toHaveLength(2);
+  });
+
+  it('always rolls show queries up server-side via the per-item query', async () => {
+    await setSnapshot(LIBRARY, { leaf: new Map([['10', [{ ratingKey: '10' }]]]) });
 
     const queryAll = jest.fn().mockResolvedValue({
       MediaContainer: {
@@ -1224,7 +1418,7 @@ describe('PlexApiService.getWatchHistory bulk map', () => {
     });
     (service as any).plexClient = { queryAll };
 
-    const result = await service.getWatchHistory('10', true, 'show');
+    const result = await service.getWatchHistory('10', true, 'show', LIBRARY);
 
     expect(result).toHaveLength(1);
     expect(result[0].ratingKey).toBe('101');
@@ -1236,14 +1430,8 @@ describe('PlexApiService.getWatchHistory bulk map', () => {
     );
   });
 
-  it('always rolls up season queries server-side via the per-item query, even when the leaf map is populated', async () => {
-    const cacheManager = (await import('../lib/cache')).default;
-    cacheManager
-      .getCache('plexwatchhistory')
-      .data.set(
-        WATCH_HISTORY_BULK_CACHE_KEY,
-        new Map([['20', [{ ratingKey: '20' }]]]),
-      );
+  it('always rolls season queries up server-side via the per-item query', async () => {
+    await setSnapshot(LIBRARY, { leaf: new Map([['20', [{ ratingKey: '20' }]]]) });
 
     const queryAll = jest.fn().mockResolvedValue({
       MediaContainer: {
@@ -1252,7 +1440,7 @@ describe('PlexApiService.getWatchHistory bulk map', () => {
     });
     (service as any).plexClient = { queryAll };
 
-    const result = await service.getWatchHistory('20', true, 'season');
+    const result = await service.getWatchHistory('20', true, 'season', LIBRARY);
 
     expect(result).toHaveLength(1);
     expect(queryAll).toHaveBeenCalledWith(
@@ -1263,39 +1451,46 @@ describe('PlexApiService.getWatchHistory bulk map', () => {
     );
   });
 
-  it('serves episode queries from the leaf map without a per-item call', async () => {
-    const cacheManager = (await import('../lib/cache')).default;
-    const epRecord = {
-      ratingKey: '301',
-      type: 'episode',
-      accountID: 5,
-      viewedAt: 1700000002,
-    };
-    const leafMap = new Map([['301', [epRecord]]]);
-    cacheManager
-      .getCache('plexwatchhistory')
-      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, leafMap);
+  it('serves episode queries from the snapshot without a per-item call', async () => {
+    await setSnapshot(LIBRARY, {
+      leaf: new Map([
+        [
+          '301',
+          [
+            {
+              ratingKey: '301',
+              type: 'episode',
+              accountID: 5,
+              viewedAt: 1700000002,
+            },
+          ],
+        ],
+      ]),
+    });
 
     const queryAll = jest.fn();
     (service as any).plexClient = { queryAll };
 
-    const result = await service.getWatchHistory('301', true, 'episode');
+    const result = await service.getWatchHistory(
+      '301',
+      true,
+      'episode',
+      LIBRARY,
+    );
 
     expect(result).toHaveLength(1);
     expect(result[0].ratingKey).toBe('301');
     expect(queryAll).not.toHaveBeenCalled();
   });
 
-  it('bypasses the bulk snapshot for explicit useCache: false callers and reads per-item', async () => {
+  it('bypasses the snapshot for explicit useCache: false callers and reads per-item', async () => {
     // Keep an escape hatch for callers that explicitly need a live per-item
     // read; rule evaluation uses useCache: true to share the run snapshot.
-    const cacheManager = (await import('../lib/cache')).default;
-    const bulkMap = new Map([
-      ['42', [{ ratingKey: '42', accountID: 10, viewedAt: 1700000000 }]],
-    ]);
-    cacheManager
-      .getCache('plexwatchhistory')
-      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, bulkMap);
+    await setSnapshot(LIBRARY, {
+      leaf: new Map([
+        ['42', [{ ratingKey: '42', accountID: 10, viewedAt: 1700000000 }]],
+      ]),
+    });
 
     const queryAll = jest.fn().mockResolvedValue({
       MediaContainer: {
@@ -1304,7 +1499,7 @@ describe('PlexApiService.getWatchHistory bulk map', () => {
     });
     (service as any).plexClient = { queryAll };
 
-    const result = await service.getWatchHistory('42', false, 'movie');
+    const result = await service.getWatchHistory('42', false, 'movie', LIBRARY);
 
     expect(queryAll).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1315,13 +1510,13 @@ describe('PlexApiService.getWatchHistory bulk map', () => {
     expect(result[0].accountID).toBe(99);
   });
 
-  it('passes useCache: false through to the per-item query when the bulk map is absent', async () => {
+  it('passes useCache: false through to the per-item query when no snapshot exists', async () => {
     const queryAll = jest.fn().mockResolvedValue({
       MediaContainer: { Metadata: [] },
     });
     (service as any).plexClient = { queryAll };
 
-    await service.getWatchHistory('42', false, 'movie');
+    await service.getWatchHistory('42', false, 'movie', LIBRARY);
 
     expect(queryAll).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1331,31 +1526,26 @@ describe('PlexApiService.getWatchHistory bulk map', () => {
     );
   });
 
-  it('serves untyped callers from the leaf map on a hit', async () => {
-    const cacheManager = (await import('../lib/cache')).default;
-    const bulkMap = new Map([
-      ['42', [{ ratingKey: '42', accountID: 10, viewedAt: 1700000000 }]],
-    ]);
-    cacheManager
-      .getCache('plexwatchhistory')
-      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, bulkMap);
+  it('serves untyped callers from the snapshot on a hit', async () => {
+    await setSnapshot(LIBRARY, {
+      leaf: new Map([
+        ['42', [{ ratingKey: '42', accountID: 10, viewedAt: 1700000000 }]],
+      ]),
+    });
 
     const queryAll = jest.fn();
     (service as any).plexClient = { queryAll };
 
-    const result = await service.getWatchHistory('42');
+    const result = await service.getWatchHistory('42', true, undefined, LIBRARY);
 
     expect(result).toHaveLength(1);
     expect(queryAll).not.toHaveBeenCalled();
   });
 
-  it('falls through to per-item query for untyped callers on a leaf-map miss', async () => {
-    // Untyped callers may pass show or season ratingKeys, which are never in
-    // the leaf map - a miss must not be reported as confirmed-empty history.
-    const cacheManager = (await import('../lib/cache')).default;
-    cacheManager
-      .getCache('plexwatchhistory')
-      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, new Map());
+  it('falls through to per-item query for untyped callers on a miss', async () => {
+    // Untyped callers may pass show or season ratingKeys, which are not leaf
+    // entries - a miss must not be reported as confirmed-empty history.
+    await setSnapshot(LIBRARY, { leaf: new Map() });
 
     const queryAll = jest.fn().mockResolvedValue({
       MediaContainer: {
@@ -1364,7 +1554,7 @@ describe('PlexApiService.getWatchHistory bulk map', () => {
     });
     (service as any).plexClient = { queryAll };
 
-    const result = await service.getWatchHistory('10');
+    const result = await service.getWatchHistory('10', true, undefined, LIBRARY);
 
     expect(result).toHaveLength(1);
     expect(queryAll).toHaveBeenCalledWith(
@@ -1376,37 +1566,36 @@ describe('PlexApiService.getWatchHistory bulk map', () => {
   });
 
   it('returns a copy so callers sorting in place do not mutate the cached array', async () => {
-    const cacheManager = (await import('../lib/cache')).default;
     const records = [
       { ratingKey: '42', accountID: 10, viewedAt: 2 },
       { ratingKey: '42', accountID: 11, viewedAt: 1 },
     ];
-    const bulkMap = new Map([['42', records]]);
-    cacheManager
-      .getCache('plexwatchhistory')
-      .data.set(WATCH_HISTORY_BULK_CACHE_KEY, bulkMap);
+    await setSnapshot(LIBRARY, { leaf: new Map([['42', records]]) });
 
     (service as any).plexClient = { queryAll: jest.fn() };
 
-    const first = await service.getWatchHistory('42', true, 'movie');
+    const first = await service.getWatchHistory('42', true, 'movie', LIBRARY);
     first.sort((a: any, b: any) => a.viewedAt - b.viewedAt);
     first.pop();
 
-    const second = await service.getWatchHistory('42', true, 'movie');
+    const second = await service.getWatchHistory('42', true, 'movie', LIBRARY);
     expect(second.map((r: any) => r.accountID)).toEqual([10, 11]);
   });
 
-  it('falls through to per-item query when the bulk map is absent', async () => {
+  it('falls through to per-item query when no snapshot exists at all', async () => {
     const queryAll = jest.fn().mockResolvedValue({
-      MediaContainer: { Metadata: [] },
+      MediaContainer: {
+        Metadata: [{ ratingKey: '42', accountID: 1, viewedAt: 1 }],
+      },
     });
     (service as any).plexClient = { queryAll };
 
-    await service.getWatchHistory('5', true, 'movie');
+    const result = await service.getWatchHistory('42', true, 'movie', LIBRARY);
 
+    expect(result).toHaveLength(1);
     expect(queryAll).toHaveBeenCalledWith(
       expect.objectContaining({
-        uri: expect.stringContaining('metadataItemID=5'),
+        uri: expect.stringContaining('metadataItemID=42'),
       }),
       true,
     );

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -877,11 +877,13 @@ describe('PlexApiService.prefetchWatchHistory', () => {
   // The sweep proves its rollup with one live per-item read; unless a test says
   // otherwise, have that read agree with what the rollup claims.
   const agreeingVerification = (rows: Record<string, unknown>[]) =>
-    jest.fn().mockImplementation(async (query: { uri: string }) =>
-      query.uri.includes('metadataItemID')
-        ? { MediaContainer: { Metadata: rows } }
-        : { MediaContainer: { Metadata: rows, totalSize: rows.length } },
-    );
+    jest
+      .fn()
+      .mockImplementation(async (query: { uri: string }) =>
+        query.uri.includes('metadataItemID')
+          ? { MediaContainer: { Metadata: rows } }
+          : { MediaContainer: { Metadata: rows, totalSize: rows.length } },
+      );
 
   const snapshotFor = async (libraryId: string) => {
     const cacheManager = (await import('../lib/cache')).default;
@@ -959,11 +961,20 @@ describe('PlexApiService.prefetchWatchHistory', () => {
     // plausible-looking rollup that under-reports the show. The sweep asks
     // Plex the same question and throws the rollup away when it differs.
     const rows = [episodeRow({ ratingKey: '101', viewedAt: 1 })];
-    const queryAll = jest.fn().mockImplementation(async (query: { uri: string }) =>
-      query.uri.includes('metadataItemID')
-        ? { MediaContainer: { Metadata: [...rows, episodeRow({ ratingKey: '102', viewedAt: 2 })] } }
-        : { MediaContainer: { Metadata: rows, totalSize: rows.length } },
-    );
+    const queryAll = jest
+      .fn()
+      .mockImplementation(async (query: { uri: string }) =>
+        query.uri.includes('metadataItemID')
+          ? {
+              MediaContainer: {
+                Metadata: [
+                  ...rows,
+                  episodeRow({ ratingKey: '102', viewedAt: 2 }),
+                ],
+              },
+            }
+          : { MediaContainer: { Metadata: rows, totalSize: rows.length } },
+      );
     (service as any).plexClient = { queryAll };
 
     await service.prefetchWatchHistory(LIBRARY);
@@ -978,10 +989,12 @@ describe('PlexApiService.prefetchWatchHistory', () => {
 
   it('drops the rollup when the verification read fails', async () => {
     const rows = [episodeRow({ ratingKey: '101', viewedAt: 1 })];
-    const queryAll = jest.fn().mockImplementation(async (query: { uri: string }) => {
-      if (query.uri.includes('metadataItemID')) throw new Error('network');
-      return { MediaContainer: { Metadata: rows, totalSize: rows.length } };
-    });
+    const queryAll = jest
+      .fn()
+      .mockImplementation(async (query: { uri: string }) => {
+        if (query.uri.includes('metadataItemID')) throw new Error('network');
+        return { MediaContainer: { Metadata: rows, totalSize: rows.length } };
+      });
     (service as any).plexClient = { queryAll };
 
     await service.prefetchWatchHistory(LIBRARY);
@@ -1006,7 +1019,9 @@ describe('PlexApiService.prefetchWatchHistory', () => {
     expect(snapshot?.rollup).toBeUndefined();
     // No rollup to prove, so no verification request was spent on it.
     expect(
-      queryAll.mock.calls.filter((c: any[]) => c[0].uri.includes('metadataItemID')),
+      queryAll.mock.calls.filter((c: any[]) =>
+        c[0].uri.includes('metadataItemID'),
+      ),
     ).toHaveLength(0);
   });
 
@@ -1018,7 +1033,9 @@ describe('PlexApiService.prefetchWatchHistory', () => {
     await service.prefetchWatchHistory(LIBRARY);
 
     expect(
-      queryAll.mock.calls.filter((c: any[]) => c[0].uri.includes('metadataItemID')),
+      queryAll.mock.calls.filter((c: any[]) =>
+        c[0].uri.includes('metadataItemID'),
+      ),
     ).toHaveLength(0);
     expect((await snapshotFor(LIBRARY))?.rollup?.show.size ?? 0).toBe(0);
   });
@@ -1405,11 +1422,15 @@ describe('PlexApiService.getWatchHistory snapshot', () => {
 
     (await service.getWatchHistory('10', true, 'show', LIBRARY)).pop();
 
-    expect(await service.getWatchHistory('10', true, 'show', LIBRARY)).toHaveLength(2);
+    expect(
+      await service.getWatchHistory('10', true, 'show', LIBRARY),
+    ).toHaveLength(2);
   });
 
   it('always rolls show queries up server-side via the per-item query', async () => {
-    await setSnapshot(LIBRARY, { leaf: new Map([['10', [{ ratingKey: '10' }]]]) });
+    await setSnapshot(LIBRARY, {
+      leaf: new Map([['10', [{ ratingKey: '10' }]]]),
+    });
 
     const queryAll = jest.fn().mockResolvedValue({
       MediaContainer: {
@@ -1431,7 +1452,9 @@ describe('PlexApiService.getWatchHistory snapshot', () => {
   });
 
   it('always rolls season queries up server-side via the per-item query', async () => {
-    await setSnapshot(LIBRARY, { leaf: new Map([['20', [{ ratingKey: '20' }]]]) });
+    await setSnapshot(LIBRARY, {
+      leaf: new Map([['20', [{ ratingKey: '20' }]]]),
+    });
 
     const queryAll = jest.fn().mockResolvedValue({
       MediaContainer: {
@@ -1536,7 +1559,12 @@ describe('PlexApiService.getWatchHistory snapshot', () => {
     const queryAll = jest.fn();
     (service as any).plexClient = { queryAll };
 
-    const result = await service.getWatchHistory('42', true, undefined, LIBRARY);
+    const result = await service.getWatchHistory(
+      '42',
+      true,
+      undefined,
+      LIBRARY,
+    );
 
     expect(result).toHaveLength(1);
     expect(queryAll).not.toHaveBeenCalled();
@@ -1554,7 +1582,12 @@ describe('PlexApiService.getWatchHistory snapshot', () => {
     });
     (service as any).plexClient = { queryAll };
 
-    const result = await service.getWatchHistory('10', true, undefined, LIBRARY);
+    const result = await service.getWatchHistory(
+      '10',
+      true,
+      undefined,
+      LIBRARY,
+    );
 
     expect(result).toHaveLength(1);
     expect(queryAll).toHaveBeenCalledWith(

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -53,8 +53,45 @@ import {
 import {
   PLEX_PAGE_SIZE,
   PLEX_REQUEST_TIMEOUT_MS,
-  WATCH_HISTORY_BULK_CACHE_KEY,
+  WATCH_HISTORY_EXCLUDE_FIELDS,
+  WATCH_HISTORY_MAX_ENTRIES,
+  watchHistoryCacheKey,
 } from './plex-api.constants';
+
+/**
+ * One library's swept watch history. `leaf` holds every row keyed by its own
+ * ratingKey (movies and episodes).
+ *
+ * `rollup` groups episode rows by show and season so container queries skip the
+ * per-item round trip. It is only ever present once proven: `grandparentKey`/
+ * `parentKey` are undocumented on this endpoint and were observed absent over
+ * some Plex connections (#3082), where a missing key would read as "nobody
+ * watched this" and delete a watched show. It is therefore built all-or-nothing
+ * and then checked against Plex's own server-side rollup before being kept -
+ * see buildWatchHistorySnapshot and verifyRollup. Absent, container queries fall
+ * back to the per-item metadataItemID query exactly as they did before.
+ */
+interface PlexWatchHistorySnapshot {
+  leaf: Map<string, PlexSeenBy[]>;
+  rollup?: {
+    show: Map<string, PlexSeenBy[]>;
+    season: Map<string, PlexSeenBy[]>;
+  };
+}
+
+/** `/library/metadata/1234` -> `1234`. Undefined for an absent or empty key. */
+const ratingKeyFromPath = (path?: string): string | undefined => {
+  if (!path) return undefined;
+  const key = path.slice(path.lastIndexOf('/') + 1);
+  return key.length > 0 ? key : undefined;
+};
+
+/** Identity of a history row, for comparing two sources of the same history. */
+const historyFingerprint = (records: PlexSeenBy[]): string =>
+  records
+    .map((record) => `${record.ratingKey}:${record.viewedAt}`)
+    .sort()
+    .join('|');
 
 @Injectable()
 export class PlexApiService {
@@ -62,7 +99,7 @@ export class PlexApiService {
   private plexTvClient: PlexTvApi;
   private plexCommunityClient: PlexCommunityApi;
   private machineId: string;
-  private watchHistoryPrefetch?: Promise<void>;
+  private watchHistoryPrefetches = new Map<string, Promise<void>>();
 
   constructor(
     private readonly settings: SettingsDataService,
@@ -188,9 +225,9 @@ export class PlexApiService {
     this.plexClient = undefined;
     this.plexCommunityClient = undefined;
     this.plexTvClient = undefined;
-    // Drop the watch-history snapshot too - on a server/token switch it would
-    // otherwise serve the previous server's history for up to its TTL.
-    this.watchHistoryPrefetch = undefined;
+    // Drop the watch-history snapshots too - on a server/token switch they
+    // would otherwise serve the previous server's history for up to their TTL.
+    this.watchHistoryPrefetches.clear();
     cacheManager.getCache('plexguid').data.flushAll();
     cacheManager.getCache('plextv').data.flushAll();
     cacheManager.getCache('plexcommunity').data.flushAll();
@@ -742,58 +779,81 @@ export class PlexApiService {
   }
 
   /**
-   * Fetches the complete watch history in a single paginated sweep and stores
-   * a leaf lookup map (movies + episodes keyed by their own ratingKey) in the
-   * 'plexwatchhistory' cache (1 hour TTL). Subsequent getWatchHistory calls for
-   * leaf items are served from this map instead of issuing one HTTP request per
-   * item. Returns immediately when the map is already cached, so it is safe to
-   * call at the start of every rule group.
+   * Sweeps one library's watch history in a single paginated pass and stores a
+   * snapshot in the 'plexwatchhistory' cache (1 hour TTL). Subsequent
+   * getWatchHistory calls for items in that library are served from the
+   * snapshot instead of issuing one HTTP request per item. Returns immediately
+   * when the library is already cached, so it is safe to call at the start of
+   * every rule group.
    *
-   * Show/season history is intentionally NOT rolled up here: the bulk endpoint
-   * keys each row by leaf ratingKey, and grouping to show/season would depend on
-   * grandparentKey/parentKey, which are undocumented on this endpoint and absent
-   * over some Plex connections - a missing key would silently read as "never
-   * watched". Show/season queries therefore fall through to the per-item
-   * metadataItemID query in getWatchHistory, which Plex rolls up server-side.
+   * Scoped to one library via `librarySectionID`: a rule group only evaluates
+   * items from its own library, and the endpoint otherwise returns every view
+   * event on the server - every library, every user, every rewatch.
    *
    * On failure the error is logged and swallowed - getWatchHistory falls back
-   * to per-item queries automatically when the map is absent.
+   * to per-item queries automatically when the snapshot is absent.
    */
-  public prefetchWatchHistory(abortSignal?: AbortSignal): Promise<void> {
+  public prefetchWatchHistory(
+    libraryId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<void> {
     const cache = cacheManager.getCache('plexwatchhistory').data;
-    if (cache.has(WATCH_HISTORY_BULK_CACHE_KEY)) {
+    if (cache.has(watchHistoryCacheKey(libraryId))) {
       return Promise.resolve();
     }
 
-    // Deduplicate concurrent callers onto one in-flight fetch.
-    this.watchHistoryPrefetch ??= this.fetchWatchHistoryMap(
-      abortSignal,
-    ).finally(() => {
-      this.watchHistoryPrefetch = undefined;
-    });
-    return this.watchHistoryPrefetch;
+    // Deduplicate concurrent callers onto one in-flight fetch per library.
+    const existing = this.watchHistoryPrefetches.get(libraryId);
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const inFlight = this.fetchWatchHistorySnapshot(libraryId, abortSignal).finally(
+      () => {
+        this.watchHistoryPrefetches.delete(libraryId);
+      },
+    );
+    this.watchHistoryPrefetches.set(libraryId, inFlight);
+    return inFlight;
   }
 
-  private async fetchWatchHistoryMap(abortSignal?: AbortSignal): Promise<void> {
-    this.logger.log('Prefetching watch history for all library items...');
+  private async fetchWatchHistorySnapshot(
+    libraryId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<void> {
+    // Spell out what the count means: one entry per view event across all
+    // users, so the total has no relation to how many items the library holds.
+    this.logger.log(
+      `Prefetching watch history for library ${libraryId} ` +
+        `(one entry per view event, across all users)...`,
+    );
+
+    // Plex reports totalSize on the first page, so an oversized history is
+    // abandoned one request in rather than paged through in full. queryAll
+    // materialises every row before returning, so unlike the Jellyfin sweep
+    // there is no way to fold pages in and stop partway.
+    let exceededCeiling = false;
 
     try {
       abortSignal?.throwIfAborted();
       const historyQuery = {
-        uri: '/status/sessions/history/all?sort=viewedAt:desc',
+        uri:
+          `/status/sessions/history/all?sort=viewedAt:desc` +
+          `&librarySectionID=${libraryId}` +
+          `&excludeFields=${WATCH_HISTORY_EXCLUDE_FIELDS}`,
       };
 
-      // The sweep is one sequential Plex request per 120-record page, so a big
-      // watch history can take minutes with no output - which reads as a hang
-      // (users reported the run "stuck" at the single start line). Log each 10%
-      // it crosses so progress is visible without flooding the log. The final
-      // page (fetched == totalSize) is skipped so it never prints a misleading
+      // The sweep is one sequential Plex request per page, so a big watch
+      // history can take minutes with no output - which reads as a hang (users
+      // reported the run "stuck" at the single start line). Log each 10% it
+      // crosses so progress is visible without flooding the log. The final page
+      // (fetched == totalSize) is skipped so it never prints a misleading
       // partial percentage; the completion line below reports the total. A
       // history that fits in one page stays silent here for the same reason.
       const reportProgress = createPrefetchProgressReporter(
         (message) => this.logger.log(message),
-        'Prefetching watch history',
-        'records',
+        `Prefetching watch history for library ${libraryId}`,
+        'entries',
       );
       const onProgress = ({
         fetched,
@@ -801,76 +861,174 @@ export class PlexApiService {
       }: {
         fetched: number;
         totalSize: number;
-      }): void => reportProgress(fetched, totalSize);
+      }): void => {
+        if (totalSize > WATCH_HISTORY_MAX_ENTRIES) {
+          exceededCeiling = true;
+          throw new Error('watch history ceiling exceeded');
+        }
+        reportProgress(fetched, totalSize);
+      };
 
       const response = await this.plexClient.queryAll<PlexLibraryResponse>(
         historyQuery,
         false,
         abortSignal,
         onProgress,
+        PLEX_PAGE_SIZE.MAX_PAGE_SIZE,
       );
 
       const container = response?.MediaContainer;
       const records = (container?.Metadata as PlexSeenBy[]) ?? [];
 
-      // The leaf map is authoritative for "never watched": a movie/episode
-      // absent from it is read as empty history with NO per-item fallback. So
-      // only cache a sweep we can prove is complete. Plex reports totalSize on
-      // this endpoint; queryAll stops paging once totalSize is reached, but a
-      // missing/short totalSize would make it stop early and silently truncate.
-      // Treat that as a failed prefetch so callers fall back to per-item queries
-      // rather than trusting a partial map.
+      // The snapshot is authoritative for "never watched": an item absent from
+      // it is read as empty history with NO per-item fallback. So only cache a
+      // sweep we can prove is complete. Plex reports totalSize on this endpoint;
+      // queryAll stops paging once totalSize is reached, but a missing/short
+      // totalSize would make it stop early and silently truncate. Treat that as
+      // a failed prefetch so callers fall back to per-item queries rather than
+      // trusting a partial snapshot.
       const totalSize = container?.totalSize;
       if (typeof totalSize !== 'number' || records.length < totalSize) {
         this.logger.warn(
-          `Watch history prefetch returned an unverifiable result ` +
-            `(received ${records.length}, totalSize ${totalSize ?? 'absent'}) - ` +
-            `falling back to per-item queries.`,
+          `Watch history prefetch for library ${libraryId} returned an ` +
+            `unverifiable result (received ${records.length}, totalSize ` +
+            `${totalSize ?? 'absent'}) - falling back to per-item reads.`,
         );
         return;
       }
 
-      const leafMap = new Map<string, PlexSeenBy[]>();
-      for (const record of records) {
-        const existing = leafMap.get(record.ratingKey);
-        if (existing) {
-          existing.push(record);
-        } else {
-          leafMap.set(record.ratingKey, [record]);
-        }
+      const snapshot = this.buildWatchHistorySnapshot(records);
+      if (snapshot.rollup && !(await this.verifyRollup(snapshot, libraryId))) {
+        snapshot.rollup = undefined;
       }
 
       cacheManager
         .getCache('plexwatchhistory')
-        .data.set(WATCH_HISTORY_BULK_CACHE_KEY, leafMap);
+        .data.set(watchHistoryCacheKey(libraryId), snapshot);
 
       this.logger.log(
-        `Watch history prefetch complete: ${records.length} records - ` +
-          `${leafMap.size} leaf items.`,
+        `Watch history prefetch for library ${libraryId} complete: ` +
+          `${records.length} entries - ${snapshot.leaf.size} items` +
+          `${snapshot.rollup ? ` across ${snapshot.rollup.show.size} shows` : ''}.`,
       );
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {
         throw error;
       }
 
+      if (exceededCeiling) {
+        this.logger.warn(
+          `Watch history for library ${libraryId} passed ` +
+            `${WATCH_HISTORY_MAX_ENTRIES} entries - falling back to per-item reads.`,
+        );
+        return;
+      }
+
       this.logger.warn(
-        `Watch history prefetch failed - falling back to per-item queries. Error: ${error}`,
+        `Watch history prefetch for library ${libraryId} failed - falling back to per-item reads. Error: ${error}`,
       );
     }
   }
 
+  /**
+   * One episode row missing its parent keys disables the rollup for the whole
+   * library: dropping just that row would under-report its show's history,
+   * which is the false "never watched" #3082 avoided by skipping the rollup
+   * altogether. Movies legitimately carry no parent keys and never gate it.
+   */
+  private buildWatchHistorySnapshot(
+    records: PlexSeenBy[],
+  ): PlexWatchHistorySnapshot {
+    const leaf = new Map<string, PlexSeenBy[]>();
+    const show = new Map<string, PlexSeenBy[]>();
+    const season = new Map<string, PlexSeenBy[]>();
+    let rollupComplete = true;
+
+    const add = (
+      map: Map<string, PlexSeenBy[]>,
+      key: string,
+      record: PlexSeenBy,
+    ): void => {
+      const existing = map.get(key);
+      if (existing) {
+        existing.push(record);
+      } else {
+        map.set(key, [record]);
+      }
+    };
+
+    for (const record of records) {
+      add(leaf, record.ratingKey, record);
+
+      if (record.type !== 'episode') continue;
+
+      const showKey = ratingKeyFromPath(record.grandparentKey);
+      const seasonKey = ratingKeyFromPath(record.parentKey);
+      if (!showKey || !seasonKey) {
+        rollupComplete = false;
+        continue;
+      }
+
+      add(show, showKey, record);
+      add(season, seasonKey, record);
+    }
+
+    return { leaf, rollup: rollupComplete ? { show, season } : undefined };
+  }
+
+  /**
+   * Proves the rollup against Plex before anything reads it: takes one show it
+   * claims history for and compares it with the same question asked of Plex's
+   * own server-side rollup. That turns a dependency on an undocumented field
+   * into a checked one - if this connection reports the parent keys in a shape
+   * `ratingKeyFromPath` mis-reads, the two answers disagree and the rollup is
+   * dropped rather than silently under-reporting a show.
+   *
+   * Costs one request per sweep, and only for libraries with episode history.
+   * A failed check drops the rollup, never the snapshot: the leaf map is what
+   * the expensive per-episode walks read and it is unaffected.
+   */
+  private async verifyRollup(
+    snapshot: PlexWatchHistorySnapshot,
+    libraryId: string,
+  ): Promise<boolean> {
+    const sample = snapshot.rollup?.show.entries().next();
+    if (!sample || sample.done) return false;
+
+    const [showKey, expected] = sample.value;
+    try {
+      const live = await this.getWatchHistory(showKey, false, 'show');
+      if (historyFingerprint(live) === historyFingerprint(expected)) {
+        return true;
+      }
+      this.logger.warn(
+        `Watch history rollup for library ${libraryId} disagreed with Plex on ` +
+          `show ${showKey} (${expected.length} entries vs ${live.length}) - ` +
+          `show and season reads stay per-item.`,
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Could not verify the watch history rollup for library ${libraryId} - ` +
+          `show and season reads stay per-item. Error: ${error}`,
+      );
+    }
+    return false;
+  }
+
+  private getWatchHistorySnapshot(
+    libraryId: string,
+  ): PlexWatchHistorySnapshot | undefined {
+    return cacheManager
+      .getCache('plexwatchhistory')
+      .data.get<PlexWatchHistorySnapshot>(watchHistoryCacheKey(libraryId));
+  }
+
   // The 'plexwatchhistory' cache stores by reference (useClones: false), so
   // always hand callers a copy - plex-getter sorts these arrays in place.
-  private getBulkWatchHistory(
-    mapKey: string,
+  private copyRecords(
+    map: Map<string, PlexSeenBy[]>,
     itemId: string,
-  ): PlexSeenBy[] | undefined {
-    const map = cacheManager
-      .getCache('plexwatchhistory')
-      .data.get<Map<string, PlexSeenBy[]>>(mapKey);
-    if (map === undefined) {
-      return undefined;
-    }
+  ): PlexSeenBy[] {
     const records = map.get(itemId);
     return records ? [...records] : [];
   }
@@ -879,36 +1037,39 @@ export class PlexApiService {
     itemId: string,
     useCache: boolean = true,
     itemType?: PlexLibraryItem['type'],
+    libraryId?: string,
   ): Promise<PlexSeenBy[]> {
-    // Serve leaf items (movies, episodes) from the bulk map when caching is
-    // allowed. The map is a point-in-time snapshot taken at prefetch time;
-    // callers that pass useCache: false intentionally bypass it and read the
-    // per-item endpoint instead.
-    if (useCache) {
+    // Serve from the library's snapshot when caching is allowed. The snapshot
+    // is a point-in-time picture taken at prefetch time; callers that pass
+    // useCache: false intentionally bypass it and read the per-item endpoint.
+    // Without a libraryId there is no snapshot we can safely attribute the item
+    // to, so the read falls through rather than risk another library's answer.
+    const snapshot =
+      useCache && libraryId ? this.getWatchHistorySnapshot(libraryId) : undefined;
+
+    if (snapshot) {
       switch (itemType) {
         case 'movie':
-        case 'episode': {
-          const records = this.getBulkWatchHistory(
-            WATCH_HISTORY_BULK_CACHE_KEY,
-            itemId,
-          );
-          if (records !== undefined) return records;
-          break;
-        }
+        case 'episode':
+          return this.copyRecords(snapshot.leaf, itemId);
         case 'show':
+          // Only from a rollup this sweep proved against Plex; otherwise fall
+          // through to the per-item metadataItemID query, which Plex rolls up
+          // server-side.
+          if (snapshot.rollup) {
+            return this.copyRecords(snapshot.rollup.show, itemId);
+          }
+          break;
         case 'season':
-          // The bulk map holds no show/season rollups (see
-          // prefetchWatchHistory); fall through to the per-item metadataItemID
-          // query, which Plex rolls up server-side.
+          if (snapshot.rollup) {
+            return this.copyRecords(snapshot.rollup.season, itemId);
+          }
           break;
         default: {
           // Untyped callers may pass any kind of ratingKey, so only a non-empty
           // leaf hit is trusted - a miss falls through to the per-item query.
-          const records = this.getBulkWatchHistory(
-            WATCH_HISTORY_BULK_CACHE_KEY,
-            itemId,
-          );
-          if (records !== undefined && records.length > 0) return records;
+          const records = this.copyRecords(snapshot.leaf, itemId);
+          if (records.length > 0) return records;
           break;
         }
       }

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -808,11 +808,12 @@ export class PlexApiService {
       return existing;
     }
 
-    const inFlight = this.fetchWatchHistorySnapshot(libraryId, abortSignal).finally(
-      () => {
-        this.watchHistoryPrefetches.delete(libraryId);
-      },
-    );
+    const inFlight = this.fetchWatchHistorySnapshot(
+      libraryId,
+      abortSignal,
+    ).finally(() => {
+      this.watchHistoryPrefetches.delete(libraryId);
+    });
     this.watchHistoryPrefetches.set(libraryId, inFlight);
     return inFlight;
   }
@@ -1045,7 +1046,9 @@ export class PlexApiService {
     // Without a libraryId there is no snapshot we can safely attribute the item
     // to, so the read falls through rather than risk another library's answer.
     const snapshot =
-      useCache && libraryId ? this.getWatchHistorySnapshot(libraryId) : undefined;
+      useCache && libraryId
+        ? this.getWatchHistorySnapshot(libraryId)
+        : undefined;
 
     if (snapshot) {
       switch (itemType) {

--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
@@ -342,6 +342,10 @@ export class SeerrApiService {
       let skip = 0;
 
       const requests: SeerrRequest[] = [];
+      // Bracket the sweep like the media-server ones do: with only the decile
+      // lines, a sweep that fits in one page said nothing at all, and a slow
+      // one had no line to attribute the wait to.
+      this.logger.log('Prefetching Seerr requests...');
       const reportProgress = createPrefetchProgressReporter(
         (message) => this.logger.log(message),
         'Prefetching Seerr requests',
@@ -373,6 +377,9 @@ export class SeerrApiService {
           hasNext = false;
         }
       }
+      this.logger.log(
+        `Seerr request prefetch complete: ${requests.length} requests.`,
+      );
       return requests;
     } catch (error) {
       this.logger.warn(

--- a/apps/server/src/modules/rules/constants/constants.service.spec.ts
+++ b/apps/server/src/modules/rules/constants/constants.service.spec.ts
@@ -1,4 +1,8 @@
-import { Application, MediaType } from '@maintainerr/contracts';
+import {
+  Application,
+  MediaServerType,
+  MediaType,
+} from '@maintainerr/contracts';
 import { RuleConstanstService } from './constants.service';
 import { RuleConstants, RuleType } from './rules.constants';
 
@@ -80,6 +84,77 @@ describe('RuleConstanstService', () => {
     expect(service.getValueNullReason([Application.PLEX, 999])).toBe(
       'Value unavailable',
     );
+  });
+
+  describe('naming a value after the server it was read from', () => {
+    // The getter routes every media-server app to the configured server and
+    // looks the property id up there, so a rule left unmigrated after a server
+    // switch reads a different property than the one it stores. Property ids
+    // do not line up across servers, so the label has to follow the value.
+    beforeEach(() => {
+      service.ruleConstants = {
+        applications: [
+          {
+            id: Application.PLEX,
+            name: 'Plex',
+            mediaType: MediaType.BOTH,
+            props: [
+              {
+                id: 39,
+                name: 'collectionsIncludingSmart',
+                humanName: 'Present in amount of other collections',
+                mediaType: MediaType.BOTH,
+                type: RuleType.NUMBER,
+              },
+            ],
+          },
+          {
+            id: Application.JELLYFIN,
+            name: 'Jellyfin',
+            mediaType: MediaType.BOTH,
+            props: [
+              {
+                id: 39,
+                name: 'favoritedBy',
+                humanName: '[list] Favorited by (username)',
+                mediaType: MediaType.BOTH,
+                type: RuleType.TEXT_LIST,
+              },
+            ],
+          },
+        ],
+      } as RuleConstants;
+    });
+
+    it('names a media-server value after the configured server, not the stored app', () => {
+      expect(
+        service.getValueHumanName(
+          [Application.PLEX, 39],
+          MediaServerType.JELLYFIN,
+        ),
+      ).toBe('Jellyfin - [list] Favorited by (username)');
+    });
+
+    it('explains a missing value with the configured server property too', () => {
+      expect(
+        service.getValueNullReason(
+          [Application.PLEX, 39],
+          MediaServerType.JELLYFIN,
+        ),
+      ).toBe('Jellyfin Favorited by (username) has no entries for this item');
+    });
+
+    it('leaves the stored app alone when it already matches the server', () => {
+      expect(
+        service.getValueHumanName([Application.PLEX, 39], MediaServerType.PLEX),
+      ).toBe('Plex - Present in amount of other collections');
+    });
+
+    it('leaves the stored app alone when the server is unknown', () => {
+      expect(service.getValueHumanName([Application.PLEX, 39])).toBe(
+        'Plex - Present in amount of other collections',
+      );
+    });
   });
 
   describe('getCustomValueFromIdentifier', () => {

--- a/apps/server/src/modules/rules/constants/constants.service.ts
+++ b/apps/server/src/modules/rules/constants/constants.service.ts
@@ -124,7 +124,8 @@ export class RuleConstanstService {
     configuredServerType?: MediaServerType | null,
   ): string {
     const application = this.ruleConstants.applications.find(
-      (el) => el.id === resolveValueApplication(location[0], configuredServerType),
+      (el) =>
+        el.id === resolveValueApplication(location[0], configuredServerType),
     );
     const prop = application?.props.find((el) => el.id === location[1]);
     if (!prop) return 'Value unavailable';

--- a/apps/server/src/modules/rules/constants/constants.service.ts
+++ b/apps/server/src/modules/rules/constants/constants.service.ts
@@ -1,4 +1,6 @@
+import { MediaServerType } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
+import { resolveValueApplication } from '../helpers/media-server-application.helper';
 import { Property, RuleConstants, RuleType } from './rules.constants';
 
 /**
@@ -85,13 +87,27 @@ export class RuleConstanstService {
     return application.name + '.' + rule.name;
   }
 
-  public getValueHumanName(location: [number, number]) {
-    return `${
-      this.ruleConstants.applications.find((el) => el.id === location[0])?.name
-    } - ${
-      this.ruleConstants.applications
-        .find((el) => el.id === location[0])
-        ?.props.find((el) => el.id === location[1])?.humanName
+  /**
+   * @param configuredServerType - Names the value after the server that will
+   *   actually be read. A rule stores the app it was authored against, but the
+   *   getter routes every media-server app to the configured server and looks
+   *   the property id up there; property ids do not line up across servers, so
+   *   naming it from the stored app can describe a different property than the
+   *   one that produced the value. Omit to name it exactly as stored.
+   */
+  public getValueHumanName(
+    location: [number, number],
+    configuredServerType?: MediaServerType | null,
+  ) {
+    const applicationId = resolveValueApplication(
+      location[0],
+      configuredServerType,
+    );
+    const application = this.ruleConstants.applications.find(
+      (el) => el.id === applicationId,
+    );
+    return `${application?.name} - ${
+      application?.props.find((el) => el.id === location[1])?.humanName
     }`;
   }
 
@@ -103,9 +119,12 @@ export class RuleConstanstService {
    * static table to maintain. Rules comparisons still fail closed; this is
    * purely diagnostic.
    */
-  public getValueNullReason(location: [number, number]): string {
+  public getValueNullReason(
+    location: [number, number],
+    configuredServerType?: MediaServerType | null,
+  ): string {
     const application = this.ruleConstants.applications.find(
-      (el) => el.id === location[0],
+      (el) => el.id === resolveValueApplication(location[0], configuredServerType),
     );
     const prop = application?.props.find((el) => el.id === location[1]);
     if (!prop) return 'Value unavailable';

--- a/apps/server/src/modules/rules/getter/getter.service.ts
+++ b/apps/server/src/modules/rules/getter/getter.service.ts
@@ -35,6 +35,15 @@ export class ValueGetterService {
     private readonly mediaServerFactory: MediaServerFactory,
   ) {}
 
+  /**
+   * The media server every media-server rule value is actually read from.
+   * Exposed so callers that describe a value (rule statistics, missing-value
+   * diagnostics) can name the same property `get` resolved it against.
+   */
+  async getConfiguredServerType(): Promise<MediaServerType | null> {
+    return this.mediaServerFactory.getConfiguredServerType();
+  }
+
   async get(
     [val1, val2]: [number, number],
     libItem: MediaItem,

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
@@ -10,6 +10,8 @@ import {
 import { Mocked, TestBed } from '@suites/unit';
 import { createRulesDto } from '../../../../test/utils/data';
 
+const LIBRARY_ID = 'lib-1';
+
 import cacheManager from '../../api/lib/cache';
 import { JellyfinAdapterService } from '../../api/media-server/jellyfin/jellyfin-adapter.service';
 import { JellyfinGetterService } from './jellyfin-getter.service';
@@ -125,7 +127,7 @@ describe('JellyfinGetterService', () => {
         0, // addDate
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeNull();
@@ -248,7 +250,7 @@ describe('JellyfinGetterService', () => {
           id,
           mediaItem,
           'movie',
-          createRulesDto({ dataType: 'movie' }),
+          createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
         );
 
         expect(response).toEqual(expected);
@@ -280,7 +282,7 @@ describe('JellyfinGetterService', () => {
         11,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Drama', 'Mystery']);
@@ -310,7 +312,7 @@ describe('JellyfinGetterService', () => {
         11,
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Sci-Fi']);
@@ -335,7 +337,7 @@ describe('JellyfinGetterService', () => {
         11,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual([]);
@@ -359,7 +361,7 @@ describe('JellyfinGetterService', () => {
         11,
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual([]);
@@ -382,7 +384,7 @@ describe('JellyfinGetterService', () => {
         44,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(6.9);
@@ -405,7 +407,7 @@ describe('JellyfinGetterService', () => {
         1,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Alice', 'Bob']);
@@ -430,7 +432,7 @@ describe('JellyfinGetterService', () => {
         1,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Bob', 'user-missing', 'Alice']);
@@ -447,7 +449,7 @@ describe('JellyfinGetterService', () => {
         1,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual([]);
@@ -473,12 +475,13 @@ describe('JellyfinGetterService', () => {
         39,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Bob', 'user-missing', 'Alice']);
       expect(jellyfinAdapter.getItemFavoritedBy).toHaveBeenCalledWith(
         'movie-1',
+        LIBRARY_ID,
       );
     });
 
@@ -509,12 +512,15 @@ describe('JellyfinGetterService', () => {
         40, // sw_favoritedBy
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'episode' }),
+        createRulesDto({ dataType: 'episode', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Bob']);
       expect(jellyfinAdapter.getItemFavoritedBy).toHaveBeenCalledTimes(1);
-      expect(jellyfinAdapter.getItemFavoritedBy).toHaveBeenCalledWith('ep-1');
+      expect(jellyfinAdapter.getItemFavoritedBy).toHaveBeenCalledWith(
+        'ep-1',
+        LIBRARY_ID,
+      );
     });
 
     it('sw_favoritedBy_including_parent (id: 41) should include favorites from item, parent and grandparent', async () => {
@@ -560,7 +566,7 @@ describe('JellyfinGetterService', () => {
         41, // sw_favoritedBy_including_parent
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'episode' }),
+        createRulesDto({ dataType: 'episode', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Alice', 'Bob', 'Carol', 'Dave']);
@@ -568,14 +574,17 @@ describe('JellyfinGetterService', () => {
       expect(jellyfinAdapter.getItemFavoritedBy).toHaveBeenNthCalledWith(
         1,
         'ep-1',
+        LIBRARY_ID,
       );
       expect(jellyfinAdapter.getItemFavoritedBy).toHaveBeenNthCalledWith(
         2,
         'season-1',
+        LIBRARY_ID,
       );
       expect(jellyfinAdapter.getItemFavoritedBy).toHaveBeenNthCalledWith(
         3,
         'show-1',
+        LIBRARY_ID,
       );
     });
   });
@@ -594,7 +603,7 @@ describe('JellyfinGetterService', () => {
         5,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(3);
@@ -615,7 +624,7 @@ describe('JellyfinGetterService', () => {
         JELLYFIN_IS_WATCHED_PROP_ID,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(true);
@@ -634,7 +643,7 @@ describe('JellyfinGetterService', () => {
         JELLYFIN_IS_WATCHED_PROP_ID,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(false);
@@ -831,7 +840,7 @@ describe('JellyfinGetterService', () => {
         7,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2024-06-15'));
@@ -847,7 +856,7 @@ describe('JellyfinGetterService', () => {
         7,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeNull();
@@ -865,7 +874,7 @@ describe('JellyfinGetterService', () => {
         7,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeUndefined();
@@ -919,7 +928,7 @@ describe('JellyfinGetterService', () => {
         7,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-03-06'));
@@ -959,7 +968,7 @@ describe('JellyfinGetterService', () => {
         7,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-03-04'));
@@ -1013,7 +1022,7 @@ describe('JellyfinGetterService', () => {
         12,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Bob']);
@@ -1046,7 +1055,7 @@ describe('JellyfinGetterService', () => {
           propertyId,
           showItem,
           'show',
-          createRulesDto({ dataType: 'show' }),
+          createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
         );
 
         expect(response).toBeUndefined();
@@ -1090,7 +1099,7 @@ describe('JellyfinGetterService', () => {
         14,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(3);
@@ -1120,7 +1129,7 @@ describe('JellyfinGetterService', () => {
         16,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-01-12'));
@@ -1168,7 +1177,7 @@ describe('JellyfinGetterService', () => {
         27,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-02-08'));
@@ -1207,7 +1216,7 @@ describe('JellyfinGetterService', () => {
         29,
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-03-10'));
@@ -1281,7 +1290,7 @@ describe('JellyfinGetterService', () => {
         13,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-03-06'));
@@ -1334,7 +1343,7 @@ describe('JellyfinGetterService', () => {
         13,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       // ep-2 is the highest-numbered watched episode; its rewatch wins.
@@ -1371,7 +1380,7 @@ describe('JellyfinGetterService', () => {
         13,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeNull();
@@ -1409,7 +1418,7 @@ describe('JellyfinGetterService', () => {
         13,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-02-01'));
@@ -1455,7 +1464,7 @@ describe('JellyfinGetterService', () => {
         13,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-03-01'));
@@ -1509,7 +1518,7 @@ describe('JellyfinGetterService', () => {
         15, // sw_viewedEpisodes
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(2); // 2 episodes have been watched
@@ -1542,7 +1551,7 @@ describe('JellyfinGetterService', () => {
         15,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(0);
@@ -1589,7 +1598,7 @@ describe('JellyfinGetterService', () => {
         17, // sw_amountOfViews
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(5); // 3 + 2 = 5 total views
@@ -1622,7 +1631,7 @@ describe('JellyfinGetterService', () => {
         17,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(0);
@@ -1652,13 +1661,13 @@ describe('JellyfinGetterService', () => {
         21,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
       const count = await jellyfinGetterService.get(
         20,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(names).toEqual(['Friday Queue']);
@@ -1701,7 +1710,7 @@ describe('JellyfinGetterService', () => {
         21,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Show Queue']);
@@ -1727,12 +1736,13 @@ describe('JellyfinGetterService', () => {
           id,
           mediaItem,
           type,
-          createRulesDto({ dataType: type }),
+          createRulesDto({ dataType: type, libraryId: LIBRARY_ID }),
         );
 
         expect(response).toBe(expected);
         expect(jellyfinAdapter.getTotalPlayCount).toHaveBeenCalledWith(
           `play-count-${id}`,
+          LIBRARY_ID,
         );
       },
     );
@@ -1760,7 +1770,7 @@ describe('JellyfinGetterService', () => {
         id,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(expected);
@@ -1804,7 +1814,7 @@ describe('JellyfinGetterService', () => {
           id,
           seasonItem,
           'season',
-          createRulesDto({ dataType: 'show' }),
+          createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
         );
 
         expect(response).toBe(expected);
@@ -1834,7 +1844,7 @@ describe('JellyfinGetterService', () => {
         35,
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(9.1);
@@ -1853,7 +1863,7 @@ describe('JellyfinGetterService', () => {
         999, // Unknown property ID
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeNull();
@@ -1889,13 +1899,13 @@ describe('JellyfinGetterService', () => {
         SW_WATCHERS_PROP_ID,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Alice', 'Bob']);
       expect(
         jellyfinAdapter.getDescendantEpisodeWatchHistory,
-      ).toHaveBeenCalledWith('show-1');
+      ).toHaveBeenCalledWith('show-1', LIBRARY_ID);
     });
 
     it('returns an empty list when no user has watched any episode', async () => {
@@ -1916,7 +1926,7 @@ describe('JellyfinGetterService', () => {
         SW_WATCHERS_PROP_ID,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual([]);
@@ -1941,13 +1951,13 @@ describe('JellyfinGetterService', () => {
         SW_WATCHERS_PROP_ID,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Bob']);
       expect(
         jellyfinAdapter.getDescendantEpisodeWatchHistory,
-      ).toHaveBeenCalledWith('season-1');
+      ).toHaveBeenCalledWith('season-1', LIBRARY_ID);
     });
 
     it('keeps episode watcher lookups on direct watch history', async () => {
@@ -1967,11 +1977,14 @@ describe('JellyfinGetterService', () => {
         SW_WATCHERS_PROP_ID,
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'episode' }),
+        createRulesDto({ dataType: 'episode', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Bob']);
-      expect(jellyfinAdapter.getItemSeenBy).toHaveBeenCalledWith('episode-1');
+      expect(jellyfinAdapter.getItemSeenBy).toHaveBeenCalledWith(
+        'episode-1',
+        LIBRARY_ID,
+      );
       expect(
         jellyfinAdapter.getDescendantEpisodeWatchHistory,
       ).not.toHaveBeenCalled();
@@ -1995,7 +2008,7 @@ describe('JellyfinGetterService', () => {
         SW_WATCHERS_PROP_ID,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['user-ghost']);
@@ -2011,7 +2024,7 @@ describe('JellyfinGetterService', () => {
         0,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeUndefined();
@@ -2028,7 +2041,7 @@ describe('JellyfinGetterService', () => {
         0,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeUndefined();
@@ -2102,13 +2115,25 @@ describe('JellyfinGetterService', () => {
       expect(jellyfinAdapter.getCollectionChildren).toHaveBeenCalledWith(
         'coll-franchise-a',
       );
-      expect(jellyfinAdapter.getWatchHistory).toHaveBeenCalledWith(ITEM_ID);
-      expect(jellyfinAdapter.getWatchHistory).toHaveBeenCalledWith('sibling-a');
+      expect(jellyfinAdapter.getWatchHistory).toHaveBeenCalledWith(
+        ITEM_ID,
+        true,
+        LIBRARY_ID,
+      );
+      expect(jellyfinAdapter.getWatchHistory).toHaveBeenCalledWith(
+        'sibling-a',
+        true,
+        LIBRARY_ID,
+      );
       expect(jellyfinAdapter.getWatchHistory).not.toHaveBeenCalledWith(
         'other-1',
+        true,
+        LIBRARY_ID,
       );
       expect(jellyfinAdapter.getWatchHistory).not.toHaveBeenCalledWith(
         'other-2',
+        true,
+        LIBRARY_ID,
       );
     });
 
@@ -2209,7 +2234,7 @@ describe('JellyfinGetterService', () => {
           propertyId,
           episodeItem,
           'episode',
-          createRulesDto({ dataType: 'episode' }),
+          createRulesDto({ dataType: 'episode', libraryId: LIBRARY_ID }),
         );
 
         expect(response).toEqual(expected);
@@ -2229,7 +2254,7 @@ describe('JellyfinGetterService', () => {
         7,
         movieItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeNull();

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
@@ -791,10 +791,10 @@ export class JellyfinGetterService {
       case 'season':
       case 'show': {
         const watchHistory = await this.descendantWatchHistory(
-      itemId,
-      type,
-      libraryId,
-    );
+          itemId,
+          type,
+          libraryId,
+        );
         const watched = new Set(
           Object.values(watchHistory).flatMap((records) =>
             records.map((record) => record.userId),

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
@@ -68,6 +68,10 @@ export class JellyfinGetterService {
         return null;
       }
 
+      // Which library's prefetched watch snapshot may answer the reads below.
+      // Absent (a single-item rule test) simply means every read goes live.
+      const libraryId = ruleGroup?.libraryId;
+
       // Fetch full metadata from Jellyfin
       // Note: libItem.id maps to Jellyfin item ID
       const metadata = await this.jellyfinAdapter.getMetadata(libItem.id);
@@ -109,6 +113,7 @@ export class JellyfinGetterService {
           // Get users who have watched this item
           const seenByUserIds = await this.jellyfinAdapter.getItemSeenBy(
             metadata.id,
+            libraryId,
           );
           const users = await this.jellyfinAdapter.getUsers();
           return mapRuleUserIdsToNames(
@@ -121,7 +126,10 @@ export class JellyfinGetterService {
 
         case 'favoritedBy': {
           const favoritedByUserIds =
-            await this.jellyfinAdapter.getItemFavoritedBy(metadata.id);
+            await this.jellyfinAdapter.getItemFavoritedBy(
+              metadata.id,
+              libraryId,
+            );
           const users = await this.jellyfinAdapter.getUsers();
           return mapRuleUserIdsToNames(
             favoritedByUserIds,
@@ -177,7 +185,10 @@ export class JellyfinGetterService {
 
         case 'playCount': {
           // Get total play attempts across all users (includes unfinished views)
-          return await this.jellyfinAdapter.getTotalPlayCount(metadata.id);
+          return await this.jellyfinAdapter.getTotalPlayCount(
+            metadata.id,
+            libraryId,
+          );
         }
 
         case 'labels': {
@@ -205,9 +216,10 @@ export class JellyfinGetterService {
             return await this.getLastWatchedShowDate(
               metadata.id,
               metadata.type,
+              libraryId,
             );
           }
-          return await this.getLastViewedAt(metadata.id);
+          return await this.getLastViewedAt(metadata.id, libraryId);
         }
 
         case 'fileVideoResolution': {
@@ -235,13 +247,18 @@ export class JellyfinGetterService {
         }
 
         case 'sw_allEpisodesSeenBy': {
-          return await this.getAllEpisodesSeenBy(metadata.id, metadata.type);
+          return await this.getAllEpisodesSeenBy(
+            metadata.id,
+            metadata.type,
+            libraryId,
+          );
         }
 
         case 'sw_lastWatched': {
           return await this.getNewestWatchedEpisodeDate(
             metadata.id,
             metadata.type,
+            libraryId,
           );
         }
 
@@ -250,7 +267,11 @@ export class JellyfinGetterService {
         }
 
         case 'sw_viewedEpisodes': {
-          return await this.getViewedEpisodeCount(metadata.id, metadata.type);
+          return await this.getViewedEpisodeCount(
+            metadata.id,
+            metadata.type,
+            libraryId,
+          );
         }
 
         case 'sw_lastEpisodeAddedAt': {
@@ -258,17 +279,27 @@ export class JellyfinGetterService {
         }
 
         case 'sw_amountOfViews': {
-          return await this.getTotalShowViews(metadata.id, metadata.type);
+          return await this.getTotalShowViews(
+            metadata.id,
+            metadata.type,
+            libraryId,
+          );
         }
 
         case 'sw_playCount': {
           // For episodes, get total play attempts (includes unfinished views)
-          return await this.jellyfinAdapter.getTotalPlayCount(metadata.id);
+          return await this.jellyfinAdapter.getTotalPlayCount(
+            metadata.id,
+            libraryId,
+          );
         }
 
         case 'sw_favoritedBy': {
           const favoritedByUserIds =
-            await this.jellyfinAdapter.getItemFavoritedBy(metadata.id);
+            await this.jellyfinAdapter.getItemFavoritedBy(
+              metadata.id,
+              libraryId,
+            );
           const users = await this.jellyfinAdapter.getUsers();
           return mapRuleUserIdsToNames(
             favoritedByUserIds,
@@ -285,6 +316,7 @@ export class JellyfinGetterService {
             metadata.id,
             parent?.id,
             grandparent?.id,
+            libraryId,
           );
           const users = await this.jellyfinAdapter.getUsers();
           return mapRuleUserIdsToNames(
@@ -302,7 +334,11 @@ export class JellyfinGetterService {
         // jellyfin-getter.service.spec.ts. Use `sw_allEpisodesSeenBy` when
         // you need "watched every episode" semantics instead.
         case 'sw_watchers': {
-          return await this.getSwWatchers(metadata.id, metadata.type);
+          return await this.getSwWatchers(
+            metadata.id,
+            metadata.type,
+            libraryId,
+          );
         }
 
         case 'collection_names': {
@@ -493,12 +529,16 @@ export class JellyfinGetterService {
   private async descendantWatchHistory(
     itemId: string,
     type: MediaItemType,
+    libraryId: string | undefined,
   ): Promise<Record<string, WatchRecord[]>> {
     if (!isMediaType(type, 'show') && !isMediaType(type, 'season')) {
       return {};
     }
 
-    return this.jellyfinAdapter.getDescendantEpisodeWatchHistory(itemId);
+    return this.jellyfinAdapter.getDescendantEpisodeWatchHistory(
+      itemId,
+      libraryId,
+    );
   }
 
   private newestWatchedAt(records: WatchRecord[]): Date | null {
@@ -510,19 +550,23 @@ export class JellyfinGetterService {
     return times.length > 0 ? new Date(Math.max(...times)) : null;
   }
 
-  private async getLastViewedAt(itemId: string): Promise<Date | null> {
+  private async getLastViewedAt(
+    itemId: string,
+    libraryId: string | undefined,
+  ): Promise<Date | null> {
     return this.newestWatchedAt(
-      await this.jellyfinAdapter.getWatchHistory(itemId),
+      await this.jellyfinAdapter.getWatchHistory(itemId, true, libraryId),
     );
   }
 
   private async getAllEpisodesSeenBy(
     itemId: string,
     type: MediaItemType,
+    libraryId: string | undefined,
   ): Promise<string[]> {
     const users = await this.jellyfinAdapter.getUsers();
     const episodeWatchers = Object.values(
-      await this.descendantWatchHistory(itemId, type),
+      await this.descendantWatchHistory(itemId, type, libraryId),
     );
 
     if (episodeWatchers.length === 0) return [];
@@ -553,6 +597,7 @@ export class JellyfinGetterService {
   private async getNewestWatchedEpisodeDate(
     itemId: string,
     type: MediaItemType,
+    libraryId: string | undefined,
   ): Promise<Date | null> {
     const seasons: Array<{ id: string }> =
       type === 'season'
@@ -565,7 +610,11 @@ export class JellyfinGetterService {
       viewedAt: Date;
     }> = [];
 
-    const watchHistory = await this.descendantWatchHistory(itemId, type);
+    const watchHistory = await this.descendantWatchHistory(
+      itemId,
+      type,
+      libraryId,
+    );
 
     for (const season of seasons) {
       const episodes = await this.jellyfinAdapter.getChildrenMetadata(
@@ -611,8 +660,13 @@ export class JellyfinGetterService {
   private async getLastWatchedShowDate(
     itemId: string,
     type: MediaItemType,
+    libraryId: string | undefined,
   ): Promise<Date | null> {
-    const watchHistory = await this.descendantWatchHistory(itemId, type);
+    const watchHistory = await this.descendantWatchHistory(
+      itemId,
+      type,
+      libraryId,
+    );
 
     return this.newestWatchedAt(Object.values(watchHistory).flat());
   }
@@ -648,8 +702,13 @@ export class JellyfinGetterService {
   private async getViewedEpisodeCount(
     itemId: string,
     type: MediaItemType,
+    libraryId: string | undefined,
   ): Promise<number> {
-    const watchHistory = await this.descendantWatchHistory(itemId, type);
+    const watchHistory = await this.descendantWatchHistory(
+      itemId,
+      type,
+      libraryId,
+    );
 
     return Object.values(watchHistory).filter((records) => records.length > 0)
       .length;
@@ -687,13 +746,22 @@ export class JellyfinGetterService {
   private async getTotalShowViews(
     itemId: string,
     type: MediaItemType,
+    libraryId: string | undefined,
   ): Promise<number> {
     if (type === 'episode') {
-      const history = await this.jellyfinAdapter.getWatchHistory(itemId);
+      const history = await this.jellyfinAdapter.getWatchHistory(
+        itemId,
+        true,
+        libraryId,
+      );
       return history.length;
     }
 
-    const watchHistory = await this.descendantWatchHistory(itemId, type);
+    const watchHistory = await this.descendantWatchHistory(
+      itemId,
+      type,
+      libraryId,
+    );
 
     return Object.values(watchHistory).reduce(
       (total, records) => total + records.length,
@@ -704,13 +772,17 @@ export class JellyfinGetterService {
   private async getSwWatchers(
     itemId: string,
     type: MediaItemType,
+    libraryId: string | undefined,
   ): Promise<string[]> {
     const users = await this.jellyfinAdapter.getUsers();
     let watcherIds: string[];
 
     switch (type) {
       case 'episode': {
-        watcherIds = await this.jellyfinAdapter.getItemSeenBy(itemId);
+        watcherIds = await this.jellyfinAdapter.getItemSeenBy(
+          itemId,
+          libraryId,
+        );
         break;
       }
 
@@ -718,7 +790,11 @@ export class JellyfinGetterService {
       // (#2559). sw_allEpisodesSeenBy is the "watched every episode" one.
       case 'season':
       case 'show': {
-        const watchHistory = await this.descendantWatchHistory(itemId, type);
+        const watchHistory = await this.descendantWatchHistory(
+      itemId,
+      type,
+      libraryId,
+    );
         const watched = new Set(
           Object.values(watchHistory).flatMap((records) =>
             records.map((record) => record.userId),
@@ -782,6 +858,7 @@ export class JellyfinGetterService {
     itemId: string,
     parentId: string | undefined,
     grandparentId: string | undefined,
+    libraryId: string | undefined,
   ): Promise<string[]> {
     const idsToCheck = [...new Set([itemId, parentId, grandparentId])].filter(
       (id): id is string => id !== undefined,
@@ -789,7 +866,10 @@ export class JellyfinGetterService {
 
     const favoritedByUserIds = new Set<string>();
     for (const id of idsToCheck) {
-      const users = await this.jellyfinAdapter.getItemFavoritedBy(id);
+      const users = await this.jellyfinAdapter.getItemFavoritedBy(
+        id,
+        libraryId,
+      );
       users.forEach((userId) => favoritedByUserIds.add(userId));
     }
 
@@ -921,7 +1001,11 @@ export class JellyfinGetterService {
       for (const child of children) {
         // getWatchHistory aggregates LastPlayedDate across all Jellyfin users
         // (unlike child.lastViewedAt which is scoped to the admin user).
-        const history = await this.jellyfinAdapter.getWatchHistory(child.id);
+        const history = await this.jellyfinAdapter.getWatchHistory(
+          child.id,
+          true,
+          libraryId,
+        );
         for (const record of history) {
           const watchedMs = record.watchedAt?.getTime() ?? 0;
           if (watchedMs > latestMs) {

--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -174,9 +174,16 @@ describe('PlexGetterService', () => {
         isWatched: true,
       });
 
-      const result = await service.get(VIEWCOUNT_PROP_ID, libItem);
+      const result = await service.get(
+        VIEWCOUNT_PROP_ID,
+        libItem,
+        'movie',
+        createRulesDto({ dataType: 'movie' }),
+      );
 
       expect(result).toBe(7);
+      // Watch state is never served from the run snapshot (#3352) - it is the
+      // current-state read that feeds deletions.
       expect(plexAdapter.getWatchState).toHaveBeenCalledWith('12345', 0);
     });
 
@@ -186,7 +193,12 @@ describe('PlexGetterService', () => {
         isWatched: false,
       });
 
-      const result = await service.get(ISWATCHED_PROP_ID, libItem);
+      const result = await service.get(
+        ISWATCHED_PROP_ID,
+        libItem,
+        'movie',
+        createRulesDto({ dataType: 'movie' }),
+      );
 
       expect(result).toBe(false);
       expect(plexAdapter.getWatchState).toHaveBeenCalledWith('12345', 0);
@@ -310,11 +322,12 @@ describe('PlexGetterService', () => {
         makeWatchEntry({ viewedAt: 1_710_000_000 }),
       ]);
 
+      const ruleGroup = createRulesDto({ dataType: 'movie' });
       const result = await service.get(
         7,
         createMediaItem({ type: 'movie' }),
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        ruleGroup,
       );
 
       expect(result).toEqual(new Date(1_720_000_000 * 1000));
@@ -322,6 +335,7 @@ describe('PlexGetterService', () => {
         '12345',
         true,
         'movie',
+        ruleGroup.libraryId,
       );
     });
 
@@ -469,11 +483,12 @@ describe('PlexGetterService', () => {
         }),
       ]);
 
+      const ruleGroup = createRulesDto({ dataType: 'show' });
       const result = await service.get(
         13,
         createMediaItem({ type: 'show' }),
         'show',
-        createRulesDto({ dataType: 'show' }),
+        ruleGroup,
       );
 
       expect(result).toEqual(new Date(1_710_000_000 * 1000));
@@ -481,6 +496,7 @@ describe('PlexGetterService', () => {
         'show-1',
         true,
         'show',
+        ruleGroup.libraryId,
       );
     });
 
@@ -614,11 +630,12 @@ describe('PlexGetterService', () => {
         makeWatchEntry({ accountID: 1 }),
       ]);
 
+      const ruleGroup = createRulesDto({ dataType: 'show' });
       const result = await service.get(
         18,
         createMediaItem({ type: 'show' }),
         'show',
-        createRulesDto({ dataType: 'show' }),
+        ruleGroup,
       );
 
       expect(result).toEqual(['bob', 'alice']);
@@ -626,6 +643,7 @@ describe('PlexGetterService', () => {
         'show-1',
         true,
         'show',
+        ruleGroup.libraryId,
       );
     });
 
@@ -1246,16 +1264,19 @@ describe('PlexGetterService', () => {
         '12345',
         true,
         'movie',
+        'lib-1',
       );
       expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
         'sibling-a',
         true,
         'movie',
+        'lib-1',
       );
       expect(plexApi.getWatchHistory).toHaveBeenCalledWith(
         'sibling-b',
         true,
         'movie',
+        'lib-1',
       );
     });
 
@@ -1400,9 +1421,12 @@ describe('PlexGetterService', () => {
         makeWatchEntry({ accountID: 2 }),
       ]);
 
+      const ruleGroup = createRulesDto({ dataType: 'movie' });
       const result = await service.get(
         SEEN_BY_PROP_ID,
         createMediaItem({ type: 'movie' }),
+        'movie',
+        ruleGroup,
       );
 
       expect(result).toEqual(['bob', 'alice']);
@@ -1410,6 +1434,7 @@ describe('PlexGetterService', () => {
         '12345',
         true,
         'movie',
+        ruleGroup.libraryId,
       );
     });
 

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -51,6 +51,11 @@ export class PlexGetterService {
     try {
       const prop = this.plexProperties.find((el) => el.id === id);
 
+      // Which library's prefetched watch-history snapshot may answer the reads
+      // below. Absent (a single-item rule test) means every watch read goes
+      // live rather than risk another library's snapshot.
+      const libraryId = ruleGroup?.libraryId;
+
       // fetch metadata, parent & grandparent from cache, this data is more complete
       // libItem.id maps to Plex's ratingKey
       const metadata: PlexMetadata = await this.plexApi.getMetadata(
@@ -93,6 +98,7 @@ export class PlexGetterService {
             metadata.ratingKey,
             true,
             metadata.type,
+            libraryId,
           );
           const viewerIds = viewers.map((el) => +el.accountID);
           return mapMatchingRuleUsersToNames(
@@ -256,6 +262,7 @@ export class PlexGetterService {
             metadata.ratingKey,
             true,
             metadata.type,
+            libraryId,
           );
           // Marking something played by hand, or a scrobble from an external
           // tracker, moves the item's own lastViewedAt without writing a
@@ -308,6 +315,7 @@ export class PlexGetterService {
                 episode.ratingKey,
                 true,
                 'episode',
+                libraryId,
               );
 
               const arrLength = allViewers.length - 1;
@@ -348,6 +356,7 @@ export class PlexGetterService {
             metadata.ratingKey,
             true,
             metadata.type,
+            libraryId,
           );
 
           const viewers = watchHistory
@@ -370,6 +379,7 @@ export class PlexGetterService {
             metadata.ratingKey,
             true,
             metadata.type,
+            libraryId,
           );
           // getWatchHistory returns [] for a confirmed-empty history (it throws
           // on a real outage). [] is truthy and the sort/filter below index
@@ -410,6 +420,7 @@ export class PlexGetterService {
                 episode.ratingKey,
                 true,
                 'episode',
+                libraryId,
               );
               if (views?.length > 0) {
                 viewCount++;
@@ -434,6 +445,7 @@ export class PlexGetterService {
               metadata.ratingKey,
               true,
               metadata.type,
+              libraryId,
             );
             viewCount =
               views?.length > 0 ? viewCount + views.length : viewCount;
@@ -452,6 +464,7 @@ export class PlexGetterService {
                   episode.ratingKey,
                   true,
                   'episode',
+                  libraryId,
                 );
                 viewCount =
                   views?.length > 0 ? viewCount + views.length : viewCount;
@@ -865,6 +878,7 @@ export class PlexGetterService {
                 child.ratingKey,
                 true,
                 child.type,
+                libraryId,
               );
               for (const entry of history) {
                 if (entry.viewedAt && +entry.viewedAt > latest) {

--- a/apps/server/src/modules/rules/helpers/media-server-application.helper.ts
+++ b/apps/server/src/modules/rules/helpers/media-server-application.helper.ts
@@ -2,10 +2,13 @@ import { MediaServerType } from '@maintainerr/contracts';
 import { Application } from '../constants/rules.constants';
 
 /**
- * Maps a configured media server onto the `Application` whose properties
- * describe it. The `Record<MediaServerType, …>` type is exhaustive - adding a
- * new media server to `MediaServerType` is a compile error until it is mapped
+ * Single source of truth mapping each supported media server to its rule
+ * `Application` id. The `Record<MediaServerType, …>` type is exhaustive - adding
+ * a new media server to `MediaServerType` is a compile error until it is mapped
  * here, which keeps every consumer in step with the supported-server list.
+ *
+ * Lives here rather than beside its first consumer (RuleMigrationService) so
+ * the rules layer can use it without importing from settings.
  */
 export const MEDIA_SERVER_TYPE_TO_APP: Record<MediaServerType, Application> = {
   [MediaServerType.PLEX]: Application.PLEX,

--- a/apps/server/src/modules/rules/helpers/media-server-application.helper.ts
+++ b/apps/server/src/modules/rules/helpers/media-server-application.helper.ts
@@ -1,0 +1,50 @@
+import { MediaServerType } from '@maintainerr/contracts';
+import { Application } from '../constants/rules.constants';
+
+/**
+ * Maps a configured media server onto the `Application` whose properties
+ * describe it. The `Record<MediaServerType, …>` type is exhaustive - adding a
+ * new media server to `MediaServerType` is a compile error until it is mapped
+ * here, which keeps every consumer in step with the supported-server list.
+ */
+export const MEDIA_SERVER_TYPE_TO_APP: Record<MediaServerType, Application> = {
+  [MediaServerType.PLEX]: Application.PLEX,
+  [MediaServerType.JELLYFIN]: Application.JELLYFIN,
+  [MediaServerType.EMBY]: Application.EMBY,
+};
+
+/**
+ * Apps that represent the media server itself and therefore differ between
+ * servers. Every other app (Radarr, Sonarr, Seerr, Tautulli) is media-server
+ * independent and means the same thing whatever is configured.
+ */
+export const MEDIA_SERVER_APPS = new Set<Application>(
+  Object.values(MEDIA_SERVER_TYPE_TO_APP),
+);
+
+export const isMediaServerApplication = (application: number): boolean =>
+  MEDIA_SERVER_APPS.has(application);
+
+/**
+ * The application a rule's value will actually be read from.
+ *
+ * A rule stores the app it was authored against, but the getter routes every
+ * media-server app to whichever server is configured and looks the property id
+ * up in *that* server's list. A rule authored on Plex and left unmigrated after
+ * a switch to Jellyfin therefore reads Jellyfin's property with that id. Naming
+ * it from the stored app would describe a different property than the one that
+ * produced the value - property ids do not line up across servers (id 39 is
+ * `collectionsIncludingSmart` on Plex and `favoritedBy` on Jellyfin).
+ *
+ * Returns the stored application unchanged for non-media-server apps, and when
+ * the configured server is unknown.
+ */
+export const resolveValueApplication = (
+  storedApplication: number,
+  configuredServerType: MediaServerType | undefined | null,
+): number => {
+  if (!configuredServerType || !isMediaServerApplication(storedApplication)) {
+    return storedApplication;
+  }
+  return MEDIA_SERVER_TYPE_TO_APP[configuredServerType] ?? storedApplication;
+};

--- a/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -98,7 +98,8 @@ export class RuleComparatorService {
       this.resultIds = new Set<string>();
       this.statsById = new Map<string, IComparisonStatistics>();
       this.transientFailureIds = new Set<string>();
-      this.configuredServerType = await this.valueGetter.getConfiguredServerType();
+      this.configuredServerType =
+        await this.valueGetter.getConfiguredServerType();
 
       // run rules
       let currentSection = 0;

--- a/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -1,5 +1,6 @@
 import {
   IComparisonStatistics,
+  MediaServerType,
   IRuleComparisonResult,
   MediaItem,
   MediaItemType,
@@ -58,6 +59,9 @@ export class RuleComparatorService {
   private statsById: Map<string, IComparisonStatistics>;
   private transientFailureIds: Set<string>;
   private arrLookupCache?: ArrLookupCache;
+  // Resolved once per run: names every value after the server it was read
+  // from, rather than the one the rule was authored against.
+  private configuredServerType?: MediaServerType | null;
 
   private static readonly UNARY_RULE_ACTIONS = new Set<RulePossibility>([
     RulePossibility.EXISTS,
@@ -94,6 +98,7 @@ export class RuleComparatorService {
       this.resultIds = new Set<string>();
       this.statsById = new Map<string, IComparisonStatistics>();
       this.transientFailureIds = new Set<string>();
+      this.configuredServerType = await this.valueGetter.getConfiguredServerType();
 
       // run rules
       let currentSection = 0;
@@ -364,11 +369,13 @@ export class RuleComparatorService {
     if (firstVal == null) {
       reasons.firstValueReason = this.ruleConstanstService.getValueNullReason(
         rule.firstVal,
+        this.configuredServerType,
       );
     }
     if (secondVal == null && rule.lastVal) {
       reasons.secondValueReason = this.ruleConstanstService.getValueNullReason(
         rule.lastVal,
+        this.configuredServerType,
       );
     }
     return reasons;
@@ -500,6 +507,7 @@ export class RuleComparatorService {
       action: RulePossibility[rule.action].toLowerCase(),
       firstValueName: this.ruleConstanstService.getValueHumanName(
         rule.firstVal,
+        this.configuredServerType,
       ),
       firstValue: firstVal,
       ...(reasons?.firstValueReason
@@ -519,6 +527,7 @@ export class RuleComparatorService {
   ): void {
     const firstValueName = this.ruleConstanstService.getValueHumanName(
       rule.firstVal,
+      this.configuredServerType,
     );
 
     this.logger.debug(
@@ -532,7 +541,10 @@ export class RuleComparatorService {
 
   private getSecondValueName(rule: RuleDto): string {
     if (rule.lastVal) {
-      return this.ruleConstanstService.getValueHumanName(rule.lastVal);
+      return this.ruleConstanstService.getValueHumanName(
+        rule.lastVal,
+        this.configuredServerType,
+      );
     }
     // Unary actions (EXISTS / NOT_EXISTS) have neither a second value nor a
     // custom value. Guard against it so this diagnostic-only helper never

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -268,18 +268,22 @@ export class RuleExecutorService {
         );
 
         // Prefetch watch history so per-item getWatchHistory calls during
-        // evaluation are served from an in-memory map instead of individual
-        // HTTP requests. Reused across rule groups within a scheduler batch;
-        // rebuilt here when the reset above flushed it. Gated on the server
-        // being able to answer watch history in bulk - Plex from one central
-        // endpoint, Jellyfin from one sweep per user; Emby cannot and keeps its
-        // per-item path. Abort-checked first so a cancellation that lands just
-        // before evaluation doesn't kick off a long history sweep.
+        // evaluation are served from an in-memory snapshot instead of
+        // individual HTTP requests. Scoped to this group's library, since that
+        // is the only library it evaluates. Reused across rule groups within a
+        // scheduler batch; rebuilt here when the reset above flushed it. Gated
+        // on the server being able to answer watch history in bulk - Plex from
+        // one central endpoint, Jellyfin from one sweep per user; Emby cannot
+        // and keeps its per-item path. Abort-checked first so a cancellation
+        // that lands just before evaluation doesn't kick off a long sweep.
         abortSignal.throwIfAborted();
         if (
           mediaServer.supportsFeature(MediaServerFeature.CENTRAL_WATCH_HISTORY)
         ) {
-          await mediaServer.prefetchWatchHistory(abortSignal);
+          await mediaServer.prefetchWatchHistory({
+            libraryId: ruleGroup.libraryId,
+            abortSignal,
+          });
         }
 
         // prepare

--- a/apps/server/src/modules/settings/rule-migration.service.ts
+++ b/apps/server/src/modules/settings/rule-migration.service.ts
@@ -14,6 +14,10 @@ import {
   RuleOperators,
 } from '../rules/constants/rules.constants';
 import { RuleDto } from '../rules/dtos/rule.dto';
+import {
+  MEDIA_SERVER_APPS,
+  MEDIA_SERVER_TYPE_TO_APP,
+} from '../rules/helpers/media-server-application.helper';
 import { reassertSectionBoundaryOperators } from '../rules/helpers/section-operators';
 import { RuleGroup } from '../rules/entities/rule-group.entities';
 import { Rules } from '../rules/entities/rules.entities';
@@ -21,26 +25,6 @@ import { Rules } from '../rules/entities/rules.entities';
 /** Singleton instance - avoids re-creating the constant data on every call. */
 const RULE_CONSTANTS = new RuleConstants();
 
-/**
- * Single source of truth mapping each supported media server to its rule
- * `Application` id. The `Record<MediaServerType, …>` type is exhaustive - adding
- * a new media server to `MediaServerType` is a compile error until it is mapped
- * here, which keeps the migrator in step with the supported-server list.
- */
-const MEDIA_SERVER_TYPE_TO_APP: Record<MediaServerType, Application> = {
-  [MediaServerType.PLEX]: Application.PLEX,
-  [MediaServerType.JELLYFIN]: Application.JELLYFIN,
-  [MediaServerType.EMBY]: Application.EMBY,
-};
-
-/**
- * Apps that represent the media server itself and therefore differ between
- * servers. Only these are remapped during migration; every other app (Radarr,
- * Sonarr, Seerr, Tautulli) is media-server independent and left exactly as-is.
- */
-const MEDIA_SERVER_APPS = new Set<Application>(
-  Object.values(MEDIA_SERVER_TYPE_TO_APP),
-);
 
 /**
  * Outcome of checking whether a single rule can be migrated.

--- a/apps/server/src/modules/settings/rule-migration.service.ts
+++ b/apps/server/src/modules/settings/rule-migration.service.ts
@@ -25,7 +25,6 @@ import { Rules } from '../rules/entities/rules.entities';
 /** Singleton instance - avoids re-creating the constant data on every call. */
 const RULE_CONSTANTS = new RuleConstants();
 
-
 /**
  * Outcome of checking whether a single rule can be migrated.
  */


### PR DESCRIPTION
Reported on Discord: rules sitting 15+ minutes on `Prefetching watch history`, showing 88432 records against a 6540-episode TV library.

The count was never wrong - those are view *events*, server-wide, all users, every rewatch - but the sweep read all of them for every rule group regardless of what the group actually needed. The reporter's own progress timings put the cost at a flat ~11.2 ms per entry with no offset degradation, so the fix is to fetch fewer and smaller entries, not to page them differently.

- **Scoped per library.** `librarySectionID` on Plex, `parentId` on Jellyfin, with snapshots keyed per library. Plex needs the per-library key for correctness, not just cost: its leaf map answers a miss with a confirmed empty history, so under one shared key an item from an unswept library would read as never watched.
- **Trimmed rows.** `excludeFields` on the Plex sweep, measured 405 -> 148 bytes per row on PMS 1.43.3. Every field the getters read is verified still present.
- **Bounded memory.** The Plex snapshot had no ceiling at all and its cache is exempt from the key-count bound (#3284); 500k trimmed rows measured ~74MB retained. Now bounded at 500k to mirror `JELLYFIN_WATCH_SNAPSHOT_MAX_RECORDS`, and since Plex reports `totalSize` on the first page an oversized history is abandoned after one request.
- **Show/season rollup on Plex.** `grandparentKey`/`parentKey` are undocumented on this endpoint and were absent over some connections (#3082), so the rollup is built all-or-nothing and then checked against Plex's own server-side rollup for one show before it is kept. Any disagreement, or a failed check, drops it and container reads stay per-item.

Also fixes a silent truncation in `queryAll`: it advanced the offset by the requested page size rather than the rows actually returned, so a short page skipped everything the server withheld. Only the watch-history sweep had a `totalSize` check to catch it; the other callers had none.

Watch state (`isWatched`/`viewCount`) deliberately still reads live on both servers - it is the current-state read that feeds deletions (#3352).

Log wording is reworked across all three bulk sweeps: the Plex line claimed "for all library items" when it counts view events, the Jellyfin sweep carries play counts and favourites as well as history, and the Seerr sweep had no start or completion line at all.

### Verification

Both servers were checked against the real stack with a fault-injecting proxy that fails only the bulk sweep, so a snapshot-served run can be compared against one forced entirely live. Results must be identical, and were:

| | groups | value probes | diffs |
|---|---|---|---|
| Plex, snapshot vs live | 20 | 52 | 0 |
| Jellyfin, snapshot vs live | 27 | 66 | 0 |

Both baselines were captured the same way before the change. End-to-end through the UI on real Plex, `Times viewed > 0` and `Last view date exists` correctly return different sets - the second also matches an item marked watched with no history row, which is the #3352 case.