### PR TITLE
fix(actions): report the leftover-cleanup skip for items not tracked in the *arr

### DIFF
--- a/apps/server/src/modules/actions/leftover-folder-cleanup.service.ts
+++ b/apps/server/src/modules/actions/leftover-folder-cleanup.service.ts
@@ -91,6 +91,19 @@ export class LeftoverFolderCleanupService {
     logger.setContext(LeftoverFolderCleanupService.name);
   }
 
+  /**
+   * The media-server delete fallback runs when the item is not tracked in the
+   * *arr, which is also where every fence comes from: no root folders, no
+   * sibling item paths, nothing to prove the folder is the one just emptied. So
+   * the cleanup cannot run there. Say so, otherwise an enabled cleanup appears
+   * to do nothing at all (#3370).
+   */
+  public logSkippedForUntrackedItem(label?: string): void {
+    this.logger.warn(
+      `Leftover-folder cleanup skipped${label ? ` for '${label}'` : ''}: the item is not tracked in the *arr, so there are no root folders to fence the delete against. Only the media file was removed; its folder was left in place.`,
+    );
+  }
+
   public async cleanupAfterDelete(input: LeftoverCleanupInput): Promise<void> {
     const label = input.label ? ` for '${input.label}'` : '';
     try {

--- a/apps/server/src/modules/actions/radarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/radarr-action-handler.spec.ts
@@ -281,6 +281,44 @@ describe('RadarrActionHandler', () => {
       expect(folderCleanup.cleanupAfterDelete).not.toHaveBeenCalled();
     });
 
+    it('reports the skip when the movie is not tracked in Radarr, so an enabled cleanup is not silent', async () => {
+      const collection = createCollection({
+        arrAction: ServarrAction.UNMONITOR_DELETE_ALL,
+        radarrSettingsId: 1,
+        type: 'movie',
+        cleanupLeftoverFolders: true,
+      });
+      const collectionMedia = createCollectionMedia(collection, { tmdbId: 1 });
+      const mockedRadarrApi = mockRadarrApi(servarrService, logger);
+      jest.spyOn(mockedRadarrApi, 'getMovieByTmdbId').mockResolvedValue(null);
+
+      await radarrActionHandler.handleAction(collection, collectionMedia);
+
+      expect(folderCleanup.logSkippedForUntrackedItem).toHaveBeenCalledWith(
+        collectionMedia.mediaServerId,
+      );
+      expect(folderCleanup.cleanupAfterDelete).not.toHaveBeenCalled();
+      expect(mediaServer.deleteFromDisk).toHaveBeenCalledWith(
+        collectionMedia.mediaServerId,
+      );
+    });
+
+    it('stays quiet about the skip when the collection has not opted in', async () => {
+      const collection = createCollection({
+        arrAction: ServarrAction.UNMONITOR_DELETE_ALL,
+        radarrSettingsId: 1,
+        type: 'movie',
+        cleanupLeftoverFolders: false,
+      });
+      const collectionMedia = createCollectionMedia(collection, { tmdbId: 1 });
+      const mockedRadarrApi = mockRadarrApi(servarrService, logger);
+      jest.spyOn(mockedRadarrApi, 'getMovieByTmdbId').mockResolvedValue(null);
+
+      await radarrActionHandler.handleAction(collection, collectionMedia);
+
+      expect(folderCleanup.logSkippedForUntrackedItem).not.toHaveBeenCalled();
+    });
+
     it('reads no cleanup inputs when the collection has not opted in', async () => {
       const collection = createCollection({
         arrAction: ServarrAction.UNMONITOR_DELETE_ALL,

--- a/apps/server/src/modules/actions/radarr-action-handler.ts
+++ b/apps/server/src/modules/actions/radarr-action-handler.ts
@@ -202,6 +202,12 @@ export class RadarrActionHandler {
           this.logger.log(
             `Couldn't find movie in Radarr using resolved external IDs [${attemptedIds}] for media server ID ${media.mediaServerId}. Attempting to remove from the filesystem via media server.`,
           );
+          if (
+            collection.cleanupLeftoverFolders &&
+            leftoverCleanupScope(collection.type, collection.arrAction)
+          ) {
+            this.folderCleanup.logSkippedForUntrackedItem(media.mediaServerId);
+          }
           const mediaServer = await this.mediaServerFactory.getService();
           await mediaServer.deleteFromDisk(media.mediaServerId);
           return true;

--- a/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -513,6 +513,33 @@ describe('SonarrActionHandler', () => {
     },
   );
 
+  it('reports the skip when the show is not tracked in Sonarr, so an enabled cleanup is not silent', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      sonarrSettingsId: 1,
+      type: 'season',
+      cleanupLeftoverFolders: true,
+    });
+    const collectionMedia = createCollectionMediaWithMetadata(collection, {
+      tmdbId: 1,
+    });
+
+    mockMediaServerMetadata(collectionMedia.mediaData);
+
+    const mockedSonarrApi = mockSonarrApi(servarrService, logger);
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(null);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(folderCleanup.logSkippedForUntrackedItem).toHaveBeenCalledWith(
+      collectionMedia.mediaServerId,
+    );
+    expect(folderCleanup.cleanupAfterDelete).not.toHaveBeenCalled();
+    expect(mediaServer.deleteFromDisk).toHaveBeenCalled();
+  });
+
   // A transient Sonarr lookup failure (getSeriesByTvdbId → undefined) must NOT
   // be read as "not in Sonarr" and trigger a media-server delete - fail closed
   // so the item stays in the collection and is retried next run. (#3125)

--- a/apps/server/src/modules/actions/sonarr-action-handler.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.ts
@@ -116,6 +116,12 @@ export class SonarrActionHandler {
         this.logger.log(
           `Couldn't find show in Sonarr using resolved external IDs [${attemptedIds}] for media server item ${media.mediaServerId}. Attempting to remove from the filesystem via media server.`,
         );
+        if (
+          collection.cleanupLeftoverFolders &&
+          leftoverCleanupScope(collection.type, collection.arrAction)
+        ) {
+          this.folderCleanup.logSkippedForUntrackedItem(media.mediaServerId);
+        }
         await mediaServer.deleteFromDisk(media.mediaServerId);
         return true;
       } else {


### PR DESCRIPTION
When Radarr/Sonarr does not track an item, the action handlers fall back to deleting through the media server. The leftover-folder cleanup cannot run on that path because every fence it needs (root folders, sibling item paths) comes from the *arr, so a collection that opted in saw the media file removed, the folder left behind, and nothing in the log explaining why.

The skip is now reported, gated on the collection having opted in and the action/type actually qualifying for a scope, so instances that never enabled the cleanup see no new output.

Refs #3370, which stays open for deriving real fences from the media server.