### PR TITLE
fix: make the delete and prefetch logs report what actually happened

### DIFF
--- a/apps/server/src/modules/actions/radarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/radarr-action-handler.spec.ts
@@ -319,6 +319,28 @@ describe('RadarrActionHandler', () => {
       expect(folderCleanup.logSkippedForUntrackedItem).not.toHaveBeenCalled();
     });
 
+    it('does not claim a file removal when Radarr held no files for the movie', async () => {
+      const collection = createCollection({
+        arrAction: ServarrAction.UNMONITOR_DELETE_ALL,
+        radarrSettingsId: 1,
+        type: 'movie',
+      });
+      const collectionMedia = createCollectionMedia(collection, { tmdbId: 1 });
+      const mockedRadarrApi = mockRadarrApi(servarrService, logger);
+      jest
+        .spyOn(mockedRadarrApi, 'getMovieByTmdbId')
+        .mockResolvedValue(createRadarrMovie({ id: 5 }));
+      jest
+        .spyOn(mockedRadarrApi, 'updateMovie')
+        .mockResolvedValue({ ok: true, deletedFileCount: 0 });
+
+      await radarrActionHandler.handleAction(collection, collectionMedia);
+
+      expect(logger.log).toHaveBeenCalledWith(
+        expect.stringContaining('it had no files to remove'),
+      );
+    });
+
     it('reads no cleanup inputs when the collection has not opted in', async () => {
       const collection = createCollection({
         arrAction: ServarrAction.UNMONITOR_DELETE_ALL,

--- a/apps/server/src/modules/actions/radarr-action-handler.ts
+++ b/apps/server/src/modules/actions/radarr-action-handler.ts
@@ -115,10 +115,12 @@ export class RadarrActionHandler {
             return true;
           case ServarrAction.UNMONITOR:
             if (
-              !(await radarrApiClient.updateMovie(radarrMedia.id, {
-                monitored: false,
-                addImportExclusion: collection.listExclusions,
-              }))
+              !(
+                await radarrApiClient.updateMovie(radarrMedia.id, {
+                  monitored: false,
+                  addImportExclusion: collection.listExclusions,
+                })
+              ).ok
             ) {
               return false;
             }
@@ -126,18 +128,28 @@ export class RadarrActionHandler {
               `Unmonitored movie with ${matchedProvider} ID ${matchedId}${collection.listExclusions ? ' & added to import exclusion list' : ''} in Radarr`,
             );
             return true;
-          case ServarrAction.UNMONITOR_DELETE_ALL:
-            if (
-              !(await radarrApiClient.updateMovie(radarrMedia.id, {
+          case ServarrAction.UNMONITOR_DELETE_ALL: {
+            const updateResult = await radarrApiClient.updateMovie(
+              radarrMedia.id,
+              {
                 monitored: false,
                 deleteFiles: true,
                 addImportExclusion: collection.listExclusions,
-              }))
-            ) {
+              },
+            );
+
+            if (!updateResult.ok) {
               return false;
             }
+            // Say what was actually removed: Radarr holding no file records for
+            // the movie deletes nothing, and claiming otherwise leaves a later
+            // "it kept my file" report with no way to tell the two apart.
             this.logger.log(
-              `Unmonitored movie with ${matchedProvider} ID ${matchedId}${collection.listExclusions ? ', added to import exclusion list' : ''} & removed files from filesystem in Radarr`,
+              `Unmonitored movie with ${matchedProvider} ID ${matchedId}${collection.listExclusions ? ', added to import exclusion list' : ''}${
+                updateResult.deletedFileCount > 0
+                  ? ` & removed ${updateResult.deletedFileCount} file(s) from filesystem in Radarr`
+                  : ' in Radarr; it had no files to remove'
+              }`,
             );
             await this.downloadClient.removeDownloads(downloadIds);
             if (cleanupScope && cleanupInputs) {
@@ -149,6 +161,7 @@ export class RadarrActionHandler {
               });
             }
             return true;
+          }
           case ServarrAction.CHANGE_QUALITY_PROFILE: {
             const targetProfileId = collection.radarrQualityProfileId;
 
@@ -171,9 +184,11 @@ export class RadarrActionHandler {
             }
 
             if (
-              !(await radarrApiClient.updateMovie(radarrMedia.id, {
-                qualityProfileId: targetProfileId,
-              }))
+              !(
+                await radarrApiClient.updateMovie(radarrMedia.id, {
+                  qualityProfileId: targetProfileId,
+                })
+              ).ok
             ) {
               return false;
             }

--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
@@ -377,9 +377,9 @@ export class SeerrApiService {
           hasNext = false;
         }
       }
-      this.logger.log(
-        `Seerr request prefetch complete: ${requests.length} requests.`,
-      );
+      // The completion line belongs to buildRequestIndex, this method's only
+      // caller: it reports the same sweep plus the title count, so logging it
+      // here too reads as two prefetches.
       return requests;
     } catch (error) {
       this.logger.warn(

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
@@ -62,7 +62,10 @@ describe('RadarrApi', () => {
     it('adds the exclusion via the de-duping bulk endpoint', async () => {
       postSpy.mockResolvedValue([exclusionFor(movie)]);
 
-      await expect(unmonitorWithExclusion()).resolves.toBe(true);
+      await expect(unmonitorWithExclusion()).resolves.toEqual({
+        ok: true,
+        deletedFileCount: 0,
+      });
       expect(postSpy).toHaveBeenCalledWith(
         '/exclusions/bulk',
         [exclusionFor(movie)],
@@ -89,7 +92,10 @@ describe('RadarrApi', () => {
         },
       });
 
-      await expect(unmonitorWithExclusion()).resolves.toBe(true);
+      await expect(unmonitorWithExclusion()).resolves.toEqual({
+        ok: true,
+        deletedFileCount: 0,
+      });
     });
 
     // A 400 from a different validation rule (e.g. an invalid year) is a real
@@ -108,7 +114,10 @@ describe('RadarrApi', () => {
         },
       });
 
-      await expect(unmonitorWithExclusion()).resolves.toBe(false);
+      await expect(unmonitorWithExclusion()).resolves.toEqual({
+        ok: false,
+        deletedFileCount: 0,
+      });
     });
 
     it('returns false when the exclusion request fails for another reason', async () => {
@@ -117,7 +126,10 @@ describe('RadarrApi', () => {
         response: { status: 500 },
       });
 
-      await expect(unmonitorWithExclusion()).resolves.toBe(false);
+      await expect(unmonitorWithExclusion()).resolves.toEqual({
+        ok: false,
+        deletedFileCount: 0,
+      });
     });
   });
 
@@ -149,9 +161,10 @@ describe('RadarrApi', () => {
         .spyOn(api as any, 'runPut')
         .mockResolvedValue(true);
 
-      await expect(api.updateMovie(5, { monitored: false })).resolves.toBe(
-        true,
-      );
+      await expect(api.updateMovie(5, { monitored: false })).resolves.toEqual({
+        ok: true,
+        deletedFileCount: 0,
+      });
 
       expect(getSpy).not.toHaveBeenCalled();
       expect(runPutSpy).toHaveBeenCalledWith(
@@ -177,7 +190,7 @@ describe('RadarrApi', () => {
 
       await expect(
         api.updateMovie(5, { monitored: false, deleteFiles: true }),
-      ).resolves.toBe(true);
+      ).resolves.toEqual({ ok: true, deletedFileCount: 1 });
 
       // Same slow-instance headroom as getMovieByTmdbId (#3181).
       expect(getWithoutCacheSpy).toHaveBeenNthCalledWith(2, 'movie/5', {
@@ -198,7 +211,7 @@ describe('RadarrApi', () => {
 
       await expect(
         api.updateMovie(5, { monitored: false, deleteFiles: true }),
-      ).resolves.toBe(false);
+      ).resolves.toEqual({ ok: false, deletedFileCount: 0 });
 
       expect(runDeleteSpy).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
@@ -218,7 +231,7 @@ describe('RadarrApi', () => {
 
       await expect(
         api.updateMovie(5, { monitored: false, deleteFiles: true }),
-      ).resolves.toBe(false);
+      ).resolves.toEqual({ ok: false, deletedFileCount: 0 });
 
       expect(runDeleteSpy).not.toHaveBeenCalled();
     });
@@ -230,9 +243,9 @@ describe('RadarrApi', () => {
         .mockResolvedValueOnce({ ...movie, qualityProfileId: 4 });
       jest.spyOn(api as any, 'runPut').mockResolvedValue(false);
 
-      await expect(api.updateMovie(5, { qualityProfileId: 9 })).resolves.toBe(
-        false,
-      );
+      await expect(
+        api.updateMovie(5, { qualityProfileId: 9 }),
+      ).resolves.toEqual({ ok: false, deletedFileCount: 0 });
 
       expect(logger.warn).toHaveBeenCalledWith(
         'Could not confirm movie 5 was updated.',
@@ -245,9 +258,10 @@ describe('RadarrApi', () => {
         .mockResolvedValue(movie);
       jest.spyOn(api as any, 'runPut').mockResolvedValue(true);
 
-      await expect(api.updateMovie(5, { monitored: false })).resolves.toBe(
-        true,
-      );
+      await expect(api.updateMovie(5, { monitored: false })).resolves.toEqual({
+        ok: true,
+        deletedFileCount: 0,
+      });
 
       expect(getWithoutCacheSpy).toHaveBeenCalledTimes(1);
     });
@@ -264,12 +278,48 @@ describe('RadarrApi', () => {
 
       await expect(
         api.updateMovie(5, { monitored: false, deleteFiles: true }),
-      ).resolves.toBe(false);
+      ).resolves.toEqual({ ok: false, deletedFileCount: 0 });
 
       expect(runDeleteSpy).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
         "Could not list movie 5's files; leaving them in place.",
       );
+    });
+
+    // A confirmed-empty file list is not a failure - the update applied - but it
+    // deleted nothing, and the caller has to be able to tell that apart from a
+    // real deletion when a user reports a surviving file.
+    it('reports zero deleted files when Radarr holds no file records for the movie', async () => {
+      jest
+        .spyOn(api, 'getWithoutCache')
+        .mockResolvedValueOnce(movie)
+        .mockResolvedValueOnce([]);
+      jest.spyOn(api as any, 'runPut').mockResolvedValue(true);
+      const runDeleteSpy = jest
+        .spyOn(api as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      await expect(
+        api.updateMovie(5, { monitored: false, deleteFiles: true }),
+      ).resolves.toEqual({ ok: true, deletedFileCount: 0 });
+
+      expect(runDeleteSpy).not.toHaveBeenCalled();
+    });
+
+    it('counts every file it removed', async () => {
+      jest
+        .spyOn(api, 'getWithoutCache')
+        .mockResolvedValueOnce(movie)
+        .mockResolvedValueOnce([
+          createRadarrMovieFile({ id: 900 }),
+          createRadarrMovieFile({ id: 901 }),
+        ]);
+      jest.spyOn(api as any, 'runPut').mockResolvedValue(true);
+      jest.spyOn(api as any, 'runDelete').mockResolvedValue(true);
+
+      await expect(
+        api.updateMovie(5, { monitored: false, deleteFiles: true }),
+      ).resolves.toEqual({ ok: true, deletedFileCount: 2 });
     });
   });
 

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
@@ -12,6 +12,13 @@ import {
   RadarrMovieFile,
 } from '../interfaces/radarr.interface';
 
+export interface RadarrMovieUpdateResult {
+  /** Every requested change was applied. */
+  ok: boolean;
+  /** Files this call removed. Zero when none were requested or none existed. */
+  deletedFileCount: number;
+}
+
 export class RadarrApi extends ServarrApi<{ movieId: number }> {
   constructor(
     {
@@ -167,6 +174,12 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
     }
   }
 
+  /**
+   * Applies the requested changes and reports how many files it removed, so the
+   * caller can say what actually happened. A movie Radarr holds no file records
+   * for deletes nothing, and reporting that as "files removed" makes a later
+   * "it did not delete my file" report impossible to falsify from the log.
+   */
   public async updateMovie(
     movieId: number,
     options: {
@@ -175,14 +188,15 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
       addImportExclusion?: boolean;
       qualityProfileId?: number;
     },
-  ): Promise<boolean> {
+  ): Promise<RadarrMovieUpdateResult> {
+    let deletedFileCount = 0;
     try {
       const movieData: RadarrMovie = await this.getWithoutCache(
         `movie/${movieId}`,
       );
 
       if (!movieData) {
-        return false;
+        return { ok: false, deletedFileCount };
       }
 
       if (options?.monitored !== undefined) {
@@ -213,7 +227,7 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
               options?.deleteFiles ? '; leaving its files in place' : ''
             }.`,
           );
-          return false;
+          return { ok: false, deletedFileCount };
         }
       }
 
@@ -226,27 +240,28 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
           this.logger.warn(
             `Could not list movie ${movieId}'s files; leaving them in place.`,
           );
-          return false;
+          return { ok: false, deletedFileCount };
         }
 
         for (const movieFile of movieFiles) {
           if (!(await this.runDelete(`moviefile/${movieFile.id}`))) {
-            return false;
+            return { ok: false, deletedFileCount };
           }
+          deletedFileCount++;
         }
       }
 
       if (options?.addImportExclusion) {
         if (!(await this.addImportExclusion(movieData))) {
-          return false;
+          return { ok: false, deletedFileCount };
         }
       }
 
-      return true;
+      return { ok: true, deletedFileCount };
     } catch (error) {
       this.logger.warn("Couldn't unmonitor movie. Does it exist in radarr?");
       this.logger.debug(error);
-      return false;
+      return { ok: false, deletedFileCount };
     }
   }
 

--- a/apps/server/test/utils/servarr-mock.ts
+++ b/apps/server/test/utils/servarr-mock.ts
@@ -19,7 +19,10 @@ export const mockRadarrApi = (
 
   jest.spyOn(api, 'getMovieByTmdbId').mockResolvedValue(undefined);
   jest.spyOn(api, 'deleteMovie').mockResolvedValue(true);
-  jest.spyOn(api, 'updateMovie').mockResolvedValue(true);
+  // Default to the ordinary case: the update applied and one file was removed.
+  jest
+    .spyOn(api, 'updateMovie')
+    .mockResolvedValue({ ok: true, deletedFileCount: 1 });
   jest.spyOn(api, 'ensureTag').mockResolvedValue(1);
   jest.spyOn(api, 'setMovieTags').mockResolvedValue(true);
   // Leftover-folder cleanup inputs; default to "nothing known" so tests that


### PR DESCRIPTION
Two small log-truthfulness fixes found while debugging a "the action says delete but my file is still there" report.

**Radarr file deletes.** `updateMovie({deleteFiles: true})` treated a confirmed-empty `getMovieFiles` result as a successful deletion: `undefined` fails closed, but `[]` fell straight through the delete loop. A movie Radarr holds no file records for therefore logged "removed files from filesystem in Radarr" having deleted nothing, which makes a later "it kept my file" report impossible to falsify from the log. `updateMovie` now returns `{ ok, deletedFileCount }` and the handler reports either the count it removed or that there was nothing to remove.

**Seerr request prefetch.** `getRequests` and `buildRequestIndex` (its only caller) each logged a completion line for the same sweep, so one prefetch read as two.