### PR TITLE
fix(actions): stop claiming a media-server delete strands the folder

### DIFF
--- a/apps/server/src/modules/actions/leftover-folder-cleanup.service.ts
+++ b/apps/server/src/modules/actions/leftover-folder-cleanup.service.ts
@@ -92,15 +92,16 @@ export class LeftoverFolderCleanupService {
   }
 
   /**
-   * The media-server delete fallback runs when the item is not tracked in the
-   * *arr, which is also where every fence comes from: no root folders, no
-   * sibling item paths, nothing to prove the folder is the one just emptied. So
-   * the cleanup cannot run there. Say so, otherwise an enabled cleanup appears
-   * to do nothing at all (#3370).
+   * The media-server delete fallback runs when the *arr does not track the item,
+   * which is also where every fence comes from - so this cleanup cannot run
+   * there. It is not needed there either: Jellyfin and Emby delete the item's
+   * own folder along with it, so nothing is stranded to clean up. Report it as
+   * "does not apply" rather than a skipped cleanup, and keep the per-server
+   * detail in the docs instead of naming servers here (#3370).
    */
-  public logSkippedForUntrackedItem(label?: string): void {
-    this.logger.warn(
-      `Leftover-folder cleanup skipped${label ? ` for '${label}'` : ''}: the item is not tracked in the *arr, so there are no root folders to fence the delete against. Only the media file was removed; its folder was left in place.`,
+  public logNotApplicableForUntrackedItem(label?: string): void {
+    this.logger.log(
+      `Leftover-folder cleanup does not apply${label ? ` to '${label}'` : ''}: the item is not tracked in the *arr, so the media server deleted it directly - see docs/leftover-folder-cleanup.md.`,
     );
   }
 

--- a/apps/server/src/modules/actions/radarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/radarr-action-handler.spec.ts
@@ -294,9 +294,9 @@ describe('RadarrActionHandler', () => {
 
       await radarrActionHandler.handleAction(collection, collectionMedia);
 
-      expect(folderCleanup.logSkippedForUntrackedItem).toHaveBeenCalledWith(
-        collectionMedia.mediaServerId,
-      );
+      expect(
+        folderCleanup.logNotApplicableForUntrackedItem,
+      ).toHaveBeenCalledWith(collectionMedia.mediaServerId);
       expect(folderCleanup.cleanupAfterDelete).not.toHaveBeenCalled();
       expect(mediaServer.deleteFromDisk).toHaveBeenCalledWith(
         collectionMedia.mediaServerId,
@@ -316,7 +316,9 @@ describe('RadarrActionHandler', () => {
 
       await radarrActionHandler.handleAction(collection, collectionMedia);
 
-      expect(folderCleanup.logSkippedForUntrackedItem).not.toHaveBeenCalled();
+      expect(
+        folderCleanup.logNotApplicableForUntrackedItem,
+      ).not.toHaveBeenCalled();
     });
 
     it('does not claim a file removal when Radarr held no files for the movie', async () => {

--- a/apps/server/src/modules/actions/radarr-action-handler.ts
+++ b/apps/server/src/modules/actions/radarr-action-handler.ts
@@ -221,7 +221,9 @@ export class RadarrActionHandler {
             collection.cleanupLeftoverFolders &&
             leftoverCleanupScope(collection.type, collection.arrAction)
           ) {
-            this.folderCleanup.logSkippedForUntrackedItem(media.mediaServerId);
+            this.folderCleanup.logNotApplicableForUntrackedItem(
+              media.mediaServerId,
+            );
           }
           const mediaServer = await this.mediaServerFactory.getService();
           await mediaServer.deleteFromDisk(media.mediaServerId);

--- a/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -533,7 +533,7 @@ describe('SonarrActionHandler', () => {
 
     await sonarrActionHandler.handleAction(collection, collectionMedia);
 
-    expect(folderCleanup.logSkippedForUntrackedItem).toHaveBeenCalledWith(
+    expect(folderCleanup.logNotApplicableForUntrackedItem).toHaveBeenCalledWith(
       collectionMedia.mediaServerId,
     );
     expect(folderCleanup.cleanupAfterDelete).not.toHaveBeenCalled();

--- a/apps/server/src/modules/actions/sonarr-action-handler.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.ts
@@ -120,7 +120,9 @@ export class SonarrActionHandler {
           collection.cleanupLeftoverFolders &&
           leftoverCleanupScope(collection.type, collection.arrAction)
         ) {
-          this.folderCleanup.logSkippedForUntrackedItem(media.mediaServerId);
+          this.folderCleanup.logNotApplicableForUntrackedItem(
+            media.mediaServerId,
+          );
         }
         await mediaServer.deleteFromDisk(media.mediaServerId);
         return true;

--- a/docs/leftover-folder-cleanup.md
+++ b/docs/leftover-folder-cleanup.md
@@ -41,8 +41,32 @@ Not covered:
 - **Sportarr**. A league carries no folder path in its API, so there is no item
   folder to fence a delete against - unlike Radarr's `movie.path` and Sonarr's
   `series.path`.
-- Deletes performed directly through the media server (Plex/Jellyfin/Emby, when
-  no \*arr is configured).
+- Deletes performed directly through the media server - see below.
+
+## Deletes that go through the media server
+
+Maintainerr deletes through the media server in two cases: when no \*arr is
+configured for the collection, and when an \*arr is configured but does not track
+the item (a TMDB/TVDB id it cannot resolve). Either way it calls the server's own
+delete endpoint, and this cleanup does not run - every fence it needs
+(root folders, the paths just deleted, the other tracked items' folders) comes
+from the \*arr. When the option is on, a log line says so rather than leaving you
+to wonder.
+
+That is not a gap for Jellyfin and Emby, because they already remove the folder
+themselves. Deleting an item deletes its **containing folder**, recursively,
+sidecars and extras included - not just the media file. Jellyfin implements this
+in `Video.GetDeletePaths()`, which returns `ContainingFolderPath` as a directory
+whenever the item is not in a mixed folder, and `LibraryManager` then calls
+`Directory.Delete(path, recursive: true)`. Emby behaves the same way. It is
+observable: point either server at a read-only library and the delete fails with
+`Access to the path '/media/movies/Some Movie (2024)' is denied` - the folder, not
+the file. In a mixed-folder library (several movies sharing one folder) they
+delete only the file, which is also correct, since the folder still holds the
+other movies.
+
+Plex is not covered: Maintainerr does not clean up after a Plex media-server
+delete, and makes no claim about what Plex leaves behind.
 
 ## Requirement: same-path mount
 


### PR DESCRIPTION
#3370 assumed that when the *arr does not track an item, the media-server fallback removes the media file and leaves its folder behind. That assumption is wrong for Jellyfin and Emby, and the log line added in #3371 repeated it.

Jellyfin deletes an item's **containing folder**, recursively. `Video.GetDeletePaths()` returns `ContainingFolderPath` as a directory whenever the item is not in a mixed folder, and `LibraryManager.DeleteItemPath` then calls `Directory.Delete(path, recursive: true)`. Emby behaves identically. Both are observable against a read-only library: the delete fails with `Access to the path '/media/movies/Some Movie (2024)' is denied` - the folder, not the file. In a mixed-folder library they delete only the file, which is correct, because the folder still holds the other movies.

So there is nothing stranded to clean on that path, and building media-server-derived fences would clean folders the server has already removed. The log line now reports the cleanup as not applicable and points at the docs, which carry the per-server detail instead of a shared log string asserting it. Level drops from warn to info: an opt-in feature that does not apply is not a warning.

Plex is documented as not covered, with no claim about what it leaves behind - its delete could not be exercised in the dev stack (HTTP 400 with media deletion enabled), so I have no evidence either way.

Verified against the real dev stack: a collection item Jellyfin has and Radarr does not track, handled through `POST /api/collections/media/handle` with the opt-in on and off. Radarr confirms the miss, the new line fires only when the option is on, and Jellyfin's own error names the folder it tried to remove. UI checked with Playwright: the checkbox is still offered only for actions `leftoverCleanupScope` covers.

Closes #3370