### PR TITLE
fix(actions): keep the leftover-cleanup fences intact on a failed listing

### DIFF
--- a/apps/server/src/modules/actions/leftover-folder-cleanup.service.spec.ts
+++ b/apps/server/src/modules/actions/leftover-folder-cleanup.service.spec.ts
@@ -9,7 +9,7 @@ import {
   writeFile,
 } from 'fs/promises';
 import { tmpdir } from 'os';
-import { dirname, join } from 'path';
+import { dirname, join, sep } from 'path';
 import { LeftoverFolderCleanupService } from './leftover-folder-cleanup.service';
 
 // Exercises the destructive guardrail pipeline against a real temp filesystem.
@@ -261,6 +261,29 @@ describe('LeftoverFolderCleanupService', () => {
       scope: 'movie',
     });
 
+    expect(await exists(realTarget)).toBe(true);
+    expect(await exists(link)).toBe(true);
+  });
+
+  // lstat resolves a trailing separator, so statting the raw path would report
+  // the target and clear the leaf-symlink gate. The target sits inside the root
+  // here, so containment would not catch it either.
+  it('refuses a symlinked folder reported with a trailing separator', async () => {
+    const root = join(tmp, 'movies');
+    const realTarget = join(root, 'Actual Folder');
+    await mkdir(realTarget, { recursive: true });
+    await writeFile(join(realTarget, 'a.srt'), 'x');
+    const link = join(root, 'Sample Movie');
+    await symlink(realTarget, link);
+
+    await service.cleanupAfterDelete({
+      folderPath: link + sep,
+      rootFolderPaths: [root],
+      deletedFilePaths: [join(link, 'deleted.mkv')],
+      scope: 'movie',
+    });
+
+    expect(await exists(join(realTarget, 'a.srt'))).toBe(true);
     expect(await exists(realTarget)).toBe(true);
     expect(await exists(link)).toBe(true);
   });

--- a/apps/server/src/modules/actions/leftover-folder-cleanup.service.ts
+++ b/apps/server/src/modules/actions/leftover-folder-cleanup.service.ts
@@ -157,27 +157,30 @@ export class LeftoverFolderCleanupService {
       }
 
       // Existence + leaf-symlink check in one. A missing folder means the *arr
-      // already removed it (a clean delete) - nothing to do.
+      // already removed it (a clean delete) - nothing to do. Stat the
+      // normalized path, not the raw one: lstat resolves a trailing separator,
+      // so `lstat('link/')` reports the target and would slip a symlinked
+      // folder past this gate.
       let rawLeaf: Awaited<ReturnType<typeof lstat>>;
       try {
-        rawLeaf = await lstat(rawPath);
+        rawLeaf = await lstat(rawFolder);
       } catch (error) {
         if (this.isENOENT(error)) {
-          this.logger.debug(`Folder already gone${label}: ${rawPath}`);
+          this.logger.debug(`Folder already gone${label}: ${rawFolder}`);
           return;
         }
         throw error;
       }
       if (rawLeaf.isSymbolicLink()) {
         this.logger.warn(
-          `Refusing to remove a symlinked folder${label}: ${rawPath}`,
+          `Refusing to remove a symlinked folder${label}: ${rawFolder}`,
         );
         return;
       }
 
       // Canonicalize (resolves any parent symlinks - common in atomic-move
       // layouts) so containment is checked against real paths.
-      const candidate = normalizeDiskPath(await realpath(rawPath));
+      const candidate = normalizeDiskPath(await realpath(rawFolder));
       const candidateStat = await stat(candidate);
       if (!candidateStat.isDirectory()) {
         this.logger.warn(`Target is not a directory${label}: ${candidate}`);

--- a/apps/server/src/modules/actions/radarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/radarr-action-handler.spec.ts
@@ -264,6 +264,28 @@ describe('RadarrActionHandler', () => {
       });
     });
 
+    // A failed listing is not "no other movies": fencing on an empty list drops
+    // the guard that keeps the cleanup off another tracked item's folder.
+    it('skips the cleanup when the movie listing failed', async () => {
+      const collection = createCollection({
+        arrAction: ServarrAction.UNMONITOR_DELETE_ALL,
+        radarrSettingsId: 1,
+        type: 'movie',
+        cleanupLeftoverFolders: true,
+      });
+      const collectionMedia = createCollectionMedia(collection, { tmdbId: 1 });
+      const mockedRadarrApi = arrangeCleanup(
+        createRadarrMovie({ id: 5, path: '/data/movies/Sample Movie (2024)' }),
+      );
+      jest
+        .spyOn(mockedRadarrApi, 'getMovies')
+        .mockResolvedValue(undefined as never);
+
+      await radarrActionHandler.handleAction(collection, collectionMedia);
+
+      expect(folderCleanup.cleanupAfterDelete).not.toHaveBeenCalled();
+    });
+
     it('does not clean after a DELETE: Radarr removes the movie folder itself', async () => {
       const collection = createCollection({
         arrAction: ServarrAction.DELETE,

--- a/apps/server/src/modules/actions/radarr-action-handler.ts
+++ b/apps/server/src/modules/actions/radarr-action-handler.ts
@@ -270,9 +270,12 @@ export class RadarrActionHandler {
         radarrApiClient.getMovies(),
       ]);
 
-      // undefined = the listing failed, so which files are about to be deleted
-      // is unknown - not "none". Skip rather than fence on a guess.
-      if (movieFiles === undefined) {
+      // undefined = the listing failed, so what it would have fenced is
+      // unknown - not "nothing". Skip rather than fence on a guess: an empty
+      // deleted-file list drops the proof that this is the folder the delete
+      // emptied, and an empty movie list drops the fence that keeps the
+      // cleanup off another tracked item's folder.
+      if (movieFiles === undefined || movies === undefined) {
         return undefined;
       }
 
@@ -283,7 +286,7 @@ export class RadarrActionHandler {
         deletedFilePaths: movieFiles
           .map((file) => file.path)
           .filter((p): p is string => !!p),
-        otherItemPaths: (movies ?? [])
+        otherItemPaths: movies
           .filter((movie) => movie.id !== radarrMedia.id)
           .map((movie) => movie.path)
           .filter((p): p is string => !!p),

--- a/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -294,6 +294,26 @@ describe('SonarrActionHandler', () => {
       expect(folderCleanup.cleanupAfterDelete).not.toHaveBeenCalled();
     });
 
+    // Likewise for the series listing: an empty list drops the fence that keeps
+    // the cleanup off another tracked item's folder.
+    it('skips the cleanup when the series listing failed', async () => {
+      const collection = createCollection({
+        arrAction: ServarrAction.UNMONITOR_DELETE_ALL,
+        sonarrSettingsId: 1,
+        cleanupLeftoverFolders: true,
+        type: 'show',
+      });
+      const collectionMedia = createCollectionMediaWithMetadata(collection, {
+        tmdbId: 1,
+      });
+      const api = arrangeCleanup(seriesFixture());
+      jest.spyOn(api, 'getSeries').mockResolvedValue(undefined as never);
+
+      await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+      expect(folderCleanup.cleanupAfterDelete).not.toHaveBeenCalled();
+    });
+
     it('does not clean a season when the series has no season folders', async () => {
       const collection = createCollection({
         arrAction: ServarrAction.DELETE,

--- a/apps/server/src/modules/actions/sonarr-action-handler.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.ts
@@ -641,9 +641,12 @@ export class SonarrActionHandler {
         sonarrApiClient.getEpisodeFiles(sonarrMedia.id),
       ]);
 
-      // undefined = the listing failed, so which files are about to be deleted
-      // is unknown - not "none". Skip rather than fence on a guess.
-      if (episodeFiles === undefined) {
+      // undefined = the listing failed, so what it would have fenced is
+      // unknown - not "nothing". Skip rather than fence on a guess: an empty
+      // deleted-file list drops the proof that this is the folder the delete
+      // emptied, and an empty series list drops the fence that keeps the
+      // cleanup off another tracked item's folder.
+      if (episodeFiles === undefined || allSeries === undefined) {
         return undefined;
       }
 
@@ -664,7 +667,7 @@ export class SonarrActionHandler {
             .map((folder) => folder.path)
             .filter((p): p is string => !!p),
           deletedFilePaths,
-          otherItemPaths: (allSeries ?? [])
+          otherItemPaths: allSeries
             .filter((series) => series.id !== sonarrMedia.id)
             .map((series) => series.path)
             .filter((p): p is string => !!p),

--- a/apps/server/src/modules/api/media-server/media-provider-ids.utils.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-provider-ids.utils.spec.ts
@@ -32,6 +32,10 @@ describe('media provider ids', () => {
     ['a missing provider', undefined, '12345'],
     ['a missing id', 'imdb', undefined],
     ['an empty id', 'imdb', ''],
+    // A server is free to send any key; these two resolve on an object
+    // literal's prototype chain, so a lookup there would throw mid-mapping.
+    ['the constructor key', 'constructor', '12345'],
+    ['the __proto__ key', '__proto__', '12345'],
   ])('ignores %s', (scenario, name, id) => {
     const providerIds = emptyProviderIds();
     addProviderId(providerIds, name, id);

--- a/apps/server/src/modules/api/media-server/media-provider-ids.utils.ts
+++ b/apps/server/src/modules/api/media-server/media-provider-ids.utils.ts
@@ -3,13 +3,17 @@ import { MediaProviderIds } from '@maintainerr/contracts';
 // Every name a media server may use for the providers Maintainerr tracks:
 // the bare ones, the capitalised keys Jellyfin and Emby send, and the
 // spelled-out ones a legacy Plex agent carries. Matched lowercased.
-const PROVIDER_BY_NAME: Record<string, keyof MediaProviderIds> = {
-  imdb: 'imdb',
-  tmdb: 'tmdb',
-  themoviedb: 'tmdb',
-  tvdb: 'tvdb',
-  thetvdb: 'tvdb',
-};
+//
+// A Map, not an object literal: the name comes from the server's own metadata,
+// and `constructor` / `__proto__` resolve on an object literal's prototype
+// chain - a truthy hit that then throws when the id is pushed.
+const PROVIDER_BY_NAME = new Map<string, keyof MediaProviderIds>([
+  ['imdb', 'imdb'],
+  ['tmdb', 'tmdb'],
+  ['themoviedb', 'tmdb'],
+  ['tvdb', 'tvdb'],
+  ['thetvdb', 'tvdb'],
+]);
 
 export const emptyProviderIds = (): MediaProviderIds => ({
   imdb: [],
@@ -26,7 +30,7 @@ export const addProviderId = (
   name: string | undefined | null,
   id: string | undefined | null,
 ): void => {
-  const provider = PROVIDER_BY_NAME[name?.toLowerCase()];
+  const provider = PROVIDER_BY_NAME.get(name?.toLowerCase() ?? '');
   if (provider && id) {
     providerIds[provider].push(id);
   }


### PR DESCRIPTION
Three fail-closed gaps found while security-reviewing v3.17.0..development. Each is reachable from data a real *arr or media server actually produces, and each was reproduced against the dev stack before and after the fix.

**Leaf-symlink gate stats the raw path.** `lstat` resolves a trailing separator, so `lstat('link/')` reports the target and clears the "refusing a symlinked folder" check. Radarr does **not** normalize a trailing separator away - `PUT /api/v3/movie/{id}` with `path: "/media/movies/X/"` is stored and returned verbatim, and the file paths under it inherit it. Verified against Radarr 6.3.0: with a folder symlinked to a sibling inside the same root, the old code resolved through the link and removed the *target* directory (which Radarr never named), leaving a dangling symlink; containment does not catch it because the target is inside the root. Fixed by statting the normalized path the neighbouring checks already use.

**A failed item listing silently emptied a fence.** `getMovies()`/`getSeries()` return `undefined` when the listing fails, and `?? []` turned that into "no other tracked items", dropping the guard that keeps the cleanup off another item's folder. Verified with a proxy that 500s only the bare `GET /api/v3/movie` while passing everything else: same real per-file `DELETE /moviefile/{id}` in both runs, old code cleaned the folder anyway, fixed code skips. Now treated like the file listing already was - unknown, so skip.

**Provider-name lookup hit the prototype chain.** `PROVIDER_BY_NAME[name]` on an object literal resolves `constructor` and `__proto__` to truthy non-providers, throwing on the id push. Jellyfin 10.11.11 accepts and persists both as `ProviderIds` keys, so the input is real server data. Feeding that item's real response through the compiled mapper: old code throws `TypeError: Cannot read properties of undefined (reading 'push')`, fixed code ignores the bogus keys and still extracts the valid id. Now a `Map`.

Each fix has a regression test that fails without it.