### PR TITLE
chore(vscode): bound the TypeScript language server's memory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,15 @@
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "typescript.tsserver.experimental.enableProjectDiagnostics": true,
+  // Bound the language server. VS Code defaults each tsserver to a 3 GB heap
+  // and spawns a pair per window, so a few open windows can reserve more than
+  // the devbox has. 1.5 GB sits well above the ~1.2 GB a full load of this
+  // monorepo actually uses. Raise it if the server starts recycling.
+  //
+  // experimental.enableProjectDiagnostics is deliberately left unset: it keeps
+  // diagnostics for the whole monorepo resident in every server, and CI already
+  // covers project-wide errors via `yarn check-types`.
+  "typescript.tsserver.maxTsServerMemory": 1536,
   "typescript.tsserver.experimental.useVsCodeWatcher": false,
   "sqltools.connections": [
     {


### PR DESCRIPTION
The devbox kept ending up a few hundred MB from the OOM killer. Profiling it, VS Code was 7.5 GB of the 16 GB box, and 5.3 GB of that was eight `tsserver.js` processes.

Two causes, both fixed here:

- **No heap ceiling.** VS Code defaults each tsserver to `--max-old-space-size=3072` and spawns a pair per window. Three open windows was an 18 GB entitlement on a 16 GB box with no swap. Capped at 1.5 GB, comfortably above the ~1.2 GB a full load of this monorepo actually uses.
- **`experimental.enableProjectDiagnostics` was on.** It keeps diagnostics for the whole monorepo resident in every server, multiplying the above. It arrived incidentally in #1545 rather than as a deliberate choice, and `yarn check-types` already covers project-wide errors in CI.

Editor config only, no runtime or build impact.