### PR TITLE
feat(actions): clean up dangling symlinks left by a per-file *arr delete

### DIFF
--- a/apps/server/src/modules/actions/leftover-folder-cleanup.service.spec.ts
+++ b/apps/server/src/modules/actions/leftover-folder-cleanup.service.spec.ts
@@ -133,6 +133,57 @@ describe('LeftoverFolderCleanupService', () => {
     expect(await exists(link)).toBe(true);
   });
 
+  // The other half of the symlinked-library case: once the *arr has deleted the
+  // target, the link is the leftover. Extension is deliberately not checked -
+  // a dead media link is the normal outcome of a per-file delete.
+  it('removes a folder whose only media link is dangling', async () => {
+    const root = join(tmp, 'movies');
+    const store = join(tmp, 'remote-store');
+    await mkdir(root, { recursive: true });
+    await mkdir(store, { recursive: true });
+    const { folder, deletedFilePaths } = await makeItemFolder(
+      root,
+      'Sample Movie',
+      ['poster.jpg'],
+    );
+    // Never created in the store, so the link is born dangling.
+    await symlink(join(store, 'gone.mkv'), join(folder, 'Sample Movie.mkv'));
+
+    await service.cleanupAfterDelete({
+      folderPath: folder,
+      rootFolderPaths: [root],
+      deletedFilePaths,
+      scope: 'movie',
+    });
+
+    expect(await exists(folder)).toBe(false);
+    // The store itself is never touched - only the pointer is removed.
+    expect(await exists(store)).toBe(true);
+  });
+
+  it('keeps a folder whose symlink cannot be resolved', async () => {
+    const root = join(tmp, 'movies');
+    await mkdir(root, { recursive: true });
+    const { folder, deletedFilePaths } = await makeItemFolder(
+      root,
+      'Sample Movie',
+      ['poster.jpg'],
+    );
+    // A loop stats as ELOOP, not ENOENT: inconclusive, so it must not count as
+    // dangling and must keep the folder.
+    await symlink(join(folder, 'b.mkv'), join(folder, 'a.mkv'));
+    await symlink(join(folder, 'a.mkv'), join(folder, 'b.mkv'));
+
+    await service.cleanupAfterDelete({
+      folderPath: folder,
+      rootFolderPaths: [root],
+      deletedFilePaths,
+      scope: 'movie',
+    });
+
+    expect(await exists(folder)).toBe(true);
+  });
+
   it('refuses to remove a root folder itself', async () => {
     const root = join(tmp, 'movies');
     await mkdir(root, { recursive: true });

--- a/apps/server/src/modules/actions/leftover-folder-cleanup.service.ts
+++ b/apps/server/src/modules/actions/leftover-folder-cleanup.service.ts
@@ -11,9 +11,11 @@ import { MaintainerrLogger } from '../logging/logs.service';
  * The master safety gate is an allowlist, not a media denylist, on purpose: a
  * destructive delete must fail safe. Only a plain file whose extension is a
  * recognized sidecar may be removed; anything else - a media file, an unknown
- * extension, a symlink, a socket - keeps the whole folder. A missing entry here
- * therefore only ever leaves a folder uncleaned, never deletes real data.
- * Matched on the lower-cased extension.
+ * extension, a live symlink, a socket - keeps the whole folder. (A dangling
+ * symlink is removed regardless of extension: its target is already gone, so
+ * there is nothing left to protect.) A missing entry here therefore only ever
+ * leaves a folder uncleaned, never deletes real data. Matched on the
+ * lower-cased extension.
  *
  * Kept deliberately narrow: generic extensions (txt, log, md, ...) carry no
  * *arr-sidecar signal and would only widen the blast radius.
@@ -199,19 +201,19 @@ export class LeftoverFolderCleanupService {
       }
 
       // Master net: collect every file to remove and abort on anything that is
-      // not a plain sidecar. Only the collected paths are deleted, so a file
-      // that appears after this walk is never removed unseen.
+      // not a plain sidecar or a dead link. Only the collected paths are
+      // deleted, so a file that appears after this walk is never removed unseen.
       const companions = await this.collectCompanionFiles(candidate);
       if (companions === undefined) {
         this.logger.log(
-          `Keeping ${input.scope} folder${label}: it still holds a non-sidecar entry (media, an unrecognized extension or a link) at ${candidate}.`,
+          `Keeping ${input.scope} folder${label}: it still holds a non-sidecar entry (media, an unrecognized extension or a live link) at ${candidate}.`,
         );
         return;
       }
 
       await this.removeVerified(candidate, companions);
       this.logger.log(
-        `Removed leftover ${input.scope} folder${label} and ${companions.length} sidecar file(s): ${candidate}`,
+        `Removed leftover ${input.scope} folder${label} and ${companions.length} leftover file(s): ${candidate}`,
       );
     } catch (error) {
       // Cleanup is best-effort; the delete already succeeded.
@@ -357,9 +359,14 @@ export class LeftoverFolderCleanupService {
 
   /**
    * Every file under `dir`, or undefined when the folder must be kept. Anything
-   * that is not a plain directory or a plain sidecar file aborts the walk -
-   * notably symlinks, which `readdir` reports as neither a file nor a directory
-   * and which a recursive remove would silently unlink.
+   * that is not a plain directory, a plain sidecar file or a dangling symlink
+   * aborts the walk.
+   *
+   * A symlink whose target still resolves keeps the folder: in a symlinked
+   * library the media file is a link to the seeded copy, and removing it would
+   * drop a watchable item. A *dangling* one is the opposite - the *arr already
+   * deleted its target, so the link is the leftover. Extension is not checked
+   * for those: a dead `.mkv` link is exactly what a per-file delete strands.
    */
   private async collectCompanionFiles(
     dir: string,
@@ -376,11 +383,31 @@ export class LeftoverFolderCleanupService {
         files.push(...nested);
       } else if (entry.isFile() && this.isCompanionFile(entry.name)) {
         files.push(full);
+      } else if (entry.isSymbolicLink() && (await this.isDangling(full))) {
+        files.push(full);
       } else {
         return undefined;
       }
     }
     return files;
+  }
+
+  /**
+   * True only when the link's target is confirmed absent. Any other stat error
+   * (a permission problem, a symlink loop) is inconclusive, so the link counts
+   * as live and the folder is kept.
+   *
+   * Caveat: an unmounted target reads as absent, so an unreachable mount can
+   * cost the link. That removes a pointer, never data - the target reappears
+   * with its mount and the item can be re-imported.
+   */
+  private async isDangling(linkPath: string): Promise<boolean> {
+    try {
+      await stat(linkPath);
+      return false;
+    } catch (error) {
+      return this.isENOENT(error);
+    }
   }
 
   /**


### PR DESCRIPTION
A symlink-backed library (rclone/zurg, atomic-move layouts) points its media file at a separate store. Once the *arr has deleted that target the link is the leftover, but the sidecar walk treated every symlink alike and kept the folder, so those libraries were never cleaned at all.

Remove a symlink only when its target is confirmed absent, and never touch the target: `unlink` acts on the link itself, so a live store is unaffected.

- A link that still resolves keeps the folder, as before. Dropping it would remove a watchable item, which is a different decision from clearing a stranded folder.
- Extension is not checked for a dead link. A stranded `.mkv` link is the normal outcome of a per-file delete, so the sidecar allowlist would defeat the purpose.
- Any other stat error (permissions, a symlink loop) is inconclusive and counts as live, so the folder is kept.

One caveat, called out in the code: an unmounted target reads as absent, so an unreachable mount can cost the link. That removes a pointer, never data, and the item can be re-imported once the mount returns.

Verified against the real dev stack (Radarr 6.3.0 + Plex), driving a real per-file delete through `POST /api/collections/media/handle`:

- dangling link + a **live** link -> `Keeping movie folder ... a live link`, both links intact
- dangling link + sidecar -> `Removed leftover movie folder ... and 2 leftover file(s)`, and the store directory untouched