### PR TITLE
fix(collections): add a whole show to a season or episode collection (#3381)

### DIFF
--- a/apps/server/src/modules/api/media-server/context-action.util.spec.ts
+++ b/apps/server/src/modules/api/media-server/context-action.util.spec.ts
@@ -14,18 +14,6 @@ describe('resolveContextActionIds', () => {
 
   beforeEach(() => get.mockClear());
 
-  it('returns the media id for the "all" sentinel', async () => {
-    expect(
-      await resolveContextActionIds(
-        'season',
-        { type: 'season', id: '-1' },
-        'm',
-        get,
-      ),
-    ).toEqual(['m']);
-    expect(get).not.toHaveBeenCalled();
-  });
-
   // Emby returned [mediaId] here, so excluding one season excluded the whole
   // show. A global exclusion cascades from the item acted on, not the top one.
   it('cascades a global season exclusion to the season and its episodes', async () => {
@@ -72,6 +60,8 @@ describe('resolveContextActionIds', () => {
     ).toEqual(['e1', 'e2']);
   });
 
+  // Both show cases used to return the show's own id, which Plex rejects with
+  // a 400 when the collection holds seasons or episodes (#3381).
   it('expands a show context to every season for a season collection', async () => {
     expect(
       await resolveContextActionIds(
@@ -81,6 +71,17 @@ describe('resolveContextActionIds', () => {
         get,
       ),
     ).toEqual(['s1']);
+  });
+
+  it('expands a show context to every episode for an episode collection', async () => {
+    expect(
+      await resolveContextActionIds(
+        'episode',
+        { type: 'show', id: 'series' },
+        'series',
+        get,
+      ),
+    ).toEqual(['e1', 'e2']);
   });
 
   it('reports episodes into a season collection as unsupported', async () => {

--- a/apps/server/src/modules/api/media-server/context-action.util.ts
+++ b/apps/server/src/modules/api/media-server/context-action.util.ts
@@ -5,10 +5,14 @@ import { MediaItem, MediaItemType } from '@maintainerr/contracts';
  * remove) should apply to, given the collection's media type and the item the
  * user acted on.
  *
- * Jellyfin and Emby resolve this identically - both walk show -> season ->
- * episode through `getChildrenMetadata` - so the traversal lives here rather
- * than being duplicated per adapter. Plex has its own implementation because it
- * resolves the hierarchy through the Plex API instead.
+ * Shared by every media server: the traversal is the same show -> season ->
+ * episode walk, only the `getChildren` lookup behind it differs.
+ *
+ * `context.id` is always a real media server id. Do not add a "whole item"
+ * sentinel case: short-circuiting on one is what handed a show's id to a season
+ * collection for Plex to reject with a 400 (#3381). A context that names no
+ * season or episode is expressed by `context.type`, which the switches below
+ * resolve from `mediaId`.
  */
 export const resolveContextActionIds = async (
   collectionType: MediaItemType | undefined,
@@ -17,11 +21,6 @@ export const resolveContextActionIds = async (
   getChildren: (parentId: string, type: MediaItemType) => Promise<MediaItem[]>,
   onUnsupported?: (message: string) => void,
 ): Promise<string[]> => {
-  // -1 is the UI's "all" sentinel.
-  if (context.id === '-1') {
-    return [mediaId];
-  }
-
   const handleMedia: string[] = [];
   const childIds = async (parentId: string, type: MediaItemType) =>
     (await getChildren(parentId, type)).map((child) => child.id);

--- a/apps/ui/src/components/AddModal/index.spec.tsx
+++ b/apps/ui/src/components/AddModal/index.spec.tsx
@@ -166,3 +166,50 @@ describe('AddModal - global exclusion warning', () => {
     expect(screen.queryByText('Confirmation Required')).toBeNull()
   })
 })
+
+describe('AddModal - context payload', () => {
+  const getApiHandlerMock = vi.mocked(GetApiHandler)
+  const postApiHandlerMock = vi.mocked(PostApiHandler)
+
+  beforeEach(() => {
+    getApiHandlerMock.mockReset()
+    postApiHandlerMock.mockReset()
+    getApiHandlerMock.mockImplementation(((url: string) => {
+      if (url.startsWith('/media-server/meta/')) return Promise.resolve([])
+      if (url === '/collections?typeId=season')
+        return Promise.resolve([{ id: 4, title: 'Season cleanup' }])
+      if (url.startsWith('/collections')) return Promise.resolve([])
+      return Promise.resolve(undefined)
+    }) as typeof GetApiHandler)
+    postApiHandlerMock.mockResolvedValue(undefined as never)
+  })
+  afterEach(() => cleanup())
+
+  // A -1 context id let the server act on the show itself, so a season
+  // collection received a show id and Plex answered 400 (#3381).
+  it('identifies "all seasons" by the show id rather than a sentinel', async () => {
+    render(
+      <AddModal
+        mediaServerId="show-1"
+        type="show"
+        modalType="add"
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Submit' }))
+
+    await waitFor(() =>
+      expect(postApiHandlerMock).toHaveBeenCalledWith(
+        '/collections/media/add',
+        {
+          mediaId: 'show-1',
+          context: { id: 'show-1', type: 'show' },
+          collectionId: 4,
+          action: 0,
+        },
+      ),
+    )
+  })
+})

--- a/apps/ui/src/components/AddModal/index.tsx
+++ b/apps/ui/src/components/AddModal/index.tsx
@@ -63,13 +63,15 @@ const AddModal = (props: IAddModal) => {
     [props.modalType],
   )
 
+  // The context is the narrowest thing picked; with no season or episode
+  // selected that is the item itself. Same shape as TestMediaItem.
   const selectedMediaId = useMemo(() => {
-    return props.type === 'movie'
-      ? -1
-      : selectedEpisodes !== -1
-        ? selectedEpisodes
-        : selectedSeasons
-  }, [selectedSeasons, selectedEpisodes, props.type])
+    return selectedEpisodes !== -1
+      ? selectedEpisodes
+      : selectedSeasons !== -1
+        ? selectedSeasons
+        : props.mediaServerId
+  }, [selectedSeasons, selectedEpisodes, props.mediaServerId])
 
   const selectedContext = useMemo((): MediaItemType => {
     return props.type === 'show'
@@ -179,7 +181,7 @@ const AddModal = (props: IAddModal) => {
       if (props.modalType === 'add') {
         await PostApiHandler(`/collections/media/add`, {
           mediaId: props.mediaServerId,
-          context: { id: -1, type: props.type },
+          context: { id: props.mediaServerId, type: props.type },
           collectionId: undefined,
           action: 1,
         })


### PR DESCRIPTION
Closes #3381.

Adding a show from Overview with "All seasons" selected failed against Plex with `400 Bad Request`, and the modal reported success anyway.

Resolving a context action short-circuited on the "all seasons" sentinel and returned the show's own id, so the show's ratingKey was PUT into a collection holding seasons or episodes. Verified against a real Plex server: a show into a season- or episode-subtype collection is rejected with the exact response body from the report, while the correct subtype is accepted. Two more behaviours came from the same line - a global show exclusion stopped cascading to its seasons and episodes, and "Remove from all collections" stopped removing them.

Jellyfin and Emby did not fail loudly; a BoxSet accepts mixed types, so the show was simply left sitting in a collection of the wrong media type.

Introduced in #3353, which moved Plex onto the shared resolver and inherited the sentinel from the Jellyfin implementation. The resolver now leaves `context.id` alone and expands through `context.type`, which is what the Plex implementation did before #3353. The modal sends the item's id rather than a sentinel, matching the shape the rule-test picker already used.

Note that a second, older cause of the same 400 remains: the collection dropdown is not filtered by library, so a show can be pointed at a collection in another Plex library section. That needs the item's library on the media item contract and is left for a follow-up.