### PR TITLE
fix(collections): report manual add failures, and the defects that cause them

### DIFF
--- a/apps/server/src/modules/actions/servarr-tag.service.ts
+++ b/apps/server/src/modules/actions/servarr-tag.service.ts
@@ -20,7 +20,7 @@ interface ArrInstanceRef {
 // The ids are passed as resolution fallbacks (exactly like the *arr action
 // handlers), so an item whose media-server metadata omits a tmdb/tvdb still
 // resolves to its *arr entity.
-interface ArrTagItem {
+export interface ArrTagItem {
   mediaServerId: string;
   tmdbId?: number | null;
   tvdbId?: number | null;

--- a/apps/server/src/modules/api/media-server/context-action.util.ts
+++ b/apps/server/src/modules/api/media-server/context-action.util.ts
@@ -8,6 +8,10 @@ import { MediaItem, MediaItemType } from '@maintainerr/contracts';
  * Shared by every media server: the traversal is the same show -> season ->
  * episode walk, only the `getChildren` lookup behind it differs.
  *
+ * `getChildren` must throw on a failed read rather than answer an empty list:
+ * the walk cannot tell the two apart, so a swallowed failure silently drops the
+ * expansion and the action is reported as done.
+ *
  * `context.id` is always a real media server id. Do not add a "whole item"
  * sentinel case: short-circuiting on one is what handed a show's id to a season
  * collection for Plex to reject with a 400 (#3381). A context that names no

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -820,16 +820,34 @@ describe('EmbyAdapterService', () => {
         ),
       ).resolves.toEqual(['episode-1', 'episode-2']);
 
+      // Throwing reads: an expansion that silently resolved to nothing
+      // reported the action as done (#3381).
       expect(getChildrenMetadata).toHaveBeenNthCalledWith(
         1,
         'show-1',
         'season',
+        true,
       );
       expect(getChildrenMetadata).toHaveBeenNthCalledWith(
         2,
         'season-1',
         'episode',
+        true,
       );
+    });
+
+    it('propagates a failed children read instead of resolving to nothing', async () => {
+      jest
+        .spyOn(service, 'getChildrenMetadata')
+        .mockRejectedValue(new Error('emby down'));
+
+      await expect(
+        service.getAllIdsForContextAction(
+          'season',
+          { type: 'show', id: 'show-1' },
+          'show-1',
+        ),
+      ).rejects.toThrow('emby down');
     });
   });
 

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -484,8 +484,14 @@ export class EmbyAdapterService implements IMediaServerService {
   async getChildrenMetadata(
     parentId: string,
     childType?: MediaItemType,
+    throwOnError = false,
   ): Promise<MediaItem[]> {
-    if (!this.http) return [];
+    if (!this.http) {
+      if (throwOnError) {
+        throw new Error('Emby API not initialized');
+      }
+      return [];
+    }
 
     const cacheKey = `${EMBY_CACHE_KEYS.CHILDREN}:${parentId}:${childType ?? 'any'}`;
     const cached = this.cache.data.get<MediaItem[]>(cacheKey);
@@ -530,6 +536,10 @@ export class EmbyAdapterService implements IMediaServerService {
         (data.Items ?? []).map(EmbyMapper.toMediaItem),
       );
     } catch (error) {
+      if (throwOnError) {
+        throw error;
+      }
+
       this.logger.debug(
         `Emby getChildrenMetadata(${parentId}) failed: ${formatConnectionFailureMessage(error, 'Connection failed')}`,
       );
@@ -1443,7 +1453,9 @@ export class EmbyAdapterService implements IMediaServerService {
       collectionType,
       context,
       mediaId,
-      (parentId, type) => this.getChildrenMetadata(parentId, type),
+      // Throwing: a swallowed read reads as "no children", which silently
+      // drops the expansion and reports the action as done.
+      (parentId, type) => this.getChildrenMetadata(parentId, type, true),
       (message) => this.logger.warn(message),
     );
   }

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -1453,8 +1453,6 @@ export class EmbyAdapterService implements IMediaServerService {
       collectionType,
       context,
       mediaId,
-      // Throwing: a swallowed read reads as "no children", which silently
-      // drops the expansion and reports the action as done.
       (parentId, type) => this.getChildrenMetadata(parentId, type, true),
       (message) => this.logger.warn(message),
     );

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -537,7 +537,12 @@ export class EmbyAdapterService implements IMediaServerService {
       );
     } catch (error) {
       if (throwOnError) {
-        throw error;
+        // Worded like the Plex adapter's: the raw client error reaches the user
+        // as "Request failed with status code 404", which names nothing.
+        throw new Error(
+          `Could not read the children of Emby item ${parentId}`,
+          { cause: error },
+        );
       }
 
       this.logger.debug(

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -1067,7 +1067,12 @@ export class JellyfinAdapterService implements IMediaServerService {
       );
     } catch (error) {
       if (throwOnError) {
-        throw error;
+        // Worded like the Plex adapter's: the raw client error reaches the user
+        // as "Request failed with status code 404", which names nothing.
+        throw new Error(
+          `Could not read the children of Jellyfin item ${parentId}`,
+          { cause: error },
+        );
       }
 
       this.logger.error(`Failed to get children for ${parentId}`);

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -2490,8 +2490,6 @@ export class JellyfinAdapterService implements IMediaServerService {
       collectionType,
       context,
       mediaId,
-      // Throwing: a swallowed read reads as "no children", which silently
-      // drops the expansion and reports the action as done.
       (parentId, type) => this.getChildrenMetadata(parentId, type, true),
       (message) => this.logger.warn(message),
     );

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -999,8 +999,14 @@ export class JellyfinAdapterService implements IMediaServerService {
   async getChildrenMetadata(
     parentId: string,
     childType?: MediaItemType,
+    throwOnError = false,
   ): Promise<MediaItem[]> {
-    if (!this.api) return [];
+    if (!this.api) {
+      if (throwOnError) {
+        throw new Error('Jellyfin API not initialized');
+      }
+      return [];
+    }
 
     const cacheKey = `${JELLYFIN_CACHE_KEYS.CHILDREN}:${parentId}:${childType ?? 'any'}`;
     const cached = this.cache.data.get<MediaItem[]>(cacheKey);
@@ -1060,6 +1066,10 @@ export class JellyfinAdapterService implements IMediaServerService {
         (response.data.Items || []).map(JellyfinMapper.toMediaItem),
       );
     } catch (error) {
+      if (throwOnError) {
+        throw error;
+      }
+
       this.logger.error(`Failed to get children for ${parentId}`);
       this.logger.debug(error);
       return [];
@@ -2480,7 +2490,9 @@ export class JellyfinAdapterService implements IMediaServerService {
       collectionType,
       context,
       mediaId,
-      (parentId, type) => this.getChildrenMetadata(parentId, type),
+      // Throwing: a swallowed read reads as "no children", which silently
+      // drops the expansion and reports the action as done.
+      (parentId, type) => this.getChildrenMetadata(parentId, type, true),
       (message) => this.logger.warn(message),
     );
   }

--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -154,7 +154,16 @@ export interface IMediaServerService {
   /**
    * Get child items (seasons for shows, episodes for seasons).
    */
-  getChildrenMetadata(parentId: string): Promise<MediaItem[]>;
+  /**
+   * @param throwOnError - by default a failed read answers with an empty list,
+   * which reads as "no children" downstream. Callers that must not mistake the
+   * two pass true.
+   */
+  getChildrenMetadata(
+    parentId: string,
+    childType?: MediaItemType,
+    throwOnError?: boolean,
+  ): Promise<MediaItem[]>;
 
   /**
    * Get recently added items from a library.

--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -153,8 +153,7 @@ export interface IMediaServerService {
 
   /**
    * Get child items (seasons for shows, episodes for seasons).
-   */
-  /**
+   *
    * @param throwOnError - by default a failed read answers with an empty list,
    * which reads as "no children" downstream. Callers that must not mistake the
    * two pass true.

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -947,11 +947,21 @@ describe('PlexAdapterService', () => {
       plexApi.deleteChildFromCollection.mockImplementation(
         async (collectionId, itemId) => {
           if (itemId === 'missing') {
-            throw new Error('404 Not Found');
+            throw new Error(
+              'DELETE /library/collections/col123/items/missing failed with exception: response code: 404',
+            );
           }
 
           if (itemId === 'bad') {
             throw new Error('boom');
+          }
+
+          // A ratingKey can contain 404 without the request having 404'd, and
+          // the failure message carries the request URL.
+          if (itemId === '1404') {
+            throw new Error(
+              'DELETE /library/collections/col123/items/1404 failed with exception: response code: 500',
+            );
           }
 
           return { status: 'OK' } as any;
@@ -959,8 +969,13 @@ describe('PlexAdapterService', () => {
       );
 
       await expect(
-        service.removeBatchFromCollection('col123', ['good', 'missing', 'bad']),
-      ).resolves.toEqual(['bad']);
+        service.removeBatchFromCollection('col123', [
+          'good',
+          'missing',
+          'bad',
+          '1404',
+        ]),
+      ).resolves.toEqual(['bad', '1404']);
     });
 
     it('should default optional visibility flags to false', async () => {

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -197,9 +197,22 @@ export class PlexAdapterService implements IMediaServerService {
     return this.plexApi.itemExists(itemId);
   }
 
-  async getChildrenMetadata(parentId: string): Promise<MediaItem[]> {
+  async getChildrenMetadata(
+    parentId: string,
+    childType?: MediaItemType,
+    throwOnError = false,
+  ): Promise<MediaItem[]> {
+    // Plex children are unambiguous - a show's are seasons, a season's are
+    // episodes - so childType is not needed to pick an endpoint.
+    void childType;
+
     const children = await this.plexApi.getChildrenMetadata(parentId);
-    if (!children) return [];
+    if (!children) {
+      if (throwOnError) {
+        throw new Error(`Could not read the children of Plex item ${parentId}`);
+      }
+      return [];
+    }
     return children.map(PlexMapper.metadataToMediaItem);
   }
 
@@ -685,7 +698,13 @@ export class PlexAdapterService implements IMediaServerService {
       try {
         await this.removeFromCollection(collectionId, itemId);
       } catch (error) {
-        if (error instanceof Error && error.message.includes('404')) {
+        // An item Plex no longer holds is the outcome the caller wanted. Match
+        // the status the message ends with, not "404" anywhere in it - the
+        // message carries the request URL, so a ratingKey like 1404 matched.
+        if (
+          error instanceof Error &&
+          error.message.endsWith('response code: 404')
+        ) {
           continue;
         }
 
@@ -837,7 +856,9 @@ export class PlexAdapterService implements IMediaServerService {
       collectionType,
       context,
       mediaId,
-      (parentId) => this.getChildrenMetadata(parentId),
+      // Throwing: a swallowed read reads as "no children", which silently
+      // drops the expansion and reports the action as done.
+      (parentId) => this.getChildrenMetadata(parentId, undefined, true),
       (message) => this.logger.warn(message),
     );
   }

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -856,8 +856,6 @@ export class PlexAdapterService implements IMediaServerService {
       collectionType,
       context,
       mediaId,
-      // Throwing: a swallowed read reads as "no children", which silently
-      // drops the expansion and reports the action as done.
       (parentId) => this.getChildrenMetadata(parentId, undefined, true),
       (message) => this.logger.warn(message),
     );

--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
@@ -12,6 +12,7 @@ import {
   MediaSource,
   MediaUser,
   WatchRecord,
+  isValidMediaItemType,
 } from '@maintainerr/contracts';
 import { EPlexDataType } from '../../plex-api/enums/plex-data-type-enum';
 import {
@@ -308,6 +309,10 @@ export class PlexMapper {
       addedAt: plex.addedAt ? new Date(plex.addedAt * 1000) : undefined,
       updatedAt: plex.updatedAt ? new Date(plex.updatedAt * 1000) : undefined,
       smart: plex.smart,
+      // Deliberately not toMediaItemType: that defaults to 'movie', which would
+      // turn an unrecognised subtype into a confident wrong answer, and callers
+      // read undefined as "unknown" rather than as a mismatch.
+      type: isValidMediaItemType(plex.subtype) ? plex.subtype : undefined,
       libraryId: undefined, // Not available on PlexCollection directly
     };
   }

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -1090,6 +1090,29 @@ describe('PlexApiService.prefetchWatchHistory', () => {
     expect(snapshot?.leaf.get('2')).toHaveLength(1);
   });
 
+  // Playback finishing mid-sweep shifts every later offset by one, so the row
+  // at the boundary comes back on the next page too.
+  it('counts a row re-read by a shifted page only once', async () => {
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: {
+        Metadata: [
+          historyRow({ ratingKey: '1', accountID: 10, viewedAt: 1700000000 }),
+          historyRow({ ratingKey: '1', accountID: 10, viewedAt: 1700000000 }),
+          historyRow({ ratingKey: '1', accountID: 10, viewedAt: 1700000900 }),
+          historyRow({ ratingKey: '1', accountID: 11, viewedAt: 1700000000 }),
+        ],
+        totalSize: 4,
+      },
+    });
+    (service as any).plexClient = { queryAll };
+
+    await service.prefetchWatchHistory(LIBRARY);
+
+    // The duplicate is dropped; a different view time and a different account
+    // are distinct views and stay.
+    expect((await snapshotFor(LIBRARY))?.leaf.get('1')).toHaveLength(3);
+  });
+
   it('caches per library, so one library does not answer for another', async () => {
     const queryAll = jest.fn().mockResolvedValue({
       MediaContainer: { Metadata: [historyRow()], totalSize: 1 },

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -737,13 +737,18 @@ export class PlexApiService {
     }
   }
 
+  /**
+   * @returns the children, or undefined when the read failed. A container with
+   * no children answers without a Metadata node, so an empty array is a
+   * confirmed "no children" rather than a swallowed failure.
+   */
   public async getChildrenMetadata(key: string): Promise<PlexMetadata[]> {
     try {
       const response = await this.plexClient.queryAll<PlexMetadataResponse>({
         uri: `/library/metadata/${key}/children`,
       });
 
-      return response.MediaContainer.Metadata;
+      return response.MediaContainer.Metadata ?? [];
     } catch (error) {
       this.logger.error(
         'Plex api communication failure.. Is the application running?',
@@ -959,6 +964,18 @@ export class PlexApiService {
     };
 
     for (const record of records) {
+      // Offset paging over a viewedAt:desc sort re-reads a row for every view
+      // that lands mid-sweep: the new row takes offset 0 and pushes each later
+      // page one slot older. Counting it twice inflates sw_amountOfViews.
+      const alreadyStored = leaf
+        .get(record.ratingKey)
+        ?.some(
+          (stored) =>
+            stored.viewedAt === record.viewedAt &&
+            stored.accountID === record.accountID,
+        );
+      if (alreadyStored) continue;
+
       add(leaf, record.ratingKey, record);
 
       if (record.type !== 'episode') continue;

--- a/apps/server/src/modules/collections/collections.controller.spec.ts
+++ b/apps/server/src/modules/collections/collections.controller.spec.ts
@@ -221,9 +221,11 @@ describe('CollectionsController', () => {
   });
 
   it('allows manual removal actions without a collection id', async () => {
-    collectionsService.MediaCollectionActionWithContext.mockResolvedValue(
-      createCollection(),
-    );
+    collectionsService.MediaCollectionActionWithContext.mockResolvedValue({
+      collection: createCollection(),
+      serverRejectedIds: [],
+      resolvedCount: 1,
+    });
 
     await controller.ManualActionOnCollection({
       mediaId: '10',
@@ -245,6 +247,54 @@ describe('CollectionsController', () => {
       { mediaServerId: '10' },
       'remove',
     );
+  });
+
+  // A rejected add used to answer 201, so the modal closed as though it had
+  // worked and the 400 only appeared in the debug log (#3381).
+  describe('manual add failures', () => {
+    const addRequest = {
+      mediaId: '10',
+      context: { id: '10', type: 'show' as const },
+      collectionId: 7,
+      action: 0 as const,
+    };
+
+    it('reports the items the media server refused', async () => {
+      collectionsService.MediaCollectionActionWithContext.mockResolvedValue({
+        collection: createCollection(),
+        serverRejectedIds: ['10'],
+        resolvedCount: 1,
+      });
+
+      await expect(
+        controller.ManualActionOnCollection(addRequest),
+      ).rejects.toThrow('refused 1 of 1');
+    });
+
+    it('reports a context that resolves to nothing', async () => {
+      collectionsService.MediaCollectionActionWithContext.mockResolvedValue({
+        collection: createCollection(),
+        serverRejectedIds: [],
+        resolvedCount: 0,
+      });
+
+      await expect(
+        controller.ManualActionOnCollection(addRequest),
+      ).rejects.toThrow('cannot be applied');
+    });
+
+    it('returns the collection when every item lands', async () => {
+      const collection = createCollection();
+      collectionsService.MediaCollectionActionWithContext.mockResolvedValue({
+        collection,
+        serverRejectedIds: [],
+        resolvedCount: 1,
+      });
+
+      await expect(
+        controller.ManualActionOnCollection(addRequest),
+      ).resolves.toBe(collection);
+    });
   });
 
   it('accepts a hex-GUID context.id for manual season/episode actions (Jellyfin/Emby, #3185)', () => {

--- a/apps/server/src/modules/collections/collections.controller.ts
+++ b/apps/server/src/modules/collections/collections.controller.ts
@@ -18,6 +18,7 @@ import {
   mediaSortOrders,
 } from '@maintainerr/contracts';
 import {
+  BadGatewayException,
   BadRequestException,
   Body,
   ConflictException,
@@ -404,16 +405,33 @@ export class CollectionsController {
   }
 
   @Post('/media/add')
-  ManualActionOnCollection(
+  async ManualActionOnCollection(
     @Body(new ZodValidationPipe(manualCollectionActionBodySchema))
     request: ManualCollectionActionBody,
   ) {
-    return this.collectionService.MediaCollectionActionWithContext(
-      request.collectionId,
-      request.context,
-      { mediaServerId: request.mediaId },
-      request.action === 0 ? 'add' : 'remove',
-    );
+    const result =
+      await this.collectionService.MediaCollectionActionWithContext(
+        request.collectionId,
+        request.context,
+        { mediaServerId: request.mediaId },
+        request.action === 0 ? 'add' : 'remove',
+      );
+
+    // A rejected item and an item the context resolved to nothing both used to
+    // answer 201, so the modal closed as though the action had worked.
+    if (result.resolvedCount === 0) {
+      throw new BadRequestException(
+        'This item cannot be applied to the selected collection',
+      );
+    }
+
+    if (result.serverRejectedIds.length > 0) {
+      throw new BadGatewayException(
+        `The media server refused ${result.serverRejectedIds.length} of ${result.resolvedCount} item(s)`,
+      );
+    }
+
+    return result.collection;
   }
 
   @Post('/media/handle')

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -3332,6 +3332,35 @@ describe('CollectionsService', () => {
     });
   });
 
+  // A library id used to discard the type filter, so the add modal listed the
+  // same collection once per type it asked for.
+  describe('getCollections filtering', () => {
+    it.each([
+      [
+        'both filters',
+        '2',
+        'season' as const,
+        { libraryId: '2', type: 'season' },
+      ],
+      ['a library only', '2', undefined, { libraryId: '2' }],
+      ['a type only', undefined, 'season' as const, { type: 'season' }],
+    ])('applies %s', async (label, libraryId, typeId, expected) => {
+      collectionRepo.find.mockResolvedValue([]);
+
+      await service.getCollections(libraryId, typeId);
+
+      expect(collectionRepo.find).toHaveBeenCalledWith({ where: expected });
+    });
+
+    it('reads every collection when neither filter is given', async () => {
+      collectionRepo.find.mockResolvedValue([]);
+
+      await service.getCollections();
+
+      expect(collectionRepo.find).toHaveBeenCalledWith(undefined);
+    });
+  });
+
   describe('findMediaServerCollection', () => {
     const boxset = (props: Partial<MediaCollection>): MediaCollection =>
       ({ id: 'box-1', title: 'Shared', smart: false, ...props }) as never;
@@ -3367,6 +3396,40 @@ describe('CollectionsService', () => {
       const found = await service.findMediaServerCollection('Shared', 'shows');
 
       expect(found).toBeUndefined();
+    });
+
+    // Adopting a show collection for a season rule group made every later add
+    // a 400 on Plex, which fixes a collection's media type at creation.
+    it('leaves a same-named collection of another media type alone', async () => {
+      mediaServer.getCollections.mockResolvedValue([
+        boxset({ title: 'Shared', type: 'show' }),
+      ]);
+
+      await expect(
+        service.findMediaServerCollection('Shared', 'shows', false, 'season'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('adopts a same-named collection of the expected media type', async () => {
+      mediaServer.getCollections.mockResolvedValue([
+        boxset({ title: 'Shared', type: 'season' }),
+      ]);
+
+      await expect(
+        service.findMediaServerCollection('Shared', 'shows', false, 'season'),
+      ).resolves.toMatchObject({ id: 'box-1' });
+    });
+
+    // A false miss creates a second collection beside the real one (#3344),
+    // so an unknown type on either side still matches.
+    it('adopts a same-named collection whose media type the server omits', async () => {
+      mediaServer.getCollections.mockResolvedValue([
+        boxset({ title: 'Shared', type: undefined }),
+      ]);
+
+      await expect(
+        service.findMediaServerCollection('Shared', 'shows', false, 'season'),
+      ).resolves.toMatchObject({ id: 'box-1' });
     });
 
     it('falls back to other libraries for a cross-library server when opted in', async () => {

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -91,6 +91,7 @@ describe('CollectionsService', () => {
       getCollection: jest.fn().mockResolvedValue(undefined),
       getCollections: jest.fn().mockResolvedValue([]),
       getCollectionChildren: jest.fn().mockResolvedValue([]),
+      getAllIdsForContextAction: jest.fn().mockResolvedValue([]),
       getLibraries: jest.fn().mockResolvedValue([{ id: 'library-1' }]),
       getMetadata: jest.fn().mockResolvedValue(undefined),
       itemExists: jest.fn().mockResolvedValue(true),
@@ -3329,6 +3330,35 @@ describe('CollectionsService', () => {
       await service.removeStaleCollectionMedia();
 
       expect(collectionMediaRepo.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  // Both used to answer 201 with an empty body, which is the same silent
+  // success the manual add was reporting for a rejected item.
+  describe('MediaCollectionActionWithContext failures', () => {
+    const context = { type: 'show' as const, id: '7' };
+    const media = { mediaServerId: '7' };
+
+    it('reports an add naming a collection that does not exist', async () => {
+      collectionRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.MediaCollectionActionWithContext(999, context, media, 'add'),
+      ).rejects.toThrow('Collection 999 not found');
+    });
+
+    it('reports a context the media server could not resolve', async () => {
+      collectionRepo.findOne.mockResolvedValue({
+        id: 1,
+        type: 'season',
+      } as any);
+      mediaServer.getAllIdsForContextAction.mockRejectedValue(
+        new Error('plex unreachable'),
+      );
+
+      await expect(
+        service.MediaCollectionActionWithContext(1, context, media, 'add'),
+      ).rejects.toThrow('plex unreachable');
     });
   });
 

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -3347,6 +3347,55 @@ describe('CollectionsService', () => {
       ).rejects.toThrow('Collection 999 not found');
     });
 
+    it('reports a remove naming a collection that does not exist', async () => {
+      collectionRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.MediaCollectionActionWithContext(999, context, media, 'remove'),
+      ).rejects.toThrow('Collection 999 not found');
+    });
+
+    // addToCollectionInternal swallows its own failures so a rule run survives
+    // one bad collection; the interactive path must not read that as done.
+    it('reports an add whose internal work failed', async () => {
+      collectionRepo.findOne.mockResolvedValue({ id: 1, type: 'show' } as any);
+      mediaServer.getAllIdsForContextAction.mockResolvedValue(['7']);
+      jest
+        .spyOn(service as any, 'addToCollectionInternal')
+        .mockResolvedValue({ collection: undefined, serverRejectedIds: [] });
+
+      await expect(
+        service.MediaCollectionActionWithContext(1, context, media, 'add'),
+      ).rejects.toThrow('could not be updated');
+    });
+
+    it('reports a remove whose internal work failed', async () => {
+      collectionRepo.findOne.mockResolvedValue({ id: 1, type: 'show' } as any);
+      mediaServer.getAllIdsForContextAction.mockResolvedValue(['7']);
+      jest.spyOn(service, 'removeFromCollection').mockResolvedValue(undefined);
+
+      await expect(
+        service.MediaCollectionActionWithContext(1, context, media, 'remove'),
+      ).rejects.toThrow('could not be updated');
+    });
+
+    it('still allows a global remove, which names no collection', async () => {
+      mediaServer.getAllIdsForContextAction.mockResolvedValue(['7']);
+      const removeAll = jest
+        .spyOn(service, 'removeFromAllCollections')
+        .mockResolvedValue(undefined as never);
+
+      await expect(
+        service.MediaCollectionActionWithContext(
+          undefined,
+          context,
+          media,
+          'remove',
+        ),
+      ).resolves.toMatchObject({ resolvedCount: 1 });
+      expect(removeAll).toHaveBeenCalled();
+    });
+
     it('reports a context the media server could not resolve', async () => {
       collectionRepo.findOne.mockResolvedValue({
         id: 1,

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -115,6 +115,11 @@ export interface CollectionAddResult {
   serverRejectedIds: string[];
 }
 
+export interface ContextActionResult extends CollectionAddResult {
+  /** Ids the context resolved to. Zero means it cannot apply to this collection. */
+  resolvedCount: number;
+}
+
 @Injectable()
 export class CollectionsService {
   constructor(
@@ -2544,7 +2549,7 @@ export class CollectionsService {
     context: AlterableMediaContext,
     media: CollectionMediaChange,
     action: 'add' | 'remove',
-  ): Promise<CollectionAddResult & { resolvedCount: number }> {
+  ): Promise<ContextActionResult> {
     const mediaServer = await this.getMediaServer();
     const collection =
       collectionDbId !== -1 && collectionDbId !== undefined

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -17,7 +17,11 @@ import {
   MediaSortOrder,
   parseCollectionSortKey,
 } from '@maintainerr/contracts';
-import { Injectable } from '@nestjs/common';
+import {
+  BadGatewayException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Brackets, DataSource, In, LessThan, Not, Repository } from 'typeorm';
@@ -2558,12 +2562,32 @@ export class CollectionsService {
           })
         : undefined;
 
+    // An add names its collection, so a missing one is the caller's mistake
+    // rather than an empty result to report as done.
+    if (action === 'add' && !collection) {
+      throw new NotFoundException(`Collection ${collectionDbId} not found`);
+    }
+
     // get media - traverse show -> seasons -> episodes if needed
-    const ids = await mediaServer.getAllIdsForContextAction(
-      collection?.type,
-      { type: context.type, id: String(context.id) },
-      media.mediaServerId,
-    );
+    let ids: string[];
+    try {
+      ids = await mediaServer.getAllIdsForContextAction(
+        collection?.type,
+        { type: context.type, id: String(context.id) },
+        media.mediaServerId,
+      );
+    } catch (error) {
+      // The hierarchy walk reads the media server, so a failure here means we
+      // do not know what to act on - which is not the same as "nothing to do".
+      this.logger.debug(error);
+      throw new BadGatewayException(
+        getErrorMessage(
+          error,
+          `The media server could not resolve ${media.mediaServerId}`,
+        ),
+      );
+    }
+
     const handleMedia: CollectionMediaChange[] = ids.map((id) => ({
       mediaServerId: id,
     }));

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -22,6 +22,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Brackets, DataSource, In, LessThan, Not, Repository } from 'typeorm';
 import { CollectionLog } from '../../modules/collections/entities/collection_log.entities';
+import { getErrorMessage } from '../../utils/connection-error';
 import { MediaServerFactory } from '../api/media-server/media-server.factory';
 import { IMediaServerService } from '../api/media-server/media-server.interface';
 import {
@@ -103,6 +104,15 @@ export interface PostponeCollectionMediaResult {
   addDate: Date;
   deleteAfterDays: number | null;
   deletionDate: Date | null;
+}
+
+/**
+ * Adds report which ids the media server refused, so a caller acting on a
+ * user's behalf can say so instead of reporting a silent success.
+ */
+export interface CollectionAddResult {
+  collection?: Collection;
+  serverRejectedIds: string[];
 }
 
 @Injectable()
@@ -1796,12 +1806,16 @@ export class CollectionsService {
   }
 
   private async findCollections(libraryId?: string, typeId?: MediaItemType) {
+    // Both filters apply together. A library id used to discard the type
+    // filter, so asking for one library's season collections returned every
+    // collection it holds.
+    const where = {
+      ...(libraryId ? { libraryId } : {}),
+      ...(typeId ? { type: typeId } : {}),
+    };
+
     return await this.collectionRepo.find(
-      libraryId
-        ? { where: { libraryId: libraryId } }
-        : typeId
-          ? { where: { type: typeId } }
-          : undefined,
+      Object.keys(where).length > 0 ? { where } : undefined,
     );
   }
 
@@ -1921,6 +1935,7 @@ export class CollectionsService {
           collection.manualCollectionName,
           collection.libraryId,
           true,
+          collection.type,
         );
         if (foundCollection) {
           // Handle visibility settings (Plex-only feature)
@@ -2173,6 +2188,7 @@ export class CollectionsService {
           collection.manualCollectionName,
           collection.libraryId,
           true,
+          collection.type,
         );
       } catch (error) {
         // "Could not look" is not "does not exist".
@@ -2298,6 +2314,8 @@ export class CollectionsService {
           foundColl = await this.findMediaServerCollection(
             collection.title,
             collection.libraryId,
+            false,
+            collection.type,
           );
         } catch (error) {
           // The library could not be enumerated, so we cannot tell whether a
@@ -2516,12 +2534,17 @@ export class CollectionsService {
     return collection;
   }
 
+  /**
+   * Drives the manual add/remove modal. Reports what the media server refused
+   * so the caller can tell the user, rather than answering "done" to an action
+   * that changed nothing.
+   */
   async MediaCollectionActionWithContext(
     collectionDbId: number | undefined,
     context: AlterableMediaContext,
     media: CollectionMediaChange,
     action: 'add' | 'remove',
-  ): Promise<Collection | undefined> {
+  ): Promise<CollectionAddResult & { resolvedCount: number }> {
     const mediaServer = await this.getMediaServer();
     const collection =
       collectionDbId !== -1 && collectionDbId !== undefined
@@ -2540,17 +2563,25 @@ export class CollectionsService {
       mediaServerId: id,
     }));
 
-    if (handleMedia) {
-      if (action === 'add') {
-        return this.addToCollection(collectionDbId, handleMedia, true);
-      } else if (action === 'remove') {
-        if (collectionDbId) {
-          return this.removeFromCollection(collectionDbId, handleMedia);
-        } else {
-          await this.removeFromAllCollections(handleMedia);
-        }
-      }
+    if (action === 'add') {
+      const result = await this.addToCollectionInternal(
+        collectionDbId,
+        handleMedia,
+        true,
+      );
+      return { ...result, resolvedCount: handleMedia.length };
     }
+
+    if (!collectionDbId) {
+      await this.removeFromAllCollections(handleMedia);
+      return { serverRejectedIds: [], resolvedCount: handleMedia.length };
+    }
+
+    return {
+      collection: await this.removeFromCollection(collectionDbId, handleMedia),
+      serverRejectedIds: [],
+      resolvedCount: handleMedia.length,
+    };
   }
 
   async addToCollection(
@@ -2559,14 +2590,16 @@ export class CollectionsService {
     manual = false,
     manualMembershipSource = CollectionMediaManualMembershipSource.LOCAL,
   ): Promise<Collection> {
-    return this.addToCollectionInternal(
-      collectionDbId,
-      media,
-      manual,
-      false,
-      false,
-      manualMembershipSource,
-    );
+    return (
+      await this.addToCollectionInternal(
+        collectionDbId,
+        media,
+        manual,
+        false,
+        false,
+        manualMembershipSource,
+      )
+    ).collection;
   }
 
   async addToCollectionWithResolvedLink(
@@ -2576,14 +2609,16 @@ export class CollectionsService {
     manualMembershipSource = CollectionMediaManualMembershipSource.LOCAL,
   ): Promise<Collection> {
     if (!collection) return undefined;
-    return this.addToCollectionInternal(
-      collection.id,
-      media,
-      manual,
-      true,
-      false,
-      manualMembershipSource,
-    );
+    return (
+      await this.addToCollectionInternal(
+        collection.id,
+        media,
+        manual,
+        true,
+        false,
+        manualMembershipSource,
+      )
+    ).collection;
   }
 
   async syncMediaServerChildrenToCollection(
@@ -2592,14 +2627,16 @@ export class CollectionsService {
     manualMembershipSource = CollectionMediaManualMembershipSource.LOCAL,
   ): Promise<Collection> {
     if (!collection) return undefined;
-    return this.addToCollectionInternal(
-      collection.id,
-      media,
-      true,
-      true,
-      true,
-      manualMembershipSource,
-    );
+    return (
+      await this.addToCollectionInternal(
+        collection.id,
+        media,
+        true,
+        true,
+        true,
+        manualMembershipSource,
+      )
+    ).collection;
   }
 
   private async addToCollectionInternal(
@@ -2609,7 +2646,7 @@ export class CollectionsService {
     skipAutomaticLinkCheck = false,
     skipMediaServerAdd = false,
     manualMembershipSource = CollectionMediaManualMembershipSource.LOCAL,
-  ): Promise<Collection> {
+  ): Promise<CollectionAddResult> {
     try {
       const mediaServer = await this.getMediaServer();
       let collection = await this.collectionRepo.findOne({
@@ -2633,6 +2670,7 @@ export class CollectionsService {
         (m) =>
           !collectionMedia.find((el) => el.mediaServerId === m.mediaServerId),
       );
+      let rejectedByServer: string[] = [];
 
       if (collection) {
         if (!skipAutomaticLinkCheck) {
@@ -2661,6 +2699,7 @@ export class CollectionsService {
                 name,
                 collection.libraryId,
                 searchAllLibraries,
+                collection.type,
               );
             } catch (error) {
               searchCompleted = false;
@@ -2830,6 +2869,7 @@ export class CollectionsService {
               skipMediaServerAdd,
               manualMembershipSource,
             );
+          rejectedByServer = [...serverRejectedIds];
 
           // Only notify for items whose membership was persisted - both
           // server-rejected items and locally-rolled-back items never
@@ -2889,7 +2929,7 @@ export class CollectionsService {
         // Update cached total size (non-blocking)
         this.updateCollectionTotalSize(collectionDbId).catch(() => {});
 
-        return collection;
+        return { collection, serverRejectedIds: rejectedByServer };
       } else {
         this.logger.warn("Collection doesn't exist.");
       }
@@ -2898,8 +2938,9 @@ export class CollectionsService {
         'An error occurred while performing collection actions.',
       );
       this.logger.debug(error);
-      return undefined;
     }
+
+    return { collection: undefined, serverRejectedIds: [] };
   }
 
   async removeFromCollection(
@@ -3418,12 +3459,19 @@ export class CollectionsService {
         try {
           await mediaServer.deleteCollection(collection.mediaServerId);
         } catch (error) {
-          this.logger.warn('Failed to delete collection from media server');
+          // The media server says why it refused - Plex names its own
+          // "allow media deletion" setting - and this is a dead end until the
+          // user acts on it, so the reason has to reach them.
+          const reason = getErrorMessage(
+            error,
+            'Failed to delete collection from media server',
+          );
+          this.logger.warn(`Failed to delete collection: ${reason}`);
           this.logger.debug(error);
           return {
             status: 'NOK',
             code: 0,
-            message: 'Failed to delete collection from media server',
+            message: reason,
           };
         }
       }
@@ -3870,6 +3918,7 @@ export class CollectionsService {
     name: string,
     libraryId: string,
     searchAllLibraries = false,
+    expectedType?: MediaItemType,
   ): Promise<MediaCollection | undefined> {
     // Cannot search for collections without a valid library ID
     if (!libraryId || libraryId === '') {
@@ -3887,6 +3936,7 @@ export class CollectionsService {
         mediaServer,
         name,
         libraryId,
+        expectedType,
       );
       if (found) {
         return found;
@@ -3930,6 +3980,7 @@ export class CollectionsService {
               mediaServer,
               name,
               library.id,
+              expectedType,
             );
             if (crossLibraryMatch) {
               return crossLibraryMatch;
@@ -3961,6 +4012,7 @@ export class CollectionsService {
     mediaServer: IMediaServerService,
     name: string,
     libraryId: string,
+    expectedType?: MediaItemType,
   ): Promise<MediaCollection | undefined> {
     // Live read: a stale miss here creates a duplicate.
     const collections = await mediaServer.getCollections(libraryId, false);
@@ -3968,9 +4020,27 @@ export class CollectionsService {
       return undefined;
     }
     const target = name.trim();
-    return collections.find(
+    const named = collections.filter(
       (coll) => coll.title.trim() === target && !coll.smart,
     );
+
+    // An unknown type on either side matches: a false miss makes the caller
+    // create a second collection beside the real one, which is the #3344 class
+    // of bug and worse than adopting a mismatched one.
+    const match = named.find(
+      (coll) =>
+        coll.type === undefined ||
+        expectedType === undefined ||
+        coll.type === expectedType,
+    );
+
+    if (!match && named.length > 0) {
+      this.logger.warn(
+        `A collection named "${target}" exists in library ${libraryId} but holds ${named[0].type} items, not ${expectedType} - leaving it alone.`,
+      );
+    }
+
+    return match;
   }
 
   async getCollectionLogsWithPaging(

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -1964,8 +1964,10 @@ export class CollectionsService {
 
           collection.mediaServerId = foundCollection.id;
         } else {
+          // The name is only one of the reasons it can miss: a collection of
+          // the wrong media type is left alone too, and says so a line above.
           this.logger.error(
-            `Manual collection not found.. Is the spelling correct? `,
+            `Could not link the manual collection '${collection.manualCollectionName}'. Check the name, and that its media type matches the rule.`,
           );
           return undefined;
         }
@@ -2219,7 +2221,7 @@ export class CollectionsService {
         );
       } else {
         this.logger.error(
-          'Manual collection not found.. Is it still available in the media server?',
+          `Could not relink the manual collection '${collection.manualCollectionName}'. Check that it still exists and that its media type matches the rule.`,
         );
         await this.addLogRecord(
           { id: collection.id } as Collection,

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -2564,9 +2564,12 @@ export class CollectionsService {
           })
         : undefined;
 
-    // An add names its collection, so a missing one is the caller's mistake
-    // rather than an empty result to report as done.
-    if (action === 'add' && !collection) {
+    // Any action naming a collection needs it to exist. Without this a remove
+    // resolved its ids as a global action and then removed nothing, and an add
+    // had no collection to add to - both reported as done.
+    const namesCollection =
+      collectionDbId !== undefined && collectionDbId !== -1;
+    if ((namesCollection || action === 'add') && !collection) {
       throw new NotFoundException(`Collection ${collectionDbId} not found`);
     }
 
@@ -2594,13 +2597,29 @@ export class CollectionsService {
       mediaServerId: id,
     }));
 
+    // Both helpers swallow their own failures and answer undefined, so one bad
+    // collection cannot abort a rule run. A user waiting on the modal has to be
+    // told instead of watching it close on nothing.
+    const orFail = (collection: Collection | undefined): Collection => {
+      if (!collection) {
+        throw new BadGatewayException(
+          `The collection could not be updated. Check the logs for what failed.`,
+        );
+      }
+      return collection;
+    };
+
     if (action === 'add') {
       const result = await this.addToCollectionInternal(
         collectionDbId,
         handleMedia,
         true,
       );
-      return { ...result, resolvedCount: handleMedia.length };
+      return {
+        ...result,
+        collection: orFail(result.collection),
+        resolvedCount: handleMedia.length,
+      };
     }
 
     if (!collectionDbId) {
@@ -2609,7 +2628,9 @@ export class CollectionsService {
     }
 
     return {
-      collection: await this.removeFromCollection(collectionDbId, handleMedia),
+      collection: orFail(
+        await this.removeFromCollection(collectionDbId, handleMedia),
+      ),
       serverRejectedIds: [],
       resolvedCount: handleMedia.length,
     };

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -11,7 +11,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import axios from 'axios';
 import _ from 'lodash';
 import { DataSource, IsNull, Not, Repository } from 'typeorm';
-import { ServarrTagService } from '../actions/servarr-tag.service';
+import { ArrTagItem, ServarrTagService } from '../actions/servarr-tag.service';
 import cacheManager from '../api/lib/cache';
 import { MediaServerFactory } from '../api/media-server/media-server.factory';
 import { IMediaServerService } from '../api/media-server/media-server.interface';
@@ -294,9 +294,13 @@ export class RulesService {
 
       if (group) {
         if (group.collectionId) {
-          // Behavior A: deleting a tagging group makes every member "leave" - strip
-          // their *arr membership tags first (best-effort), while the collection
-          // media rows still exist (deleteCollection removes them next).
+          // Behavior A: deleting a tagging group makes every member "leave" -
+          // strip their *arr membership tags. The rows this needs are removed
+          // by deleteCollection, so read them first but only write to the *arr
+          // once the delete has gone through: a refused delete leaves the group
+          // standing, and untagging it anyway is damage nothing undoes.
+          let leavingMembers:
+            { collection: Collection; items: ArrTagItem[] } | undefined;
           try {
             const collection = await this.collectionService.getCollection(
               group.collectionId,
@@ -306,11 +310,10 @@ export class RulesService {
                 (await this.collectionService.getCollectionMedia(
                   group.collectionId,
                 )) ?? [];
-              await this.servarrTagService.syncMembershipTags(
+              leavingMembers = {
                 collection,
-                [],
-                members.map((m) => this.toArrTagItem(m)),
-              );
+                items: members.map((m) => this.toArrTagItem(m)),
+              };
             }
           } catch (error) {
             this.logger.debug(error);
@@ -330,6 +333,18 @@ export class RulesService {
               false,
               collectionDeleteResult.message || 'Delete Failed',
             );
+          }
+
+          if (leavingMembers) {
+            try {
+              await this.servarrTagService.syncMembershipTags(
+                leavingMembers.collection,
+                [],
+                leavingMembers.items,
+              );
+            } catch (error) {
+              this.logger.debug(error);
+            }
           }
         }
       }

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -915,6 +915,33 @@ export class RulesService {
     }
   }
 
+  /**
+   * Ids a context action applies to. The walk reads the media server, so a
+   * failure means we do not know what to act on - reported as a failed status
+   * rather than swallowed into "nothing to do".
+   */
+  private async resolveContextActionIdsOrFail(
+    mediaServer: IMediaServerService,
+    collectionType: MediaItemType | undefined,
+    context: { type: MediaItemType; id: string },
+    mediaId: string,
+  ): Promise<CollectionMediaChange[] | undefined> {
+    try {
+      const ids = await mediaServer.getAllIdsForContextAction(
+        collectionType,
+        context,
+        mediaId,
+      );
+      return ids.map((id) => ({ mediaServerId: id }));
+    } catch (error) {
+      this.logger.warn(
+        `Could not resolve which items to act on for media ${mediaId}`,
+      );
+      this.logger.debug(error);
+      return undefined;
+    }
+  }
+
   async setExclusion(data: ExclusionContextDto) {
     const mediaServer = await this.getMediaServer();
     let handleMedia: CollectionMediaChange[] = [];
@@ -928,14 +955,21 @@ export class RulesService {
         },
       });
       // get media - traverse show -> seasons -> episodes if needed
-      const ids = await mediaServer.getAllIdsForContextAction(
+      const resolved = await this.resolveContextActionIdsOrFail(
+        mediaServer,
         group?.dataType,
         data.context
           ? { type: data.context.type, id: String(data.context.id) }
           : { type: group.dataType, id: String(data.mediaId) },
         String(data.mediaId),
       );
-      handleMedia = ids.map((id) => ({ mediaServerId: id }));
+      if (!resolved) {
+        return this.createReturnStatus(
+          false,
+          'Failed - media server unreadable',
+        );
+      }
+      handleMedia = resolved;
       data.ruleGroupId = group.id;
       topLevelType = group?.dataType;
     } else {
@@ -949,14 +983,21 @@ export class RulesService {
       }
 
       // get media - traverse show -> seasons -> episodes if needed
-      const ids = await mediaServer.getAllIdsForContextAction(
+      const resolved = await this.resolveContextActionIdsOrFail(
+        mediaServer,
         undefined,
         data.context
           ? { type: data.context.type, id: String(data.context.id) }
           : { type: metaData.type, id: String(data.mediaId) },
         String(data.mediaId),
       );
-      handleMedia = ids.map((id) => ({ mediaServerId: id }));
+      if (!resolved) {
+        return this.createReturnStatus(
+          false,
+          'Failed - media server unreadable',
+        );
+      }
+      handleMedia = resolved;
       topLevelType = metaData.type;
     }
     try {
@@ -1135,22 +1176,36 @@ export class RulesService {
       data.ruleGroupId = group.id;
       topLevelType = group?.dataType;
       // get media - traverse show -> seasons -> episodes if needed
-      const ids = await mediaServer.getAllIdsForContextAction(
+      const resolved = await this.resolveContextActionIdsOrFail(
+        mediaServer,
         group?.dataType,
         data.context
           ? { type: data.context.type, id: String(data.context.id) }
           : { type: group.dataType, id: String(data.mediaId) },
         String(data.mediaId),
       );
-      handleMedia = ids.map((id) => ({ mediaServerId: id }));
+      if (!resolved) {
+        return this.createReturnStatus(
+          false,
+          'Failed - media server unreadable',
+        );
+      }
+      handleMedia = resolved;
     } else {
       // get media - traverse show -> seasons -> episodes if needed
-      const ids = await mediaServer.getAllIdsForContextAction(
+      const resolved = await this.resolveContextActionIdsOrFail(
+        mediaServer,
         undefined,
         { type: data.context.type, id: String(data.context.id) },
         String(data.mediaId),
       );
-      handleMedia = ids.map((id) => ({ mediaServerId: id }));
+      if (!resolved) {
+        return this.createReturnStatus(
+          false,
+          'Failed - media server unreadable',
+        );
+      }
+      handleMedia = resolved;
     }
 
     try {

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -59,6 +59,9 @@ describe('RuleExecutorService', () => {
       getSiblingRuleOwnedMediaServerIds: jest
         .fn()
         .mockResolvedValue(new Set<string>()),
+      getSiblingMemberMediaServerIds: jest
+        .fn()
+        .mockResolvedValue(new Set<string>()),
       reconcileRuleRemovedOrphans: jest
         .fn()
         .mockResolvedValue(new Set<string>()),
@@ -603,6 +606,110 @@ describe('RuleExecutorService', () => {
     ).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('Could not determine sibling rule ownership'),
+    );
+  });
+
+  it('skips importing items a sibling collection holds as manual members', async () => {
+    const { service, mediaServer, collectionService } = createService(
+      MediaServerType.PLEX,
+    );
+
+    collectionService.getCollection.mockResolvedValue({
+      id: 1,
+      title: 'Shared Title',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+    } as any);
+    collectionService.checkAutomaticMediaServerLink.mockResolvedValue({
+      id: 1,
+      title: 'Shared Title',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+    } as any);
+    collectionService.getCollectionMedia.mockResolvedValue([]);
+    collectionService.getSiblingMemberMediaServerIds.mockResolvedValue(
+      new Set(['m-sibling-manual']),
+    );
+    mediaServer.getCollectionChildren.mockResolvedValue([
+      { id: 'm-sibling-manual' },
+      { id: 'm-truly-manual' },
+    ]);
+
+    await (
+      service as unknown as {
+        syncManualMediaServerToCollectionDB: (
+          ruleGroup: { id: number; collectionId: number },
+          collectionSyncChanges: {
+            addedMediaServerIds: Set<string>;
+            removedMediaServerIds: Set<string>;
+          },
+        ) => Promise<void>;
+      }
+    ).syncManualMediaServerToCollectionDB(
+      { id: 10, collectionId: 1 },
+      {
+        addedMediaServerIds: new Set(),
+        removedMediaServerIds: new Set(),
+      },
+    );
+
+    expect(
+      collectionService.syncMediaServerChildrenToCollection,
+    ).toHaveBeenCalledWith(
+      expect.anything(),
+      [expect.objectContaining({ mediaServerId: 'm-truly-manual' })],
+      'local',
+    );
+  });
+
+  it('skips manual child import when sibling membership lookup fails', async () => {
+    const { service, mediaServer, collectionService, logger } = createService(
+      MediaServerType.PLEX,
+    );
+
+    collectionService.getCollection.mockResolvedValue({
+      id: 1,
+      title: 'Shared Title',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+    } as any);
+    collectionService.checkAutomaticMediaServerLink.mockResolvedValue({
+      id: 1,
+      title: 'Shared Title',
+      mediaServerId: 'coll-1',
+      manualCollection: false,
+    } as any);
+    collectionService.getCollectionMedia.mockResolvedValue([]);
+    collectionService.getSiblingMemberMediaServerIds.mockRejectedValue(
+      new Error('db down'),
+    );
+    mediaServer.getCollectionChildren.mockResolvedValue([
+      { id: 'm-truly-manual' },
+    ]);
+
+    await (
+      service as unknown as {
+        syncManualMediaServerToCollectionDB: (
+          ruleGroup: { id: number; collectionId: number },
+          collectionSyncChanges: {
+            addedMediaServerIds: Set<string>;
+            removedMediaServerIds: Set<string>;
+          },
+        ) => Promise<void>;
+      }
+    ).syncManualMediaServerToCollectionDB(
+      { id: 10, collectionId: 1 },
+      {
+        addedMediaServerIds: new Set(),
+        removedMediaServerIds: new Set(),
+      },
+    );
+
+    expect(
+      collectionService.syncMediaServerChildrenToCollection,
+    ).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Could not determine sibling membership'),
     );
   });
 

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -470,17 +470,25 @@ export class RuleExecutorService {
           // Members a sibling collection holds under any membership type. The
           // rule-owned set above drives reconcile; this wider one guards
           // adoption, because a sibling's manual-only member is still theirs.
-          let siblingMemberIds = new Set<string>();
+          // Unknown membership refuses the import for the same reason unknown
+          // ownership does.
+          let siblingMemberIds: Set<string> | undefined;
           try {
             siblingMemberIds =
               await this.collectionService.getSiblingMemberMediaServerIds(
                 collection,
               );
           } catch (error) {
+            this.logger.warn(
+              `Could not determine sibling membership for '${collection.title}'. Skipping manual child import to avoid cross-rule contamination.`,
+            );
             this.logger.debug(error);
           }
 
-          if (siblingRuleOwnedIds !== undefined) {
+          if (
+            siblingRuleOwnedIds !== undefined &&
+            siblingMemberIds !== undefined
+          ) {
             // Heal items a rule removed that the media server never dropped: an
             // active marker means the item is our orphan, not a user's manual
             // add, so remove it from the server rather than re-adopt it below.

--- a/apps/ui/src/components/AddModal/index.spec.tsx
+++ b/apps/ui/src/components/AddModal/index.spec.tsx
@@ -242,6 +242,59 @@ describe('AddModal - context payload', () => {
     ])
   })
 
+  // A slow read for the wider selection used to land last and re-offer
+  // collection types the current selection cannot fill.
+  it('ignores a collection read the selection has moved past', async () => {
+    let releaseWide: (value: unknown) => void = () => {}
+    const wide = new Promise((resolve) => {
+      releaseWide = resolve
+    })
+
+    getApiHandlerMock.mockImplementation(((url: string) => {
+      if (url.startsWith('/media-server/meta/'))
+        return Promise.resolve([
+          { id: 'season-1', title: 'Season 1', index: 1 },
+        ])
+      // The show read only happens for the wider "all seasons" selection.
+      if (url.startsWith('/collections?typeId=show'))
+        return wide.then(() => [{ id: 1, title: 'Show collection' }])
+      if (url.startsWith('/collections?typeId=season'))
+        return Promise.resolve([{ id: 2, title: 'Season collection' }])
+      if (url.startsWith('/collections?typeId=episode'))
+        return Promise.resolve([{ id: 3, title: 'Episode collection' }])
+      return Promise.resolve(undefined)
+    }) as typeof GetApiHandler)
+
+    render(
+      <AddModal
+        mediaServerId="show-1"
+        type="show"
+        modalType="add"
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    // Narrow to a season while the wider read is still outstanding.
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Seasons' }), {
+      target: { value: 'season-1' },
+    })
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('option', { name: 'Show collection' }),
+      ).toBeNull(),
+    )
+
+    releaseWide(undefined)
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('option', { name: 'Season collection' }),
+      ).toBeTruthy(),
+    )
+    expect(screen.queryByRole('option', { name: 'Show collection' })).toBeNull()
+  })
+
   // A -1 context id let the server act on the show itself, so a season
   // collection received a show id and Plex answered 400 (#3381).
   it('identifies "all seasons" by the show id rather than a sentinel', async () => {

--- a/apps/ui/src/components/AddModal/index.spec.tsx
+++ b/apps/ui/src/components/AddModal/index.spec.tsx
@@ -185,6 +185,63 @@ describe('AddModal - context payload', () => {
   })
   afterEach(() => cleanup())
 
+  // Every failure used to be swallowed by a bare catch, so a refused add
+  // looked identical to a successful one (#3381).
+  it('shows why the server refused the action', async () => {
+    postApiHandlerMock.mockRejectedValue(
+      Object.assign(new Error('Request failed with status code 502'), {
+        isAxiosError: true,
+        response: {
+          data: { message: 'The media server refused 1 of 1 item(s)' },
+        },
+      }),
+    )
+    const onSubmit = vi.fn()
+
+    render(
+      <AddModal
+        mediaServerId="show-1"
+        type="show"
+        modalType="add"
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Submit' }))
+
+    expect(
+      await screen.findByText('The media server refused 1 of 1 item(s)'),
+    ).toBeTruthy()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  // A season or episode can only go into a collection of that type, and the
+  // list is refetched as the picker narrows.
+  it('offers only the collection types the current selection can produce', async () => {
+    render(
+      <AddModal
+        mediaServerId="show-1"
+        type="show"
+        modalType="add"
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    await screen.findByRole('button', { name: 'Submit' })
+
+    const requested = getApiHandlerMock.mock.calls
+      .map((call) => String(call[0]))
+      .filter((url) => url.startsWith('/collections'))
+
+    expect(requested).toEqual([
+      '/collections?typeId=show',
+      '/collections?typeId=season',
+      '/collections?typeId=episode',
+    ])
+  })
+
   // A -1 context id let the server act on the show itself, so a season
   // collection received a show id and Plex answered 400 (#3381).
   it('identifies "all seasons" by the show id rather than a sentinel', async () => {

--- a/apps/ui/src/components/AddModal/index.spec.tsx
+++ b/apps/ui/src/components/AddModal/index.spec.tsx
@@ -242,6 +242,35 @@ describe('AddModal - context payload', () => {
     ])
   })
 
+  // The empty list used to say "Please select a collection" with nothing to
+  // select, and left Submit enabled.
+  it('explains an empty collection list instead of asking for a choice', async () => {
+    getApiHandlerMock.mockImplementation(((url: string) => {
+      if (url.startsWith('/media-server/meta/')) return Promise.resolve([])
+      if (url.startsWith('/collections')) return Promise.resolve([])
+      return Promise.resolve(undefined)
+    }) as typeof GetApiHandler)
+
+    render(
+      <AddModal
+        mediaServerId="show-1"
+        type="show"
+        modalType="add"
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    const submit = (await screen.findByRole('button', {
+      name: 'Submit',
+    })) as HTMLButtonElement
+    await waitFor(() => expect(submit.disabled).toBe(true))
+    expect(
+      screen.getByText(/No collection in this library can take this item/),
+    ).toBeTruthy()
+    expect(screen.queryByText('Please select a collection')).toBeNull()
+  })
+
   // A slow read for the wider selection used to land last and re-offer
   // collection types the current selection cannot fill.
   it('ignores a collection read the selection has moved past', async () => {

--- a/apps/ui/src/components/AddModal/index.tsx
+++ b/apps/ui/src/components/AddModal/index.tsx
@@ -23,7 +23,6 @@ const AddModal = (props: IAddModal) => {
     number | string
   >()
   const [loading, setLoading] = useState(true)
-  const [alert, setAlert] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string>()
   const [forceRemovalCheck, setForceRemovalCheck] = useState(false)
   const [globalWarning, setGlobalWarning] = useState(false)
@@ -102,6 +101,9 @@ const AddModal = (props: IAddModal) => {
   }, [selectedContext])
 
   const currentCollectionId = selectedCollection ?? collectionOptions[0]?.id
+  // Nothing in this library holds what the current selection resolves to, so
+  // there is no choice to make and submitting cannot do anything.
+  const noCollectionsAvailable = !loading && collectionOptions.length === 0
 
   const handleCancel = () => {
     props.onCancel()
@@ -159,11 +161,7 @@ const AddModal = (props: IAddModal) => {
   }
 
   const handleOk = async () => {
-    if (submitting) return
-    if (currentCollectionId === undefined) {
-      setAlert(true)
-      return
-    }
+    if (submitting || noCollectionsAvailable) return
 
     // Only ADDING a global exclusion clears the item's rule-group exclusions.
     // If it has any, warn and list each as "item - rule group", reusing the
@@ -357,7 +355,7 @@ const AddModal = (props: IAddModal) => {
           <Button
             buttonType="primary"
             className="ml-3"
-            disabled={submitting}
+            disabled={submitting || noCollectionsAvailable}
             onClick={handleOk}
           >
             {submitting ? 'Submitting...' : 'Submit'}
@@ -437,8 +435,11 @@ const AddModal = (props: IAddModal) => {
           </Modal>
         ) : undefined}
 
-        {alert ? (
-          <Alert title="Please select a collection" type="warning" />
+        {noCollectionsAvailable ? (
+          <Alert
+            title="No collection in this library can take this item. Create one from a rule first."
+            type="warning"
+          />
         ) : undefined}
 
         {errorMessage ? <Alert title={errorMessage} type="error" /> : undefined}

--- a/apps/ui/src/components/AddModal/index.tsx
+++ b/apps/ui/src/components/AddModal/index.tsx
@@ -32,22 +32,23 @@ const AddModal = (props: IAddModal) => {
   >([])
   const [submitting, setSubmitting] = useState(false)
   const [selectedAction, setSelectedAction] = useState<number>(0)
-  // For show only
-  const [selectedSeasons, setSelectedSeasons] = useState<number | string>(-1)
-  const [selectedEpisodes, setSelectedEpisodes] = useState<number | string>(-1)
+  // For show only. Undefined is "all", so the picker never carries a value the
+  // media server would have to interpret.
+  const [selectedSeasons, setSelectedSeasons] = useState<string>()
+  const [selectedEpisodes, setSelectedEpisodes] = useState<string>()
 
   const [collectionOptions, setCollectionOptions] = useState<
     ICollectionMedia[]
   >([])
   const [seasonOptions, setSeasonOptions] = useState<ICollectionMedia[]>([
     {
-      id: -1,
+      id: '',
       title: 'All seasons',
     },
   ])
   const [episodeOptions, setEpisodeOptions] = useState<ICollectionMedia[]>([
     {
-      id: -1,
+      id: '',
       title: 'All episodes',
     },
   ])
@@ -67,13 +68,10 @@ const AddModal = (props: IAddModal) => {
 
   // The context is the narrowest thing picked; with no season or episode
   // selected that is the item itself. Same shape as TestMediaItem.
-  const selectedMediaId = useMemo(() => {
-    return selectedEpisodes !== -1
-      ? selectedEpisodes
-      : selectedSeasons !== -1
-        ? selectedSeasons
-        : props.mediaServerId
-  }, [selectedSeasons, selectedEpisodes, props.mediaServerId])
+  const selectedMediaId = useMemo(
+    () => selectedEpisodes ?? selectedSeasons ?? props.mediaServerId,
+    [selectedSeasons, selectedEpisodes, props.mediaServerId],
+  )
 
   // Only a show narrows through the season and episode pickers; every other
   // item is its own context. Reporting a season or episode as a movie offered
@@ -83,11 +81,9 @@ const AddModal = (props: IAddModal) => {
       return props.type ?? 'movie'
     }
 
-    return selectedEpisodes !== -1
-      ? 'episode'
-      : selectedSeasons !== -1
-        ? 'season'
-        : 'show'
+    if (selectedEpisodes) return 'episode'
+    if (selectedSeasons) return 'season'
+    return 'show'
   }, [selectedSeasons, selectedEpisodes, props.type])
 
   // A context resolves down the hierarchy but never up, so offer exactly the
@@ -245,7 +241,7 @@ const AddModal = (props: IAddModal) => {
         .then((resp: { id: string; title: string }[]) => {
           setSeasonOptions([
             {
-              id: -1,
+              id: '',
               title: 'All seasons',
             },
             ...resp.map((el) => {
@@ -266,7 +262,7 @@ const AddModal = (props: IAddModal) => {
   }, [props.mediaServerId, props.type])
 
   useEffect(() => {
-    if (selectedSeasons === -1) return
+    if (!selectedSeasons) return
 
     // A slower read for the season the user just moved off would otherwise
     // land last and list the wrong season's episodes.
@@ -277,7 +273,7 @@ const AddModal = (props: IAddModal) => {
         if (!current) return
         setEpisodeOptions([
           {
-            id: -1,
+            id: '',
             title: 'All episodes',
           },
           ...resp.map((el) => {
@@ -476,18 +472,18 @@ const AddModal = (props: IAddModal) => {
               <Select
                 name={`Seasons-field`}
                 id={`Seasons-field`}
-                value={selectedSeasons}
+                value={selectedSeasons ?? ''}
                 onChange={(e: { target: { value: string } }) => {
                   const value = e.target.value
                   setLoading(true)
-                  setSelectedEpisodes(-1)
+                  setSelectedEpisodes(undefined)
                   setEpisodeOptions([
                     {
-                      id: -1,
+                      id: '',
                       title: 'All episodes',
                     },
                   ])
-                  setSelectedSeasons(value === '-1' ? -1 : value)
+                  setSelectedSeasons(value || undefined)
                 }}
               >
                 {seasonOptions.map((e: ICollectionMedia) => {
@@ -501,16 +497,16 @@ const AddModal = (props: IAddModal) => {
             </FormItem>
           ) : undefined}
           {/* For shows and specific seasons */}
-          {props.type === 'show' && selectedSeasons !== -1 ? (
+          {props.type === 'show' && selectedSeasons ? (
             <FormItem label="Episodes">
               <Select
                 name={`Episodes-field`}
                 id={`Episodes-field`}
-                value={selectedEpisodes}
+                value={selectedEpisodes ?? ''}
                 onChange={(e: { target: { value: string } }) => {
                   const value = e.target.value
                   setLoading(true)
-                  setSelectedEpisodes(value === '-1' ? -1 : value)
+                  setSelectedEpisodes(value || undefined)
                 }}
               >
                 {episodeOptions.map((e: ICollectionMedia) => {

--- a/apps/ui/src/components/AddModal/index.tsx
+++ b/apps/ui/src/components/AddModal/index.tsx
@@ -1,8 +1,9 @@
-import { MediaItemType } from '@maintainerr/contracts'
+import { BasicResponseDto, MediaItemType } from '@maintainerr/contracts'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { invalidateCollectionQueries } from '../../api/collections'
+import { getApiErrorMessage } from '../../utils/ApiError'
 import GetApiHandler, { PostApiHandler } from '../../utils/ApiHandler'
 import Alert from '../Common/Alert'
 import {
@@ -23,6 +24,7 @@ const AddModal = (props: IAddModal) => {
   >()
   const [loading, setLoading] = useState(true)
   const [alert, setAlert] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string>()
   const [forceRemovalCheck, setForceRemovalCheck] = useState(false)
   const [globalWarning, setGlobalWarning] = useState(false)
   const [affectedExclusions, setAffectedExclusions] = useState<
@@ -73,15 +75,35 @@ const AddModal = (props: IAddModal) => {
         : props.mediaServerId
   }, [selectedSeasons, selectedEpisodes, props.mediaServerId])
 
+  // Only a show narrows through the season and episode pickers; every other
+  // item is its own context. Reporting a season or episode as a movie offered
+  // it movie collections, which no media server accepts it into.
   const selectedContext = useMemo((): MediaItemType => {
-    return props.type === 'show'
-      ? selectedEpisodes !== -1
-        ? 'episode'
-        : selectedSeasons !== -1
-          ? 'season'
-          : 'show'
-      : 'movie'
+    if (props.type !== 'show') {
+      return props.type ?? 'movie'
+    }
+
+    return selectedEpisodes !== -1
+      ? 'episode'
+      : selectedSeasons !== -1
+        ? 'season'
+        : 'show'
   }, [selectedSeasons, selectedEpisodes, props.type])
+
+  // A context resolves down the hierarchy but never up, so offer exactly the
+  // collection types the current selection can produce.
+  const collectionTypes = useMemo((): MediaItemType[] => {
+    switch (selectedContext) {
+      case 'show':
+        return ['show', 'season', 'episode']
+      case 'season':
+        return ['season', 'episode']
+      case 'episode':
+        return ['episode']
+      default:
+        return ['movie']
+    }
+  }, [selectedContext])
 
   const currentCollectionId = selectedCollection ?? collectionOptions[0]?.id
 
@@ -108,18 +130,35 @@ const AddModal = (props: IAddModal) => {
 
         await invalidateCollectionQueries(queryClient)
       } else {
-        await PostApiHandler('/rules/exclusion', {
-          mediaId: props.mediaServerId,
-          context: mediaDto,
-          collectionId:
-            currentCollectionId !== -1 ? currentCollectionId : undefined,
-          action: selectedAction,
-        })
+        // The exclusion endpoint reports its own failures in the body rather
+        // than the status code, so a rejected exclusion looked successful.
+        const result = await PostApiHandler<BasicResponseDto>(
+          '/rules/exclusion',
+          {
+            mediaId: props.mediaServerId,
+            context: mediaDto,
+            collectionId:
+              currentCollectionId !== -1 ? currentCollectionId : undefined,
+            action: selectedAction,
+          },
+        )
+
+        if (result?.code !== 1) {
+          throw new Error(result?.message ?? 'The exclusion could not be saved')
+        }
       }
 
       props.onSubmit()
-    } catch {
+    } catch (error) {
       setSubmitting(false)
+      setErrorMessage(
+        getApiErrorMessage(
+          error,
+          props.modalType === 'add'
+            ? 'The collection could not be updated'
+            : 'The exclusion could not be updated',
+        ),
+      )
     }
   }
 
@@ -189,15 +228,21 @@ const AddModal = (props: IAddModal) => {
         await invalidateCollectionQueries(queryClient)
       }
       props.onSubmit()
-    } catch {
+    } catch (error) {
       setSubmitting(false)
+      setErrorMessage(
+        getApiErrorMessage(
+          error,
+          'The media could not be removed from all collections',
+        ),
+      )
     }
   }
 
   useEffect(() => {
     if (props.type && props.type === 'show') {
-      GetApiHandler(`/media-server/meta/${props.mediaServerId}/children`).then(
-        (resp: { id: string; title: string }[]) => {
+      GetApiHandler(`/media-server/meta/${props.mediaServerId}/children`)
+        .then((resp: { id: string; title: string }[]) => {
           setSeasonOptions([
             {
               id: -1,
@@ -210,16 +255,20 @@ const AddModal = (props: IAddModal) => {
               } as ICollectionMedia
             }),
           ])
-          setLoading(false)
-        },
-      )
+        })
+        .catch((error) =>
+          setErrorMessage(
+            getApiErrorMessage(error, 'Could not load the seasons'),
+          ),
+        )
+        .finally(() => setLoading(false))
     }
   }, [props.mediaServerId, props.type])
 
   useEffect(() => {
     if (selectedSeasons !== -1) {
-      GetApiHandler(`/media-server/meta/${selectedSeasons}/children`).then(
-        (resp: { id: string; index: number }[]) => {
+      GetApiHandler(`/media-server/meta/${selectedSeasons}/children`)
+        .then((resp: { id: string; index: number }[]) => {
           setEpisodeOptions([
             {
               id: -1,
@@ -232,48 +281,46 @@ const AddModal = (props: IAddModal) => {
               } as ICollectionMedia
             }),
           ])
-          setLoading(false)
-        },
-      )
+        })
+        .catch((error) =>
+          setErrorMessage(
+            getApiErrorMessage(error, 'Could not load the episodes'),
+          ),
+        )
+        .finally(() => setLoading(false))
     }
   }, [selectedSeasons])
 
   useEffect(() => {
-    if (props.type === 'show') {
-      if (selectedEpisodes !== -1) {
-        GetApiHandler(`/collections?typeId=episode`).then((resp) => {
-          setCollectionOptions([...origCollectionOptions, ...resp])
-          setLoading(false)
-        })
-      } else if (selectedSeasons !== -1) {
-        GetApiHandler(`/collections?typeId=season`).then((resp) => {
-          GetApiHandler(`/collections?typeId=episode`).then((resp2) => {
-            setCollectionOptions([...origCollectionOptions, ...resp, ...resp2])
-            setLoading(false)
-          })
-        })
-      } else {
-        GetApiHandler(`/collections?typeId=show`).then((resp) => {
-          GetApiHandler(`/collections?typeId=season`).then((resp2) => {
-            GetApiHandler(`/collections?typeId=episode`).then((resp3) => {
-              setCollectionOptions([
-                ...origCollectionOptions,
-                ...resp,
-                ...resp2,
-                ...resp3,
-              ])
-              setLoading(false)
-            })
-          })
-        })
-      }
-    } else {
-      GetApiHandler(`/collections?typeId=movie`).then((resp) => {
-        setCollectionOptions([...origCollectionOptions, ...resp])
-        setLoading(false)
+    // A collection only accepts items from its own library, so offering the
+    // other libraries' collections only produces a rejected add.
+    const libraryQuery = props.libraryId
+      ? `&libraryId=${encodeURIComponent(props.libraryId)}`
+      : ''
+
+    Promise.all(
+      collectionTypes.map((type) =>
+        GetApiHandler<ICollectionMedia[]>(
+          `/collections?typeId=${type}${libraryQuery}`,
+        ),
+      ),
+    )
+      .then((responses) => {
+        const options = [...origCollectionOptions, ...responses.flat()]
+        setCollectionOptions(options)
+        // Narrowing to a season or episode drops the wider collection types,
+        // so a selection made before that can no longer be submitted.
+        setSelectedCollection((current) =>
+          options.some((option) => option.id === current) ? current : undefined,
+        )
       })
-    }
-  }, [origCollectionOptions, props.type, selectedEpisodes, selectedSeasons])
+      .catch((error) =>
+        setErrorMessage(
+          getApiErrorMessage(error, 'Could not load the collections'),
+        ),
+      )
+      .finally(() => setLoading(false))
+  }, [origCollectionOptions, collectionTypes, props.libraryId])
 
   return (
     <>
@@ -371,6 +418,8 @@ const AddModal = (props: IAddModal) => {
         {alert ? (
           <Alert title="Please select a collection" type="warning" />
         ) : undefined}
+
+        {errorMessage ? <Alert title={errorMessage} type="error" /> : undefined}
 
         <div className="mt-6">
           <FormItem label="Action">

--- a/apps/ui/src/components/AddModal/index.tsx
+++ b/apps/ui/src/components/AddModal/index.tsx
@@ -100,7 +100,15 @@ const AddModal = (props: IAddModal) => {
     }
   }, [selectedContext])
 
-  const currentCollectionId = selectedCollection ?? collectionOptions[0]?.id
+  // Derived, not synced: narrowing to a season or episode drops the wider
+  // collection types, so a selection made before that is no longer offered and
+  // falls back to the first option. Keeping the state lets it come back if the
+  // user widens the selection again.
+  const currentCollectionId = collectionOptions.some(
+    (option) => option.id === selectedCollection,
+  )
+    ? selectedCollection
+    : collectionOptions[0]?.id
   // Nothing in this library holds what the current selection resolves to, so
   // there is no choice to make and submitting cannot do anything.
   const noCollectionsAvailable = !loading && collectionOptions.length === 0
@@ -317,15 +325,7 @@ const AddModal = (props: IAddModal) => {
     )
       .then((responses) => {
         if (!current) return
-        const options = [...origCollectionOptions, ...responses.flat()]
-        setCollectionOptions(options)
-        // Narrowing to a season or episode drops the wider collection types,
-        // so a selection made before that can no longer be submitted.
-        setSelectedCollection((selected) =>
-          options.some((option) => option.id === selected)
-            ? selected
-            : undefined,
-        )
+        setCollectionOptions([...origCollectionOptions, ...responses.flat()])
       })
       .catch((error) => {
         if (current)

--- a/apps/ui/src/components/AddModal/index.tsx
+++ b/apps/ui/src/components/AddModal/index.tsx
@@ -266,28 +266,40 @@ const AddModal = (props: IAddModal) => {
   }, [props.mediaServerId, props.type])
 
   useEffect(() => {
-    if (selectedSeasons !== -1) {
-      GetApiHandler(`/media-server/meta/${selectedSeasons}/children`)
-        .then((resp: { id: string; index: number }[]) => {
-          setEpisodeOptions([
-            {
-              id: -1,
-              title: 'All episodes',
-            },
-            ...resp.map((el) => {
-              return {
-                id: el.id,
-                title: `Episode ${el.index}`,
-              } as ICollectionMedia
-            }),
-          ])
-        })
-        .catch((error) =>
+    if (selectedSeasons === -1) return
+
+    // A slower read for the season the user just moved off would otherwise
+    // land last and list the wrong season's episodes.
+    let current = true
+
+    GetApiHandler(`/media-server/meta/${selectedSeasons}/children`)
+      .then((resp: { id: string; index: number }[]) => {
+        if (!current) return
+        setEpisodeOptions([
+          {
+            id: -1,
+            title: 'All episodes',
+          },
+          ...resp.map((el) => {
+            return {
+              id: el.id,
+              title: `Episode ${el.index}`,
+            } as ICollectionMedia
+          }),
+        ])
+      })
+      .catch((error) => {
+        if (current)
           setErrorMessage(
             getApiErrorMessage(error, 'Could not load the episodes'),
-          ),
-        )
-        .finally(() => setLoading(false))
+          )
+      })
+      .finally(() => {
+        if (current) setLoading(false)
+      })
+
+    return () => {
+      current = false
     }
   }, [selectedSeasons])
 
@@ -298,6 +310,10 @@ const AddModal = (props: IAddModal) => {
       ? `&libraryId=${encodeURIComponent(props.libraryId)}`
       : ''
 
+    // A slower read for the wider selection the user just moved off would
+    // otherwise land last and re-offer collection types this one cannot fill.
+    let current = true
+
     Promise.all(
       collectionTypes.map((type) =>
         GetApiHandler<ICollectionMedia[]>(
@@ -306,20 +322,30 @@ const AddModal = (props: IAddModal) => {
       ),
     )
       .then((responses) => {
+        if (!current) return
         const options = [...origCollectionOptions, ...responses.flat()]
         setCollectionOptions(options)
         // Narrowing to a season or episode drops the wider collection types,
         // so a selection made before that can no longer be submitted.
-        setSelectedCollection((current) =>
-          options.some((option) => option.id === current) ? current : undefined,
+        setSelectedCollection((selected) =>
+          options.some((option) => option.id === selected)
+            ? selected
+            : undefined,
         )
       })
-      .catch((error) =>
-        setErrorMessage(
-          getApiErrorMessage(error, 'Could not load the collections'),
-        ),
-      )
-      .finally(() => setLoading(false))
+      .catch((error) => {
+        if (current)
+          setErrorMessage(
+            getApiErrorMessage(error, 'Could not load the collections'),
+          )
+      })
+      .finally(() => {
+        if (current) setLoading(false)
+      })
+
+    return () => {
+      current = false
+    }
   }, [origCollectionOptions, collectionTypes, props.libraryId])
 
   return (

--- a/apps/ui/src/components/Rules/RuleGroup/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/index.tsx
@@ -82,7 +82,9 @@ const RuleGroup = (props: {
     DeleteApiHandler(`/rules/${props.group.id}`)
       .then((resp) => {
         if (resp.code === 1) props.onDelete()
-        else toast.error('Failed to delete rule group.')
+        // The media server explains a refused delete, and it stays refused
+        // until the user acts on the reason.
+        else toast.error(resp.message || 'Failed to delete rule group.')
       })
       .catch((error: unknown) => {
         void logClientError(

--- a/packages/contracts/src/media-server/types.ts
+++ b/packages/contracts/src/media-server/types.ts
@@ -155,6 +155,12 @@ export interface WatchRecord {
 export interface MediaCollection {
   id: string
   title: string
+  /**
+   * Media type the collection holds, where the server has the concept. Plex
+   * fixes it at creation and rejects anything else; Jellyfin and Emby BoxSets
+   * have no subtype, so it stays undefined there.
+   */
+  type?: MediaItemType
   summary?: string
   thumb?: string
   childCount: number


### PR DESCRIPTION
Follow-up to #3382, which fixed adding a whole show to a season or episode collection.

**The main problem:** when an add failed, Maintainerr said it worked. The modal closed, the item was not there, and the only clue was a 400 buried in the debug log. That is why #3381 was hard to pin down. Failed adds now return a real error, and the modal shows it and stays open.

**Other reasons the same add was rejected:**

- A season or episode was treated as a movie, so only movie collections were offered for it.
- The collection list was not filtered by library, so you could pick a collection from another Plex library. Plex rejects that.
- A collection was matched by name alone, so a season rule group could latch onto a collection holding shows, which Plex then rejects every add to.
- Asking for one library's collections ignored the type filter, so the same collection was listed several times.

**Also fixed:**

- A failed read of a show's seasons or episodes looked like "nothing to do", so the action quietly did nothing.
- Deleting a rule group: Plex refuses collection deletes when "allow media deletion" is off, and the reason was thrown away, so the delete failed forever with no explanation. It now says why. Members' Radarr and Sonarr tags were also removed before the delete was even attempted and never put back when it failed; they are now removed only once the delete works.
- A guard meant to stop one rule group adopting another's manually added items was never running.
- Watch history could count the same view twice.
- Changing the season or episode quickly could leave the wrong collections in the list.

**Testing:** run against the real Plex, Jellyfin and Emby dev servers - normal use, deliberately broken input, and faults forced through a proxy in front of Plex (refused deletes, duplicated history rows). The UI was checked in a browser on each server.