### PR TITLE
fix(rules): answer a status code when a rule group cannot be saved, and drop the add modal's fetch effects

### DIFF
--- a/apps/server/src/modules/rules/rules.controller.spec.ts
+++ b/apps/server/src/modules/rules/rules.controller.spec.ts
@@ -1,0 +1,73 @@
+import { BadRequestException } from '@nestjs/common';
+import { MaintainerrLogger } from '../logging/logs.service';
+import { RulesController } from './rules.controller';
+import { RulesService } from './rules.service';
+import { RuleExecutorJobManagerService } from './tasks/rule-executor-job-manager.service';
+import { RuleExecutorSchedulerService } from './tasks/rule-executor-scheduler.service';
+
+describe('RulesController', () => {
+  let controller: RulesController;
+
+  const rulesService = {
+    setRules: jest.fn(),
+    updateRules: jest.fn(),
+  } as unknown as jest.Mocked<RulesService>;
+
+  const ruleExecutorSchedulerService =
+    {} as jest.Mocked<RuleExecutorSchedulerService>;
+  const ruleExecutorJobManagerService =
+    {} as jest.Mocked<RuleExecutorJobManagerService>;
+
+  const logger = {
+    setContext: jest.fn(),
+  } as unknown as jest.Mocked<MaintainerrLogger>;
+
+  const body = { name: 'Group', rules: [] } as never;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = new RulesController(
+      rulesService,
+      ruleExecutorSchedulerService,
+      ruleExecutorJobManagerService,
+      logger,
+    );
+  });
+
+  // A rejected rule group answered 201 with the reason in the body, so a
+  // caller could not tell it from a save (#3384).
+  it.each([
+    ['setRules', () => controller.setRules(body)],
+    ['updateRule', () => controller.updateRule(body)],
+  ])(
+    '%s answers 400 with the reason the rule group was rejected',
+    async (_name, call) => {
+      const rejected = {
+        code: 0 as const,
+        result: 'Operator is required for every rule after the first',
+        message: 'Operator is required for every rule after the first',
+      };
+      rulesService.setRules.mockResolvedValue(rejected);
+      rulesService.updateRules.mockResolvedValue(rejected);
+
+      await expect(call()).rejects.toThrow(BadRequestException);
+      await expect(call()).rejects.toThrow(
+        'Operator is required for every rule after the first',
+      );
+    },
+  );
+
+  it.each([
+    ['setRules', () => controller.setRules(body)],
+    ['updateRule', () => controller.updateRule(body)],
+  ])(
+    '%s returns the status when the rule group was saved',
+    async (_name, call) => {
+      const saved = { code: 1 as const, result: 'Success', message: 'Success' };
+      rulesService.setRules.mockResolvedValue(saved);
+      rulesService.updateRules.mockResolvedValue(saved);
+
+      await expect(call()).resolves.toEqual(saved);
+    },
+  );
+});

--- a/apps/server/src/modules/rules/rules.controller.ts
+++ b/apps/server/src/modules/rules/rules.controller.ts
@@ -257,6 +257,10 @@ export class RulesController {
     status: 502,
     description: 'The media server could not be read to resolve the library.',
   })
+  @ApiResponse({
+    status: 503,
+    description: 'The configured media server adapter could not initialize.',
+  })
   async setRules(@Body() body: RulesDto): Promise<ReturnStatus> {
     return this.orFail(await this.rulesService.setRules(body));
   }
@@ -299,6 +303,10 @@ export class RulesController {
   @ApiResponse({
     status: 502,
     description: 'The media server could not be read to resolve the library.',
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'The configured media server adapter could not initialize.',
   })
   async updateRule(@Body() body: RulesDto): Promise<ReturnStatus> {
     return this.orFail(await this.rulesService.updateRules(body));

--- a/apps/server/src/modules/rules/rules.controller.ts
+++ b/apps/server/src/modules/rules/rules.controller.ts
@@ -1,5 +1,6 @@
 import { MediaItemType, RuleExecuteStatusDto } from '@maintainerr/contracts';
 import {
+  BadRequestException,
   Body,
   ConflictException,
   Controller,
@@ -232,9 +233,18 @@ export class RulesController {
     res.status(HttpStatus.ACCEPTED).send();
   }
 
+  // A rule group that failed validation used to answer 201 with the reason
+  // buried in the body, so a caller could not tell it apart from a save.
+  private orFail(status: ReturnStatus): ReturnStatus {
+    if (status.code !== 1) {
+      throw new BadRequestException(status.message ?? status.result);
+    }
+    return status;
+  }
+
   @Post()
   async setRules(@Body() body: RulesDto): Promise<ReturnStatus> {
-    return await this.rulesService.setRules(body);
+    return this.orFail(await this.rulesService.setRules(body));
   }
 
   @Post('/exclusion')
@@ -262,7 +272,7 @@ export class RulesController {
 
   @Put()
   async updateRule(@Body() body: RulesDto): Promise<ReturnStatus> {
-    return await this.rulesService.updateRules(body);
+    return this.orFail(await this.rulesService.updateRules(body));
   }
 
   @Post('/community')

--- a/apps/server/src/modules/rules/rules.controller.ts
+++ b/apps/server/src/modules/rules/rules.controller.ts
@@ -243,6 +243,20 @@ export class RulesController {
   }
 
   @Post()
+  @ApiResponse({ status: 201, description: 'The rule group was created.' })
+  @ApiResponse({
+    status: 400,
+    description:
+      'The rule group was rejected. The message names what was wrong.',
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'The rule group could not be written. The cause is logged.',
+  })
+  @ApiResponse({
+    status: 502,
+    description: 'The media server could not be read to resolve the library.',
+  })
   async setRules(@Body() body: RulesDto): Promise<ReturnStatus> {
     return this.orFail(await this.rulesService.setRules(body));
   }
@@ -271,6 +285,21 @@ export class RulesController {
   }
 
   @Put()
+  @ApiResponse({ status: 200, description: 'The rule group was updated.' })
+  @ApiResponse({
+    status: 400,
+    description:
+      'The rule group was rejected. The message names what was wrong.',
+  })
+  @ApiResponse({ status: 404, description: 'The rule group does not exist.' })
+  @ApiResponse({
+    status: 500,
+    description: 'The rule group could not be written. The cause is logged.',
+  })
+  @ApiResponse({
+    status: 502,
+    description: 'The media server could not be read to resolve the library.',
+  })
   async updateRule(@Body() body: RulesDto): Promise<ReturnStatus> {
     return this.orFail(await this.rulesService.updateRules(body));
   }

--- a/apps/server/src/modules/rules/rules.service.setRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.setRules.spec.ts
@@ -61,13 +61,34 @@ describe('RulesService.setRules', () => {
     },
   ];
 
-  const createMediaServerFactory = () => ({
+  const createMediaServerFactory = (
+    libraries: unknown[] = [{ id: '1', title: 'Movies', type: 'movie' }],
+  ) => ({
     getService: jest.fn().mockReturnValue({
-      getLibraries: jest
-        .fn()
-        .mockResolvedValue([{ id: '1', title: 'Movies', type: 'movie' }]),
+      getLibraries: jest.fn().mockResolvedValue(libraries),
     }),
   });
+
+  const setRulesFor = (libraryId: unknown, libraries?: unknown[]) => {
+    const service = createRulesService({
+      collectionService: {
+        createCollection: jest
+          .fn()
+          .mockResolvedValue({ dbCollection: { id: 9 } }),
+      },
+      mediaServerFactory: createMediaServerFactory(libraries),
+    });
+
+    return service.setRules({
+      libraryId,
+      name: 'Library probe',
+      description: '',
+      useRules: true,
+      isActive: true,
+      rules: validRules,
+      collection: { keepLogsForMonths: 6 },
+    } as any);
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -260,6 +281,31 @@ describe('RulesService.setRules', () => {
       status: 500,
       message: 'Failed to create collection',
     });
+  });
+
+  // A library the caller never named, or named wrongly, is a bad request - not
+  // the 500 a dereferenced library used to produce (#3384).
+  it.each([
+    ['no library', undefined],
+    ['an empty library', ''],
+  ])('rejects a rule group with %s', async (_name, libraryId) => {
+    await expect(setRulesFor(libraryId)).rejects.toMatchObject({
+      status: 400,
+      message: 'A library is required',
+    });
+  });
+
+  it('rejects a library the media server does not have', async () => {
+    await expect(setRulesFor('999')).rejects.toMatchObject({
+      status: 400,
+      message: 'Library 999 does not exist on the media server',
+    });
+  });
+
+  // Every getLibraries path answers [] when the media server is unreachable, so
+  // an empty list must not be read as "the caller named a bad library".
+  it('blames the media server, not the caller, when no library can be read', async () => {
+    await expect(setRulesFor('1', [])).rejects.toMatchObject({ status: 502 });
   });
 
   it('fails with a server error, and logs the cause, when saving throws', async () => {

--- a/apps/server/src/modules/rules/rules.service.setRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.setRules.spec.ts
@@ -234,9 +234,9 @@ describe('RulesService.setRules', () => {
 
   // Regression for #3044: when collection creation fails, setRules used to
   // `return undefined`, which NestJS serialized as a silent HTTP 201 with an
-  // empty body - indistinguishable from success to the client. It must now
-  // return a structured failure the UI can surface.
-  it('returns a structured failure (not undefined) when collection creation fails', async () => {
+  // empty body - indistinguishable from success to the client. A returned
+  // failure was still a 201, so it now answers with a status code (#3384).
+  it('fails with a server error when collection creation fails', async () => {
     const service = createRulesService({
       collectionService: {
         createCollection: jest
@@ -246,24 +246,23 @@ describe('RulesService.setRules', () => {
       mediaServerFactory: createMediaServerFactory(),
     });
 
-    const result = await service.setRules({
-      libraryId: '1',
-      name: 'Collection fails',
-      description: '',
-      useRules: true,
-      isActive: true,
-      rules: validRules,
-      collection: { keepLogsForMonths: 6 },
-    } as any);
-
-    expect(result).toEqual({
-      code: 0,
-      result: 'Failed to create collection',
+    await expect(
+      service.setRules({
+        libraryId: '1',
+        name: 'Collection fails',
+        description: '',
+        useRules: true,
+        isActive: true,
+        rules: validRules,
+        collection: { keepLogsForMonths: 6 },
+      } as any),
+    ).rejects.toMatchObject({
+      status: 500,
       message: 'Failed to create collection',
     });
   });
 
-  it('returns a structured failure (not undefined) when saving throws', async () => {
+  it('fails with a server error, and logs the cause, when saving throws', async () => {
     const service = createRulesService({
       collectionService: {
         createCollection: jest
@@ -273,20 +272,22 @@ describe('RulesService.setRules', () => {
       mediaServerFactory: createMediaServerFactory(),
     });
 
-    const result = await service.setRules({
-      libraryId: '1',
-      name: 'Throws',
-      description: '',
-      useRules: true,
-      isActive: true,
-      rules: validRules,
-      collection: { keepLogsForMonths: 6 },
-    } as any);
-
-    expect(result).toEqual({
-      code: 0,
-      result: 'Failed to save the rule group',
+    await expect(
+      service.setRules({
+        libraryId: '1',
+        name: 'Throws',
+        description: '',
+        useRules: true,
+        isActive: true,
+        rules: validRules,
+        collection: { keepLogsForMonths: 6 },
+      } as any),
+    ).rejects.toMatchObject({
+      status: 500,
       message: 'Failed to save the rule group',
     });
+    // Short reason at error, the stack behind debug.
+    expect(logger.error).toHaveBeenCalledWith('Failed to save the rule group');
+    expect(logger.debug).toHaveBeenCalledWith(expect.any(Error));
   });
 });

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -5,7 +5,12 @@ import {
   MediaItemType,
   MediaServerType,
 } from '@maintainerr/contracts';
-import { Injectable } from '@nestjs/common';
+import {
+  HttpException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import axios from 'axios';
@@ -469,7 +474,7 @@ export class RulesService {
       )?.dbCollection;
 
       if (!collection) {
-        return this.createReturnStatus(false, 'Failed to create collection');
+        throw new InternalServerErrorException('Failed to create collection');
       }
 
       const groupId = await this.createOrUpdateGroup(
@@ -502,9 +507,7 @@ export class RulesService {
 
       return state;
     } catch (error) {
-      this.logger.warn('Rules - Action failed');
-      this.logger.debug(error);
-      return this.createReturnStatus(false, 'Failed to save the rule group');
+      throw this.asSaveFailure(error);
     }
   }
 
@@ -546,7 +549,7 @@ export class RulesService {
         });
 
         if (!group) {
-          return this.createReturnStatus(false, 'Rule group not found');
+          throw new NotFoundException('Rule group not found');
         }
 
         const dbCollection = group.collectionId
@@ -704,8 +707,7 @@ export class RulesService {
         }
 
         if (!collectionId) {
-          return this.createReturnStatus(
-            false,
+          throw new InternalServerErrorException(
             'Failed to create/update collection',
           );
         }
@@ -773,11 +775,24 @@ export class RulesService {
         return state;
       }
     } catch (error) {
-      this.logger.warn('Rules - Action failed');
-      this.logger.debug(error);
-      return this.createReturnStatus(false, 'Failed to save the rule group');
+      throw this.asSaveFailure(error);
     }
   }
+
+  // A rule group that could not be saved answers with a status the caller can
+  // act on, not a 201 carrying a failure in the body. Anything already
+  // classified (the group is gone, the collection could not be written) keeps
+  // its own status; only an unclassified fault becomes a 500.
+  private asSaveFailure(error: unknown): HttpException {
+    if (error instanceof HttpException) {
+      return error;
+    }
+
+    this.logger.error('Failed to save the rule group');
+    this.logger.debug(error);
+    return new InternalServerErrorException('Failed to save the rule group');
+  }
+
   // A collection_media row reduced to the fields ServarrTagService needs to
   // resolve an item to its *arr entity (id + provider-id fallbacks).
   private toArrTagItem(m: CollectionMedia) {
@@ -1413,6 +1428,15 @@ export class RulesService {
           return this.createReturnStatus(false, "Types don't match");
         }
       } else if (rule.customVal) {
+        // Same reason as the first-value guard: a custom value without a rule
+        // type threw a TypeError below, which surfaced as the catch-all
+        // "Unexpected error occurred" instead of naming what was wrong.
+        if (rule.customVal.ruleTypeId == null) {
+          return this.createReturnStatus(
+            false,
+            'Custom value is missing a rule type',
+          );
+        }
         if (
           val1.type.toString() === rule.customVal.ruleTypeId.toString() ||
           (val1.type === RuleType.DATE &&
@@ -1442,10 +1466,8 @@ export class RulesService {
         return this.createReturnStatus(false, 'No second value found');
       }
     } catch (error) {
-      this.logger.debug(
-        'Unexpected error occurred while validating a rule',
-        error,
-      );
+      this.logger.error('Unexpected error occurred while validating a rule');
+      this.logger.debug(error);
       return this.createReturnStatus(false, 'Unexpected error occurred');
     }
   }

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -3,9 +3,12 @@ import {
   leftoverCleanupScope,
   MaintainerrEvent,
   MediaItemType,
+  MediaLibrary,
   MediaServerType,
 } from '@maintainerr/contracts';
 import {
+  BadGatewayException,
+  BadRequestException,
   HttpException,
   Injectable,
   InternalServerErrorException,
@@ -374,6 +377,38 @@ export class RulesService {
     }
   }
 
+  // An id the media server does not know is the caller's mistake, but an empty
+  // library list is not: every getLibraries path answers [] when the server is
+  // unreachable or unconfigured, so only a list we could actually read proves
+  // the id wrong. Blaming the caller for an outage is how a broken connection
+  // gets read as a broken rule group.
+  private async resolveLibraryOrFail(
+    libraryId: string | undefined,
+  ): Promise<MediaLibrary> {
+    if (!libraryId) {
+      throw new BadRequestException('A library is required');
+    }
+
+    const mediaServer = await this.getMediaServer();
+    const libraries = await mediaServer.getLibraries();
+
+    if (libraries.length === 0) {
+      throw new BadGatewayException(
+        'No libraries could be read from the media server. Check its connection in the settings.',
+      );
+    }
+
+    const library = libraries.find((el) => el.id === libraryId);
+
+    if (!library) {
+      throw new BadRequestException(
+        `Library ${libraryId} does not exist on the media server`,
+      );
+    }
+
+    return library;
+  }
+
   // Resolve the collection's media type: a movie library is always 'movie';
   // a TV library uses the rule group's selected dataType (show/season/episode),
   // defaulting to 'show'.
@@ -422,10 +457,7 @@ export class RulesService {
         return state;
       }
 
-      const mediaServer = await this.getMediaServer();
-      const lib = (await mediaServer.getLibraries()).find(
-        (el) => el.id === params.libraryId,
-      );
+      const lib = await this.resolveLibraryOrFail(params.libraryId);
       const collectionType = this.resolveCollectionType(lib.type, params);
       const collection = (
         await this.collectionService.createCollection({
@@ -513,6 +545,12 @@ export class RulesService {
 
   async updateRules(params: RulesDto) {
     try {
+      // Without one there is nothing to update, and TypeORM drops an undefined
+      // id from the where clause rather than rejecting it.
+      if (params.id == null) {
+        throw new BadRequestException('A rule group id is required');
+      }
+
       const managerState = this.validateSingleShowManager(params);
       if (managerState.code !== 1) {
         return managerState;
@@ -551,6 +589,11 @@ export class RulesService {
         if (!group) {
           throw new NotFoundException('Rule group not found');
         }
+
+        // Resolved before the crucial-setting wipe below, not after it: a
+        // library we cannot accept must not cost the collection its members
+        // on the way to being rejected.
+        const lib = await this.resolveLibraryOrFail(params.libraryId);
 
         const dbCollection = group.collectionId
           ? await this.collectionService.getCollection(group.collectionId)
@@ -628,11 +671,6 @@ export class RulesService {
         }
 
         // update or create the collection
-        const mediaServer = await this.getMediaServer();
-        const lib = (await mediaServer.getLibraries()).find(
-          (el) => el.id === params.libraryId,
-        );
-
         const collectionType = this.resolveCollectionType(lib.type, params);
         const collectionData = {
           libraryId: params.libraryId,

--- a/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
@@ -62,25 +62,24 @@ describe('RulesService.updateRules', () => {
     jest.clearAllMocks();
   });
 
-  it('returns error status when rule group is not found', async () => {
+  it('fails with a not-found status when the rule group is gone', async () => {
     const ruleGroupRepository = {
       findOne: jest.fn().mockResolvedValue(null),
     };
 
     const service = createRulesService({ ruleGroupRepository });
 
-    const result = await service.updateRules({
-      id: 999,
-      libraryId: '1',
-      dataType: 'show',
-      name: 'Test',
-      rules: [],
-      description: '',
-    });
-
-    expect(result).toEqual({
-      code: 0,
-      result: 'Rule group not found',
+    await expect(
+      service.updateRules({
+        id: 999,
+        libraryId: '1',
+        dataType: 'show',
+        name: 'Test',
+        rules: [],
+        description: '',
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
       message: 'Rule group not found',
     });
   });
@@ -92,33 +91,31 @@ describe('RulesService.updateRules', () => {
 
     const service = createRulesService({ ruleGroupRepository });
 
-    const result = await service.updateRules({
-      id: 999,
-      libraryId: '1',
-      dataType: 'movie',
-      name: 'Test',
-      description: '',
-      rules: [
-        {
-          operator: null,
-          action: RulePossibility.EQUALS,
-          firstVal: [Application.PLEX, 7],
-          customVal: {
-            ruleTypeId: +RuleType.NUMBER,
-            value: (330 * 86400).toString(),
+    // Reaching the (missing) rule group means validation let the rule through.
+    await expect(
+      service.updateRules({
+        id: 999,
+        libraryId: '1',
+        dataType: 'movie',
+        name: 'Test',
+        description: '',
+        rules: [
+          {
+            operator: null,
+            action: RulePossibility.EQUALS,
+            firstVal: [Application.PLEX, 7],
+            customVal: {
+              ruleTypeId: +RuleType.NUMBER,
+              value: (330 * 86400).toString(),
+            },
+            section: 0,
           },
-          section: 0,
-        },
-      ],
-    } as any);
+        ],
+      } as any),
+    ).rejects.toMatchObject({ status: 404 });
 
     expect(ruleGroupRepository.findOne).toHaveBeenCalledWith({
       where: { id: 999 },
-    });
-    expect(result).toEqual({
-      code: 0,
-      result: 'Rule group not found',
-      message: 'Rule group not found',
     });
   });
 

--- a/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
@@ -62,6 +62,77 @@ describe('RulesService.updateRules', () => {
     jest.clearAllMocks();
   });
 
+  // TypeORM drops an undefined id from the where clause instead of rejecting
+  // it, so this has to be caught before the lookup (#3384).
+  it('rejects an update that names no rule group', async () => {
+    const ruleGroupRepository = { findOne: jest.fn() };
+    const service = createRulesService({ ruleGroupRepository });
+
+    await expect(
+      service.updateRules({
+        libraryId: '1',
+        dataType: 'movie',
+        name: 'Test',
+        rules: [],
+        description: '',
+      } as any),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: 'A rule group id is required',
+    });
+    expect(ruleGroupRepository.findOne).not.toHaveBeenCalled();
+  });
+
+  // Moving libraries wipes the collection's members. A library the media
+  // server does not have is rejected before that happens, so a bad payload
+  // cannot cost the collection its contents on the way to a 400.
+  it('rejects an unknown library without wiping the collection first', async () => {
+    const collectionMediaRepository = { delete: jest.fn() };
+    const exclusionRepo = { delete: jest.fn() };
+    const mediaServer = {
+      getLibraries: jest
+        .fn()
+        .mockResolvedValue([{ id: '1', title: 'Movies', type: 'movie' }]),
+      cleanupCollectionForLibrary: jest.fn(),
+    };
+
+    const service = createRulesService({
+      ruleGroupRepository: {
+        findOne: jest
+          .fn()
+          .mockResolvedValue({ id: 5, collectionId: 42, dataType: 'movie' }),
+      },
+      collectionMediaRepository,
+      exclusionRepo,
+      collectionService: {
+        getCollection: jest
+          .fn()
+          .mockResolvedValue({ id: 42, libraryId: 'old-library' }),
+      },
+      mediaServerFactory: {
+        getService: jest.fn().mockReturnValue(mediaServer),
+      },
+    });
+
+    await expect(
+      service.updateRules({
+        id: 5,
+        libraryId: 'gone-library',
+        dataType: 'movie',
+        name: 'Test',
+        rules: [],
+        description: '',
+      } as any),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: 'Library gone-library does not exist on the media server',
+    });
+
+    expect(collectionMediaRepository.delete).not.toHaveBeenCalled();
+    expect(exclusionRepo.delete).not.toHaveBeenCalled();
+    expect(mediaServer.cleanupCollectionForLibrary).not.toHaveBeenCalled();
+  });
+
   it('fails with a not-found status when the rule group is gone', async () => {
     const ruleGroupRepository = {
       findOne: jest.fn().mockResolvedValue(null),

--- a/apps/ui/src/api/media-server.ts
+++ b/apps/ui/src/api/media-server.ts
@@ -206,6 +206,48 @@ export const useMediaServerMetadata = (
   })
 }
 
+type UseMediaServerMetadataChildrenQueryKey = ReturnType<
+  typeof mediaServerKeys.metadataChildren
+>
+type UseMediaServerMetadataChildrenOptions = Omit<
+  UseQueryOptions<
+    MediaItem[],
+    Error,
+    MediaItem[],
+    UseMediaServerMetadataChildrenQueryKey
+  >,
+  'queryKey' | 'queryFn'
+>
+
+/**
+ * Hook to fetch an item's direct children: a show's seasons, a season's
+ * episodes.
+ */
+export const useMediaServerMetadataChildren = (
+  itemId?: string,
+  options?: UseMediaServerMetadataChildrenOptions,
+) => {
+  const queryEnabled = !!itemId && (options?.enabled ?? true)
+
+  return useQuery<
+    MediaItem[],
+    Error,
+    MediaItem[],
+    UseMediaServerMetadataChildrenQueryKey
+  >({
+    queryKey: mediaServerKeys.metadataChildren(itemId ?? ''),
+    queryFn: async () => {
+      return await GetApiHandler<MediaItem[]>(
+        `/media-server/meta/${itemId}/children`,
+      )
+    },
+    staleTime: 60000, // 1 minute
+    retry: 1,
+    ...options,
+    enabled: queryEnabled,
+  })
+}
+
 type UseMediaServerSearchQueryKey = ReturnType<typeof mediaServerKeys.search>
 type UseMediaServerSearchOptions = Omit<
   UseQueryOptions<
@@ -253,5 +295,8 @@ export type UseMediaServerCollectionsResult = ReturnType<
 >
 export type UseMediaServerMetadataResult = ReturnType<
   typeof useMediaServerMetadata
+>
+export type UseMediaServerMetadataChildrenResult = ReturnType<
+  typeof useMediaServerMetadataChildren
 >
 export type UseMediaServerSearchResult = ReturnType<typeof useMediaServerSearch>

--- a/apps/ui/src/components/AddModal/index.spec.tsx
+++ b/apps/ui/src/components/AddModal/index.spec.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
   cleanup,
   fireEvent,
@@ -6,18 +7,12 @@ import {
   waitFor,
 } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestQueryClient } from '../../test-utils/queryClient'
 import GetApiHandler, { PostApiHandler } from '../../utils/ApiHandler'
+import type { IAddModal } from './interfaces'
 import AddModal from './index'
 
-const invalidateQueries = vi.fn()
 const navigate = vi.fn()
-
-vi.mock('@tanstack/react-query', async () => {
-  const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
-    '@tanstack/react-query',
-  )
-  return { ...actual, useQueryClient: () => ({ invalidateQueries }) }
-})
 
 vi.mock('react-router-dom', async () => {
   const actual =
@@ -29,6 +24,43 @@ vi.mock('../../utils/ApiHandler', () => ({
   default: vi.fn(),
   PostApiHandler: vi.fn(),
 }))
+
+let queryClient: QueryClient
+let invalidateQueries: ReturnType<typeof vi.spyOn>
+
+const renderModal = (props: Partial<IAddModal> = {}) => {
+  const onCancel = props.onCancel ?? vi.fn()
+  const onSubmit = props.onSubmit ?? vi.fn()
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AddModal
+        mediaServerId="m1"
+        type="movie"
+        modalType="add"
+        {...props}
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+      />
+    </QueryClientProvider>,
+  )
+
+  return { onCancel, onSubmit }
+}
+
+beforeEach(() => {
+  // The hooks set their own retry count, so only the delay can be flattened.
+  queryClient = createTestQueryClient({
+    defaultOptions: { queries: { retryDelay: 0 } },
+  })
+  invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+  navigate.mockReset()
+})
+
+afterEach(() => {
+  cleanup()
+  queryClient.clear()
+})
 
 describe('AddModal - global exclusion warning', () => {
   const getApiHandlerMock = vi.mocked(GetApiHandler)
@@ -55,19 +87,7 @@ describe('AddModal - global exclusion warning', () => {
     postApiHandlerMock.mockResolvedValue(undefined as never)
   }
 
-  const renderExclude = () => {
-    const onCancel = vi.fn()
-    render(
-      <AddModal
-        mediaServerId="m1"
-        type="movie"
-        modalType="exclude"
-        onCancel={onCancel}
-        onSubmit={vi.fn()}
-      />,
-    )
-    return { onCancel }
-  }
+  const renderExclude = () => renderModal({ modalType: 'exclude' })
 
   const exclusionPost = () =>
     postApiHandlerMock.mock.calls.find(
@@ -77,10 +97,7 @@ describe('AddModal - global exclusion warning', () => {
   beforeEach(() => {
     getApiHandlerMock.mockReset()
     postApiHandlerMock.mockReset()
-    navigate.mockReset()
-    invalidateQueries.mockReset()
   })
-  afterEach(() => cleanup())
 
   it('Add + all collections, item has scoped exclusions: warns with item - rule-group links, then Proceed submits a global exclusion', async () => {
     stubApi(scopedStatus)
@@ -171,19 +188,37 @@ describe('AddModal - context payload', () => {
   const getApiHandlerMock = vi.mocked(GetApiHandler)
   const postApiHandlerMock = vi.mocked(PostApiHandler)
 
+  const collections = [
+    { id: 1, title: 'Show collection', type: 'show' },
+    { id: 2, title: 'Season collection', type: 'season' },
+    { id: 3, title: 'Episode collection', type: 'episode' },
+    { id: 4, title: 'Movie collection', type: 'movie' },
+  ]
+
+  const stubApi = (children: unknown[] = []) => {
+    getApiHandlerMock.mockImplementation(((url: string) => {
+      if (url.startsWith('/media-server/meta/'))
+        return Promise.resolve(children)
+      if (url.startsWith('/collections')) return Promise.resolve(collections)
+      return Promise.resolve(undefined)
+    }) as typeof GetApiHandler)
+  }
+
+  const optionTitles = () =>
+    Array.from(
+      (
+        screen.getByRole('combobox', {
+          name: 'Collection',
+        }) as HTMLSelectElement
+      ).options,
+    ).map((option) => option.text)
+
   beforeEach(() => {
     getApiHandlerMock.mockReset()
     postApiHandlerMock.mockReset()
-    getApiHandlerMock.mockImplementation(((url: string) => {
-      if (url.startsWith('/media-server/meta/')) return Promise.resolve([])
-      if (url === '/collections?typeId=season')
-        return Promise.resolve([{ id: 4, title: 'Season cleanup' }])
-      if (url.startsWith('/collections')) return Promise.resolve([])
-      return Promise.resolve(undefined)
-    }) as typeof GetApiHandler)
+    stubApi()
     postApiHandlerMock.mockResolvedValue(undefined as never)
   })
-  afterEach(() => cleanup())
 
   // Every failure used to be swallowed by a bare catch, so a refused add
   // looked identical to a successful one (#3381).
@@ -196,17 +231,7 @@ describe('AddModal - context payload', () => {
         },
       }),
     )
-    const onSubmit = vi.fn()
-
-    render(
-      <AddModal
-        mediaServerId="show-1"
-        type="show"
-        modalType="add"
-        onCancel={vi.fn()}
-        onSubmit={onSubmit}
-      />,
-    )
+    const { onSubmit } = renderModal({ mediaServerId: 'show-1', type: 'show' })
 
     fireEvent.click(await screen.findByRole('button', { name: 'Submit' }))
 
@@ -217,29 +242,45 @@ describe('AddModal - context payload', () => {
   })
 
   // A season or episode can only go into a collection of that type, and the
-  // list is refetched as the picker narrows.
+  // list narrows as the picker does.
   it('offers only the collection types the current selection can produce', async () => {
-    render(
-      <AddModal
-        mediaServerId="show-1"
-        type="show"
-        modalType="add"
-        onCancel={vi.fn()}
-        onSubmit={vi.fn()}
-      />,
-    )
+    stubApi([{ id: 'season-1', title: 'Season 1', index: 1 }])
+    renderModal({ mediaServerId: 'show-1', type: 'show' })
 
-    await screen.findByRole('button', { name: 'Submit' })
-
-    const requested = getApiHandlerMock.mock.calls
-      .map((call) => String(call[0]))
-      .filter((url) => url.startsWith('/collections'))
-
-    expect(requested).toEqual([
-      '/collections?typeId=show',
-      '/collections?typeId=season',
-      '/collections?typeId=episode',
+    await screen.findByRole('option', { name: 'Show collection' })
+    expect(optionTitles()).toEqual([
+      'Show collection',
+      'Season collection',
+      'Episode collection',
     ])
+
+    // Narrowing to a season drops the show collection without a refetch.
+    fireEvent.change(screen.getByRole('combobox', { name: 'Seasons' }), {
+      target: { value: 'season-1' },
+    })
+
+    await waitFor(() =>
+      expect(optionTitles()).toEqual([
+        'Season collection',
+        'Episode collection',
+      ]),
+    )
+  })
+
+  it('offers only movie collections for a movie', async () => {
+    renderModal({ mediaServerId: 'movie-1', type: 'movie' })
+
+    await screen.findByRole('option', { name: 'Movie collection' })
+    expect(optionTitles()).toEqual(['Movie collection'])
+  })
+
+  // A collection only accepts items from its own library, so the read is
+  // scoped to the one the item is in.
+  it('reads collections for the item library only', async () => {
+    renderModal({ mediaServerId: 'movie-1', type: 'movie', libraryId: '3' })
+
+    await screen.findByRole('option', { name: 'Movie collection' })
+    expect(getApiHandlerMock).toHaveBeenCalledWith('/collections?libraryId=3')
   })
 
   // The empty list used to say "Please select a collection" with nothing to
@@ -251,15 +292,7 @@ describe('AddModal - context payload', () => {
       return Promise.resolve(undefined)
     }) as typeof GetApiHandler)
 
-    render(
-      <AddModal
-        mediaServerId="show-1"
-        type="show"
-        modalType="add"
-        onCancel={vi.fn()}
-        onSubmit={vi.fn()}
-      />,
-    )
+    renderModal({ mediaServerId: 'show-1', type: 'show' })
 
     const submit = (await screen.findByRole('button', {
       name: 'Submit',
@@ -271,71 +304,30 @@ describe('AddModal - context payload', () => {
     expect(screen.queryByText('Please select a collection')).toBeNull()
   })
 
-  // A slow read for the wider selection used to land last and re-offer
-  // collection types the current selection cannot fill.
-  it('ignores a collection read the selection has moved past', async () => {
-    let releaseWide: (value: unknown) => void = () => {}
-    const wide = new Promise((resolve) => {
-      releaseWide = resolve
-    })
-
+  // A failed read leaves the same empty picker as an empty library, but the
+  // cause is different - and Submit has nothing to send either way.
+  it('reports a failed collection read instead of an empty picker', async () => {
     getApiHandlerMock.mockImplementation(((url: string) => {
-      if (url.startsWith('/media-server/meta/'))
-        return Promise.resolve([
-          { id: 'season-1', title: 'Season 1', index: 1 },
-        ])
-      // The show read only happens for the wider "all seasons" selection.
-      if (url.startsWith('/collections?typeId=show'))
-        return wide.then(() => [{ id: 1, title: 'Show collection' }])
-      if (url.startsWith('/collections?typeId=season'))
-        return Promise.resolve([{ id: 2, title: 'Season collection' }])
-      if (url.startsWith('/collections?typeId=episode'))
-        return Promise.resolve([{ id: 3, title: 'Episode collection' }])
-      return Promise.resolve(undefined)
+      if (url.startsWith('/media-server/meta/')) return Promise.resolve([])
+      return Promise.reject(new Error('Network Error'))
     }) as typeof GetApiHandler)
 
-    render(
-      <AddModal
-        mediaServerId="show-1"
-        type="show"
-        modalType="add"
-        onCancel={vi.fn()}
-        onSubmit={vi.fn()}
-      />,
-    )
+    renderModal({ mediaServerId: 'movie-1', type: 'movie' })
 
-    // Narrow to a season while the wider read is still outstanding.
-    fireEvent.change(await screen.findByRole('combobox', { name: 'Seasons' }), {
-      target: { value: 'season-1' },
-    })
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('option', { name: 'Show collection' }),
-      ).toBeNull(),
-    )
-
-    releaseWide(undefined)
-
-    await waitFor(() =>
-      expect(
-        screen.getByRole('option', { name: 'Season collection' }),
-      ).toBeTruthy(),
-    )
-    expect(screen.queryByRole('option', { name: 'Show collection' })).toBeNull()
+    expect(await screen.findByText('Network Error')).toBeTruthy()
+    expect(
+      screen.queryByText(/No collection in this library can take this item/),
+    ).toBeNull()
+    const submit = screen.getByRole('button', {
+      name: 'Submit',
+    }) as HTMLButtonElement
+    expect(submit.disabled).toBe(true)
   })
 
   // A -1 context id let the server act on the show itself, so a season
   // collection received a show id and Plex answered 400 (#3381).
   it('identifies "all seasons" by the show id rather than a sentinel', async () => {
-    render(
-      <AddModal
-        mediaServerId="show-1"
-        type="show"
-        modalType="add"
-        onCancel={vi.fn()}
-        onSubmit={vi.fn()}
-      />,
-    )
+    renderModal({ mediaServerId: 'show-1', type: 'show' })
 
     fireEvent.click(await screen.findByRole('button', { name: 'Submit' }))
 
@@ -345,7 +337,7 @@ describe('AddModal - context payload', () => {
         {
           mediaId: 'show-1',
           context: { id: 'show-1', type: 'show' },
-          collectionId: 4,
+          collectionId: 1,
           action: 0,
         },
       ),

--- a/apps/ui/src/components/AddModal/index.tsx
+++ b/apps/ui/src/components/AddModal/index.tsx
@@ -1,8 +1,12 @@
 import { BasicResponseDto, MediaItemType } from '@maintainerr/contracts'
 import { useQueryClient } from '@tanstack/react-query'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { invalidateCollectionQueries } from '../../api/collections'
+import {
+  invalidateCollectionQueries,
+  useCollections,
+} from '../../api/collections'
+import { useMediaServerMetadataChildren } from '../../api/media-server'
 import { getApiErrorMessage } from '../../utils/ApiError'
 import GetApiHandler, { PostApiHandler } from '../../utils/ApiHandler'
 import Alert from '../Common/Alert'
@@ -22,7 +26,6 @@ const AddModal = (props: IAddModal) => {
   const [selectedCollection, setSelectedCollection] = useState<
     number | string
   >()
-  const [loading, setLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string>()
   const [forceRemovalCheck, setForceRemovalCheck] = useState(false)
   const [globalWarning, setGlobalWarning] = useState(false)
@@ -35,22 +38,6 @@ const AddModal = (props: IAddModal) => {
   // media server would have to interpret.
   const [selectedSeasons, setSelectedSeasons] = useState<string>()
   const [selectedEpisodes, setSelectedEpisodes] = useState<string>()
-
-  const [collectionOptions, setCollectionOptions] = useState<
-    ICollectionMedia[]
-  >([])
-  const [seasonOptions, setSeasonOptions] = useState<ICollectionMedia[]>([
-    {
-      id: '',
-      title: 'All seasons',
-    },
-  ])
-  const [episodeOptions, setEpisodeOptions] = useState<ICollectionMedia[]>([
-    {
-      id: '',
-      title: 'All episodes',
-    },
-  ])
 
   const origCollectionOptions = useMemo(
     () =>
@@ -100,6 +87,79 @@ const AddModal = (props: IAddModal) => {
     }
   }, [selectedContext])
 
+  const seasonsQuery = useMediaServerMetadataChildren(
+    String(props.mediaServerId),
+    { enabled: props.type === 'show' },
+  )
+  const episodesQuery = useMediaServerMetadataChildren(selectedSeasons)
+  // A collection only accepts items from its own library, so offering the
+  // other libraries' collections only produces a rejected add. The type filter
+  // runs here rather than per type on the server: it is the same library read
+  // the rest of the app already caches, so narrowing the picker re-filters
+  // what is on screen instead of refetching.
+  const collectionsQuery = useCollections(props.libraryId)
+
+  const seasonOptions = useMemo(
+    (): ICollectionMedia[] => [
+      { id: '', title: 'All seasons' },
+      ...(seasonsQuery.data ?? []).map((season) => ({
+        id: season.id,
+        title: season.title,
+      })),
+    ],
+    [seasonsQuery.data],
+  )
+
+  const episodeOptions = useMemo(
+    (): ICollectionMedia[] => [
+      { id: '', title: 'All episodes' },
+      ...(episodesQuery.data ?? []).map((episode) => ({
+        id: episode.id,
+        title: `Episode ${episode.index}`,
+      })),
+    ],
+    [episodesQuery.data],
+  )
+
+  const collectionOptions = useMemo(
+    (): ICollectionMedia[] => [
+      ...origCollectionOptions,
+      ...(collectionsQuery.data ?? []).flatMap((collection) =>
+        collection.id !== undefined && collectionTypes.includes(collection.type)
+          ? [{ id: collection.id, title: collection.title }]
+          : [],
+      ),
+    ],
+    [origCollectionOptions, collectionsQuery.data, collectionTypes],
+  )
+
+  const loading =
+    seasonsQuery.isLoading ||
+    episodesQuery.isLoading ||
+    collectionsQuery.isLoading
+
+  const loadErrorMessage = useMemo(() => {
+    if (seasonsQuery.error) {
+      return getApiErrorMessage(
+        seasonsQuery.error,
+        'Could not load the seasons',
+      )
+    }
+    if (episodesQuery.error) {
+      return getApiErrorMessage(
+        episodesQuery.error,
+        'Could not load the episodes',
+      )
+    }
+    if (collectionsQuery.error) {
+      return getApiErrorMessage(
+        collectionsQuery.error,
+        'Could not load the collections',
+      )
+    }
+    return undefined
+  }, [seasonsQuery.error, episodesQuery.error, collectionsQuery.error])
+
   // Derived, not synced: narrowing to a season or episode drops the wider
   // collection types, so a selection made before that is no longer offered and
   // falls back to the first option. Keeping the state lets it come back if the
@@ -109,9 +169,12 @@ const AddModal = (props: IAddModal) => {
   )
     ? selectedCollection
     : collectionOptions[0]?.id
-  // Nothing in this library holds what the current selection resolves to, so
-  // there is no choice to make and submitting cannot do anything.
-  const noCollectionsAvailable = !loading && collectionOptions.length === 0
+  // With nothing to pick there is nothing to submit - whether the library
+  // holds no collection this selection fits, or the read that would list them
+  // failed. Only the first is worth explaining; the second already shows why.
+  const noCollectionSelectable = currentCollectionId === undefined
+  const noCollectionsAvailable =
+    noCollectionSelectable && collectionsQuery.isSuccess
 
   const handleCancel = () => {
     props.onCancel()
@@ -169,7 +232,7 @@ const AddModal = (props: IAddModal) => {
   }
 
   const handleOk = async () => {
-    if (submitting || noCollectionsAvailable) return
+    if (submitting || noCollectionSelectable) return
 
     // Only ADDING a global exclusion clears the item's rule-group exclusions.
     // If it has any, warn and list each as "item - rule group", reusing the
@@ -241,107 +304,6 @@ const AddModal = (props: IAddModal) => {
     }
   }
 
-  useEffect(() => {
-    if (props.type && props.type === 'show') {
-      GetApiHandler(`/media-server/meta/${props.mediaServerId}/children`)
-        .then((resp: { id: string; title: string }[]) => {
-          setSeasonOptions([
-            {
-              id: '',
-              title: 'All seasons',
-            },
-            ...resp.map((el) => {
-              return {
-                id: el.id,
-                title: el.title,
-              } as ICollectionMedia
-            }),
-          ])
-        })
-        .catch((error) =>
-          setErrorMessage(
-            getApiErrorMessage(error, 'Could not load the seasons'),
-          ),
-        )
-        .finally(() => setLoading(false))
-    }
-  }, [props.mediaServerId, props.type])
-
-  useEffect(() => {
-    if (!selectedSeasons) return
-
-    // A slower read for the season the user just moved off would otherwise
-    // land last and list the wrong season's episodes.
-    let current = true
-
-    GetApiHandler(`/media-server/meta/${selectedSeasons}/children`)
-      .then((resp: { id: string; index: number }[]) => {
-        if (!current) return
-        setEpisodeOptions([
-          {
-            id: '',
-            title: 'All episodes',
-          },
-          ...resp.map((el) => {
-            return {
-              id: el.id,
-              title: `Episode ${el.index}`,
-            } as ICollectionMedia
-          }),
-        ])
-      })
-      .catch((error) => {
-        if (current)
-          setErrorMessage(
-            getApiErrorMessage(error, 'Could not load the episodes'),
-          )
-      })
-      .finally(() => {
-        if (current) setLoading(false)
-      })
-
-    return () => {
-      current = false
-    }
-  }, [selectedSeasons])
-
-  useEffect(() => {
-    // A collection only accepts items from its own library, so offering the
-    // other libraries' collections only produces a rejected add.
-    const libraryQuery = props.libraryId
-      ? `&libraryId=${encodeURIComponent(props.libraryId)}`
-      : ''
-
-    // A slower read for the wider selection the user just moved off would
-    // otherwise land last and re-offer collection types this one cannot fill.
-    let current = true
-
-    Promise.all(
-      collectionTypes.map((type) =>
-        GetApiHandler<ICollectionMedia[]>(
-          `/collections?typeId=${type}${libraryQuery}`,
-        ),
-      ),
-    )
-      .then((responses) => {
-        if (!current) return
-        setCollectionOptions([...origCollectionOptions, ...responses.flat()])
-      })
-      .catch((error) => {
-        if (current)
-          setErrorMessage(
-            getApiErrorMessage(error, 'Could not load the collections'),
-          )
-      })
-      .finally(() => {
-        if (current) setLoading(false)
-      })
-
-    return () => {
-      current = false
-    }
-  }, [origCollectionOptions, collectionTypes, props.libraryId])
-
   return (
     <>
       <Modal
@@ -355,7 +317,7 @@ const AddModal = (props: IAddModal) => {
           <Button
             buttonType="primary"
             className="ml-3"
-            disabled={submitting || noCollectionsAvailable}
+            disabled={submitting || noCollectionSelectable}
             onClick={handleOk}
           >
             {submitting ? 'Submitting...' : 'Submit'}
@@ -442,7 +404,9 @@ const AddModal = (props: IAddModal) => {
           />
         ) : undefined}
 
-        {errorMessage ? <Alert title={errorMessage} type="error" /> : undefined}
+        {(errorMessage ?? loadErrorMessage) ? (
+          <Alert title={errorMessage ?? loadErrorMessage} type="error" />
+        ) : undefined}
 
         <div className="mt-6">
           <FormItem label="Action">
@@ -476,14 +440,7 @@ const AddModal = (props: IAddModal) => {
                 value={selectedSeasons ?? ''}
                 onChange={(e: { target: { value: string } }) => {
                   const value = e.target.value
-                  setLoading(true)
                   setSelectedEpisodes(undefined)
-                  setEpisodeOptions([
-                    {
-                      id: '',
-                      title: 'All episodes',
-                    },
-                  ])
                   setSelectedSeasons(value || undefined)
                 }}
               >
@@ -506,7 +463,6 @@ const AddModal = (props: IAddModal) => {
                 value={selectedEpisodes ?? ''}
                 onChange={(e: { target: { value: string } }) => {
                   const value = e.target.value
-                  setLoading(true)
                   setSelectedEpisodes(value || undefined)
                 }}
               >

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -37,6 +37,7 @@ import {
   useUpdateRuleGroup,
 } from '../../../../api/rules'
 import { useMediaServerType } from '../../../../hooks/useMediaServerType'
+import { getApiErrorMessage } from '../../../../utils/ApiError'
 import { PostApiHandler } from '../../../../utils/ApiHandler'
 import { logClientError } from '../../../../utils/ClientLogger'
 import Alert from '../../../Common/Alert'
@@ -534,14 +535,22 @@ const AddModal = (props: AddModal) => {
 
   const {
     mutateAsync: createRuleGroup,
-    isError: isCreateError,
+    error: createError,
     isPending: isCreatePending,
   } = useCreateRuleGroup()
   const {
     mutateAsync: updateRuleGroup,
-    isError: isUpdateError,
+    error: updateError,
     isPending: isUpdatePending,
   } = useUpdateRuleGroup()
+
+  // The server names what it rejected ("Operator is required for every rule
+  // after the first"); saying "something went wrong" instead left the user to
+  // guess which of the form's values it meant.
+  const saveError = createError ?? updateError
+  const saveErrorMessage = saveError
+    ? getApiErrorMessage(saveError, 'The rule group could not be saved')
+    : undefined
 
   const selectedLibraryId = useWatch({ control, name: 'libraryId' }) ?? ''
   const selectedType = useWatch({ control, name: 'dataType' }) ?? ''
@@ -1033,7 +1042,9 @@ const AddModal = (props: AddModal) => {
         mutationError,
         'RuleGroup.AddModal.handleSave',
       )
-      toast.error('Failed to save rule group. Check logs for details.')
+      toast.error(
+        getApiErrorMessage(mutationError, 'The rule group could not be saved'),
+      )
     }
   }
 
@@ -1087,12 +1098,7 @@ const AddModal = (props: AddModal) => {
           </Alert>
         )}
 
-        {(isCreateError || isUpdateError) && (
-          <Alert>
-            Something went wrong saving the group.. Please verify that all
-            values are valid
-          </Alert>
-        )}
+        {saveErrorMessage && <Alert>{saveErrorMessage}</Alert>}
 
         {formIncomplete && (
           <Alert>


### PR DESCRIPTION
Closes #3384.

**`POST` / `PUT /api/rules` always answered 201.** Whether the rule group was written or not, the reason sat in the body as `{"code":0,...}`, so a caller could not tell a save from a rejection. The routes now answer, and document, what actually happened:

| | |
|---|---|
| rejected payload | **400** with what was wrong |
| library the media server does not have, or none named | **400** |
| `PUT` naming no rule group, or one that is gone | **400** / **404** |
| library list unreadable | **502** |
| anything else | **500**, cause logged |

An empty library list is deliberately *not* a 400: every `getLibraries` path answers `[]` when the media server is unreachable or unconfigured, so treating "not in the list" as a bad request would blame the caller for an outage.

The library is also resolved before the crucial-setting wipe rather than after it, so a rejected update no longer costs the collection its members on the way to being rejected.

The rule form showed "Something went wrong saving the group.." for every one of these. It now shows the reason the server gave.

Two smaller things behind the same issue: a custom value with no rule type threw a `TypeError` that surfaced as "Unexpected error occurred", and the validator put its short reason on `logger.debug`, so a default install logged nothing for the request. It follows the existing convention now - short reason at `error`, stack at `debug`.

**The add/exclude modal drove three reads from `useEffect`,** each with its own stale-response guard, keeping results in state. They are TanStack queries now: a new `useMediaServerMetadataChildren` for the season and episode pickers, and the shared `useCollections` for the list. The collection list is read once per library and filtered by type on the client instead of once per offered type, so opening the modal on a show makes 2 requests instead of 4 and narrowing to a season refetches nothing. A failed collection read also left Submit enabled with nothing to submit; it is disabled now.

Verified against the dev stack (real Plex): every status code by hand, both log levels, and the outage counterfactual with Plex pointed at a closed port - a valid library then answers 5xx, never 400. The modal round-tripped a show into a season collection and a movie into a movie collection, both confirmed in Plex, and the 404 alert was driven end to end by deleting a rule group behind an open edit page.