### PR TITLE
fix(rules): keep Plex watchlist rules working when a user's watchlist is private

### DIFF
--- a/apps/server/src/modules/api/lib/plextvApi.spec.ts
+++ b/apps/server/src/modules/api/lib/plextvApi.spec.ts
@@ -156,3 +156,81 @@ describe('PlexTvApi.getDevices', () => {
     await expect(createApi().getDevices('client-123')).resolves.toEqual([]);
   });
 });
+
+describe('PlexTvApi.getUsers', () => {
+  const get = jest.fn();
+
+  const usersXml = (username: string) =>
+    `<?xml version="1.0" encoding="UTF-8"?><MediaContainer size="1">` +
+    `<User id="2" username="${username}" thumb="https://plex.tv/users/aaaaaaaaaaaaaaaa/avatar?c=1"/>` +
+    `</MediaContainer>`;
+
+  const createApi = () =>
+    new PlexTvApi(
+      'a-token',
+      createMockLogger() as unknown as MaintainerrLogger,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axios.create.mockReturnValue({ get });
+    (axiosRetry as unknown as jest.Mock).mockImplementation(() => undefined);
+    cacheManager.getCache('plextv').data.flushAll();
+  });
+
+  // plex.tv answers XML, which the response cache never holds, so the shared
+  // user list was re-fetched and re-parsed once per evaluated item.
+  it('reads plex.tv once and serves the parsed list from cache', async () => {
+    get.mockResolvedValue({ data: usersXml('alice') });
+    const api = createApi();
+
+    const first = await api.getUsers();
+    const second = await api.getUsers();
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+    expect(first.MediaContainer.User[0].$.username).toBe('alice');
+  });
+
+  // Rule evaluation resolves a whole batch of items at once, so a cold cache
+  // used to send one plex.tv request per item in the batch.
+  it('shares one request across callers that race a cold cache', async () => {
+    let release: (value: { data: string }) => void;
+    get.mockReturnValue(new Promise((resolve) => (release = resolve)));
+    const api = createApi();
+
+    const inFlight = [api.getUsers(), api.getUsers(), api.getUsers()];
+    release!({ data: usersXml('alice') });
+
+    for (const users of await Promise.all(inFlight)) {
+      expect(users.MediaContainer.User[0].$.username).toBe('alice');
+    }
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache a failed fetch', async () => {
+    get.mockResolvedValueOnce({ data: undefined });
+    const api = createApi();
+
+    await expect(api.getUsers()).rejects.toThrow('Failed to fetch users');
+
+    get.mockResolvedValue({ data: usersXml('bob') });
+    await expect(api.getUsers()).resolves.toMatchObject({
+      MediaContainer: { User: [{ $: { username: 'bob' } }] },
+    });
+  });
+
+  it('re-reads plex.tv after the cache is flushed between rule runs', async () => {
+    get.mockResolvedValue({ data: usersXml('alice') });
+    const api = createApi();
+    await api.getUsers();
+
+    cacheManager.flushAll();
+    get.mockResolvedValue({ data: usersXml('carol') });
+
+    await expect(api.getUsers()).resolves.toMatchObject({
+      MediaContainer: { User: [{ $: { username: 'carol' } }] },
+    });
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/server/src/modules/api/lib/plextvApi.ts
+++ b/apps/server/src/modules/api/lib/plextvApi.ts
@@ -1,5 +1,6 @@
 import { AxiosError } from 'axios';
 import { parseStringPromise } from 'xml2js';
+import { PLEX_TV_USERS_CACHE_KEY } from '../../api/plex-api/plex-api.constants';
 import { PlexDevice } from '../../api/plex-api/interfaces/server.interface';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { ExternalApiService } from '../external-api/external-api.service';
@@ -106,6 +107,7 @@ interface UsersResponse {
 
 export class PlexTvApi extends ExternalApiService {
   private authToken: string;
+  private usersRequest: Promise<UsersResponse> | undefined;
 
   constructor(
     authToken: string,
@@ -169,6 +171,23 @@ export class PlexTvApi extends ExternalApiService {
   }
 
   public async getUsers(): Promise<UsersResponse> {
+    const cached = cacheManager
+      .getCache('plextv')
+      .data.get<UsersResponse>(PLEX_TV_USERS_CACHE_KEY);
+    if (cached) {
+      return cached;
+    }
+
+    // Rule evaluation resolves operands in parallel batches, so a cold cache
+    // otherwise sends the whole batch to plex.tv at once. Share one in-flight
+    // request, as the watch-history prefetch does.
+    this.usersRequest ??= this.fetchUsers().finally(() => {
+      this.usersRequest = undefined;
+    });
+    return this.usersRequest;
+  }
+
+  private async fetchUsers(): Promise<UsersResponse> {
     const response = await this.get('/api/users', {
       transformResponse: [],
       responseType: 'text',
@@ -179,6 +198,12 @@ export class PlexTvApi extends ExternalApiService {
     }
 
     const parsedXml = (await parseStringPromise(response)) as UsersResponse;
+    // Cached here rather than by the response cache, which only holds objects -
+    // this endpoint answers XML text. A failure never gets this far, so only a
+    // successfully parsed list is ever cached.
+    cacheManager
+      .getCache('plextv')
+      .data.set(PLEX_TV_USERS_CACHE_KEY, parsedXml);
     return parsedXml;
   }
 

--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.spec.ts
@@ -64,6 +64,32 @@ describe('PlexMapper', () => {
     });
   });
 
+  describe('extractPlexAgentId', () => {
+    it.each([
+      ['plex://movie/5d776830880197001ec7f3eb', '5d776830880197001ec7f3eb'],
+      ['plex://show/5d9c07f4705e7a001e6e59a2', '5d9c07f4705e7a001e6e59a2'],
+      ['plex://episode/5d9c1176e264b7001fef1d0e', '5d9c1176e264b7001fef1d0e'],
+    ])('reads the agent id out of %s', (guid, expected) => {
+      expect(PlexMapper.extractPlexAgentId(guid)).toBe(expected);
+    });
+
+    // Watchlist entries are keyed on the Plex agent id, so anything without one
+    // has to come back undefined rather than a partial match.
+    it.each([
+      ['a legacy agent guid', 'com.plexapp.agents.imdb://tt1234567?lang=en'],
+      ['a provider guid', 'tmdb://12345'],
+      ['personal media', 'local://12345'],
+      ['a guid that only looks like one', 'notplex://movie/5d7768308801'],
+      ['a missing type segment', 'plex://5d776830880197001ec7f3eb'],
+      ['an empty type segment', 'plex:///5d776830880197001ec7f3eb'],
+      ['a trailing separator', 'plex://movie/'],
+      ['an id with unexpected characters', 'plex://movie/5d7768-30?lang=en'],
+      ['nothing at all', undefined],
+    ])('returns undefined for %s', (label, guid) => {
+      expect(PlexMapper.extractPlexAgentId(guid)).toBeUndefined();
+    });
+  });
+
   describe('extractProviderIds', () => {
     it('should extract IMDB id from guid', () => {
       const guids = [{ id: 'imdb://tt1234567' }];

--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
@@ -32,6 +32,7 @@ import { addProviderId, emptyProviderIds } from '../media-provider-ids.utils';
 
 const GUID_SCHEME_SEPARATOR = '://';
 const LEGACY_AGENT_PREFIX = 'com.plexapp.agents.';
+const PLEX_AGENT_GUID_PREFIX = `plex${GUID_SCHEME_SEPARATOR}`;
 
 /**
  * Mapper for converting Plex-specific types to server-agnostic MediaItem types.
@@ -160,6 +161,36 @@ export class PlexMapper {
     collect(fallbackGuid);
 
     return providerIds;
+  }
+
+  /**
+   * The id Plex's own agent gives an item, from a `plex://<type>/<uuid>` guid.
+   *
+   * Undefined for anything else - a legacy-agent, unmatched or personal-media
+   * guid carries no such id. plex.tv keys watchlist entries on it, so an item
+   * without one can never appear on a watchlist.
+   */
+  static extractPlexAgentId(guid?: string): string | undefined {
+    if (!guid?.startsWith(PLEX_AGENT_GUID_PREFIX)) {
+      return undefined;
+    }
+
+    const typeEnd = guid.indexOf('/', PLEX_AGENT_GUID_PREFIX.length);
+    if (typeEnd <= PLEX_AGENT_GUID_PREFIX.length) {
+      return undefined;
+    }
+
+    const id = guid.slice(typeEnd + 1);
+    for (const character of id) {
+      const isDigit = character >= '0' && character <= '9';
+      const isLowercaseLetter = character >= 'a' && character <= 'z';
+
+      if (!isDigit && !isLowercaseLetter) {
+        return undefined;
+      }
+    }
+
+    return id || undefined;
   }
 
   /**

--- a/apps/server/src/modules/api/plex-api/plex-api.constants.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.constants.ts
@@ -17,6 +17,25 @@ export const PLEX_PAGE_SIZE = {
 // CONNECTION_TEST_TIMEOUT_MS; this applies to the long-lived runtime client.
 export const PLEX_REQUEST_TIMEOUT_MS = 30_000;
 
+// plex.tv answers with HTTP 200 and a `User not found:` GraphQL error when it
+// refuses to resolve the requested user at all: the account keeps its watchlist
+// private ("User privacy prevents viewing"), or the uuid is unknown to plex.tv.
+// That is a definitive answer, not a transport failure, and no retry changes it.
+//
+// The endpoint is undocumented (python-plexapi and Seerr only ever read the
+// authenticated account's own watchlist), so this comes from probing it: query
+// errors - unknown field, syntax error, introspection - all answer HTTP 400,
+// which never reaches this branch. Only resolver errors arrive as 200 + errors.
+// Anything else that turns up there stays transient, per the #3307 contract.
+export const PLEX_COMMUNITY_UNRESOLVED_USER_ERROR = 'User not found:';
+
+// Key in the 'plextv' cache for the shared-user list. plex.tv answers
+// /api/users as XML, and ExternalApiService only caches objects, so without
+// this every caller re-fetched and re-parsed the list - once per evaluated item
+// on the getters that resolve usernames. The rule executor flushes this cache
+// at the start of every run, so a run still reads a fresh list.
+export const PLEX_TV_USERS_CACHE_KEY = 'plextv-users';
+
 // Key prefix in the 'plexwatchhistory' cache for the watch-history snapshots
 // built by prefetchWatchHistory(). TTL and flush behaviour live on the cache
 // definition in lib/cache.ts.

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -1761,3 +1761,106 @@ describe('PlexApiService.resetMetadataCache', () => {
     expect(watchCache.keys()).toEqual([]);
   });
 });
+
+describe('PlexApiService.getWatchlistIdsForUser', () => {
+  let service: PlexApiService;
+  let communityLogger: { warn: jest.Mock; debug: jest.Mock };
+
+  const entry = {
+    id: 'movieuuid',
+    key: '/movieuuid',
+    title: 'Fixture Movie',
+    type: 'MOVIE',
+  };
+
+  const page = (nodes: unknown[], hasNextPage = false, endCursor = null) => ({
+    data: {
+      user: { watchlist: { nodes, pageInfo: { hasNextPage, endCursor } } },
+    },
+  });
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(PlexApiService).compile();
+    service = unit;
+
+    communityLogger = { warn: jest.fn(), debug: jest.fn() };
+    unitRef.get(MaintainerrLoggerFactory).createLogger.mockReturnValue({
+      setContext: jest.fn(),
+      log: jest.fn(),
+      error: jest.fn(),
+      ...communityLogger,
+    } as any);
+    Object.assign(unitRef.get(MaintainerrLogger), communityLogger);
+  });
+
+  const withQuery = (query: jest.Mock) => {
+    (service as any).plexCommunityClient = { query };
+    return query;
+  };
+
+  it('collects every page of the watchlist', async () => {
+    const query = withQuery(
+      jest
+        .fn()
+        .mockResolvedValueOnce(page([entry], true, 'cursor'))
+        .mockResolvedValueOnce(page([{ ...entry, id: 'showuuid' }])),
+    );
+
+    await expect(
+      service.getWatchlistIdsForUser('uuid-a', 'alice'),
+    ).resolves.toEqual([entry, { ...entry, id: 'showuuid' }]);
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  // plex.tv answers HTTP 200 with a `User not found:` GraphQL error for an
+  // account that hides its watchlist. That is definitive, so the caller must be
+  // able to skip the user instead of stalling the whole rule (#3395).
+  it.each([
+    ['a private watchlist', 'User not found: User privacy prevents viewing'],
+    [
+      'an account plex.tv does not know',
+      'User not found: Data loader item not found: users uuid=0000000000000000',
+    ],
+  ])('resolves null for %s', async (label, message) => {
+    withQuery(
+      jest.fn().mockResolvedValue({ errors: [{ message }], data: null }),
+    );
+
+    await expect(
+      service.getWatchlistIdsForUser('uuid-a', 'alice'),
+    ).resolves.toBeNull();
+    expect(communityLogger.warn).not.toHaveBeenCalled();
+  });
+
+  // Anything else stays transient: collapsing it would let a rule act on a
+  // watchlist that was never read (#3307).
+  it('resolves undefined for any other GraphQL error', async () => {
+    withQuery(
+      jest.fn().mockResolvedValue({
+        errors: [{ message: 'Internal server error' }],
+        data: null,
+      }),
+    );
+
+    await expect(
+      service.getWatchlistIdsForUser('uuid-a', 'alice'),
+    ).resolves.toBeUndefined();
+    expect(communityLogger.warn).toHaveBeenCalled();
+  });
+
+  it('resolves undefined when the request itself fails', async () => {
+    withQuery(jest.fn().mockResolvedValue(undefined));
+
+    await expect(
+      service.getWatchlistIdsForUser('uuid-a', 'alice'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves undefined when the community client throws', async () => {
+    withQuery(jest.fn().mockRejectedValue(new Error('boom')));
+
+    await expect(
+      service.getWatchlistIdsForUser('uuid-a', 'alice'),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -51,6 +51,7 @@ import {
   PlexStatusResponse,
 } from './interfaces/server.interface';
 import {
+  PLEX_COMMUNITY_UNRESOLVED_USER_ERROR,
   PLEX_PAGE_SIZE,
   PLEX_REQUEST_TIMEOUT_MS,
   WATCH_HISTORY_EXCLUDE_FIELDS,
@@ -1698,10 +1699,18 @@ export class PlexApiService {
     }
   }
 
+  /**
+   * The watchlist of a single plex.tv user.
+   *
+   * `undefined` means the read failed and the watchlist is unknown, so callers
+   * must not read it as "empty" (#3307). `null` means plex.tv answered that it
+   * will not share this user's watchlist (private profile, or an account it
+   * does not know) - a permanent condition callers should skip past (#3395).
+   */
   public async getWatchlistIdsForUser(
     userId: string,
     username: string,
-  ): Promise<PlexCommunityWatchList[]> {
+  ): Promise<PlexCommunityWatchList[] | null | undefined> {
     try {
       let result: PlexCommunityWatchList[] = [];
       let next = true;
@@ -1744,8 +1753,26 @@ export class PlexApiService {
           );
           return undefined;
         } else if (resp.errors) {
+          const reason = resp.errors.map((x) => x.message).join(', ');
+          // Every error has to be the definitive one - a mixed response could
+          // still be hiding a transient failure.
+          const unresolvedUser =
+            resp.errors.length > 0 &&
+            resp.errors.every((x) =>
+              x.message?.startsWith(PLEX_COMMUNITY_UNRESOLVED_USER_ERROR),
+            );
+
+          if (unresolvedUser) {
+            // Debug, not warn: a normal, permanent state of that account, which
+            // the admin cannot act on from Maintainerr.
+            this.logger.debug(
+              `Plex is not sharing the watchlist of user ${userId} (${username}), skipping them: ${reason}`,
+            );
+            return null;
+          }
+
           this.logger.warn(
-            `Failure while fetching watchlist of user ${userId} (${username}): ${resp.errors.map((x) => x.message).join(', ')}`,
+            `Failure while fetching watchlist of user ${userId} (${username}): ${reason}`,
           );
           return undefined;
         }

--- a/apps/server/src/modules/rules/constants/constants.service.spec.ts
+++ b/apps/server/src/modules/rules/constants/constants.service.spec.ts
@@ -86,6 +86,17 @@ describe('RuleConstanstService', () => {
     );
   });
 
+  // A getter answering `undefined` never established the value. Reporting that
+  // as "has no entries" sent users hunting for missing data instead of a failed
+  // lookup (#3395).
+  it('separates a failed lookup from a confirmed empty value', () => {
+    expect(
+      service.getValueNullReason([Application.PLEX, 5], undefined, {
+        lookupFailed: true,
+      }),
+    ).toBe('Plex Collection titles could not be read for this item');
+  });
+
   describe('naming a value after the server it was read from', () => {
     // The getter routes every media-server app to the configured server and
     // looks the property id up there, so a rule left unmigrated after a server

--- a/apps/server/src/modules/rules/constants/constants.service.ts
+++ b/apps/server/src/modules/rules/constants/constants.service.ts
@@ -17,10 +17,17 @@ import { Property, RuleConstants, RuleType } from './rules.constants';
 const buildDynamicNullReason = (
   property: Property,
   applicationName?: string,
+  lookupFailed?: boolean,
 ): string => {
   const cleanHuman = stripHumanNamePrefix(property.humanName);
   const noun = cleanHuman || property.name;
   const label = applicationName ? `${applicationName} ${noun}` : noun;
+
+  // A getter answering `undefined` never established the value, so reporting
+  // it as empty/unset sends the user looking for the wrong problem.
+  if (lookupFailed) {
+    return `${label} could not be read for this item`;
+  }
 
   switch (property.type) {
     case RuleType.DATE:
@@ -122,6 +129,7 @@ export class RuleConstanstService {
   public getValueNullReason(
     location: [number, number],
     configuredServerType?: MediaServerType | null,
+    options?: { lookupFailed?: boolean },
   ): string {
     const application = this.ruleConstants.applications.find(
       (el) =>
@@ -129,7 +137,11 @@ export class RuleConstanstService {
     );
     const prop = application?.props.find((el) => el.id === location[1]);
     if (!prop) return 'Value unavailable';
-    return buildDynamicNullReason(prop, application?.name);
+    return buildDynamicNullReason(
+      prop,
+      application?.name,
+      options?.lookupFailed,
+    );
   }
 
   /**

--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -811,6 +811,94 @@ describe('PlexGetterService', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('skips users whose watchlist Plex will not share and keeps evaluating the rest (ids 28 and 30)', async () => {
+      // getWatchlistIdsForUser resolves null for a private watchlist. That is
+      // permanent, so it must not stall the rule the way a failed read does
+      // (#3395).
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({
+          ratingKey: 'movie-1',
+          type: 'movie',
+          guid: 'plex://movie/movieuuid',
+        }),
+      );
+      plexApi.getCorrectedUsers.mockResolvedValue([
+        makePlexUser({ plexId: 1, username: 'alice', uuid: 'uuid-a' }),
+        makePlexUser({ plexId: 2, username: 'bob', uuid: 'uuid-b' }),
+      ]);
+      plexApi.getWatchlistIdsForUser.mockImplementation(async (uuid) =>
+        uuid === 'uuid-a'
+          ? null
+          : [
+              {
+                id: 'movieuuid',
+                key: '/movieuuid',
+                title: 'Fixture Movie',
+                type: 'movie',
+              },
+            ],
+      );
+
+      const libItem = createMediaItem({ id: 'movie-1', type: 'movie' });
+      const ruleGroup = createRulesDto({ dataType: 'movie' });
+
+      await expect(
+        service.get(28, libItem, 'movie', ruleGroup),
+      ).resolves.toEqual(['bob']);
+      await expect(service.get(30, libItem, 'movie', ruleGroup)).resolves.toBe(
+        true,
+      );
+    });
+
+    it('reports nobody when every watchlist is private (ids 28 and 30)', async () => {
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({
+          ratingKey: 'movie-1',
+          type: 'movie',
+          guid: 'plex://movie/movieuuid',
+        }),
+      );
+      plexApi.getCorrectedUsers.mockResolvedValue([
+        makePlexUser({ plexId: 1, username: 'alice', uuid: 'uuid-a' }),
+      ]);
+      plexApi.getWatchlistIdsForUser.mockResolvedValue(null);
+
+      const libItem = createMediaItem({ id: 'movie-1', type: 'movie' });
+      const ruleGroup = createRulesDto({ dataType: 'movie' });
+
+      await expect(
+        service.get(28, libItem, 'movie', ruleGroup),
+      ).resolves.toEqual([]);
+      await expect(service.get(30, libItem, 'movie', ruleGroup)).resolves.toBe(
+        false,
+      );
+    });
+
+    it('reports nobody without querying plex.tv when the item has no plex guid (ids 28 and 30)', async () => {
+      // Legacy-agent, unmatched and personal media carry a non-plex:// guid,
+      // and watchlist entries are keyed on the plex:// uuid, so they can never
+      // be watchlisted.
+      plexApi.getMetadata.mockResolvedValue(
+        makeMetadata({
+          ratingKey: 'movie-1',
+          type: 'movie',
+          guid: 'local://movie-1',
+        }),
+      );
+
+      const libItem = createMediaItem({ id: 'movie-1', type: 'movie' });
+      const ruleGroup = createRulesDto({ dataType: 'movie' });
+
+      await expect(
+        service.get(28, libItem, 'movie', ruleGroup),
+      ).resolves.toEqual([]);
+      await expect(service.get(30, libItem, 'movie', ruleGroup)).resolves.toBe(
+        false,
+      );
+      expect(plexApi.getCorrectedUsers).not.toHaveBeenCalled();
+      expect(plexApi.getWatchlistIdsForUser).not.toHaveBeenCalled();
+    });
+
     it.each([
       { id: 31, name: 'rating_imdb', expected: 7.8 },
       { id: 32, name: 'rating_rottenTomatoesCritic', expected: 6.6 },
@@ -896,6 +984,27 @@ describe('PlexGetterService', () => {
 
       expect(result).toBe(rule.expected);
     });
+
+    // A show has no show above it. Plex threw on the missing parent, and the
+    // outer catch turned "does not apply" into the transient signal, stalling
+    // the rule; Jellyfin and Emby already answer null here.
+    it.each([35, 36, 37, 38])(
+      'returns null for show ratings evaluated on a show itself (id %i)',
+      async (id) => {
+        plexApi.getMetadata.mockResolvedValue(
+          makeMetadata({ ratingKey: 'show-1', type: 'show', Rating: [] }),
+        );
+
+        await expect(
+          service.get(
+            id,
+            createMediaItem({ id: 'show-1', type: 'show' }),
+            'show',
+            createRulesDto({ dataType: 'show' }),
+          ),
+        ).resolves.toBeNull();
+      },
+    );
 
     it('counts regular and smart collections while excluding rule-managed regular collections (id 39)', async () => {
       plexApi.getMetadata.mockResolvedValue(

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -7,6 +7,7 @@ import { Injectable } from '@nestjs/common';
 import { SimplePlexUser } from '../../..//modules/api/plex-api/interfaces/library.interfaces';
 import { PlexApiService } from '../../../modules/api/plex-api/plex-api.service';
 import { PlexAdapterService } from '../../api/media-server/plex/plex-adapter.service';
+import { PlexMapper } from '../../api/media-server/plex/plex.mapper';
 import { PlexMetadata } from '../../api/plex-api/interfaces/media.interface';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import {
@@ -95,6 +96,16 @@ export class PlexGetterService {
         );
         return grandparentPromise;
       };
+
+      // The show a season/episode belongs to. Undefined for anything else, so
+      // the `*Show` properties answer `null` (does not apply) instead of
+      // throwing into the transient signal - same as Jellyfin and Emby.
+      const getShowMetadata = async (): Promise<PlexMetadata | undefined> =>
+        metadata?.type === 'season'
+          ? getParent()
+          : metadata?.type === 'episode'
+            ? getGrandparent()
+            : undefined;
 
       switch (prop.name) {
         case 'addDate': {
@@ -521,55 +532,10 @@ export class PlexGetterService {
           // originallyAvailableAt is usually an ISO 8601 date string, no need to convert from epoch time
           return lastEpDate ? new Date(lastEpDate) : null;
         }
-        case 'watchlist_isListedByUsers': {
-          // returns a list of users that have this media item, or parent, in their watchlist
-          const parent = await getParent();
-          const grandparent = await getGrandparent();
-          const guid = grandparent
-            ? grandparent.guid
-            : parent
-              ? parent.guid
-              : metadata.guid;
-          const media_uuid = guid.match(/plex:\/\/[a-z]+\/([a-z0-9]+)$/);
-
-          const plexUsers: SimplePlexUser[] =
-            await this.plexApi.getCorrectedUsers();
-
-          // When plex.tv is unreachable, no users will have UUIDs. This is a
-          // transient transport failure, so return `undefined` - `null` would
-          // read as "confirmed absent" and let the executor remove protected
-          // items (#3307).
-          if (
-            plexUsers.length > 0 &&
-            !plexUsers.some((u) => u.uuid !== undefined)
-          ) {
-            this.logger.warn(
-              'Unable to check watchlists: no user UUIDs available (plex.tv may be unreachable)',
-            );
-            return undefined;
-          }
-
-          const usernames: string[] = [];
-          for (const u of plexUsers.filter(
-            (u) => u.uuid !== undefined && media_uuid !== undefined,
-          )) {
-            const watchlist = await this.plexApi.getWatchlistIdsForUser(
-              u.uuid,
-              u.username,
-            );
-            // A failed fetch would silently understate the list, so surface
-            // it as transient instead of a confirmed answer.
-            if (watchlist === undefined) {
-              return undefined;
-            }
-            if (watchlist.find((i) => i.id === media_uuid[1]) !== undefined) {
-              usernames.push(u.username);
-            }
-          }
-
-          return usernames;
-        }
+        case 'watchlist_isListedByUsers':
         case 'watchlist_isWatchlisted': {
+          // returns the users that have this media item, or its parent, in
+          // their watchlist
           const parent = await getParent();
           const grandparent = await getGrandparent();
           const guid = grandparent
@@ -577,43 +543,18 @@ export class PlexGetterService {
             : parent
               ? parent.guid
               : metadata.guid;
-          const media_uuid = guid.match(/plex:\/\/[a-z]+\/([a-z0-9]+)$/);
 
-          const plexUsers: SimplePlexUser[] =
-            await this.plexApi.getCorrectedUsers();
+          const asBoolean = prop.name === 'watchlist_isWatchlisted';
+          const usernames = await this.getWatchlistedByUsernames(
+            guid,
+            asBoolean,
+          );
 
-          // When plex.tv is unreachable, no users will have UUIDs. This is a
-          // transient transport failure, so return `undefined` - `null` would
-          // read as "confirmed absent" and let the executor remove protected
-          // items (#3307).
-          if (
-            plexUsers.length > 0 &&
-            !plexUsers.some((u) => u.uuid !== undefined)
-          ) {
-            this.logger.warn(
-              'Unable to check watchlists: no user UUIDs available (plex.tv may be unreachable)',
-            );
+          if (usernames === undefined) {
             return undefined;
           }
 
-          for (const u of plexUsers.filter(
-            (u) => u.uuid !== undefined && media_uuid !== undefined,
-          )) {
-            const watchlist = await this.plexApi.getWatchlistIdsForUser(
-              u.uuid,
-              u.username,
-            );
-            // A failed fetch cannot confirm "not watchlisted", so surface it
-            // as transient instead of a false negative.
-            if (watchlist === undefined) {
-              return undefined;
-            }
-            if (watchlist.find((i) => i.id === media_uuid[1]) !== undefined) {
-              return true;
-            }
-          }
-
-          return false;
+          return asBoolean ? usernames.length > 0 : usernames;
         }
         case 'sw_seasonLastEpisodeAiredAt': {
           const parent = await getParent();
@@ -660,10 +601,8 @@ export class PlexGetterService {
           );
         }
         case 'rating_imdbShow': {
-          const showMetadata =
-            metadata.type === 'season'
-              ? await getParent()
-              : await getGrandparent();
+          const showMetadata = await getShowMetadata();
+          if (!showMetadata) return null;
 
           return (
             showMetadata.Rating?.find(
@@ -672,10 +611,8 @@ export class PlexGetterService {
           );
         }
         case 'rating_rottenTomatoesCriticShow': {
-          const showMetadata =
-            metadata.type === 'season'
-              ? await getParent()
-              : await getGrandparent();
+          const showMetadata = await getShowMetadata();
+          if (!showMetadata) return null;
 
           return (
             showMetadata.Rating?.find(
@@ -684,10 +621,8 @@ export class PlexGetterService {
           );
         }
         case 'rating_rottenTomatoesAudienceShow': {
-          const showMetadata =
-            metadata.type === 'season'
-              ? await getParent()
-              : await getGrandparent();
+          const showMetadata = await getShowMetadata();
+          if (!showMetadata) return null;
 
           return (
             showMetadata.Rating?.find(
@@ -697,10 +632,8 @@ export class PlexGetterService {
           );
         }
         case 'rating_tmdbShow': {
-          const showMetadata =
-            metadata.type === 'season'
-              ? await getParent()
-              : await getGrandparent();
+          const showMetadata = await getShowMetadata();
+          if (!showMetadata) return null;
 
           return (
             showMetadata.Rating?.find(
@@ -915,5 +848,67 @@ export class PlexGetterService {
       );
       return undefined;
     }
+  }
+
+  /**
+   * The users whose plex.tv watchlist holds the item behind `guid`.
+   *
+   * `undefined` means the answer could not be established and must not be read
+   * as "nobody" (#3307). `stopAtFirstMatch` skips the remaining lookups once a
+   * user matches, for the boolean property.
+   */
+  private async getWatchlistedByUsernames(
+    guid: string | undefined,
+    stopAtFirstMatch: boolean,
+  ): Promise<string[] | undefined> {
+    // An item without a Plex agent id can never be on a watchlist - that is a
+    // definitive empty answer, not a failed lookup.
+    const plexAgentId = PlexMapper.extractPlexAgentId(guid);
+    if (!plexAgentId) {
+      return [];
+    }
+
+    const plexUsers: SimplePlexUser[] = await this.plexApi.getCorrectedUsers();
+
+    // When plex.tv is unreachable, no users will have UUIDs. This is a
+    // transient transport failure, so return `undefined` - `null` would
+    // read as "confirmed absent" and let the executor remove protected
+    // items (#3307).
+    if (plexUsers.length > 0 && !plexUsers.some((u) => u.uuid !== undefined)) {
+      this.logger.warn(
+        'Unable to check watchlists: no user UUIDs available (plex.tv may be unreachable)',
+      );
+      return undefined;
+    }
+
+    const usernames: string[] = [];
+    for (const user of plexUsers.filter((u) => u.uuid !== undefined)) {
+      const watchlist = await this.plexApi.getWatchlistIdsForUser(
+        user.uuid,
+        user.username,
+      );
+
+      // A failed fetch would silently understate the list, so surface it as
+      // transient instead of a confirmed answer.
+      if (watchlist === undefined) {
+        return undefined;
+      }
+
+      // A watchlist Plex refuses to share is permanently unreadable, so skip
+      // that user and let the others still decide the rule - blocking on it
+      // stalls the whole rule forever (#3395).
+      if (watchlist === null) {
+        continue;
+      }
+
+      if (watchlist.some((entry) => entry.id === plexAgentId)) {
+        usernames.push(user.username);
+        if (stopAtFirstMatch) {
+          break;
+        }
+      }
+    }
+
+    return usernames;
   }
 }

--- a/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -367,16 +367,21 @@ export class RuleComparatorService {
   ): { firstValueReason?: string; secondValueReason?: string } {
     const reasons: { firstValueReason?: string; secondValueReason?: string } =
       {};
+    // `undefined` is the transport-failure signal, `null` a confirmed absence -
+    // keep them apart here so the Test Media output stops reporting a failed
+    // lookup as "no entries for this item".
     if (firstVal == null) {
       reasons.firstValueReason = this.ruleConstanstService.getValueNullReason(
         rule.firstVal,
         this.configuredServerType,
+        { lookupFailed: firstVal === undefined },
       );
     }
     if (secondVal == null && rule.lastVal) {
       reasons.secondValueReason = this.ruleConstanstService.getValueNullReason(
         rule.lastVal,
         this.configuredServerType,
+        { lookupFailed: secondVal === undefined },
       );
     }
     return reasons;

--- a/apps/server/src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts
+++ b/apps/server/src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts
@@ -512,6 +512,35 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       expect(result.data).toEqual([]);
     });
 
+    // A failed lookup reported as "no entries for this item" reads as real data
+    // and hides the outage from whoever is debugging the rule (#3395).
+    it.each([
+      [undefined, true],
+      [null, false],
+    ])('reports %p as a failed lookup: %p', async (value, lookupFailed) => {
+      const rules = [
+        createStoredRule(1, {
+          operator: null,
+          action: RulePossibility.EXISTS,
+          firstVal: [Application.PLEX, 6],
+          section: 0,
+        }),
+      ];
+
+      mockGetterSequence(value);
+
+      await ruleComparatorService.executeRulesWithData(
+        createRulesDto({ dataType: 'movie', rules }),
+        [createSingleMedia()],
+      );
+
+      expect(ruleConstanstService.getValueNullReason).toHaveBeenCalledWith(
+        [Application.PLEX, 6],
+        undefined,
+        { lookupFailed },
+      );
+    });
+
     it('completes the run and logs a skip (not a crash) when a unary rule value is unavailable', async () => {
       // getCustomValueIdentifier dereferences customValue.ruleTypeId. A unary
       // rule (EXISTS/NOT_EXISTS) carries no customVal, so logging the skipped


### PR DESCRIPTION
Fixes #3395.

plex.tv answers a watchlist query for a user it will not share with HTTP 200 and a `User not found:` GraphQL error. #3318 made that read as a transport failure, so a single private watchlist left every item permanently evaluation-failed: nothing added, existing members frozen, a warning per item.

- Reading a user's watchlist now answers three states: the list, `null` when plex.tv definitively will not share it, `undefined` for everything else. Only the `User not found:` family maps to `null`, so the #3307 guarantee is unchanged - probing the endpoint shows query errors (unknown field, syntax, introspection) all answer HTTP 400 and never reach that branch. The getter skips those users and lets the readable ones decide the rule.
- An item without a Plex agent id (legacy agent, unmatched, personal media) threw on the guid parse and stalled the rule; it can never be on a watchlist, so it answers an empty list. Parsed with string operations, alongside the other Plex guid parsing.
- The `*Show` rating properties threw on a show-typed item, where Jellyfin and Emby already answer null.
- A failed lookup was reported as "has no entries for this item"; it now says the value could not be read.
- plex.tv's shared-user list is XML, so the response cache never held it and it was re-fetched and re-parsed once per evaluated item (measured 37 reads in one small run, now 1). It is cached in the existing `plextv` cache and shares one in-flight request, since rule evaluation resolves operands in parallel batches and a cold cache otherwise sends the whole batch at once.

  Two notes on that cache: the rule executor flushes it at the start of every run, so a run always reads a fresh list; outside a run it lives for the 20 minute default TTL, so a newly added Plex friend can take that long to appear in settings-side reads. It is bundled here rather than split out because the fix itself is what calls `getCorrectedUsers` once per item.

The two watchlist properties share one helper instead of two near-identical case bodies.
