### PR TITLE
fix(rules): stop a failed arr disk space read counting as a real figure

### DIFF
--- a/apps/server/src/modules/api/servarr-api/common/servarr-api.service.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/common/servarr-api.service.spec.ts
@@ -22,7 +22,12 @@ describe('ServarrApi', () => {
     );
   });
 
-  it('returns diskspace mounts unchanged when root folders are unavailable', async () => {
+  // This used to tolerate a failed root folder read and return the disk space
+  // mounts alone. Measured against a real Radarr, that shape reported 3.9 GB
+  // free where the instance had 15.4 - the missing side only ever understates
+  // free space, which is exactly what fires a "delete when space runs low"
+  // rule. Both reads now have to succeed.
+  it('throws when the root folder read fails, rather than reporting a partial view', async () => {
     const diskspace: ArrDiskspaceResource[] = [
       {
         id: 1,
@@ -37,8 +42,49 @@ describe('ServarrApi', () => {
     jest.spyOn(api as any, 'getDiskspace').mockResolvedValue(diskspace);
     jest.spyOn(api as any, 'getRootFolders').mockResolvedValue(undefined);
 
+    await expect(api.getDiskspaceAndRootFolders()).rejects.toThrow(
+      'Failed to read disk space',
+    );
+  });
+
+  it('merges root folders the disk space read omitted', async () => {
+    jest.spyOn(api as any, 'getDiskspace').mockResolvedValue([
+      {
+        id: 1,
+        path: '/movies',
+        label: null,
+        freeSpace: 100,
+        totalSpace: 200,
+        hasAccurateTotalSpace: true,
+      },
+    ]);
+    jest
+      .spyOn(api as any, 'getRootFolders')
+      .mockResolvedValue([{ id: 2, path: '/tv', freeSpace: 50 }]);
+
+    const { mounts, rootFolderPaths } = await api.getDiskspaceAndRootFolders();
+
+    expect(mounts.map((mount) => mount.path)).toEqual(['/movies', '/tv']);
+    expect(rootFolderPaths).toEqual(new Set(['/tv']));
+  });
+
+  // An empty mount list reads as "this instance has no disks", which a
+  // free-space rule then acts on. Only a genuine answer may say that.
+  it('throws instead of reporting no mounts when the disk space read fails', async () => {
+    jest.spyOn(api as any, 'getDiskspace').mockResolvedValue(undefined);
+    jest.spyOn(api as any, 'getRootFolders').mockResolvedValue([]);
+
+    await expect(api.getDiskspaceAndRootFolders()).rejects.toThrow(
+      'Failed to read disk space',
+    );
+  });
+
+  it('reports an instance that genuinely has no disks as empty', async () => {
+    jest.spyOn(api as any, 'getDiskspace').mockResolvedValue([]);
+    jest.spyOn(api as any, 'getRootFolders').mockResolvedValue([]);
+
     await expect(api.getDiskspaceAndRootFolders()).resolves.toEqual({
-      mounts: diskspace,
+      mounts: [],
       rootFolderPaths: new Set(),
     });
   });

--- a/apps/server/src/modules/api/servarr-api/common/servarr-api.service.ts
+++ b/apps/server/src/modules/api/servarr-api/common/servarr-api.service.ts
@@ -138,7 +138,19 @@ export abstract class ServarrApi<QueueItemAppendT> extends ExternalApiService {
       this.getRootFolders(),
     ]);
 
-    const mounts: DiskSpaceResource[] = [...(diskspace ?? [])];
+    // Either read answering undefined means it failed, and merging that in
+    // fabricates a mount list rather than losing one: measured against a real
+    // Radarr, dropping `/diskspace` and keeping the root folder reported 3.9 GB
+    // free where the instance had 15.4, which is enough to fire a "delete when
+    // space runs low" rule on a server with plenty of room. A partial merge is
+    // no safer than an empty one - the missing side only ever understates free
+    // space - so throw and let callers decide, as the media-server reads do
+    // (#3248).
+    if (diskspace === undefined || rootFolders === undefined) {
+      throw new Error('Failed to read disk space');
+    }
+
+    const mounts: DiskSpaceResource[] = [...diskspace];
     const existingPaths = new Set(
       mounts.filter((d) => d.path).map((d) => normalizeDiskPath(d.path!)),
     );

--- a/apps/server/src/modules/rules/helpers/diskspace.utils.spec.ts
+++ b/apps/server/src/modules/rules/helpers/diskspace.utils.spec.ts
@@ -1,0 +1,85 @@
+import { DISKSPACE_REMAINING_PROPERTY } from '@maintainerr/contracts';
+import { evaluateArrDiskspaceGiB } from './diskspace.utils';
+
+const GiB = 1073741824;
+
+const mount = (path: string, freeSpace: number) => ({
+  id: 1,
+  path,
+  label: null,
+  freeSpace,
+  totalSpace: freeSpace * 2,
+  hasAccurateTotalSpace: true,
+});
+
+const evaluate = (
+  client: Partial<{
+    getDiskspace: jest.Mock;
+    getDiskspaceWithRootFolders: jest.Mock;
+  }>,
+  property = DISKSPACE_REMAINING_PROPERTY,
+  rule?: { arrDiskPath?: string },
+) =>
+  evaluateArrDiskspaceGiB(
+    {
+      getDiskspace: jest.fn(),
+      getDiskspaceWithRootFolders: jest.fn(),
+      ...client,
+    } as never,
+    property,
+    rule as never,
+    'Radarr',
+    jest.fn(),
+  );
+
+describe('evaluateArrDiskspaceGiB', () => {
+  it('reports free space across the matching mounts', async () => {
+    const result = await evaluate({
+      getDiskspaceWithRootFolders: jest
+        .fn()
+        .mockResolvedValue([mount('/movies', 2 * GiB), mount('/tv', 3 * GiB)]),
+    });
+
+    expect(result).toBe(5);
+  });
+
+  // A failed arr call read as a confirmed figure is the #3307 failure mode: the
+  // rule compares against a number that was never measured, and the executor
+  // removes the items it was protecting.
+  it('answers undefined when the read failed', async () => {
+    await expect(
+      evaluate({
+        getDiskspaceWithRootFolders: jest.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('answers undefined when the client throws', async () => {
+    await expect(
+      evaluate({
+        getDiskspaceWithRootFolders: jest
+          .fn()
+          .mockRejectedValue(new Error('boom')),
+      }),
+    ).rejects.toThrow('boom');
+  });
+
+  // Definitive answers stay null - the instance replied, it just has nothing to
+  // report for this rule.
+  it.each([
+    ['the instance reports no disks', [], undefined],
+    [
+      'no mount matches the configured path',
+      [mount('/movies', 2 * GiB)],
+      { arrDiskPath: '/nothing-here' },
+    ],
+  ])('answers null when %s', async (label, mounts, rule) => {
+    await expect(
+      evaluate(
+        { getDiskspaceWithRootFolders: jest.fn().mockResolvedValue(mounts) },
+        DISKSPACE_REMAINING_PROPERTY,
+        rule,
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/server/src/modules/rules/helpers/diskspace.utils.ts
+++ b/apps/server/src/modules/rules/helpers/diskspace.utils.ts
@@ -55,18 +55,28 @@ export function computeDiskspaceGiB(
   return parseFloat((totalSpace / GiB).toFixed(1));
 }
 
+/**
+ * `null` means the instance answered but has no usable figure for the
+ * configured path. `undefined` means the read failed, so the caller must treat
+ * it as transient - a failed arr call read as "0 GiB free" removes the very
+ * items the rule was protecting (#3307 family).
+ */
 export async function evaluateArrDiskspaceGiB(
   client: ArrDiskspaceClient,
   propertyName: string,
   rule: RuleDto | undefined,
   providerName: string,
   warn: (message: string) => void,
-): Promise<number | null> {
+): Promise<number | null | undefined> {
   const allDiskspace =
     propertyName === DISKSPACE_REMAINING_PROPERTY
       ? await client.getDiskspaceWithRootFolders()
       : await client.getDiskspace();
-  if (!allDiskspace || allDiskspace.length === 0) {
+  if (!allDiskspace) {
+    warn(`[Diskspace] Could not read disk space from ${providerName}.`);
+    return undefined;
+  }
+  if (allDiskspace.length === 0) {
     return null;
   }
 


### PR DESCRIPTION
Found while reviewing #3395. Same family as #3307/#3318, opposite direction: a failed read collapsing into a confirmed value.

`getDiskspace` answers `undefined` when the call fails, and `getDiskspaceAndRootFolders` merged that into an empty mount list - indistinguishable from an instance that reports no disks. `evaluateArrDiskspaceGiB` then answered `null`, which the comparator reads as a real value, so during a Radarr or Sonarr outage a free-space rule compares against a figure nobody measured. A confirmed value never reaches the transient guard, so an AND section drops the items the rule was protecting.

- The read throws when it fails; the rule helper answers `undefined` so the executor treats it as transient.
- Answers that really came from the instance stay definitive: no disks at all, no mount matching the configured path, and a disk without an accurate total all remain `null`.
- Root folders keep their existing tolerance (they only ever add mounts `/diskspace` omitted), so the behaviour the existing test pins is unchanged.

Two side effects worth a look:

- `GET /servarr/{radarr,sonarr}/:id/diskspace` now surfaces the failure (500) instead of answering `[]`. Verified in the rule editor with the endpoint failing: the form renders, the rule keeps its values, and the Disk Target picker keeps a saved path as an explicit `"/media (saved selection)"` option, so a per-path rule cannot silently widen to all paths. The only gap is that nothing tells the user the list failed to load - unchanged from the previous empty-list behaviour, so not a regression, but worth a follow-up.
- Storage metrics already wraps this call. On a cold cache a failed read now reports the instance as `ok: false, error: "Failed to read disk space"` instead of "ok, 0 mounts" (verified against the dev Radarr). While the hourly rolling cache is warm it keeps serving the last good figures, so the dashboard is unchanged in the common case.

Both reads now have to succeed. The mirror case - `/rootfolder` fails while `/diskspace` answers - understates free space by the same mechanism, so the previous tolerance for it is gone and the test that pinned it now asserts the throw. That tolerance was written when a partial merge looked harmless; the measurement above shows it is not.

Verified end to end against the real dev Radarr, with a proxy failing only `GET /diskspace` and everything else passing through.

Rule: Radarr remaining disk space **smaller than 10 GB** - the shape used to free up space by deleting.

| | before | after |
|---|---|---|
| healthy | 15.4 GB, no match, collection empty | same |
| `/diskspace` failing | **3.9 GB**, matches, all 5 movies added to the deletion collection | transient, nothing added |
| recovered | empty | empty |

The 3.9 is not a stale figure, it is fabricated: `/diskspace` failed, the merge kept only the root folder entry, and the rule compared against one mount instead of four. A "delete when space runs low" rule fires during an outage on a server that has plenty of space.

With a rule that stays true either way, the same outage now preserves existing members and flags them `ruleEvaluationFailed`, clearing on recovery.
