### PR TITLE
fix(rules): say which integration a stalled rule group is waiting on

### DIFF
--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.spec.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.spec.ts
@@ -1,4 +1,5 @@
 import { Mocked, TestBed } from '@suites/unit';
+import { MaintainerrLoggerFactory } from '../../logging/logs.service';
 import { SettingsDataService } from '../../settings/settings-data.service';
 import cacheManager from '../lib/cache';
 import { SEERR_REQUESTS_CACHE_ID } from './seerr-api.constants';
@@ -507,5 +508,40 @@ describe('SeerrApiService', () => {
         'alice',
       ]);
     });
+  });
+});
+
+describe('SeerrApiService.init lifecycle', () => {
+  let service: SeerrApiService;
+  let settings: Mocked<SettingsDataService>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(SeerrApiService).compile();
+    service = unit;
+    settings = unitRef.get(
+      SettingsDataService,
+    ) as unknown as Mocked<SettingsDataService>;
+    unitRef.get(MaintainerrLoggerFactory).createLogger.mockReturnValue({
+      setContext: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as never);
+  });
+
+  // Removing Seerr from settings left the previous client in place, so the app
+  // kept querying an integration the user had deleted until the next restart.
+  it('drops the client when the settings are removed', () => {
+    settings.seerr_url = 'http://seerr.local';
+    settings.seerr_api_key = 'key';
+    service.init();
+    expect(service.api).toBeDefined();
+
+    settings.seerr_url = null;
+    settings.seerr_api_key = null;
+    service.init();
+
+    expect(service.api).toBeUndefined();
   });
 });

--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
@@ -218,6 +218,10 @@ export class SeerrApiService {
   }
 
   public init() {
+    // Drop the previous client first, so removing Seerr from settings stops
+    // the app querying it rather than leaving the old one live until restart.
+    this.api = undefined;
+
     if (!this.settings.seerr_url) {
       return;
     }

--- a/apps/server/src/modules/api/tautulli-api/tautulli-api.service.spec.ts
+++ b/apps/server/src/modules/api/tautulli-api/tautulli-api.service.spec.ts
@@ -1,0 +1,40 @@
+import { Mocked, TestBed } from '@suites/unit';
+import { MaintainerrLoggerFactory } from '../../logging/logs.service';
+import { SettingsDataService } from '../../settings/settings-data.service';
+import { TautulliApiService } from './tautulli-api.service';
+
+describe('TautulliApiService.init lifecycle', () => {
+  let service: TautulliApiService;
+  let settings: Mocked<SettingsDataService>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(TautulliApiService).compile();
+    service = unit;
+    settings = unitRef.get(
+      SettingsDataService,
+    ) as unknown as Mocked<SettingsDataService>;
+    unitRef.get(MaintainerrLoggerFactory).createLogger.mockReturnValue({
+      setContext: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as never);
+  });
+
+  // Without the reset the app kept querying an integration the user had
+  // deleted, until the next restart.
+  it('drops the client when the settings are removed', () => {
+    settings.tautulli_url = 'http://tautulli.local';
+    settings.tautulli_api_key = 'key';
+    service.init();
+    expect(service.api).toBeDefined();
+
+    settings.tautulli_url = null;
+    settings.tautulli_api_key = null;
+    service.init();
+
+    expect(service.api).toBeUndefined();
+  });
+});

--- a/apps/server/src/modules/api/tautulli-api/tautulli-api.service.ts
+++ b/apps/server/src/modules/api/tautulli-api/tautulli-api.service.ts
@@ -108,6 +108,12 @@ export class TautulliApiService {
   }
 
   public init() {
+    // Drop the previous client first. Without this, removing Tautulli from
+    // settings left the old one in place and the app kept querying an
+    // integration the user had deleted, until the next restart. Tracearr and
+    // Streamystats already reset this way.
+    this.api = undefined;
+
     if (!this.settings.tautulli_url) {
       return;
     }

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.spec.ts
@@ -183,4 +183,28 @@ describe('TautulliGetterService', () => {
       ).resolves.toEqual(new Date(1_700_000_000 * 1000));
     });
   });
+
+  describe('when Tautulli cannot answer', () => {
+    const serviceWith = (tautulliApi: Partial<TautulliApiService>) =>
+      new TautulliGetterService(
+        tautulliApi as jest.Mocked<TautulliApiService>,
+        {} as jest.Mocked<PlexApiService>,
+        {
+          findOne: jest.fn().mockResolvedValue(createCollection({})),
+        } as unknown as jest.Mocked<Repository<Collection>>,
+        createMockLogger(),
+      );
+
+    // Reading through the null threw, which surfaced as the same transient
+    // signal behind a misleading "Action failed" warning.
+    it('stays transient when Tautulli returns no metadata', async () => {
+      const service = serviceWith({
+        getMetadata: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.get(SEEN_BY, showItem, undefined, ruleGroup),
+      ).resolves.toBeUndefined();
+    });
+  });
 });

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
@@ -43,7 +43,15 @@ export class TautulliGetterService {
   ) {
     try {
       const prop = this.appProperties.find((el) => el.id === id);
+
       const metadata = await this.tautulliApi.getMetadata(libItem.id);
+      // Tautulli answers null both for an item it does not know and for a failed
+      // read, so this keeps the transient contract. Reading through the null
+      // threw instead, which surfaced as the same signal behind a misleading
+      // "Action failed" warning.
+      if (!metadata) {
+        return undefined;
+      }
       const collection = await this.collectionRepository.findOne({
         where: { id: ruleGroup.collection.id },
       });

--- a/apps/server/src/modules/rules/getter/tracearr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/tracearr-getter.service.spec.ts
@@ -412,12 +412,13 @@ describe('TracearrGetterService', () => {
     VIEWED_EPISODES,
     LAST_WATCHED,
     WATCHERS,
+    // A property that does not apply to this item type answers null, the
+    // definitive "does not apply". The transient signal froze the whole group,
+    // because the executor sweeps a library at a single dataType.
   ])('skips show property %i for a movie', async (propertyId) => {
     const { service, tracearrApi } = createService([]);
 
-    await expect(
-      service.get(propertyId, movie, ruleGroup),
-    ).resolves.toBeUndefined();
+    await expect(service.get(propertyId, movie, ruleGroup)).resolves.toBeNull();
     expect(tracearrApi.prefetchHistory).not.toHaveBeenCalled();
   });
 
@@ -428,7 +429,7 @@ describe('TracearrGetterService', () => {
 
       await expect(
         service.get(propertyId, episode, ruleGroup),
-      ).resolves.toBeUndefined();
+      ).resolves.toBeNull();
       expect(tracearrApi.prefetchHistory).not.toHaveBeenCalled();
     },
   );

--- a/apps/server/src/modules/rules/getter/tracearr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/tracearr-getter.service.ts
@@ -48,8 +48,12 @@ export class TracearrGetterService {
       if (!property) {
         return null;
       }
+      // A property that does not apply to this item type is a definitive
+      // answer, not a failed lookup - and because the executor sweeps a whole
+      // library at one dataType, the transient signal froze every item in the
+      // group. Every other getter answers `null` here.
       if (!this.supportsMediaItem(property, libItem)) {
-        return undefined;
+        return null;
       }
 
       let historyIndex = this.tracearrApi.getHistoryIndex();

--- a/apps/server/src/modules/rules/helpers/rule-application-availability.helper.spec.ts
+++ b/apps/server/src/modules/rules/helpers/rule-application-availability.helper.spec.ts
@@ -1,0 +1,94 @@
+import { Application, MediaServerType } from '@maintainerr/contracts';
+import { Settings } from '../../settings/entities/settings.entities';
+import { unavailableRuleApplications } from './rule-application-availability.helper';
+
+const allConfigured = {
+  media_server_type: MediaServerType.PLEX,
+  seerr_url: 'http://seerr',
+  seerr_api_key: 'key',
+  tautulli_url: 'http://tautulli',
+  tautulli_api_key: 'key',
+  streamystats_url: 'http://streamystats',
+  jellyfin_api_key: 'key',
+  tracearr_url: 'http://tracearr',
+  tracearr_api_key: 'key',
+  tracearr_server_id: 'server',
+} as Settings;
+
+const servarr = { radarr: true, sonarr: true, sportarr: true };
+
+describe('unavailableRuleApplications', () => {
+  it('reports only the wrong-server companion when everything is set up', () => {
+    // Streamystats is configured but this is a Plex server.
+    expect(unavailableRuleApplications(allConfigured, servarr)).toEqual([
+      Application.STREAMYSTATS,
+    ]);
+  });
+
+  // Migration carries companion operands over on purpose, so a configured
+  // Tautulli can end up on a Jellyfin server, where its ids are the other
+  // server's and every item fails. The editor already hides it; the server has
+  // to agree.
+  it.each([
+    [MediaServerType.PLEX, Application.STREAMYSTATS, Application.TAUTULLI],
+    [MediaServerType.JELLYFIN, Application.TAUTULLI, Application.STREAMYSTATS],
+    [MediaServerType.EMBY, Application.TAUTULLI, undefined],
+  ])('on %s reports %s as unavailable', (server, unavailable, available) => {
+    const result = unavailableRuleApplications(
+      { ...allConfigured, media_server_type: server } as Settings,
+      servarr,
+    );
+
+    expect(result).toContain(unavailable);
+    if (available !== undefined) {
+      expect(result).not.toContain(available);
+    }
+  });
+
+  it('reports both companions on Emby, which has neither', () => {
+    const result = unavailableRuleApplications(
+      { ...allConfigured, media_server_type: MediaServerType.EMBY } as Settings,
+      servarr,
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([Application.TAUTULLI, Application.STREAMYSTATS]),
+    );
+  });
+
+  it.each([
+    ['Seerr', { seerr_api_key: null }, Application.SEERR],
+    ['Tautulli', { tautulli_url: null }, Application.TAUTULLI],
+    ['Streamystats', { streamystats_url: null }, Application.STREAMYSTATS],
+    ['Tracearr', { tracearr_server_id: null }, Application.TRACEARR],
+  ])(
+    'reports %s when its settings are incomplete',
+    (label, patch, expected) => {
+      const result = unavailableRuleApplications(
+        { ...allConfigured, ...patch } as Settings,
+        servarr,
+      );
+
+      expect(result).toContain(expected);
+    },
+  );
+
+  it.each([
+    ['radarr', Application.RADARR],
+    ['sonarr', Application.SONARR],
+    ['sportarr', Application.SPORTARR],
+  ])('reports %s when no instance exists', (key, expected) => {
+    const result = unavailableRuleApplications(allConfigured, {
+      ...servarr,
+      [key]: false,
+    });
+
+    expect(result).toContain(expected);
+  });
+
+  // A fresh install has no settings row yet. Reporting everything as missing
+  // would fail every rule group before the user can configure anything.
+  it('reports nothing when there are no settings at all', () => {
+    expect(unavailableRuleApplications(null, servarr)).toEqual([]);
+  });
+});

--- a/apps/server/src/modules/rules/helpers/rule-application-availability.helper.ts
+++ b/apps/server/src/modules/rules/helpers/rule-application-availability.helper.ts
@@ -1,0 +1,77 @@
+import { Application, MediaServerType } from '@maintainerr/contracts';
+import { Settings } from '../../settings/entities/settings.entities';
+
+/** *arr instances live per instance, not on the settings singleton. */
+export interface ServarrAvailability {
+  radarr: boolean;
+  sonarr: boolean;
+  sportarr: boolean;
+}
+
+// Companions bound to one media server. The media-server Applications are
+// deliberately absent: `resolveValueApplication` remaps those after a migration.
+const MEDIA_SERVER_BY_APPLICATION: Partial<
+  Record<Application, MediaServerType>
+> = {
+  [Application.TAUTULLI]: MediaServerType.PLEX,
+  [Application.STREAMYSTATS]: MediaServerType.JELLYFIN,
+};
+
+/**
+ * Applications that cannot produce a value here: not set up, or not this media
+ * server's companion. Shared by the rule editor's filter and the executor's
+ * warning, so both say the same thing.
+ *
+ * Settings only, never reachability - an unreachable integration is transient
+ * and the getters already handle it.
+ */
+export const unavailableRuleApplications = (
+  settings: Settings | null | undefined,
+  servarr: ServarrAvailability,
+): Application[] => {
+  if (!settings) {
+    return [];
+  }
+
+  const unavailable = new Set<Application>();
+
+  if (!settings.seerr_api_key || !settings.seerr_url) {
+    unavailable.add(Application.SEERR);
+  }
+  if (!servarr.radarr) {
+    unavailable.add(Application.RADARR);
+  }
+  if (!servarr.sonarr) {
+    unavailable.add(Application.SONARR);
+  }
+  if (!servarr.sportarr) {
+    unavailable.add(Application.SPORTARR);
+  }
+  if (!settings.tautulli_url || !settings.tautulli_api_key) {
+    unavailable.add(Application.TAUTULLI);
+  }
+  if (!settings.streamystats_url || !settings.jellyfin_api_key) {
+    unavailable.add(Application.STREAMYSTATS);
+  }
+  if (
+    !settings.tracearr_url ||
+    !settings.tracearr_api_key ||
+    !settings.tracearr_server_id
+  ) {
+    unavailable.add(Application.TRACEARR);
+  }
+
+  // Migration carries companion operands across a server change, so a
+  // configured Tautulli can end up on Jellyfin holding the other server's ids.
+  if (settings.media_server_type) {
+    for (const [application, requiredServer] of Object.entries(
+      MEDIA_SERVER_BY_APPLICATION,
+    )) {
+      if (settings.media_server_type !== requiredServer) {
+        unavailable.add(Number(application) as Application);
+      }
+    }
+  }
+
+  return [...unavailable];
+};

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -53,6 +53,7 @@ import { CommunityRuleKarma } from './entities/community-rule-karma.entities';
 import { Exclusion } from './entities/exclusion.entities';
 import { RuleGroup } from './entities/rule-group.entities';
 import { Rules } from './entities/rules.entities';
+import { unavailableRuleApplications } from './helpers/rule-application-availability.helper';
 import { RuleComparatorServiceFactory } from './helpers/rule.comparator.service';
 import { RuleYamlService } from './helpers/yaml.service';
 
@@ -122,68 +123,29 @@ export class RulesService {
   }
 
   async getRuleConstants(): Promise<RuleConstants> {
-    const settings = await this.settingsRepo.findOne({ where: {} });
-    const radarrSettingsExist = await this.radarrSettingsRepo.exists();
-    const sonarrSettingsExist = await this.sonarrSettingsRepo.exists();
-    const sportarrSettingsExist = await this.sportarrSettingsRepo.exists();
-
     const localConstants = _.cloneDeep(this.ruleConstants);
-    if (settings) {
-      // remove seerr if not configured
-      if (!settings.seerr_api_key || !settings.seerr_url) {
-        localConstants.applications = localConstants.applications.filter(
-          (el) => el.id !== Application.SEERR,
-        );
-      }
+    const unavailable = new Set(await this.getUnavailableApplications());
 
-      // remove radarr if not configured
-      if (!radarrSettingsExist) {
-        localConstants.applications = localConstants.applications.filter(
-          (el) => el.id !== Application.RADARR,
-        );
-      }
-
-      // remove sonarr if not configured
-      if (!sonarrSettingsExist) {
-        localConstants.applications = localConstants.applications.filter(
-          (el) => el.id !== Application.SONARR,
-        );
-      }
-
-      // remove sportarr if not configured
-      if (!sportarrSettingsExist) {
-        localConstants.applications = localConstants.applications.filter(
-          (el) => el.id !== Application.SPORTARR,
-        );
-      }
-
-      // remove tautulli if not configured
-      if (!settings.tautulli_url || !settings.tautulli_api_key) {
-        localConstants.applications = localConstants.applications.filter(
-          (el) => el.id !== Application.TAUTULLI,
-        );
-      }
-
-      // remove streamystats if not configured. It is Jellyfin-only and reuses
-      // the Jellyfin API key; the UI further restricts it to Jellyfin servers.
-      if (!settings.streamystats_url || !settings.jellyfin_api_key) {
-        localConstants.applications = localConstants.applications.filter(
-          (el) => el.id !== Application.STREAMYSTATS,
-        );
-      }
-
-      if (
-        !settings.tracearr_url ||
-        !settings.tracearr_api_key ||
-        !settings.tracearr_server_id
-      ) {
-        localConstants.applications = localConstants.applications.filter(
-          (el) => el.id !== Application.TRACEARR,
-        );
-      }
-    }
+    localConstants.applications = localConstants.applications.filter(
+      (application) => !unavailable.has(application.id),
+    );
 
     return localConstants;
+  }
+
+  /**
+   * Rule Applications that cannot produce a value here - not set up, or not
+   * the configured media server's companion. The editor hides them and the
+   * executor warns when a group reads one, so both say the same thing.
+   */
+  async getUnavailableApplications(): Promise<Application[]> {
+    const settings = await this.settingsRepo.findOne({ where: {} });
+
+    return unavailableRuleApplications(settings, {
+      radarr: await this.radarrSettingsRepo.exists(),
+      sonarr: await this.sonarrSettingsRepo.exists(),
+      sportarr: await this.sportarrSettingsRepo.exists(),
+    });
   }
   async getRules(ruleGroupId: number): Promise<Rules[]> {
     try {

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -26,6 +26,7 @@ describe('RuleExecutorService', () => {
     const rulesService = {
       getRuleGroup: jest.fn(),
       getRuleGroupById: jest.fn(),
+      getUnavailableApplications: jest.fn().mockResolvedValue([]),
       resetCacheIfGroupUsesRuleThatRequiresIt: jest.fn(),
       getExclusions: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<RulesService>;
@@ -1414,6 +1415,46 @@ describe('RuleExecutorService', () => {
       MaintainerrEvent.RuleHandler_Failed,
       expect.anything(),
     );
+  });
+
+  // The per-item transient path already holds the collection and retries; the
+  // only thing missing was telling the user which integration is absent.
+  it('warns which integration is unavailable, and still runs', async () => {
+    const { service, rulesService, mediaServerFactory, logger } = createService(
+      MediaServerType.PLEX,
+    );
+
+    rulesService.getRuleGroup.mockResolvedValue({
+      id: 56,
+      name: 'Unwatched in Tautulli',
+      isActive: true,
+      libraryId: 'library-1',
+      useRules: true,
+      collection: { id: 2, title: 'Movies' },
+      rules: [
+        {
+          ruleJson: JSON.stringify({
+            operator: null,
+            action: 0,
+            section: 0,
+            firstVal: [Application.TAUTULLI, 3],
+            customVal: { ruleTypeId: 0, value: '0' },
+          }),
+        },
+      ],
+    } as any);
+    rulesService.getUnavailableApplications.mockResolvedValue([
+      Application.TAUTULLI,
+    ]);
+    mediaServerFactory.verifyConnection.mockRejectedValue(new Error('stop'));
+
+    await service.executeForRuleGroups(56, new AbortController().signal);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Tautulli'),
+    );
+    // The run itself is untouched: the getters still decide per item.
+    expect(mediaServerFactory.verifyConnection).toHaveBeenCalledTimes(1);
   });
 
   it('does not emit started and still cleans up when execution was already aborted before starting', async () => {

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -1,4 +1,5 @@
 import {
+  ApplicationNames,
   IComparisonStatistics,
   MaintainerrEvent,
   MediaItem,
@@ -136,6 +137,29 @@ export class RuleExecutorService {
     });
   }
 
+  /** Both sides of a rule count: a Seerr date compared against a Tautulli one needs both. */
+  private async findUnavailableApplications(
+    ruleGroup: RulesDto,
+  ): Promise<string[]> {
+    const referenced = new Set<Application>();
+    for (const rule of ruleGroup.rules) {
+      const parsedRule = (
+        'ruleJson' in rule ? JSON.parse(rule.ruleJson) : rule
+      ) as RuleDto;
+      referenced.add(parsedRule.firstVal[0]);
+      if (parsedRule.lastVal) {
+        referenced.add(parsedRule.lastVal[0]);
+      }
+    }
+
+    const unavailable = await this.rulesService.getUnavailableApplications();
+    return unavailable
+      .filter((application) => referenced.has(application))
+      .map(
+        (application) => ApplicationNames[application] ?? `app ${application}`,
+      );
+  }
+
   private buildRuleHandlerFailedDto(
     rulegroup?: Partial<Pick<RuleGroup, 'id' | 'name' | 'collectionId'>> & {
       collection?: { title?: string } | null;
@@ -201,6 +225,17 @@ export class RuleExecutorService {
         );
         throw new RuleExecutionFailure(
           this.buildRuleHandlerFailedDto(ruleGroup, ruleGroup.name),
+        );
+      }
+
+      // Absent, not merely unreachable: every property reading it answers the
+      // transient signal for every item, which holds the collection and retries
+      // next run. That part is by design; being silent about it is not.
+      const missing = await this.findUnavailableApplications(ruleGroup);
+      if (missing.length > 0) {
+        this.logger.warn(
+          `Rule group '${ruleGroup.name}' reads ${missing.join(', ')}, not available for this server. ` +
+            `Its collection is held until you configure it or remove those rules.`,
         );
       }
 


### PR DESCRIPTION
Found while reviewing #3395.

A getter answering `undefined` holds the item: it is flagged `ruleEvaluationFailed`, the collection handler leaves it alone, and the next run that can evaluate clears the flag. That pause-and-retry is by design and heals itself.

It also fires when an integration is *absent* rather than briefly unreachable - not configured, or belonging to a different media server - and there it is silent. The collection stops moving with nothing above debug to say why.

**Rule evaluation is unchanged.** This only logs which integration is missing, once per run:

```
WARN  Rule group 'Unwatched movies' reads Tautulli, not available for this
      server. Its collection is held until you configure it or remove those rules.
```

Absent means not configured, **or not this media server's companion**. Tautulli tracks a Plex server and Streamystats is its Jellyfin analog, and rule migration carries those operands across a server change - so a configured Tautulli can end up on a Jellyfin server holding the other server's ids. The media-server Applications themselves are exempt: `resolveValueApplication` remaps those. Settings only, never reachability.

The editor already hid these Applications, including the media-server restriction it applied client-side; that filter and this warning now share one predicate instead of keeping separate copies.

Three defects found in the same area:

- **Removing Tautulli or Seerr from settings left the previous client in place**, so the app kept querying an integration the user had deleted until the next restart. Both now drop the client when re-initialising, as Tracearr and Streamystats already did. Covered by a lifecycle test that fails without the fix.
- The Tautulli getter read through a null metadata response, which threw and surfaced as the transient signal behind a misleading "Action failed" warning.
- Tracearr answered the transient signal for a property that does not apply to the item type. The executor sweeps a library at one dataType, so that is all-or-nothing for the group; every other getter answers `null` there.

Verified against the real dev stack: Tautulli removed through `PATCH /api/settings` with no restart, and separately with the media server switched to a real Jellyfin while Tautulli stayed configured. Both log the warning; membership, flags and the collection handler behave exactly as before.
