### PR TITLE
fix(rules): stop items with no external IDs pinning arr and Seerr rules forever

### DIFF
--- a/apps/server/src/modules/metadata/metadata.service.spec.ts
+++ b/apps/server/src/modules/metadata/metadata.service.spec.ts
@@ -1372,4 +1372,38 @@ describe('MetadataService', () => {
       expect(merged).toBeUndefined();
     });
   });
+  // The predicate the arr and Seerr getters use to tell "nothing to look up"
+  // from "the lookup failed". It must never make a request, and it must be
+  // broader than "TMDB or TVDB can extract an id" - an imdb-only item has
+  // neither yet still resolves online by cross-referencing, so calling it
+  // unresolvable would un-protect exactly the items #3125 guards during a
+  // TMDB outage.
+  describe('hasExternalIds', () => {
+    it.each([
+      ['a tmdb id', { tmdb: ['550'] }, true],
+      ['a tvdb id', { tvdb: ['73141'] }, true],
+      ['only an imdb id', { imdb: ['tt0099785'] }, true],
+      ['no ids at all', {}, false],
+      ['empty id lists', { imdb: [], tmdb: [], tvdb: [] }, false],
+    ])('is %s -> %s', (label, providerIds, expected) => {
+      const { service, providers } = createService({});
+
+      expect(
+        service.hasExternalIds(
+          createMediaItem({ type: 'movie', providerIds } as never),
+        ),
+      ).toBe(expected);
+      for (const provider of providers) {
+        expect(provider.getDetails).not.toHaveBeenCalled();
+      }
+    });
+
+    it('is false when the item carries no providerIds field', () => {
+      const { service } = createService({});
+      const item = createMediaItem({ type: 'movie' });
+      delete (item as { providerIds?: unknown }).providerIds;
+
+      expect(service.hasExternalIds(item)).toBe(false);
+    });
+  });
 });

--- a/apps/server/src/modules/metadata/metadata.service.ts
+++ b/apps/server/src/modules/metadata/metadata.service.ts
@@ -232,6 +232,24 @@ export class MetadataService {
     );
   }
 
+  /**
+   * Whether the item carries any external id a lookup could start from.
+   *
+   * Purely local - it reads what the media server already sent and makes no
+   * request - so a `false` here can never be an outage. Resolution answering
+   * `undefined` otherwise means two different things: "nothing to look up" and
+   * "the lookup failed", and only the second should pause rule evaluation.
+   *
+   * Note this is broader than "TMDB or TVDB can extract an id": an item with
+   * only an imdb id has neither, but is still resolvable online by
+   * cross-referencing, so it must not count as unresolvable.
+   */
+  public hasExternalIds(item: MediaItem): boolean {
+    const ids = this.extractDirectIds(item);
+
+    return Object.entries(ids).some(([key, value]) => key !== 'type' && value);
+  }
+
   public async resolveLookupCandidatesFromMediaItemForService(
     item: MediaItem,
     service: string,

--- a/apps/server/src/modules/rules/getter/radarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.spec.ts
@@ -328,15 +328,30 @@ describe('RadarrGetterService', () => {
       await expect(callAddDate()).resolves.toBeNull();
     });
 
-    it('returns undefined (fail closed) when no external ids resolve', async () => {
-      // Empty resolution also covers a transient TMDB/TVDB validation
-      // failure, so it must stay transient (#3307).
+    it('returns undefined (fail closed) when the lookup fails for an item that has ids', async () => {
+      // The item has something to look up, so an empty resolution may be a
+      // transient TMDB/TVDB validation failure and must stay transient (#3307).
       mockRadarrApi();
+      metadataService.hasExternalIds.mockReturnValue(true);
       metadataService.resolveLookupCandidatesFromMediaItemForService.mockResolvedValue(
         [],
       );
 
       await expect(callAddDate()).resolves.toBeUndefined();
+    });
+
+    // Unmatched items, personal media and home videos reach rule evaluation
+    // with no external ids at all. Nothing is ever requested for them, so the
+    // empty resolution cannot be an outage - and answering transient pinned
+    // them in place forever.
+    it('returns null when the item carries no external ids at all', async () => {
+      mockRadarrApi();
+      metadataService.hasExternalIds.mockReturnValue(false);
+      metadataService.resolveLookupCandidatesFromMediaItemForService.mockResolvedValue(
+        [],
+      );
+
+      await expect(callAddDate()).resolves.toBeNull();
     });
   });
 

--- a/apps/server/src/modules/rules/getter/radarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.ts
@@ -73,13 +73,21 @@ export class RadarrGetterService {
       );
 
       if (lookupCandidates.length === 0) {
+        // Two very different causes look the same here. An item the media
+        // server gave no external ids for can never resolve, no matter how
+        // often it is retried, and answering the transient signal pinned it
+        // for good. A failed online validation is the case #3307 protects, so
+        // that one still pauses evaluation.
+        if (!this.metadataService.hasExternalIds(libItem)) {
+          this.logger.debug(
+            `'${libItem.title}' (media server ID '${libItem.id}') carries no external IDs, so no Radarr query is possible.`,
+          );
+          return null;
+        }
+
         this.logger.warn(
           `Failed to resolve external IDs for '${libItem.title}' (media server ID '${libItem.id}'). As a result, no Radarr query could be made.`,
         );
-        // An empty resolution cannot distinguish "item has no provider ids"
-        // from a transient TMDB/TVDB failure (validation runs online), so it
-        // must stay `undefined` - `null` would defeat the transient-removal
-        // guard and wipe collections during an internet outage (#3307).
         return undefined;
       }
 

--- a/apps/server/src/modules/rules/getter/seerr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/seerr-getter.service.ts
@@ -87,11 +87,12 @@ export class SeerrGetterService {
         this.logger.debug(
           `Couldn't find tmdb id for media '${libItem.title}' with id '${libItem.id}'. As a result, no Seerr query could be made.`,
         );
-        // An empty resolution cannot distinguish "item has no tmdb id" from a
-        // transient TMDB failure (validation runs online), so it must stay
-        // `undefined` - `null` would defeat the transient-removal guard and
-        // wipe collections during an internet outage (#3307).
-        return undefined;
+        // An item the media server gave no external ids for can never resolve
+        // one, however often it is retried, so the transient signal pinned it
+        // for good. An item that has ids but could not be cross-referenced to a
+        // tmdb id may just be a failed online lookup, which is the case #3307
+        // protects, so that one still pauses evaluation.
+        return this.metadataService.hasExternalIds(libItem) ? undefined : null;
       }
 
       // releaseDate (movie releaseDate / tv firstAirDate / season|episode

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
@@ -380,14 +380,27 @@ describe('SonarrGetterService', () => {
         ).toHaveBeenCalledTimes(2);
       });
 
-      it('returns undefined (fail closed) when no external ids resolve', async () => {
-        // Empty resolution also covers a transient TMDB/TVDB validation
-        // failure, so it must stay transient (#3307).
+      it('returns undefined (fail closed) when the lookup fails for an item that has ids', async () => {
+        // The item has something to look up, so an empty resolution may be a
+        // transient TMDB/TVDB validation failure (#3307).
+        metadataService.hasExternalIds.mockReturnValue(true);
         metadataService.resolveLookupCandidatesFromMediaItemForService.mockResolvedValue(
           [],
         );
 
         await expect(call()).resolves.toBeUndefined();
+      });
+
+      // Nothing is ever requested for an item with no external ids, so the
+      // empty resolution cannot be an outage - and answering transient pinned
+      // the item in place forever.
+      it('returns null when the item carries no external ids at all', async () => {
+        metadataService.hasExternalIds.mockReturnValue(false);
+        metadataService.resolveLookupCandidatesFromMediaItemForService.mockResolvedValue(
+          [],
+        );
+
+        await expect(call()).resolves.toBeNull();
       });
 
       it('evicts an empty resolution so a later condition retries (transient safety, #3125)', async () => {

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -106,13 +106,21 @@ export class SonarrGetterService {
       );
 
       if (lookupCandidates.length === 0) {
+        // Two very different causes look the same here. An item the media
+        // server gave no external ids for can never resolve, no matter how
+        // often it is retried, and answering the transient signal pinned it
+        // for good. A failed online validation is the case #3307 protects, so
+        // that one still pauses evaluation.
+        if (!this.metadataService.hasExternalIds(libItem)) {
+          this.logger.debug(
+            `'${libItem.title}' (media server ID '${libItem.id}') carries no external IDs, so no Sonarr query is possible.`,
+          );
+          return null;
+        }
+
         this.logger.warn(
           `Failed to resolve external IDs for '${libItem.title}' (media server ID '${libItem.id}'). As a result, no Sonarr query could be made.`,
         );
-        // An empty resolution cannot distinguish "item has no provider ids"
-        // from a transient TMDB/TVDB failure (validation runs online), so it
-        // must stay `undefined` - `null` would defeat the transient-removal
-        // guard and wipe collections during an internet outage (#3307).
         return undefined;
       }
 


### PR DESCRIPTION
Last of the getter-contract findings from the #3395 review.

The Radarr, Sonarr and Seerr getters answer the transient signal when nothing resolves, because an empty resolution can be a failed TMDB/TVDB lookup and #3307/#3125 must keep protecting those items. It can also be an item the media server gave no external IDs for at all - unmatched entries, personal media, home videos - and for those nothing is ever requested, so the condition never clears. Every arr and Seerr property stayed unavailable for that item permanently: it could never enter a collection, and if it was already in one it sat pinned as `ruleEvaluationFailed` and could never leave.

Resolution now consults whether the item carries any external ID before deciding. That reads only what the media server already sent and makes no request, so a negative answer cannot be an outage. A failed lookup on an item that does have IDs stays transient.

**The obvious predicate would have been wrong.** `hasAvailableDirectIds` inside the metadata service only asks whether TMDB or TVDB can extract an ID - they are the only two providers - but `extractDirectIds` also keeps other keys, so an item carrying just an imdb ID has neither and is still resolvable online by cross-referencing. Keying "permanent" off that flag would mark every imdb-only item unresolvable and un-protect exactly the items #3125 guards whenever TMDB is down. The predicate here asks whether *any* external ID is present, and there is a test pinning the imdb-only case for that reason.

Sportarr has the same shape and is handled separately.
