### PR TITLE
fix(rules): stop shows without a league alias pinning Sportarr rules forever

### DIFF
--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.spec.ts
@@ -75,17 +75,38 @@ describe('SportarrGetterService', () => {
     expect(result).toBeNull();
   });
 
-  it('fails closed (undefined) when no Sportarr id can be resolved', async () => {
-    // An empty resolution can't distinguish "no alias on the item" from a
-    // transient media-server failure, so it must not read as definitive
-    // absence (same reasoning as the Sonarr getter, #3307).
+  it('fails closed (undefined) when the show metadata read fails', async () => {
+    // The alias is unknown rather than absent, so it must not read as
+    // definitive absence (same reasoning as the Sonarr getter, #3307).
+    mockMediaServer.getMetadata.mockResolvedValue(undefined);
+
     const result = await service.get(
       0,
       createMediaItem({ type: 'show', providerIds: { tvdb: ['342040'] } }),
       'show',
       ruleGroup(),
     );
+
     expect(result).toBeUndefined();
+    expect(mockClient.getLeagueByExternalId).not.toHaveBeenCalled();
+  });
+
+  // An ordinary show in a sports library will never carry a league alias, so
+  // the transient signal pinned it for good: it could never enter a collection
+  // and never leave one it was already in.
+  it('answers null when the show reads fine but carries no league alias', async () => {
+    mockMediaServer.getMetadata.mockResolvedValue(
+      createMediaItem({ type: 'show', providerIds: { tvdb: ['342040'] } }),
+    );
+
+    const result = await service.get(
+      0,
+      createMediaItem({ type: 'show', providerIds: { tvdb: ['342040'] } }),
+      'show',
+      ruleGroup(),
+    );
+
+    expect(result).toBeNull();
     expect(mockClient.getLeagueByExternalId).not.toHaveBeenCalled();
   });
 

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
@@ -83,6 +83,7 @@ export class SportarrGetterService {
       let externalId = sportarrLeagueExternalIdFromProviderIds(
         showItem?.providerIds?.tvdb,
       );
+      let showMetadataRead = showItem !== undefined;
       if (!externalId) {
         // The rule executor can pass a lightweight library item whose
         // providerIds aren't populated. Re-fetch the show's full metadata to
@@ -100,20 +101,32 @@ export class SportarrGetterService {
               (item) => item === undefined,
             )
           : fetchShow());
+        // Whether the show's metadata was actually read is what separates the
+        // two causes below.
+        showMetadataRead = fullShow !== undefined;
         externalId = sportarrLeagueExternalIdFromProviderIds(
           fullShow?.providerIds?.tvdb,
         );
       }
       if (!externalId) {
-        this.logger.warn(
-          `Failed to resolve a Sportarr league id for '${libItem.title}' (media server ID '${libItem.id}'). No Sportarr query could be made.`,
+        if (!showMetadataRead) {
+          this.logger.warn(
+            `Failed to resolve a Sportarr league id for '${libItem.title}' (media server ID '${libItem.id}'). No Sportarr query could be made.`,
+          );
+          // The metadata read failed, so the alias is unknown rather than
+          // absent - `null` here would defeat the transient-removal guard and
+          // splice items out during an outage (#3307).
+          return undefined;
+        }
+
+        // The show's metadata read fine and simply carries no Sportarr alias:
+        // an ordinary show in a sports library, which will never have one.
+        // Answering transient pinned it for good - it could never enter a
+        // collection, and never leave one it was already in.
+        this.logger.debug(
+          `'${libItem.title}' (media server ID '${libItem.id}') carries no Sportarr league alias, so no Sportarr query is possible.`,
         );
-        // An empty resolution cannot distinguish "item carries no Sportarr
-        // alias" from a transient media-server failure on the metadata reads
-        // above, so it must stay `undefined` - `null` would defeat the
-        // transient-removal guard and splice items out of collections during
-        // an outage (same reasoning as the Sonarr getter, #3307).
-        return undefined;
+        return null;
       }
 
       // The /leagues list is identical for every item in the run, so pull it


### PR DESCRIPTION
Same defect class as #3403, split out because Sportarr resolves its league id straight from the media server rather than through the metadata service.

The getter answers the transient signal whenever no league id resolves, which covers two very different causes:

- The show's metadata read failed, so the alias is unknown. That has to stay transient (#3307).
- The show read fine and simply carries no Sportarr alias - an ordinary show in a sports library, which will never have one. That is permanent, so the transient signal never cleared: every Sportarr property stayed unavailable for the item for good, it could never enter a collection, and if it was already in one it sat pinned as `ruleEvaluationFailed` and could never leave.

The two are now separated by whether the show's metadata was actually read.
