### PR TITLE
fix(rules): keep items that cannot be looked up out of NOT_EXISTS matches

### DIFF
--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -874,10 +874,11 @@ describe('PlexGetterService', () => {
       );
     });
 
-    it('reports nobody without querying plex.tv when the item has no plex guid (ids 28 and 30)', async () => {
-      // Legacy-agent, unmatched and personal media carry a non-plex:// guid,
-      // and watchlist entries are keyed on the plex:// uuid, so they can never
-      // be watchlisted.
+    it('stays transient without querying plex.tv when the item has no plex guid (ids 28 and 30)', async () => {
+      // Legacy-agent, unmatched and personal media carry a non-plex:// guid and
+      // cannot be correlated with a watchlist. Answering "nobody" would let them
+      // match a "not watchlisted" rule, so it stays transient - it just no
+      // longer throws its way there.
       plexApi.getMetadata.mockResolvedValue(
         makeMetadata({
           ratingKey: 'movie-1',
@@ -891,10 +892,10 @@ describe('PlexGetterService', () => {
 
       await expect(
         service.get(28, libItem, 'movie', ruleGroup),
-      ).resolves.toEqual([]);
-      await expect(service.get(30, libItem, 'movie', ruleGroup)).resolves.toBe(
-        false,
-      );
+      ).resolves.toBeUndefined();
+      await expect(
+        service.get(30, libItem, 'movie', ruleGroup),
+      ).resolves.toBeUndefined();
       expect(plexApi.getCorrectedUsers).not.toHaveBeenCalled();
       expect(plexApi.getWatchlistIdsForUser).not.toHaveBeenCalled();
     });

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -861,11 +861,13 @@ export class PlexGetterService {
     guid: string | undefined,
     stopAtFirstMatch: boolean,
   ): Promise<string[] | undefined> {
-    // An item without a Plex agent id can never be on a watchlist - that is a
-    // definitive empty answer, not a failed lookup.
+    // Watchlist entries are keyed on the Plex agent id, so an item without one
+    // cannot be correlated with any watchlist. Transient rather than an empty
+    // answer: a definitive one would let unmatched and personal media match a
+    // "not watchlisted" rule.
     const plexAgentId = PlexMapper.extractPlexAgentId(guid);
     if (!plexAgentId) {
-      return [];
+      return undefined;
     }
 
     const plexUsers: SimplePlexUser[] = await this.plexApi.getCorrectedUsers();

--- a/apps/server/src/modules/rules/getter/radarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.spec.ts
@@ -340,18 +340,18 @@ describe('RadarrGetterService', () => {
       await expect(callAddDate()).resolves.toBeUndefined();
     });
 
-    // Unmatched items, personal media and home videos reach rule evaluation
-    // with no external ids at all. Nothing is ever requested for them, so the
-    // empty resolution cannot be an outage - and answering transient pinned
-    // them in place forever.
-    it('returns null when the item carries no external ids at all', async () => {
+    // "We could not look it up" is not "it is not there": a definitive answer
+    // would let unmatched items and personal media match NOT_EXISTS rules. Only
+    // the log level changes.
+    it('stays transient, and logs quietly, when the item carries no external ids', async () => {
       mockRadarrApi();
       metadataService.hasExternalIds.mockReturnValue(false);
       metadataService.resolveLookupCandidatesFromMediaItemForService.mockResolvedValue(
         [],
       );
 
-      await expect(callAddDate()).resolves.toBeNull();
+      await expect(callAddDate()).resolves.toBeUndefined();
+      expect(logger.warn).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/modules/rules/getter/radarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.ts
@@ -73,21 +73,18 @@ export class RadarrGetterService {
       );
 
       if (lookupCandidates.length === 0) {
-        // Two very different causes look the same here. An item the media
-        // server gave no external ids for can never resolve, no matter how
-        // often it is retried, and answering the transient signal pinned it
-        // for good. A failed online validation is the case #3307 protects, so
-        // that one still pauses evaluation.
-        if (!this.metadataService.hasExternalIds(libItem)) {
-          this.logger.debug(
-            `'${libItem.title}' (media server ID '${libItem.id}') carries no external IDs, so no Radarr query is possible.`,
-          );
-          return null;
+        // An item the media server gave no external IDs for can never resolve,
+        // so log it quietly rather than warning about it every run. The answer
+        // stays transient either way: "we could not look it up" is not the same
+        // claim as "it is not there", and a definitive one would let unmatched
+        // and personal media match NOT_EXISTS rules.
+        const message = `Failed to resolve external IDs for '${libItem.title}' (media server ID '${libItem.id}'). As a result, no Radarr query could be made.`;
+        if (this.metadataService.hasExternalIds(libItem)) {
+          this.logger.warn(message);
+        } else {
+          this.logger.debug(message);
         }
 
-        this.logger.warn(
-          `Failed to resolve external IDs for '${libItem.title}' (media server ID '${libItem.id}'). As a result, no Radarr query could be made.`,
-        );
         return undefined;
       }
 

--- a/apps/server/src/modules/rules/getter/seerr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/seerr-getter.service.ts
@@ -87,12 +87,10 @@ export class SeerrGetterService {
         this.logger.debug(
           `Couldn't find tmdb id for media '${libItem.title}' with id '${libItem.id}'. As a result, no Seerr query could be made.`,
         );
-        // An item the media server gave no external ids for can never resolve
-        // one, however often it is retried, so the transient signal pinned it
-        // for good. An item that has ids but could not be cross-referenced to a
-        // tmdb id may just be a failed online lookup, which is the case #3307
-        // protects, so that one still pauses evaluation.
-        return this.metadataService.hasExternalIds(libItem) ? undefined : null;
+        // Transient either way: "we could not look it up" is not the same claim
+        // as "it is not requested", and a definitive answer would let unmatched
+        // and personal media match NOT_EXISTS rules.
+        return undefined;
       }
 
       // releaseDate (movie releaseDate / tv firstAirDate / season|episode

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
@@ -391,16 +391,15 @@ describe('SonarrGetterService', () => {
         await expect(call()).resolves.toBeUndefined();
       });
 
-      // Nothing is ever requested for an item with no external ids, so the
-      // empty resolution cannot be an outage - and answering transient pinned
-      // the item in place forever.
-      it('returns null when the item carries no external ids at all', async () => {
+      // "We could not look it up" is not "it is not there": a definitive answer
+      // would let unmatched items and personal media match NOT_EXISTS rules.
+      it('stays transient when the item carries no external ids', async () => {
         metadataService.hasExternalIds.mockReturnValue(false);
         metadataService.resolveLookupCandidatesFromMediaItemForService.mockResolvedValue(
           [],
         );
 
-        await expect(call()).resolves.toBeNull();
+        await expect(call()).resolves.toBeUndefined();
       });
 
       it('evicts an empty resolution so a later condition retries (transient safety, #3125)', async () => {

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -106,21 +106,18 @@ export class SonarrGetterService {
       );
 
       if (lookupCandidates.length === 0) {
-        // Two very different causes look the same here. An item the media
-        // server gave no external ids for can never resolve, no matter how
-        // often it is retried, and answering the transient signal pinned it
-        // for good. A failed online validation is the case #3307 protects, so
-        // that one still pauses evaluation.
-        if (!this.metadataService.hasExternalIds(libItem)) {
-          this.logger.debug(
-            `'${libItem.title}' (media server ID '${libItem.id}') carries no external IDs, so no Sonarr query is possible.`,
-          );
-          return null;
+        // An item the media server gave no external IDs for can never resolve,
+        // so log it quietly rather than warning about it every run. The answer
+        // stays transient either way: "we could not look it up" is not the same
+        // claim as "it is not there", and a definitive one would let unmatched
+        // and personal media match NOT_EXISTS rules.
+        const message = `Failed to resolve external IDs for '${libItem.title}' (media server ID '${libItem.id}'). As a result, no Sonarr query could be made.`;
+        if (this.metadataService.hasExternalIds(libItem)) {
+          this.logger.warn(message);
+        } else {
+          this.logger.debug(message);
         }
 
-        this.logger.warn(
-          `Failed to resolve external IDs for '${libItem.title}' (media server ID '${libItem.id}'). As a result, no Sonarr query could be made.`,
-        );
         return undefined;
       }
 

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.spec.ts
@@ -91,10 +91,10 @@ describe('SportarrGetterService', () => {
     expect(mockClient.getLeagueByExternalId).not.toHaveBeenCalled();
   });
 
-  // An ordinary show in a sports library will never carry a league alias, so
-  // the transient signal pinned it for good: it could never enter a collection
-  // and never leave one it was already in.
-  it('answers null when the show reads fine but carries no league alias', async () => {
+  // An ordinary show in a sports library carries no alias, but a definitive
+  // answer would let it match NOT_EXISTS rules - so it stays transient and only
+  // the log level changes.
+  it('stays transient when the show reads fine but carries no league alias', async () => {
     mockMediaServer.getMetadata.mockResolvedValue(
       createMediaItem({ type: 'show', providerIds: { tvdb: ['342040'] } }),
     );
@@ -106,7 +106,7 @@ describe('SportarrGetterService', () => {
       ruleGroup(),
     );
 
-    expect(result).toBeNull();
+    expect(result).toBeUndefined();
     expect(mockClient.getLeagueByExternalId).not.toHaveBeenCalled();
   });
 

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
@@ -101,32 +101,24 @@ export class SportarrGetterService {
               (item) => item === undefined,
             )
           : fetchShow());
-        // Whether the show's metadata was actually read is what separates the
-        // two causes below.
         showMetadataRead = fullShow !== undefined;
         externalId = sportarrLeagueExternalIdFromProviderIds(
           fullShow?.providerIds?.tvdb,
         );
       }
       if (!externalId) {
-        if (!showMetadataRead) {
-          this.logger.warn(
-            `Failed to resolve a Sportarr league id for '${libItem.title}' (media server ID '${libItem.id}'). No Sportarr query could be made.`,
-          );
-          // The metadata read failed, so the alias is unknown rather than
-          // absent - `null` here would defeat the transient-removal guard and
-          // splice items out during an outage (#3307).
-          return undefined;
+        // A show that read fine and carries no alias is an ordinary show in a
+        // sports library, so log it quietly rather than warning every run. The
+        // answer stays transient either way - a definitive one would let those
+        // shows match NOT_EXISTS rules.
+        const message = `Failed to resolve a Sportarr league id for '${libItem.title}' (media server ID '${libItem.id}'). No Sportarr query could be made.`;
+        if (showMetadataRead) {
+          this.logger.debug(message);
+        } else {
+          this.logger.warn(message);
         }
 
-        // The show's metadata read fine and simply carries no Sportarr alias:
-        // an ordinary show in a sports library, which will never have one.
-        // Answering transient pinned it for good - it could never enter a
-        // collection, and never leave one it was already in.
-        this.logger.debug(
-          `'${libItem.title}' (media server ID '${libItem.id}') carries no Sportarr league alias, so no Sportarr query is possible.`,
-        );
-        return null;
+        return undefined;
       }
 
       // The /leagues list is identical for every item in the run, so pull it


### PR DESCRIPTION
Follow-up to #3400, #3403 and #3405, all merged. Each turned "this item cannot be correlated with the service" into a definitive answer, to stop such items sitting permanently evaluation-failed. On review that trade does not hold.

**The pin was mostly theoretical.** An item with no external IDs could not have been added by an arr rule in the first place - that needs a successful lookup - so there was rarely anything pinned.

**The definitive answer is not theoretical.** `null` and `[]` satisfy `NOT_EXISTS`, so unmatched entries, personal media and ordinary shows in a sports library could newly be added to collections that delete. That is a rule behaviour change nobody asked for, in the direction that loses data.

So all four go back to the transient signal, and rule results are unchanged from v3.21.1:

- Radarr, Sonarr and Seerr answer `undefined` again when nothing resolves
- Sportarr answers `undefined` again for a show with no league alias
- The Plex watchlist getter answers `undefined` again for an item with no `plex://` guid

What those PRs got right is kept:

- the guid parse no longer throws its way into the transient signal, it returns there deliberately
- Sportarr and Seerr still separate a failed read from a resolvable one
- the case that can never resolve logs at **debug** instead of warning about the same item on every run, which was the real user-visible cost

The private-watchlist fix itself is untouched: a watchlist plex.tv refuses to share is still skipped so the readable users decide the rule.

Net -14 lines. Each of the four specs asserted the definitive answer and now asserts the transient one; they fail without this change. Smoke-tested against the real dev Radarr to confirm resolvable items still evaluate normally.
