### PR TITLE
test(ui): unmount rendered components after every test in one place

### DIFF
--- a/apps/ui/src/components/AddModal/index.spec.tsx
+++ b/apps/ui/src/components/AddModal/index.spec.tsx
@@ -1,11 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTestQueryClient } from '../../test-utils/queryClient'
 import GetApiHandler, { PostApiHandler } from '../../utils/ApiHandler'
@@ -58,7 +52,6 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  cleanup()
   queryClient.clear()
 })
 

--- a/apps/ui/src/components/Collection/CollectionDetail/PostponeButton/index.spec.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/PostponeButton/index.spec.tsx
@@ -1,7 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import type { ReactElement } from 'react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTestQueryClient } from '../../../../test-utils/queryClient'
 import type { ICollection } from '../../index'
 import PostponeButton from './index'
@@ -49,10 +49,6 @@ describe('PostponeButton', () => {
     postponeCollectionItem.mockReset()
     invalidateCollectionQueries.mockReset()
     invalidateCollectionQueries.mockResolvedValue(undefined)
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('posts the entered days and hands the new addDate back to the caller', async () => {

--- a/apps/ui/src/components/Collection/CollectionItem/index.spec.tsx
+++ b/apps/ui/src/components/Collection/CollectionItem/index.spec.tsx
@@ -1,13 +1,7 @@
 import type { MediaLibrary } from '@maintainerr/contracts'
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useMediaServerLibraries } from '../../../api/media-server'
 import {
   buildQueryErrorResult,
@@ -49,10 +43,6 @@ describe('CollectionItem', () => {
     ]
 
     librariesHookMock.mockReturnValue(buildQuerySuccessResult(libraries))
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('renders collection preview images inside the wide backdrop layout', async () => {

--- a/apps/ui/src/components/Collection/CollectionOverview/index.spec.tsx
+++ b/apps/ui/src/components/Collection/CollectionOverview/index.spec.tsx
@@ -1,6 +1,6 @@
 import type { MediaLibrary } from '@maintainerr/contracts'
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useMediaServerLibraries } from '../../../api/media-server'
 import { useTaskStatusContext } from '../../../contexts/taskstatus-context'
 import { buildQuerySuccessResult } from '../../../test-utils/queryResults'
@@ -46,10 +46,6 @@ describe('CollectionOverview', () => {
     taskStatusHookMock.mockReturnValue({
       collectionHandlerRunning: false,
     })
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('keeps rendered collections visible while a refresh is in flight', () => {

--- a/apps/ui/src/components/Common/ConfirmActionButton.spec.tsx
+++ b/apps/ui/src/components/Common/ConfirmActionButton.spec.tsx
@@ -1,5 +1,5 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import ConfirmActionButton from './ConfirmActionButton'
 
 vi.mock('../../utils/ClientLogger', () => ({
@@ -30,10 +30,6 @@ const openDialog = () =>
   fireEvent.click(screen.getByRole('button', { name: 'Do it' }))
 
 describe('ConfirmActionButton', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('runs the action and closes the dialog once it resolves', async () => {
     const onConfirm = vi.fn().mockResolvedValue(undefined)
 

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/StreamystatsStatsPanel/index.spec.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/StreamystatsStatsPanel/index.spec.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import StreamystatsStatsPanel from './'
 
 const getApiHandler = vi.fn()
@@ -10,12 +10,7 @@ vi.mock('../../../../../utils/ApiHandler', () => ({
 
 describe('StreamystatsStatsPanel', () => {
   beforeEach(() => {
-    cleanup()
     getApiHandler.mockReset()
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('renders aggregate stats and per-user table on a valid response', async () => {

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.spec.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.spec.tsx
@@ -1,14 +1,13 @@
 import { MediaServerType, type MediaItem } from '@maintainerr/contracts'
 import { QueryClientProvider } from '@tanstack/react-query'
 import {
-  cleanup,
   fireEvent,
   render as renderComponent,
   screen,
   waitFor,
 } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useMediaServerType } from '../../../../hooks/useMediaServerType'
 import { createDeferred } from '../../../../test-utils/createDeferred'
 import { createTestQueryClient } from '../../../../test-utils/queryClient'
@@ -66,10 +65,6 @@ describe('MediaModal', () => {
       isSetupComplete: false,
       isNotConfigured: true,
     })
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('clears the previous provider badge until the current backdrop request resolves', async () => {

--- a/apps/ui/src/components/Common/MediaCard/index.spec.tsx
+++ b/apps/ui/src/components/Common/MediaCard/index.spec.tsx
@@ -1,6 +1,6 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import MediaCard from './index'
 
 vi.mock('react-router-dom', () => ({
@@ -55,10 +55,6 @@ vi.mock('./MediaModal', () => ({
 }))
 
 describe('MediaCard', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('shows the exclusion badge on overview cards only for global exclusions', () => {
     render(
       <MediaCard

--- a/apps/ui/src/components/Common/PendingButtonContent.spec.tsx
+++ b/apps/ui/src/components/Common/PendingButtonContent.spec.tsx
@@ -1,13 +1,9 @@
 import { SaveIcon } from '@heroicons/react/solid'
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
 import PendingButtonContent from './PendingButtonContent'
 
 describe('PendingButtonContent', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('reserves width for the pending label while idle', () => {
     const { container } = render(
       <PendingButtonContent

--- a/apps/ui/src/components/Common/Poster/PosterCard.spec.tsx
+++ b/apps/ui/src/components/Common/Poster/PosterCard.spec.tsx
@@ -1,10 +1,4 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import GetApiHandler from '../../../utils/ApiHandler'
 import PosterCard, { resetPosterImageCache } from './PosterCard'
@@ -39,7 +33,6 @@ describe('PosterCard', () => {
   })
 
   afterEach(() => {
-    cleanup()
     getApiHandlerMock.mockReset()
     resetPosterImageCache()
     vi.unstubAllGlobals()

--- a/apps/ui/src/components/Common/SaveButton.spec.tsx
+++ b/apps/ui/src/components/Common/SaveButton.spec.tsx
@@ -1,12 +1,8 @@
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
 import SaveButton, { SaveButtonContent } from './SaveButton'
 
 describe('SaveButtonContent', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('renders the default save label while idle', () => {
     render(<SaveButtonContent isPending={false} />)
 
@@ -21,10 +17,6 @@ describe('SaveButtonContent', () => {
 })
 
 describe('SaveButton', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('renders an enabled save button by default', () => {
     render(<SaveButton isPending={false} />)
 

--- a/apps/ui/src/components/Common/TestingButton.spec.tsx
+++ b/apps/ui/src/components/Common/TestingButton.spec.tsx
@@ -1,12 +1,8 @@
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
 import TestingButton, { getTestingButtonType } from './TestingButton'
 
 describe('TestingButton', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('keeps the committed success test button styling after a successful test', () => {
     render(
       <TestingButton type="button" isPending={false} feedbackStatus={true} />,

--- a/apps/ui/src/components/Layout/MediaServerSetupGuard.spec.tsx
+++ b/apps/ui/src/components/Layout/MediaServerSetupGuard.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const toastError = vi.fn()
@@ -40,7 +40,6 @@ describe('MediaServerSetupGuard', () => {
   })
 
   afterEach(() => {
-    cleanup()
     vi.unstubAllEnvs()
   })
 

--- a/apps/ui/src/components/Messages/Messages.spec.tsx
+++ b/apps/ui/src/components/Messages/Messages.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MaintainerrEvent } from '@maintainerr/contracts'
 import { useEffect } from 'react'
@@ -71,7 +71,6 @@ describe('Messages', () => {
   })
 
   afterEach(() => {
-    cleanup()
     useEventMock.mockReset()
   })
 

--- a/apps/ui/src/components/OverlayEditor/OverlayCanvas.spec.tsx
+++ b/apps/ui/src/components/OverlayEditor/OverlayCanvas.spec.tsx
@@ -1,5 +1,5 @@
 import type { OverlayElement } from '@maintainerr/contracts'
-import { cleanup, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { OverlayCanvas } from './OverlayCanvas'
 
@@ -202,7 +202,6 @@ describe('OverlayCanvas', () => {
   })
 
   afterEach(() => {
-    cleanup()
     Object.defineProperty(window, 'Image', {
       configurable: true,
       value: originalImage,

--- a/apps/ui/src/components/Overlays/index.spec.tsx
+++ b/apps/ui/src/components/Overlays/index.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import OverlaysWrapper from './index'
 
@@ -38,7 +38,6 @@ vi.mock('react-router-dom', async () => {
 
 describe('OverlaysWrapper', () => {
   afterEach(() => {
-    cleanup()
     useMediaServerType.mockReset()
     useOverlaySettings.mockReset()
     useLocation.mockReset()

--- a/apps/ui/src/components/Overview/Content/index.spec.tsx
+++ b/apps/ui/src/components/Overview/Content/index.spec.tsx
@@ -1,5 +1,5 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import OverviewContent from './index'
 
 vi.mock('../../Common/LoadingSpinner', () => ({
@@ -62,10 +62,6 @@ vi.mock('../../Common/MediaCard', () => ({
 }))
 
 describe('OverviewContent', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('uses the delayed shared spinner for the initial empty overview load', () => {
     render(
       <OverviewContent

--- a/apps/ui/src/components/Overview/index.spec.tsx
+++ b/apps/ui/src/components/Overview/index.spec.tsx
@@ -1,12 +1,6 @@
 import { MediaServerType, type MediaLibrary } from '@maintainerr/contracts'
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { toast } from 'react-toastify'
 import { SearchContextProvider } from '../../contexts/search-context'
 import { useBulkExcludeMedia } from '../../api/rules'
@@ -143,10 +137,6 @@ describe('Overview', () => {
 
       throw new Error(`Unexpected API request: ${path}`)
     })
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('shows title ascending as the default overview option', () => {

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.spec.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.spec.tsx
@@ -1,11 +1,5 @@
 import { Application, MediaType, RulePossibility } from '@maintainerr/contracts'
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import RuleInput from './index'
 
@@ -76,7 +70,6 @@ describe('RuleInput', () => {
   })
 
   afterEach(() => {
-    cleanup()
     vi.clearAllMocks()
   })
 

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/index.spec.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/index.spec.tsx
@@ -1,10 +1,4 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import RuleCreator, { type IRule } from './index'
 
@@ -111,7 +105,6 @@ const createRule = (
 
 describe('RuleCreator', () => {
   afterEach(() => {
-    cleanup()
     vi.clearAllMocks()
   })
 

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.spec.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.spec.tsx
@@ -1,6 +1,6 @@
 import { ServarrAction } from '@maintainerr/contracts'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useServarrSettings } from '../../../../../api/settings'
 import {
   buildQueryLoadingResult,
@@ -21,10 +21,6 @@ describe('ArrAction', () => {
     useServarrSettingsMock.mockReturnValue(
       buildQuerySuccessResult<ISonarrSetting[]>([]),
     )
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('does not clear the saved server before Servarr settings finish loading', async () => {

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/CollectionPosterPicker.spec.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/CollectionPosterPicker.spec.tsx
@@ -1,10 +1,4 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createDeferred } from '../../../../test-utils/createDeferred'
 import {
@@ -36,7 +30,6 @@ describe('CollectionPosterPicker', () => {
   })
 
   afterEach(() => {
-    cleanup()
     vi.unstubAllGlobals()
   })
 

--- a/apps/ui/src/components/Settings/ArrSettingsLoading.spec.tsx
+++ b/apps/ui/src/components/Settings/ArrSettingsLoading.spec.tsx
@@ -1,12 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query'
-import {
-  cleanup,
-  render,
-  screen,
-  type RenderResult,
-} from '@testing-library/react'
+import { render, screen, type RenderResult } from '@testing-library/react'
 import type { ReactElement } from 'react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createDeferred } from '../../test-utils/createDeferred'
 import { createTestQueryClient } from '../../test-utils/queryClient'
 import RadarrSettings from './Radarr'
@@ -67,10 +62,6 @@ describe.each([
     deleteApiHandler.mockReset()
     logClientError.mockReset()
     toastError.mockReset()
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('does not show transient loading UI while server settings load', async () => {

--- a/apps/ui/src/components/Settings/DownloadClient/index.spec.tsx
+++ b/apps/ui/src/components/Settings/DownloadClient/index.spec.tsx
@@ -1,11 +1,5 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import DownloadClientSettings from './index'
 
 const saveSettingsMock = vi.fn()
@@ -55,7 +49,6 @@ vi.mock('../../Common/DocsButton', () => ({
 
 describe('DownloadClientSettings', () => {
   beforeEach(() => {
-    cleanup()
     saveSettingsMock.mockReset()
     deleteSettingsMock.mockReset()
     testMock.mockReset()
@@ -69,10 +62,6 @@ describe('DownloadClientSettings', () => {
       download_client_delete_data: true,
       download_client_fallback_ratio: 0.5,
     }
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('saves the connection settings as a contract payload', async () => {

--- a/apps/ui/src/components/Settings/Emby/index.spec.tsx
+++ b/apps/ui/src/components/Settings/Emby/index.spec.tsx
@@ -1,11 +1,5 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import EmbySettings from './index'
 
 const saveSettingsMock = vi.fn()
@@ -64,16 +58,11 @@ vi.mock('../../Login/Emby/EmbyLoginButton', () => ({
 
 describe('EmbySettings', () => {
   beforeEach(() => {
-    cleanup()
     saveSettingsMock.mockReset()
     showUpdated.mockReset()
     showUpdateError.mockReset()
     showError.mockReset()
     clearError.mockReset()
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('surfaces backend validation failures instead of showing a success message', async () => {

--- a/apps/ui/src/components/Settings/ExternalServiceSettingsPage.spec.tsx
+++ b/apps/ui/src/components/Settings/ExternalServiceSettingsPage.spec.tsx
@@ -1,11 +1,5 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import ExternalServiceSettingsPage, {
   type ExternalServiceFieldConfig,
@@ -70,7 +64,6 @@ const tracearrFields: ExternalServiceFieldConfig[] = [
 
 describe('ExternalServiceSettingsPage', () => {
   beforeEach(() => {
-    cleanup()
     getApiHandler.mockReset()
     postApiHandler.mockReset()
     deleteApiHandler.mockReset()
@@ -78,10 +71,6 @@ describe('ExternalServiceSettingsPage', () => {
       url: 'http://seerr.local',
       api_key: 'saved-key',
     })
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('keeps Save Changes enabled regardless of whether connection values have changed', async () => {

--- a/apps/ui/src/components/Settings/Jellyfin/index.spec.tsx
+++ b/apps/ui/src/components/Settings/Jellyfin/index.spec.tsx
@@ -1,11 +1,5 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import JellyfinSettings from './index'
 
 const saveSettingsMock = vi.fn()
@@ -60,16 +54,11 @@ vi.mock('../../Common/DocsButton', () => ({
 
 describe('JellyfinSettings', () => {
   beforeEach(() => {
-    cleanup()
     saveSettingsMock.mockReset()
     showUpdated.mockReset()
     showUpdateError.mockReset()
     showError.mockReset()
     clearError.mockReset()
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('surfaces backend validation failures instead of showing a success message', async () => {

--- a/apps/ui/src/components/Settings/Jobs/index.spec.tsx
+++ b/apps/ui/src/components/Settings/Jobs/index.spec.tsx
@@ -1,11 +1,5 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import JobSettings from './index'
 
 const updateSettings = vi.fn()
@@ -71,10 +65,6 @@ describe('JobSettings', () => {
 
       return currentOverlaySettings
     })
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('keeps Save Changes disabled until the overlay schedule finishes loading', async () => {

--- a/apps/ui/src/components/Settings/Logs/index.spec.tsx
+++ b/apps/ui/src/components/Settings/Logs/index.spec.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { LOG_STREAM_ERROR_DELAY_MS, Logs } from './index'
 
@@ -72,7 +72,6 @@ describe('Logs stream reporting', () => {
   })
 
   afterEach(() => {
-    cleanup()
     vi.runOnlyPendingTimers()
     vi.useRealTimers()
   })

--- a/apps/ui/src/components/Settings/Main/DatabaseBackupModal.spec.tsx
+++ b/apps/ui/src/components/Settings/Main/DatabaseBackupModal.spec.tsx
@@ -1,12 +1,6 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { downloadDatabase } from '../../../api/settings'
 import DatabaseBackupModal from './DatabaseBackupModal'
 
@@ -41,10 +35,6 @@ describe('DatabaseBackupModal', () => {
     downloadDatabaseMock.mockReset()
     onClose.mockReset()
     onDownloaded.mockReset()
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('reports success to the parent before closing', async () => {

--- a/apps/ui/src/components/Settings/Main/index.spec.tsx
+++ b/apps/ui/src/components/Settings/Main/index.spec.tsx
@@ -1,11 +1,5 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import GetApiHandler from '../../../utils/ApiHandler'
 import MainSettings from './index'
 
@@ -60,10 +54,6 @@ describe('MainSettings', () => {
       apikey: 'saved-api-key',
       media_server_type: 'plex',
     }
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('keeps Save Changes enabled regardless of whether general settings have changed', () => {

--- a/apps/ui/src/components/Settings/MediaServerSelector/index.spec.tsx
+++ b/apps/ui/src/components/Settings/MediaServerSelector/index.spec.tsx
@@ -1,6 +1,6 @@
 import { MediaServerType } from '@maintainerr/contracts'
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import MediaServerSelector from './index'
 
 const navigate = vi.fn()
@@ -49,10 +49,6 @@ describe('MediaServerSelector', () => {
     refetchQueries.mockReset()
     previewSwitch.mockReset()
     switchServer.mockReset()
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('uses the shared icon placement classes for all media server options', () => {

--- a/apps/ui/src/components/Settings/Metadata.spec.tsx
+++ b/apps/ui/src/components/Settings/Metadata.spec.tsx
@@ -1,12 +1,6 @@
 import { MetadataProviderPreference } from '@maintainerr/contracts'
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createDeferred } from '../../test-utils/createDeferred'
 import MetadataSettings from './Metadata'
 
@@ -74,10 +68,6 @@ describe('MetadataSettings', () => {
       code: 1,
       message: 'Updated',
     })
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('keeps the selector shell and provider cards visible while provider settings load', () => {

--- a/apps/ui/src/components/Settings/Notifications/index.spec.tsx
+++ b/apps/ui/src/components/Settings/Notifications/index.spec.tsx
@@ -1,11 +1,5 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createDeferred } from '../../../test-utils/createDeferred'
 import NotificationSettings from './index'
 
@@ -21,10 +15,6 @@ vi.mock('../../../utils/ApiHandler', () => ({
 }))
 
 describe('NotificationSettings', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   beforeEach(() => {
     getApiHandler.mockReset()
     deleteApiHandler.mockReset()

--- a/apps/ui/src/components/Settings/Overlays/index.spec.tsx
+++ b/apps/ui/src/components/Settings/Overlays/index.spec.tsx
@@ -1,12 +1,6 @@
 import { DEFAULT_OVERLAY_SETTINGS } from '@maintainerr/contracts'
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import OverlaySettings from './index'
 
 const getOverlaySettings = vi.fn()
@@ -54,10 +48,6 @@ describe('OverlaySettings', () => {
     })
     resetAllOverlays.mockResolvedValue({ success: true })
     updateOverlaySettings.mockImplementation(async (payload) => payload)
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('runs a forced manual overlay pass from Run Now', async () => {

--- a/apps/ui/src/components/Settings/Plex/index.spec.tsx
+++ b/apps/ui/src/components/Settings/Plex/index.spec.tsx
@@ -1,11 +1,5 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createDeferred } from '../../../test-utils/createDeferred'
 import PlexSettings, { hasUnsavedPlexServerChanges } from './index'
 
@@ -164,10 +158,6 @@ beforeEach(() => {
 
     throw new Error(`Unexpected request: ${url}`)
   })
-})
-
-afterEach(() => {
-  cleanup()
 })
 
 describe('hasUnsavedPlexServerChanges', () => {

--- a/apps/ui/src/components/Settings/Servarr/ExclusionTagSettings.spec.tsx
+++ b/apps/ui/src/components/Settings/Servarr/ExclusionTagSettings.spec.tsx
@@ -1,11 +1,5 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ISettings } from '../../../api/settings'
 import ExclusionTagSettings from './ExclusionTagSettings'
 
@@ -46,10 +40,6 @@ describe.each([
         [tagKey]: 'dnd',
         [untagKey]: false,
       }
-    })
-
-    afterEach(() => {
-      cleanup()
     })
 
     const enableToggle = () =>

--- a/apps/ui/src/components/Settings/Servarr/ServarrSettingsModal.spec.tsx
+++ b/apps/ui/src/components/Settings/Servarr/ServarrSettingsModal.spec.tsx
@@ -1,11 +1,5 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ServarrSettingsModal from './ServarrSettingsModal'
 
 const postApiHandler = vi.fn()
@@ -51,10 +45,6 @@ describe('ServarrSettingsModal', () => {
   beforeEach(() => {
     postApiHandler.mockReset()
     putApiHandler.mockReset()
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('allows clearing an existing server and saving to remove it', async () => {

--- a/apps/ui/src/components/Settings/Settings.spec.tsx
+++ b/apps/ui/src/components/Settings/Settings.spec.tsx
@@ -1,5 +1,5 @@
 import { MediaServerType } from '@maintainerr/contracts'
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { INTERACTION_DEBOUNCE_MS } from '../../utils/uiBehavior'
 import SettingsWrapper from './index'
@@ -101,7 +101,6 @@ describe('SettingsWrapper', () => {
   })
 
   afterEach(() => {
-    cleanup()
     vi.runOnlyPendingTimers()
     vi.useRealTimers()
   })

--- a/apps/ui/src/components/Settings/Streamystats/index.spec.tsx
+++ b/apps/ui/src/components/Settings/Streamystats/index.spec.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import StreamystatsSettings from './index'
 
 const useMediaServerTypeMock = vi.fn()
@@ -32,13 +32,8 @@ vi.mock('../../Common/DocsButton', () => ({
 
 describe('StreamystatsSettings', () => {
   beforeEach(() => {
-    cleanup()
     useMediaServerTypeMock.mockReset()
     getApiHandler.mockReset()
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('renders nothing while settings are loading', () => {

--- a/apps/ui/src/components/VersionStatus/index.spec.tsx
+++ b/apps/ui/src/components/VersionStatus/index.spec.tsx
@@ -1,11 +1,5 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import VersionStatus from './index'
 
 const getApiHandler = vi.fn()
@@ -51,10 +45,6 @@ describe('VersionStatus', () => {
       updateAvailable: false,
     })
     isRouteBlocked.mockReturnValue(false)
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('blocks navigation to about when setup guard blocks the route', async () => {

--- a/apps/ui/src/hooks/useInfinitePaginatedList.spec.tsx
+++ b/apps/ui/src/hooks/useInfinitePaginatedList.spec.tsx
@@ -1,5 +1,5 @@
-import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('lodash-es', () => ({
   debounce: <T extends (...args: any[]) => void>(fn: T) => {
@@ -36,10 +36,6 @@ describe('useInfinitePaginatedList', () => {
       configurable: true,
       value: 100,
     })
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('uses the override fetcher for the first page after resetAndLoad', async () => {

--- a/apps/ui/src/hooks/useLibraryDisplay.spec.tsx
+++ b/apps/ui/src/hooks/useLibraryDisplay.spec.tsx
@@ -1,6 +1,6 @@
 import type { MediaLibrary } from '@maintainerr/contracts'
-import { cleanup, renderHook } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useMediaServerLibraries } from '../api/media-server'
 import {
   buildQueryErrorResult,
@@ -30,10 +30,6 @@ const mockHook = (overrides: { data?: MediaLibrary[]; isError?: boolean }) => {
 describe('useLibraryDisplay', () => {
   beforeEach(() => {
     vi.mocked(useMediaServerLibraries).mockReset()
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('resolves the stored libraryId to a title when present', () => {

--- a/apps/ui/src/hooks/useLibrarySelection.spec.tsx
+++ b/apps/ui/src/hooks/useLibrarySelection.spec.tsx
@@ -1,12 +1,8 @@
-import { act, cleanup, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
 import useLibrarySelection from './useLibrarySelection'
 
 describe('useLibrarySelection', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('keeps selected library state and ref in sync', () => {
     const { result } = renderHook(() =>
       useLibrarySelection({ initialLibraryId: 'all' }),

--- a/apps/ui/src/hooks/useLockBodyScroll.spec.tsx
+++ b/apps/ui/src/hooks/useLockBodyScroll.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, renderHook } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   __resetLockBodyScrollForTests,
@@ -7,7 +7,6 @@ import {
 
 describe('useLockBodyScroll', () => {
   afterEach(() => {
-    cleanup()
     __resetLockBodyScrollForTests()
   })
 

--- a/apps/ui/src/pages/CollectionDetailPage.spec.tsx
+++ b/apps/ui/src/pages/CollectionDetailPage.spec.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useCollection } from '../api/collections'
 import { useRuleGroupForCollection } from '../api/rules'
 import type { ICollection } from '../components/Collection'
@@ -107,7 +107,6 @@ describe('CollectionDetailPage', () => {
   const useRuleGroupForCollectionMock = vi.mocked(useRuleGroupForCollection)
 
   beforeEach(() => {
-    cleanup()
     navigate.mockReset()
     useLocation.mockReset()
     useParams.mockReset()
@@ -122,10 +121,6 @@ describe('CollectionDetailPage', () => {
     useRuleGroupForCollectionMock.mockReturnValue(
       buildQuerySuccessResult(buildRuleGroup()),
     )
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('renders collection content once collection data is available', () => {

--- a/apps/ui/src/pages/CollectionsListPage.spec.tsx
+++ b/apps/ui/src/pages/CollectionsListPage.spec.tsx
@@ -1,12 +1,6 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useQueryClient } from '@tanstack/react-query'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchCollections, useCollections } from '../api/collections'
 import type { ICollection } from '../components/Collection'
 import { createTestQueryClient } from '../test-utils/queryClient'
@@ -77,7 +71,6 @@ describe('CollectionsListPage', () => {
   let queryClient: ReturnType<typeof createTestQueryClient>
 
   beforeEach(() => {
-    cleanup()
     navigate.mockReset()
     fetchCollectionsMock.mockReset()
     useCollectionsMock.mockReset()
@@ -102,10 +95,6 @@ describe('CollectionsListPage', () => {
     }
 
     useCollectionsMock.mockReturnValue(buildQuerySuccessResult([collection]))
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('restores the previous library selection if a library switch request fails', async () => {

--- a/apps/ui/src/pages/OverlayTemplateEditorPage.spec.tsx
+++ b/apps/ui/src/pages/OverlayTemplateEditorPage.spec.tsx
@@ -1,6 +1,6 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { useEffect } from 'react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import OverlayTemplateEditorPage from './OverlayTemplateEditorPage'
 
 const navigate = vi.fn()
@@ -100,7 +100,6 @@ vi.mock('react-router-dom', async () => {
 
 describe('OverlayTemplateEditorPage', () => {
   beforeEach(() => {
-    cleanup()
     routeId = '42'
     navigate.mockReset()
     getOverlayTemplate.mockReset()
@@ -131,10 +130,6 @@ describe('OverlayTemplateEditorPage', () => {
       canRedo: false,
       reset: vi.fn(),
     })
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('keeps the editor shell visible while an existing template is still loading', () => {

--- a/apps/ui/src/pages/OverlayTemplateListPage.spec.tsx
+++ b/apps/ui/src/pages/OverlayTemplateListPage.spec.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import OverlayTemplateListPage from './OverlayTemplateListPage'
 
 const navigate = vi.fn()
@@ -26,13 +26,8 @@ vi.mock('react-router-dom', async () => {
 
 describe('OverlayTemplateListPage', () => {
   beforeEach(() => {
-    cleanup()
     navigate.mockReset()
     getOverlayTemplates.mockReset()
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('keeps the page shell visible while templates are still loading', () => {

--- a/apps/ui/src/test-utils/README.md
+++ b/apps/ui/src/test-utils/README.md
@@ -21,3 +21,14 @@ useFooMock.mockReturnValue({
   isLoading: false,
 } as unknown as ReturnType<typeof useFoo>)
 ```
+
+## Automatic unmounting
+
+`react-cleanup.ts` runs before every spec file (wired via `setupFiles` in
+`vite.config.ts`) and unmounts rendered components after each test. Specs do not
+need their own `afterEach(cleanup)`.
+
+A tree left mounted keeps React's scheduler holding work, and anything it runs
+after vitest tears the jsdom environment down throws `window is not defined`.
+That surfaces as an unhandled error rather than a test failure, so it fails the
+whole run while every test still reports green.

--- a/apps/ui/src/test-utils/react-cleanup.ts
+++ b/apps/ui/src/test-utils/react-cleanup.ts
@@ -1,0 +1,14 @@
+import { cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+// Unmounts whatever a test rendered. Registered globally via `setupFiles` so no
+// spec has to remember it, and so a new spec cannot reintroduce the flake below
+// by forgetting.
+//
+// A React tree left mounted keeps the scheduler holding work, and anything it
+// runs after vitest tears the jsdom environment down throws "window is not
+// defined". That surfaces as an unhandled error rather than a test failure, so
+// it fails the whole run while every test still reports green.
+afterEach(() => {
+  cleanup()
+})

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -55,6 +55,7 @@ export default defineConfig(({ mode }) => {
     },
     test: {
       environment: 'jsdom',
+      setupFiles: ['./src/test-utils/react-cleanup.ts'],
     },
     // Ensure environment variables are available and can be replaced at runtime
     define: {


### PR DESCRIPTION
The UI test job intermittently fails with every test green:

```
Test Files  31 passed (31)
     Tests  135 passed (135)
    Errors  1 error          <- the only reason the run failed

ReferenceError: window is not defined
  > node_modules/react-dom/cjs/react-dom-client.development.js:17920:15
  > Immediate.performWorkUntilDeadline scheduler.development.js:45:48
This error originated in "src/components/Calendar/index.spec.tsx"
```

Vitest fails a run on an unhandled error, not just on a failed assertion. A React tree left mounted keeps the scheduler holding work, and anything it runs after the jsdom environment is torn down throws against a missing `window`.

48 of the 52 specs that call `render()` already guarded against this with their own `afterEach(cleanup)`. Four did not - `Calendar`, `Layout`, `NavBar` and `events-context` - and `Calendar` is the file the failing run blamed. Registering cleanup once via `setupFiles` covers every spec, cannot be forgotten by a new one, and lets the 48 per-spec copies go.

Net: -286 lines.

## On the evidence

Reproduced locally at roughly **1 run in 12** using the CI command, and saw **none in 17 runs** after the change. At that base rate a clean 17 is meaningfully unlikely by chance, but I would not call it conclusive on its own - the change rests on removing the mounted-tree cause and on making the four stragglers consistent with the other 48.

What is verified directly is that the hook is live. A temporary two-test probe (render a marker, then assert it is gone) passes with `setupFiles` wired and fails without it:

```
WITH:     Tests  2 passed (2)
WITHOUT:  AssertionError: expected <div data-testid="probe-marker" /> to be null
```

So the 48 removed calls are genuinely replaced rather than silently dropped.

Full suite green on this base, and the UI suite run 3 further times with no unhandled errors and 284/284 passing each time.