### PR TITLE
fix(emby): user-scope the item reads that decide a collection's fate

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -706,6 +706,80 @@ describe('EmbyAdapterService', () => {
       expect(itemsCall[1].params.ParentId).toBe('library-1');
       expect(itemsCall[1].params.UserId).toBeUndefined();
     });
+
+    // Emby answers 404 on the unscoped route for a collection that exists, so
+    // the caller read a live collection as gone and dropped its link.
+    it('resolves a user before reading a collection instead of going unscoped', async () => {
+      clearConfiguredUser();
+      http.get.mockImplementation((path: string) =>
+        path === '/Users/Query'
+          ? Promise.resolve({
+              data: [{ Id: 'admin-9', Policy: { IsAdministrator: true } }],
+            })
+          : Promise.resolve({ data: { Id: 'box-1', Name: 'Box' } }),
+      );
+
+      await expect(service.getCollection('box-1', true)).resolves.toEqual(
+        expect.objectContaining({ id: 'box-1' }),
+      );
+      expect(http.get).toHaveBeenCalledWith('/Users/admin-9/Items/box-1');
+      expect(http.get).not.toHaveBeenCalledWith('/Items/box-1');
+    });
+
+    it('does not call a collection missing when no user can scope the lookup', async () => {
+      clearConfiguredUser();
+      http.get.mockResolvedValue({ data: { Items: [] } });
+
+      await expect(service.getCollection('box-1', true)).rejects.toThrow(
+        'no user to scope the lookup',
+      );
+      await expect(service.getCollection('box-1')).resolves.toBeUndefined();
+      expect(http.get).not.toHaveBeenCalledWith('/Items/box-1');
+    });
+
+    // The unscoped read 404s, so the update failed outright on a token-only
+    // setup; the list form would answer a trimmed item and write back a wipe.
+    it('reads the collection to update through the user-scoped route', async () => {
+      clearConfiguredUser();
+      http.get.mockImplementation((path: string) =>
+        path === '/Users/Query'
+          ? Promise.resolve({
+              data: [{ Id: 'admin-9', Policy: { IsAdministrator: true } }],
+            })
+          : Promise.resolve({ data: { Id: 'box-1', Name: 'Box' } }),
+      );
+      http.post.mockResolvedValue({ data: {} });
+
+      await service.updateCollection({
+        collectionId: 'box-1',
+        libraryId: 'library-1',
+        title: 'Renamed',
+      } as any);
+
+      expect(http.get).toHaveBeenCalledWith('/Users/admin-9/Items/box-1');
+    });
+
+    // Unscoped, Emby answers the physical folder tree, which never holds the
+    // CollectionFolder id stored as the library, so every child read as "not in
+    // this library" and the cleanup silently removed nothing.
+    it('scopes the library-membership check so cleanup can match its children', async () => {
+      jest
+        .spyOn(service, 'getCollectionChildren')
+        .mockResolvedValueOnce([{ id: 'item-1' }] as any)
+        .mockResolvedValueOnce([]);
+      const removeBatch = jest
+        .spyOn(service, 'removeBatchFromCollection')
+        .mockResolvedValue(undefined as never);
+      jest.spyOn(service, 'deleteCollection').mockResolvedValue(undefined);
+      http.get.mockResolvedValue({ data: [{ Id: 'library-1' }] });
+
+      await service.cleanupCollectionForLibrary('box-1', 'library-1', false);
+
+      expect(http.get).toHaveBeenCalledWith('/Items/item-1/Ancestors', {
+        params: { UserId: 'user-1' },
+      });
+      expect(removeBatch).toHaveBeenCalledWith('box-1', ['item-1']);
+    });
   });
 
   describe('updateCollection', () => {

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -1027,11 +1027,22 @@ export class EmbyAdapterService implements IMediaServerService {
       }
       return undefined;
     }
+    // Emby answers 404 on the unscoped /Items/{id} route for a collection that
+    // exists, so reading that as a confirmed absence unlinks a live collection.
+    // Only the user-scoped route tells the two apart, and it is also the only
+    // one that carries ChildCount, which the empty-collection heal reads.
+    const userId = await this.resolveUserId();
+    if (!userId) {
+      const message = `Emby getCollection(${collectionId}) has no user to scope the lookup to; its existence is unknown`;
+      if (throwOnError) throw new Error(message);
+      this.logger.debug(message);
+      return undefined;
+    }
+
     try {
-      const path = this.embyUserId
-        ? `/Users/${this.embyUserId}/Items/${collectionId}`
-        : `/Items/${collectionId}`;
-      const { data } = await this.http.get<EmbyBaseItemDto>(path);
+      const { data } = await this.http.get<EmbyBaseItemDto>(
+        `/Users/${userId}/Items/${collectionId}`,
+      );
       return EmbyMapper.toMediaCollection(data);
     } catch (error) {
       // A 404 is the server confirming the collection is gone; anything else
@@ -1286,10 +1297,16 @@ export class EmbyAdapterService implements IMediaServerService {
     if (!this.http) throw new Error('Emby not initialized');
     try {
       // Emby's POST /Items/{id} expects the full updated item. Fetch, mutate, send.
-      const path = this.embyUserId
-        ? `/Users/${this.embyUserId}/Items/${params.collectionId}`
-        : `/Items/${params.collectionId}`;
-      const { data: current } = await this.http.get<EmbyBaseItemDto>(path);
+      // The read has to be user-scoped: the unscoped route 404s for an item that
+      // exists, and the list form answers a trimmed item that would write back
+      // as a wipe of everything it omits.
+      const userId = await this.resolveUserId();
+      if (!userId) {
+        throw new Error('no Emby user available to read the collection');
+      }
+      const { data: current } = await this.http.get<EmbyBaseItemDto>(
+        `/Users/${userId}/Items/${params.collectionId}`,
+      );
       const updated: EmbyBaseItemDto = {
         ...current,
         Name: params.title ?? current.Name,
@@ -1631,8 +1648,16 @@ export class EmbyAdapterService implements IMediaServerService {
     if (!this.http) return undefined;
 
     try {
+      // Unscoped, Emby answers the physical folder tree, which never contains
+      // the CollectionFolder id Maintainerr stores as the library. Every child
+      // then reads as "not in this library". The user-scoped read answers the
+      // library view, matching the Jellyfin adapter's getAncestors({ userId }).
+      const userId = await this.resolveUserId();
+      if (!userId) return undefined;
+
       const { data } = await this.http.get<EmbyBaseItemDto[]>(
         `/Items/${itemId}/Ancestors`,
+        { params: { UserId: userId } },
       );
 
       return (data ?? []).some((ancestor) => ancestor.Id === libraryId);


### PR DESCRIPTION
### Description & Design

Emby answers **404 on the unscoped `/Items/{id}` route for items that exist**. Three reads in the Emby adapter relied on that route, so each one drew the wrong conclusion from it.

Verified directly against Emby 4.9.5, admin token, item and BoxSet that both exist:

| Route | Item exists | Item absent |
| --- | --- | --- |
| `/Items/{id}` | **404** | 404 |
| `/Users/{userId}/Items/{id}` | 200 | 404 |

### What was broken

- **`getCollection`** fell back to the unscoped route when `emby_user_id` is unset, and reads a 404 as the server confirming the collection is gone. `checkAutomaticMediaServerLink` then cleared `mediaServerId`, leaving a populated collection on the server that Maintainerr no longer tracks and the next run duplicates. That is #3344's shape.
- **`updateCollection`**'s read-back shared the route, so a rename failed outright on a token-only setup.
- **`itemIsInLibrary`** passed no user at all, and this one was wrong on **every** setup. Unscoped, Emby answers the physical folder tree; scoped, it answers the library view:

  ```
  unscoped: [7 'Movie (2008)' Folder, 4 'movies' Folder, 1 'root' AggregateFolder]
  scoped:   [7 'Movie (2008)' Folder, 3 'Movies' CollectionFolder, 2 'Media Folders' UserRootFolder]
  ```

  Maintainerr stores the **CollectionFolder** id (`3`) as the library, so every child read as "not in this library". `cleanupCollectionForLibrary` removed nothing, kept the collection because it was not empty, and raised nothing, while its caller dropped the link anyway.

### The fix

All three resolve a user first, through the `resolveUserId()` the adapter already has, mirroring `getCollections` and `getCollectionChildren`. `itemIsInLibrary` passes it as a query param, matching the Jellyfin adapter's `getAncestors({ userId })`.

The list form (`/Items?Ids=`) is **not** a substitute here: it answers 7 fields against the user-scoped route's 31 and omits `ChildCount` even when explicitly requested. `getCollection`'s result feeds the empty-collection heal, which deletes any collection reporting `childCount === 0`, and `updateCollection` writes its fetched item back, so a trimmed read would wipe every field it omits.

Where no user can be resolved, `getCollection` no longer claims a confirmed absence: it throws for `throwOnError` callers and returns undefined for the rest, both of which keep the link.

### Verified on the real stack

Emby 4.9.5, `emby_user_id` deliberately unset, same flow run on both versions of the adapter:

| | Collection on Emby | Children | Maintainerr link |
| --- | --- | --- | --- |
| before | still there | still populated | cleared -> orphan |
| after | deleted | - | cleared |

And through the public endpoint, for a BoxSet that exists:

| `GET /media-server/collection/2097` | result |
| --- | --- |
| before | empty, reported missing |
| after | `childCount=3` |

A genuinely absent id still reads as missing. Collections page confirmed in Playwright on Emby. Four regression tests, each verified to fail without the fix.
