### PR TITLE
fix(sonarr): require a season number before any season-scoped action

### DIFF
--- a/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -2332,4 +2332,96 @@ describe('SonarrActionHandler', () => {
       });
     });
   });
+
+  // #3415: a season item can reach the handler without a season index -
+  // its metadata was dropped by the media server, or it is one of the
+  // "Season Unknown" buckets Jellyfin/Emby create, which carry no index. That
+  // undefined index used to reach `unmonitorSeasons`' whole-show default,
+  // unmonitoring every season and deleting every remaining episode file.
+  describe('season action without a resolvable season number (#3415)', () => {
+    const seasonActions = [
+      { name: 'DELETE', arrAction: ServarrAction.DELETE },
+      { name: 'UNMONITOR', arrAction: ServarrAction.UNMONITOR },
+      {
+        name: 'UNMONITOR_DELETE_EXISTING',
+        arrAction: ServarrAction.UNMONITOR_DELETE_EXISTING,
+      },
+      {
+        name: 'DELETE_SHOW_IF_EMPTY',
+        arrAction: ServarrAction.DELETE_SHOW_IF_EMPTY,
+      },
+      {
+        name: 'UNMONITOR_SHOW_IF_EMPTY',
+        arrAction: ServarrAction.UNMONITOR_SHOW_IF_EMPTY,
+      },
+    ];
+
+    it.each(seasonActions)(
+      'fails closed and takes no Sonarr action for $name',
+      async ({ arrAction }) => {
+        const collection = createCollection({
+          arrAction,
+          sonarrSettingsId: 1,
+          type: 'season',
+        });
+        const collectionMedia = createCollectionMediaWithMetadata(collection, {
+          tmdbId: 1,
+          mediaData: { index: undefined },
+        });
+
+        mockMediaServerMetadata(collectionMedia.mediaData);
+
+        const mockedSonarrApi = mockSonarrApi(servarrService, logger);
+        jest
+          .spyOn(mockedSonarrApi, 'getSeriesByTvdbId')
+          .mockResolvedValue(createSonarrSeries());
+
+        mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+        await expect(
+          sonarrActionHandler.handleAction(collection, collectionMedia),
+        ).resolves.toBe(false);
+
+        validateNoSonarrActionsTaken(mockedSonarrApi);
+        expect(mediaServer.deleteFromDisk).not.toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledWith(
+          `[Sonarr] Couldn't determine the season number for media server item ${collectionMedia.mediaServerId}. No action was taken.`,
+        );
+      },
+    );
+
+    it('still acts on season 0 (specials), which is a valid season number', async () => {
+      const collection = createCollection({
+        arrAction: ServarrAction.UNMONITOR_DELETE_EXISTING,
+        sonarrSettingsId: 1,
+        type: 'season',
+      });
+      const collectionMedia = createCollectionMediaWithMetadata(collection, {
+        tmdbId: 1,
+        mediaData: { index: 0 },
+      });
+
+      mockMediaServerMetadata(collectionMedia.mediaData);
+
+      const series = createSonarrSeries();
+      const mockedSonarrApi = mockSonarrApi(servarrService, logger);
+      jest
+        .spyOn(mockedSonarrApi, 'getSeriesByTvdbId')
+        .mockResolvedValue(series);
+      jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+
+      mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+      await expect(
+        sonarrActionHandler.handleAction(collection, collectionMedia),
+      ).resolves.toBe(true);
+
+      expect(mockedSonarrApi.unmonitorSeasons).toHaveBeenCalledWith(
+        series.id,
+        0,
+        true,
+        true,
+      );
+    });
+  });
 });

--- a/apps/server/src/modules/actions/sonarr-action-handler.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.ts
@@ -67,6 +67,26 @@ export class SonarrActionHandler {
       mediaData = await mediaServer.getMetadata(media.mediaServerId);
     }
 
+    // Every season-scoped Sonarr call has to be limited to this one number, and
+    // it is missing more often than it looks: the metadata read fails because
+    // the season is gone (Plex drops an emptied season on its next scan, while
+    // the item stays queued for retry), or the season simply has no index -
+    // Jellyfin and Emby file episodes they can't place under a permanent
+    // "Season Unknown" that carries no IndexNumber. Either way the index used to
+    // reach `unmonitorSeasons` as its whole-show default and delete every
+    // remaining episode file of the show (#3415), so fail closed: no Sonarr call
+    // is made, and the collection handler decides whether to keep the item for
+    // retry or prune it.
+    const seasonNumber =
+      collection.type === 'season' ? mediaData?.index : undefined;
+
+    if (collection.type === 'season' && seasonNumber == null) {
+      this.logger.warn(
+        `[Sonarr] Couldn't determine the season number for media server item ${media.mediaServerId}. No action was taken.`,
+      );
+      return false;
+    }
+
     const lookupCandidates =
       await this.metadataService.resolveLookupCandidatesForService(
         media.mediaServerId,
@@ -177,7 +197,7 @@ export class SonarrActionHandler {
       ? await this.collectCleanupInputs(
           sonarrApiClient,
           sonarrMedia,
-          cleanupScope === 'season' ? mediaData?.index : undefined,
+          cleanupScope === 'season' ? seasonNumber : undefined,
         )
       : undefined;
 
@@ -191,7 +211,7 @@ export class SonarrActionHandler {
         }
         sonarrMedia = await sonarrApiClient.unmonitorSeasons(
           sonarrMedia.id,
-          mediaData?.index,
+          seasonNumber,
           true,
         );
 
@@ -200,14 +220,14 @@ export class SonarrActionHandler {
         }
 
         this.logger.log(
-          `[Sonarr] Removed season ${mediaData?.index} from show '${sonarrMedia.title}'`,
+          `[Sonarr] Removed season ${seasonNumber} from show '${sonarrMedia.title}'`,
         );
         {
           const showDeleted = await this.deleteShowIfEmpty(
             sonarrApiClient,
             matchedResult.candidate,
             media.tmdbId,
-            mediaData?.index,
+            seasonNumber,
             collection.listExclusions,
           );
           await this.downloadClient.removeDownloads(downloadIds);
@@ -228,7 +248,7 @@ export class SonarrActionHandler {
           case 'season':
             sonarrMedia = await sonarrApiClient.unmonitorSeasons(
               sonarrMedia.id,
-              mediaData?.index,
+              seasonNumber,
               true,
             );
 
@@ -237,7 +257,7 @@ export class SonarrActionHandler {
             }
 
             this.logger.log(
-              `[Sonarr] Removed season ${mediaData?.index} from show '${sonarrMedia.title}'`,
+              `[Sonarr] Removed season ${seasonNumber} from show '${sonarrMedia.title}'`,
             );
             await this.downloadClient.removeDownloads(downloadIds);
             await this.cleanupLeftoverFolder(
@@ -299,7 +319,7 @@ export class SonarrActionHandler {
         }
         sonarrMedia = await sonarrApiClient.unmonitorSeasons(
           sonarrMedia.id,
-          mediaData?.index,
+          seasonNumber,
           false,
         );
 
@@ -308,7 +328,7 @@ export class SonarrActionHandler {
         }
 
         this.logger.log(
-          `[Sonarr] Unmonitored season ${mediaData?.index} from show '${sonarrMedia.title}'`,
+          `[Sonarr] Unmonitored season ${seasonNumber} from show '${sonarrMedia.title}'`,
         );
         await this.unmonitorShowIfEmptyAndEnded(
           sonarrApiClient,
@@ -320,7 +340,7 @@ export class SonarrActionHandler {
           case 'season':
             sonarrMedia = await sonarrApiClient.unmonitorSeasons(
               sonarrMedia.id,
-              mediaData?.index,
+              seasonNumber,
               false,
             );
 
@@ -329,7 +349,7 @@ export class SonarrActionHandler {
             }
 
             this.logger.log(
-              `[Sonarr] Unmonitored season ${mediaData?.index} from show '${sonarrMedia.title}'`,
+              `[Sonarr] Unmonitored season ${seasonNumber} from show '${sonarrMedia.title}'`,
             );
             return true;
           case 'episode': {
@@ -418,7 +438,7 @@ export class SonarrActionHandler {
           case 'season':
             sonarrMedia = await sonarrApiClient.unmonitorSeasons(
               sonarrMedia.id,
-              mediaData?.index,
+              seasonNumber,
               true,
               true,
             );
@@ -428,7 +448,7 @@ export class SonarrActionHandler {
             }
 
             this.logger.log(
-              `[Sonarr] Removed existing episodes from season ${mediaData?.index} from show '${sonarrMedia.title}'`,
+              `[Sonarr] Removed existing episodes from season ${seasonNumber} from show '${sonarrMedia.title}'`,
             );
             await this.downloadClient.removeDownloads(downloadIds);
             await this.cleanupLeftoverFolder(

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
@@ -207,6 +207,47 @@ describe('SonarrApi', () => {
     expect(runDeleteSpy).not.toHaveBeenCalled();
   });
 
+  it('should refuse an episode action without a season number (#3415)', async () => {
+    // An unfiltered episode read returns every season, so episode 1 would match
+    // - and be deleted - in each of them.
+    const getSpy = jest
+      .spyOn(sonarrApi as any, 'get')
+      .mockResolvedValue([
+        createSonarrEpisode({ seasonNumber: 1, episodeNumber: 1 }),
+        createSonarrEpisode({ seasonNumber: 2, episodeNumber: 1 }),
+      ]);
+    const runPutSpy = jest.spyOn(sonarrApi as any, 'runPut');
+    const runDeleteSpy = jest.spyOn(sonarrApi as any, 'runDelete');
+
+    await expect(
+      sonarrApi.UnmonitorDeleteEpisodes(1, undefined as unknown as number, [1]),
+    ).resolves.toBe(false);
+
+    expect(getSpy).not.toHaveBeenCalled();
+    expect(runPutSpy).not.toHaveBeenCalled();
+    expect(runDeleteSpy).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Couldn't remove/unmonitor episodes for series ID 1: no valid season number was provided.",
+    );
+  });
+
+  it('should refuse a season scope that is not "all", "existing" or a number (#3415)', async () => {
+    const axiosGetSpy = jest.spyOn((sonarrApi as any).axios, 'get');
+    const runPutSpy = jest.spyOn(sonarrApi as any, 'runPut');
+    const runDeleteSpy = jest.spyOn(sonarrApi as any, 'runDelete');
+
+    await expect(
+      sonarrApi.unmonitorSeasons(1, undefined as unknown as number),
+    ).resolves.toBeUndefined();
+
+    expect(axiosGetSpy).not.toHaveBeenCalled();
+    expect(runPutSpy).not.toHaveBeenCalled();
+    expect(runDeleteSpy).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Couldn't unmonitor/delete seasons for series ID 1: 'undefined' is not a valid season scope. No action was taken.",
+    );
+  });
+
   describe('cache coherency (issue #2757 / #2891)', () => {
     it('getSeriesByTvdbId reads uncached so post-mutation state is never stale', async () => {
       const series = createSonarrSeries({ id: 1, tvdbId: 555 });

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
@@ -273,6 +273,16 @@ export class SonarrApi extends ServarrApi<{
     deleteFiles = true,
     airDate?: string | Date,
   ): Promise<boolean> {
+    // Without a season number the episode read below drops its season filter,
+    // so an episode number would match - and delete - that episode in every
+    // season of the show. Same widening as #3415, one scope down.
+    if (!Number.isInteger(seasonNumber)) {
+      this.logger.warn(
+        `Couldn't remove/unmonitor episodes for series ID ${seriesId}: no valid season number was provided.`,
+      );
+      return false;
+    }
+
     const validEpisodeIds = this.filterDefinedEpisodeNumbers(episodeIds);
 
     if (!validEpisodeIds.length && !airDate) {
@@ -320,12 +330,26 @@ export class SonarrApi extends ServarrApi<{
     }
   }
 
+  /**
+   * @param type the scope to act on: `all` seasons, only the seasons holding
+   *   files (`existing`), or a single season number. Required - there is no
+   *   whole-show default, since an unresolved season number reaching here as
+   *   `undefined` matched no season branch below yet still fell into the
+   *   "delete every episode file" arm of the delete loop (#3415).
+   */
   public async unmonitorSeasons(
     seriesId: number | string,
-    type: 'all' | number | 'existing' = 'all',
+    type: 'all' | number | 'existing',
     deleteFiles = true,
     forceExisting = false,
   ): Promise<SonarrSeries | undefined> {
+    if (type !== 'all' && type !== 'existing' && !Number.isInteger(type)) {
+      this.logger.warn(
+        `Couldn't unmonitor/delete seasons for series ID ${seriesId}: '${type}' is not a valid season scope. No action was taken.`,
+      );
+      return undefined;
+    }
+
     try {
       const data: SonarrSeries = (await this.axios.get(`series/${seriesId}`))
         .data;


### PR DESCRIPTION
Fixes #3415.

A season action passed the media server's season index straight to `unmonitorSeasons`, whose `type` parameter defaulted to `'all'`. When the index was missing the action silently became a whole-show one: every season unmonitored and every remaining episode file deleted.

The index is missing more often than the report suggests. The metadata read can fail because the season is gone (Plex drops an emptied season on its next scan while the item is still queued for retry), but Jellyfin and Emby also file episodes they cannot place under a permanent "Season Unknown" that carries no `IndexNumber` at all. Three such seasons exist in the dev stack right now, so this is reachable with no metadata failure involved.

Removing the default alone does not fix it. An undefined `type` matches none of the season branches, yet still falls into the "delete every episode file" arm of the delete loop, and now leaves the seasons monitored so Sonarr re-downloads them. The server also builds with `strictNullChecks` off, so a required parameter buys no compile-time protection. Both layers therefore guard at runtime: the handler resolves the season number once and fails closed before any Sonarr call, and `unmonitorSeasons` rejects a scope that is not `'all'`, `'existing'` or a number. The handler then leaves the item for the collection handler, which keeps it for retry or prunes it once the media server confirms it is gone.

`UnmonitorDeleteEpisodes` had the same widening one scope down: its season number feeds a query filter that vanishes when undefined, so an episode number matched that episode in every season of the show.

The `= 'all'` default dates to #474, the change that first added season and episode rules.