### PR TITLE
fix(seerr): key the forced media removal on the collection type

### DIFF
--- a/apps/server/src/modules/collections/collection-handler.spec.ts
+++ b/apps/server/src/modules/collections/collection-handler.spec.ts
@@ -654,6 +654,31 @@ describe('CollectionHandler', () => {
     expect(seerrApi.removeMediaByTmdbId).toHaveBeenCalledTimes(1);
   });
 
+  it('should still remove a show as tv when the library is no longer listed', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      forceSeerr: true,
+      type: 'show',
+    });
+    const collectionMedia = createCollectionMedia(collection);
+
+    settings.seerrConfigured.mockReturnValue(true);
+
+    // The media server no longer lists the collection's library, so the lookup
+    // misses. Reading the type off it would send the show's TMDB id to the
+    // movie endpoint, where it can name an unrelated film.
+    mediaServer.getLibraries.mockResolvedValue([]);
+
+    await expect(
+      collectionHandler.handleMedia(collection, collectionMedia),
+    ).resolves.toBe('handled');
+
+    expect(seerrApi.removeMediaByTmdbId).toHaveBeenCalledWith(
+      collectionMedia.tmdbId,
+      'tv',
+    );
+  });
+
   it('should not call SeerrApiService if forceSeerr is false', async () => {
     const collection = createCollection({
       arrAction: ServarrAction.DELETE,

--- a/apps/server/src/modules/collections/collection-handler.ts
+++ b/apps/server/src/modules/collections/collection-handler.ts
@@ -208,9 +208,15 @@ export class CollectionHandler {
               break;
             }
             default:
+              // Keyed on the collection's own type, not the library lookup:
+              // `library` is undefined whenever the media server stops listing
+              // the id, and `undefined?.type` silently reads as 'movie'. TMDB
+              // numbers movies and shows independently, so that sends a show's
+              // id to the movie endpoint, where it can resolve to an unrelated
+              // film whose Seerr record is then deleted.
               await this.seerrApi.removeMediaByTmdbId(
                 tmdbId,
-                library?.type === 'show' ? 'tv' : 'movie',
+                collection.type === 'show' ? 'tv' : 'movie',
               );
               this.logger.log(
                 `[Seerr] Removed requests of media with TMDB ID '${tmdbId}'`,


### PR DESCRIPTION
The forced Seerr removal read its media type from the library lookup: `library?.type === 'show' ? 'tv' : 'movie'`. `library` is undefined whenever the media server stops listing the collection's library id, and `undefined?.type` falls through to `'movie'` rather than failing closed.

TMDB numbers movies and shows independently, so a show's id sent to the movie endpoint can resolve to a real but unrelated film, and its Seerr media record is what gets deleted. Verified against TMDB through Seerr: id 1396 and id 4614 each name both a show and an unrelated movie.

The collection's own type is the authoritative source and is already the switch discriminant, so read it from there and drop the dependency on the lookup.

Found while auditing #3415 for other places where an unresolved value silently widens or redirects a destructive action.