### PR TITLE
fix(rules): scope Sonarr season rules to the season being evaluated

### DIFF
--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
@@ -2107,6 +2107,82 @@ describe('SonarrGetterService', () => {
     });
   });
 
+  // Jellyfin and Emby file episodes they cannot place under a permanent
+  // "Season Unknown" that carries no index. Without a season number the episode
+  // reads drop their season filter and answer with every season's episodes, so
+  // the rule would be evaluated against another season's data.
+  describe('season item without a season number', () => {
+    it.each([
+      {
+        title: 'a season with no index',
+        dataType: 'season' as const,
+        item: { type: 'season' as const, index: undefined },
+      },
+      {
+        title: 'an episode whose season has no index',
+        dataType: 'episode' as const,
+        item: {
+          type: 'episode' as const,
+          index: 1,
+          parentIndex: undefined,
+          grandparentId: '99',
+        },
+      },
+    ])('reports a transient failure for $title', async ({ dataType, item }) => {
+      const collectionMedia = createCollectionMedia(dataType);
+      collectionMedia.collection.sonarrSettingsId = 1;
+
+      const mockedSonarrApi = mockSonarrApi(createSonarrSeries());
+      const getEpisodesSpy = jest
+        .spyOn(mockedSonarrApi, 'getEpisodes')
+        .mockResolvedValue([]);
+
+      const response = await sonarrGetterService.get(
+        11,
+        createMediaItem(item),
+        dataType,
+        createRulesDto({ collection: collectionMedia.collection, dataType }),
+      );
+
+      // `undefined`, not `null`: the comparator reads it as a transport
+      // failure and skips the item rather than matching NOT_EXISTS on it.
+      expect(response).toBeUndefined();
+      expect(getEpisodesSpy).not.toHaveBeenCalled();
+      expect(mockMediaServer.getMetadata).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('specials season', () => {
+    it('resolves season 0 rather than reading it as no season', async () => {
+      const collectionMedia = createCollectionMedia('season');
+      collectionMedia.collection.sonarrSettingsId = 1;
+
+      mockMediaServer.getMetadata.mockResolvedValue(
+        createMediaItem({ type: 'show' }),
+      );
+
+      const series = createSonarrSeries({
+        seasons: [
+          { seasonNumber: 0, monitored: true },
+          { seasonNumber: 1, monitored: true },
+        ],
+      });
+      mockSonarrApi(series);
+
+      const response = await sonarrGetterService.get(
+        18,
+        createMediaItem({ type: 'season', index: 0 }),
+        'season',
+        createRulesDto({
+          collection: collectionMedia.collection,
+          dataType: 'season',
+        }),
+      );
+
+      expect(response).toBe(0);
+    });
+  });
+
   const mockSonarrApi = (series?: SonarrSeries) => {
     const mockedSonarrApi = new SonarrApi(
       { url: 'http://localhost:8989', apiKey: 'test' },

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -93,6 +93,21 @@ export class SonarrGetterService {
           ? libItem.parentIndex
           : libItem.index;
 
+        // Every season-scoped read below has to be limited to this number.
+        // Jellyfin and Emby file episodes they can't place under a permanent
+        // "Season Unknown" that carries no index, which leaves it undefined -
+        // and the episode reads drop their season filter when it is, so the
+        // rule would be answered with another season's data. Report the
+        // transport-failure signal instead (same as the outer catch): the
+        // comparator skips the item rather than matching it, and the executor
+        // keeps it in any collection it already belongs to.
+        if (seasonRatingKey == null) {
+          this.logger.debug(
+            `Sonarr-Getter - No season number for '${libItem.title}' with id '${libItem.id}'; skipping this item.`,
+          );
+          return undefined;
+        }
+
         // get (grand)parent
         const mediaServer = await this.getMediaServer();
         libItem = await mediaServer.getMetadata(
@@ -183,9 +198,14 @@ export class SonarrGetterService {
         return null;
       }
 
-      const season = seasonRatingKey
-        ? showResponse.seasons.find((el) => el.seasonNumber === seasonRatingKey)
-        : undefined;
+      // Season 0 is the specials season, so test for a number rather than
+      // truthiness - `0` would otherwise read as "no season".
+      const season =
+        seasonRatingKey != null
+          ? showResponse.seasons.find(
+              (el) => el.seasonNumber === seasonRatingKey,
+            )
+          : undefined;
 
       // Lazy-load episode / episodeFile only if a property actually needs them.
       let episodePromise: Promise<SonarrEpisode | undefined> | undefined;
@@ -203,17 +223,13 @@ export class SonarrGetterService {
         }
 
         episodePromise ??= (async () => {
-          const seasonNumber = origLibItem.grandparentId
-            ? origLibItem.parentIndex
-            : origLibItem.index;
-
           const episodeNumbers = [
             origLibItem.grandparentId ? origLibItem.index : 1,
           ];
 
           const episodes = await sonarrApiClient.getEpisodes(
             showResponse.id,
-            seasonNumber,
+            seasonRatingKey,
             episodeNumbers,
           );
 
@@ -263,9 +279,7 @@ export class SonarrGetterService {
 
         seasonEpisodesPromise ??= sonarrApiClient.getEpisodes(
           showResponse.id,
-          origLibItem.grandparentId
-            ? origLibItem.parentIndex
-            : origLibItem.index,
+          seasonRatingKey,
         );
 
         return seasonEpisodesPromise;
@@ -647,9 +661,7 @@ export class SonarrGetterService {
             return null;
           }
 
-          const targetSeasonNumber = origLibItem.grandparentId
-            ? origLibItem.parentIndex
-            : origLibItem.index;
+          const targetSeasonNumber = seasonRatingKey;
           const targetEpisodeNumber = origLibItem.grandparentId
             ? origLibItem.index
             : 1;


### PR DESCRIPTION
The season and episode readers each recomputed the season number from the media item and passed it to `getEpisodes` unguarded. That query builds its season filter conditionally, so an undefined number removed the filter and Sonarr answered with the whole series: `seasons_monitored` counted the show's monitored episodes, `seasonFinale` went show-wide, and `getEpisode` returned the episode of the lowest season instead of this one. Those values decide whether a season enters a delete collection.

It is reachable without any failure. Jellyfin and Emby file episodes they cannot place under a permanent "Season Unknown" that carries no index at all; three such seasons exist in the dev stack.

The number is already resolved once at the top of `get()`, so use it in both readers and bail before any lookup when it is missing. The getter returns `undefined` rather than `null`: the comparator reads `undefined` as a transport failure and skips the item, where `null` is definitive absence and would let `NOT_EXISTS` rules match it (#1446). The executor also preserves a transient item from removal, so an unscopable season is neither added nor dropped.

Season 0 is a real season, but the season lookup tested it for truthiness, so specials resolved to no season at all and every season property for them answered null or threw. Covered by a test that returns `undefined` before this change and `0` after.

Same root cause as #3415, one layer up. Kept separate from #3417 so the action-layer data-loss fix stays small and quick to review.