### PR TITLE
fix: reject the identifiers that turn a single delete into a bulk one

### DIFF
--- a/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.spec.ts
+++ b/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.spec.ts
@@ -138,3 +138,52 @@ describe('QbittorrentApi auth', () => {
     expect(t?.reachedSeedingGoal).toBe(true);
   });
 });
+
+describe('QbittorrentApi deleteTorrents', () => {
+  const arrange = () => {
+    const { api, axiosMock } = buildApi();
+    axiosMock.post.mockResolvedValue({ data: 'Ok.', headers: {} });
+    return { api, axiosMock };
+  };
+
+  // qBittorrent documents `hashes=all` on /torrents/delete as "delete all
+  // torrents", so it must never be forwarded as if it were one download.
+  it.each(['all', 'ALL', '  all  '])(
+    'refuses the whole-client magic value %j',
+    async (hash) => {
+      const { api, axiosMock } = arrange();
+
+      await api.deleteTorrents([hash], true);
+
+      expect(
+        axiosMock.post.mock.calls.some(([url]) =>
+          String(url).includes('/torrents/delete'),
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it('drops blank hashes rather than widening the joined list', async () => {
+    const { api, axiosMock } = arrange();
+
+    await api.deleteTorrents(['ABC123', '', '   ', 'def456'], false);
+
+    const deleteCall = axiosMock.post.mock.calls.find(([url]) =>
+      String(url).includes('/torrents/delete'),
+    );
+    expect(deleteCall).toBeDefined();
+    expect(String(deleteCall[1])).toContain('hashes=abc123%7Cdef456');
+  });
+
+  it('sends nothing when every hash was rejected', async () => {
+    const { api, axiosMock } = arrange();
+
+    await api.deleteTorrents(['', 'all'], true);
+
+    expect(
+      axiosMock.post.mock.calls.some(([url]) =>
+        String(url).includes('/torrents/delete'),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.ts
+++ b/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.ts
@@ -131,12 +131,20 @@ export class QbittorrentApi
     hashes: string[],
     deleteFiles: boolean,
   ): Promise<void> {
-    if (hashes.length === 0) {
+    // qBittorrent documents `hashes=all` on this endpoint as "delete all
+    // torrents", so a hash that arrives as the literal string would wipe the
+    // client rather than remove one download. Blanks are dropped for the same
+    // reason: they contribute nothing but widen the list they are joined into.
+    const validHashes = hashes
+      .map((hash) => hash?.trim().toLowerCase())
+      .filter((hash) => !!hash && hash !== 'all');
+
+    if (validHashes.length === 0) {
       return;
     }
 
     const body = new URLSearchParams();
-    body.set('hashes', hashes.map((hash) => hash.toLowerCase()).join('|'));
+    body.set('hashes', validHashes.join('|'));
     body.set('deleteFiles', deleteFiles ? 'true' : 'false');
 
     await this.withAuth(async () => {

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -93,6 +93,29 @@ describe('EmbyAdapterService', () => {
     setHttp();
   });
 
+  describe('deleteFromDisk', () => {
+    it.each(['', '   '])(
+      'refuses a blank item id (%j) rather than calling /Items/',
+      async (itemId) => {
+        setHttp();
+
+        await expect(service.deleteFromDisk(itemId)).rejects.toThrow(
+          'aborting to prevent unintended deletion',
+        );
+        expect(http.delete).not.toHaveBeenCalled();
+      },
+    );
+
+    it('deletes a real item', async () => {
+      setHttp();
+      http.delete.mockResolvedValue({ data: {} });
+
+      await service.deleteFromDisk('42');
+
+      expect(http.delete).toHaveBeenCalledWith('/Items/42');
+    });
+  });
+
   describe('getMetadata caching (#3355)', () => {
     it('caches a resolved item so repeat conditions do not re-read it', async () => {
       http.get.mockResolvedValue({

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -1451,6 +1451,15 @@ export class EmbyAdapterService implements IMediaServerService {
 
   async deleteFromDisk(itemId: string): Promise<void> {
     if (!this.http) throw new Error('Emby not initialized');
+
+    // Same guard as the Jellyfin adapter: a blank id would leave `/Items/`,
+    // which is a different route from the single-item delete this intends.
+    if (!itemId || itemId.trim() === '') {
+      throw new Error(
+        'deleteFromDisk called with empty itemId - aborting to prevent unintended deletion',
+      );
+    }
+
     try {
       await this.http.delete(`/Items/${itemId}`);
     } catch (error) {


### PR DESCRIPTION
Two destructive calls accepted a value that does not name one item and, instead of refusing it, addressed a broader target.

Emby's `deleteFromDisk` built `/Items/{id}` with no check, so a blank id left `/Items/`, a different route from the single-item delete it intends. The Jellyfin adapter already aborts on this with the same message; Emby now does the same.

qBittorrent [documents](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)) `hashes=all` on `/torrents/delete` as "delete all torrents", and `deleteTorrents` forwarded whatever it was given. Blank entries were joined into the list as empty segments.

Neither is reachable today: `removeDownloads` only passes a hash it has already resolved to a real torrent, and `/torrents/info` does not honour the magic value, so `all` never resolves. The helpers are public though, and the failure mode is the whole client plus its data.

Found while auditing #3415 for other places where an unresolved value silently widens a destructive action.