### PR TITLE
fix(settings): normalise trailing slashes off service URLs instead of rejecting them

### DIFF
--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
@@ -1,4 +1,4 @@
-import { BasicResponseDto } from '@maintainerr/contracts';
+import { BasicResponseDto, stripTrailingSlashes } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import { cloneDeep } from 'lodash';
 import { SettingsDataService } from '../../../modules/settings/settings-data.service';
@@ -228,7 +228,9 @@ export class SeerrApiService {
 
     this.api = new SeerrApi(
       {
-        url: `${this.settings.seerr_url.endsWith('/') ? this.settings.seerr_url.slice(0, -1) : this.settings.seerr_url}/api/v1`,
+        // Settings saved before the URL schema normalised them can still hold
+        // a trailing slash.
+        url: `${stripTrailingSlashes(this.settings.seerr_url)}/api/v1`,
         apiKey: `${this.settings.seerr_api_key}`,
       },
       this.loggerFactory.createLogger(),
@@ -692,7 +694,7 @@ export class SeerrApiService {
       ? new SeerrApi(
           {
             apiKey: params.apiKey,
-            url: `${params.url?.endsWith('/') ? params.url.slice(0, -1) : params.url}/api/v1`,
+            url: `${stripTrailingSlashes(params.url)}/api/v1`,
           },
           this.loggerFactory.createLogger(),
         )

--- a/apps/server/src/modules/settings/settings-body-validation.spec.ts
+++ b/apps/server/src/modules/settings/settings-body-validation.spec.ts
@@ -66,8 +66,9 @@ describe('settings body validation', () => {
       body: { seerr_url: 'file:///e' },
     },
     {
-      case: 'a URL with a trailing slash',
-      body: { tautulli_url: 'http://t/' },
+      // Slashes are stripped first, so this is left as the bare 'http:'.
+      case: 'a URL that is nothing but a scheme',
+      body: { seerr_url: 'http://' },
     },
     {
       case: 'a wrongly typed field',
@@ -76,6 +77,13 @@ describe('settings body validation', () => {
   ])('rejects $case', async ({ body }) => {
     expect((await patch(body)).status).toBe(400);
     expect(settingsOperationsService.patchSettings).not.toHaveBeenCalled();
+  });
+
+  it('normalises trailing slashes away instead of rejecting them (#3416)', async () => {
+    expect((await patch({ tautulli_url: 'http://t:8181//' })).status).toBe(200);
+    expect(settingsOperationsService.patchSettings).toHaveBeenCalledWith({
+      tautulli_url: 'http://t:8181',
+    });
   });
 
   it('strips keys the client has no business setting', async () => {

--- a/apps/server/src/modules/settings/settings.controller.spec.ts
+++ b/apps/server/src/modules/settings/settings.controller.spec.ts
@@ -1,6 +1,7 @@
 import {
   embyLoginRequestSchema,
   radarrSettingSchema,
+  seerrSettingSchema,
 } from '@maintainerr/contracts';
 import { BadGatewayException, StreamableFile } from '@nestjs/common';
 import { Response } from 'express';
@@ -243,6 +244,24 @@ describe('SettingsController', () => {
         },
       ),
     ).toThrow('Validation failed');
+  });
+
+  it('normalises a trailing slash off a service URL rather than rejecting it (#3416)', () => {
+    const pipe = new ZodValidationPipe(seerrSettingSchema);
+
+    expect(
+      pipe.transform(
+        {
+          url: 'http://seerr.local:5055/',
+          api_key: 'key',
+        },
+        {
+          type: 'body',
+          metatype: Object,
+          data: '',
+        },
+      ),
+    ).toEqual({ url: 'http://seerr.local:5055', api_key: 'key' });
   });
 
   it('rejects invalid Emby login requests with the shared Zod schema', () => {

--- a/apps/ui/src/components/Settings/DownloadClient/index.tsx
+++ b/apps/ui/src/components/Settings/DownloadClient/index.tsx
@@ -1,6 +1,7 @@
 import {
   DownloadClientSetting,
   downloadClientSettingSchema,
+  stripTrailingSlashes,
 } from '@maintainerr/contracts'
 import { useState } from 'react'
 import { Controller, useForm, useWatch } from 'react-hook-form'
@@ -12,7 +13,6 @@ import {
   useTestDownloadClient,
 } from '../../../api/settings'
 import { getApiErrorMessage } from '../../../utils/ApiError'
-import { stripTrailingSlashes } from '../../../utils/SettingsUtils'
 import Alert from '../../Common/Alert'
 import DocsButton from '../../Common/DocsButton'
 import SaveButton from '../../Common/SaveButton'

--- a/apps/ui/src/components/Settings/Emby/index.tsx
+++ b/apps/ui/src/components/Settings/Emby/index.tsx
@@ -3,6 +3,7 @@ import {
   type EmbySetting,
   embySettingSchema,
   maskSecret,
+  stripTrailingSlashes,
 } from '@maintainerr/contracts'
 import { useState } from 'react'
 import { Controller, useForm, useWatch } from 'react-hook-form'
@@ -15,7 +16,6 @@ import {
   useTestEmby,
 } from '../../../api/settings'
 import { getApiErrorMessage } from '../../../utils/ApiError'
-import { stripTrailingSlashes } from '../../../utils/SettingsUtils'
 import Alert from '../../Common/Alert'
 import DocsButton from '../../Common/DocsButton'
 import SaveButton from '../../Common/SaveButton'

--- a/apps/ui/src/components/Settings/Jellyfin/index.tsx
+++ b/apps/ui/src/components/Settings/Jellyfin/index.tsx
@@ -3,6 +3,7 @@ import {
   type JellyfinSetting,
   jellyfinSettingSchema,
   maskSecret,
+  stripTrailingSlashes,
 } from '@maintainerr/contracts'
 import { useState } from 'react'
 import { Controller, useForm, useWatch } from 'react-hook-form'
@@ -15,7 +16,6 @@ import {
   useTestJellyfin,
 } from '../../../api/settings'
 import { getApiErrorMessage } from '../../../utils/ApiError'
-import { stripTrailingSlashes } from '../../../utils/SettingsUtils'
 import Alert from '../../Common/Alert'
 import DocsButton from '../../Common/DocsButton'
 import SaveButton from '../../Common/SaveButton'

--- a/apps/ui/src/components/Settings/Seerr/index.tsx
+++ b/apps/ui/src/components/Settings/Seerr/index.tsx
@@ -1,6 +1,8 @@
-import { seerrSettingSchema } from '@maintainerr/contracts'
+import {
+  seerrSettingSchema,
+  stripTrailingSlashes,
+} from '@maintainerr/contracts'
 import { z } from 'zod'
-import { stripTrailingSlashes } from '../../../utils/SettingsUtils'
 import ExternalServiceSettingsPage, {
   type ExternalServiceFieldConfig,
 } from '../ExternalServiceSettingsPage'

--- a/apps/ui/src/components/Settings/Servarr/ServarrSettingsModal.tsx
+++ b/apps/ui/src/components/Settings/Servarr/ServarrSettingsModal.tsx
@@ -1,3 +1,4 @@
+import { stripTrailingSlashes } from '@maintainerr/contracts'
 import { useMemo, useState } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import {
@@ -140,10 +141,7 @@ const buildServarrPayload = <TSetting extends ServarrSettingShape>(
       ? `https://${state.hostname}`
       : `http://${state.hostname}`
 
-  const normalizedUrl = addPortToUrl(hostnameValue, Number(port))
-  const url = normalizedUrl.endsWith('/')
-    ? normalizedUrl.slice(0, -1)
-    : normalizedUrl
+  const url = stripTrailingSlashes(addPortToUrl(hostnameValue, Number(port)))
 
   return {
     payload: {

--- a/apps/ui/src/components/Settings/Streamystats/index.tsx
+++ b/apps/ui/src/components/Settings/Streamystats/index.tsx
@@ -1,8 +1,10 @@
-import { streamystatsSettingSchema } from '@maintainerr/contracts'
+import {
+  streamystatsSettingSchema,
+  stripTrailingSlashes,
+} from '@maintainerr/contracts'
 import { Navigate } from 'react-router-dom'
 import { z } from 'zod'
 import { useMediaServerType } from '../../../hooks/useMediaServerType'
-import { stripTrailingSlashes } from '../../../utils/SettingsUtils'
 import ExternalServiceSettingsPage, {
   type ExternalServiceFieldConfig,
 } from '../ExternalServiceSettingsPage'

--- a/apps/ui/src/components/Settings/Tautulli/index.tsx
+++ b/apps/ui/src/components/Settings/Tautulli/index.tsx
@@ -1,6 +1,8 @@
-import { tautulliSettingSchema } from '@maintainerr/contracts'
+import {
+  stripTrailingSlashes,
+  tautulliSettingSchema,
+} from '@maintainerr/contracts'
 import { z } from 'zod'
-import { stripTrailingSlashes } from '../../../utils/SettingsUtils'
 import ExternalServiceSettingsPage, {
   type ExternalServiceFieldConfig,
 } from '../ExternalServiceSettingsPage'

--- a/apps/ui/src/components/Settings/Tracearr/index.tsx
+++ b/apps/ui/src/components/Settings/Tracearr/index.tsx
@@ -1,9 +1,9 @@
 import {
+  stripTrailingSlashes,
   type TracearrServer,
   tracearrSettingSchema,
 } from '@maintainerr/contracts'
 import { PostApiHandler } from '../../../utils/ApiHandler'
-import { stripTrailingSlashes } from '../../../utils/SettingsUtils'
 import ExternalServiceSettingsPage, {
   type ExternalServiceFieldConfig,
 } from '../ExternalServiceSettingsPage'

--- a/apps/ui/src/utils/SettingsUtils.ts
+++ b/apps/ui/src/utils/SettingsUtils.ts
@@ -62,16 +62,6 @@ export function getBaseUrl(url: string): string | undefined {
   }
 }
 
-export function stripTrailingSlashes(value: string): string {
-  let endIndex = value.length
-
-  while (endIndex > 0 && value[endIndex - 1] === '/') {
-    endIndex -= 1
-  }
-
-  return endIndex === value.length ? value : value.slice(0, endIndex)
-}
-
 export function camelCaseToPrettyText(camelCaseStr: string): string {
   let spaced = ''
   for (let i = 0; i < camelCaseStr.length; i++) {

--- a/packages/contracts/src/settings/serviceUrl.ts
+++ b/packages/contracts/src/settings/serviceUrl.ts
@@ -1,11 +1,31 @@
 import z from 'zod'
 
 /**
- * Shared Zod refinement for service URL fields.
+ * Canonical tail form of a service URL. Manual char walk rather than a regex,
+ * per the project's string-handling convention.
+ */
+export function stripTrailingSlashes(value: string): string {
+  let endIndex = value.length
+
+  while (endIndex > 0 && value[endIndex - 1] === '/') {
+    endIndex -= 1
+  }
+
+  return endIndex === value.length ? value : value.slice(0, endIndex)
+}
+
+/**
+ * Shared Zod schema for service URL fields.
  *
- * Enforces:
- * - http:// or https:// scheme only (rejects file://, gopher://, ftp://, etc.)
- * - No trailing slash (consistent URL storage)
+ * Trailing slashes are normalised away rather than rejected: every client
+ * appends its own '/path', and storing one canonical form keeps them from
+ * producing '//path'. Stripping before the scheme check is what keeps a bare
+ * 'http://' an error instead of a silently mangled 'http:'. `overwrite` rather
+ * than `transform` because it is a check, so the schema stays a `ZodString`
+ * and every `z.infer`'d DTO keeps its field required.
+ *
+ * Only http:// and https:// are accepted (rejects file://, gopher://, ftp://,
+ * etc.).
  *
  * Note: This is input sanitization, not full SSRF protection. Maintainerr is a
  * self-hosted application that intentionally connects to user-configured services
@@ -16,9 +36,7 @@ import z from 'zod'
 export const serviceUrlSchema = z
   .string()
   .trim()
+  .overwrite(stripTrailingSlashes)
   .refine((val) => val.startsWith('http://') || val.startsWith('https://'), {
     message: 'Must start with http:// or https://',
-  })
-  .refine((val) => !val.endsWith('/'), {
-    message: "Must not end with a '/'",
   })


### PR DESCRIPTION
Fixes #3416.

`serviceUrlSchema` refuses any URL ending in `/`, while `SeerrApiService.init` strips exactly that before appending `/api/v1`. The two layers were written for the same input and contradict each other, so the normalisation is unreachable: a URL pasted with a trailing slash is rejected with `Must not end with a '/'` and never stored.

It is not Seerr-specific. The schema backs every service URL in the app: Jellyfin, Emby, Seerr, Tautulli, Streamystats, Tracearr, the download client, Radarr/Sonarr/Sportarr, and both bulk settings routes. The *arr modal composes its URL from hostname, port and base URL, so a base URL typed as `radarr/` produces a trailing slash the user never sees.

The settings forms hide it in the common case: they normalise on blur, so clicking Save strips the slash before submitting. Pressing Enter does not blur, and neither does an API client.

The schema now strips trailing slashes rather than rejecting them. Stripping runs before the scheme check, so a bare `http://` still fails instead of becoming `http:`. It uses `overwrite`, not `transform`: `overwrite` is a check, so the schema stays a `ZodString`, whereas a transform turns it into a `ZodPipe` whose key `z.infer`s as optional under the server's `strictNullChecks: false`. Every settings DTO would lose its required `url` and stop matching the TypeORM entities.

`stripTrailingSlashes` moves from the UI's `SettingsUtils` into contracts beside the schema, so the forms, the schema and the Seerr client share one implementation instead of three. The UI helper predates the schema (#2330 vs #2523), which is how the two rules drifted apart to begin with.

Anything saved through the UI was already normalised client-side, but rows written before #2523 can still hold a slash, so the Seerr client keeps stripping on read. Seerr answers `//api/v1/...` with a 308 to the single-slash path; Jellyfin 404s on the equivalent.