### PR TITLE
refactor(rules): name the rule group DTO for what it holds

### DIFF
--- a/apps/server/src/modules/rules/dtos/ruleGroup.dto.ts
+++ b/apps/server/src/modules/rules/dtos/ruleGroup.dto.ts
@@ -4,7 +4,7 @@ import { Notification } from '../../notifications/entities/notification.entities
 import { RuleDto } from './rule.dto';
 import { RuleDbDto } from './ruleDb.dto';
 
-export class RulesDto {
+export class RuleGroupDto {
   id?: number;
   libraryId: string;
   name: string;

--- a/apps/server/src/modules/rules/getter/emby-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/emby-getter.service.spec.ts
@@ -7,7 +7,7 @@ import {
   WatchRecord,
 } from '@maintainerr/contracts';
 import { Mocked, TestBed } from '@suites/unit';
-import { createRulesDto } from '../../../../test/utils/data';
+import { createRuleGroupDto } from '../../../../test/utils/data';
 
 import cacheManager from '../../api/lib/cache';
 import { EmbyAdapterService } from '../../api/media-server/emby/emby-adapter.service';
@@ -84,7 +84,7 @@ describe('EmbyGetterService', () => {
           STUDIOS_PROP_ID,
           mediaItem,
           'movie',
-          createRulesDto({ dataType: 'movie' }),
+          createRuleGroupDto({ dataType: 'movie' }),
           cache,
         ),
       ).resolves.toEqual(['Studio One']);
@@ -123,7 +123,7 @@ describe('EmbyGetterService', () => {
         1,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRuleGroupDto({ dataType: 'movie' }),
       );
 
       expect(response).toEqual(['blank-user', 'missing-user', 'Alice']);
@@ -141,7 +141,7 @@ describe('EmbyGetterService', () => {
         0,
         createMediaItem(),
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRuleGroupDto({ dataType: 'movie' }),
       );
 
       expect(response).toBeUndefined();
@@ -154,7 +154,7 @@ describe('EmbyGetterService', () => {
         id: 'movie-collections-1',
         type: 'movie',
       });
-      const ruleGroup = createRulesDto({
+      const ruleGroup = createRuleGroupDto({
         dataType: 'movie',
         libraryId: mediaItem.library.id,
         name: ' movie cleanup ',
@@ -257,7 +257,7 @@ describe('EmbyGetterService', () => {
         },
       );
 
-      const ruleGroup = createRulesDto({
+      const ruleGroup = createRuleGroupDto({
         dataType: 'episode',
         libraryId: episodeItem.library.id,
         name: ' show cleanup ',
@@ -293,7 +293,7 @@ describe('EmbyGetterService', () => {
         id: 'movie-excluded-sibling',
         type: 'movie',
       });
-      const ruleGroup = createRulesDto({
+      const ruleGroup = createRuleGroupDto({
         dataType: 'movie',
         libraryId: mediaItem.library.id,
         name: ' sibling cleanup ',

--- a/apps/server/src/modules/rules/getter/emby-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/emby-getter.service.ts
@@ -13,7 +13,7 @@ import {
   Property,
   RuleConstants,
 } from '../constants/rules.constants';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 import {
   filterRuleCollectionNames,
@@ -58,7 +58,7 @@ export class EmbyGetterService {
     id: number,
     libItem: MediaItem,
     dataType?: MediaItemType,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
     arrLookupCache?: ArrLookupCache,
   ): Promise<RuleValueType> {
     try {
@@ -808,7 +808,7 @@ export class EmbyGetterService {
   private async getCollectionNames(
     itemId: string,
     libraryId: string,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
   ): Promise<string[]> {
     // Cache the raw collection names (without exclusion filtering)
     // so we can apply different exclusions for different rule groups
@@ -906,7 +906,7 @@ export class EmbyGetterService {
     parentId: string | undefined,
     grandparentId: string | undefined,
     libraryId: string,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
   ): Promise<number> {
     const names = await this.getCollectionNamesIncludingParent(
       itemId,
@@ -923,7 +923,7 @@ export class EmbyGetterService {
     parentId: string | undefined,
     grandparentId: string | undefined,
     libraryId: string,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
   ): Promise<string[]> {
     const collections = await this.embyAdapter.getCollections(libraryId);
     const collectionNames: string[] = [];
@@ -952,7 +952,7 @@ export class EmbyGetterService {
   private async getCollectionSiblingsLastViewedAt(
     itemId: string,
     libraryId: string,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
   ): Promise<Date | null> {
     const collections = await this.embyAdapter.getCollections(libraryId);
     const includedCollectionNames = new Set(

--- a/apps/server/src/modules/rules/getter/getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/getter.service.spec.ts
@@ -6,7 +6,7 @@ import {
 import { Mocked, TestBed } from '@suites/unit';
 import { MediaServerFactory } from '../../api/media-server/media-server.factory';
 import { Application } from '../constants/rules.constants';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 import { EmbyGetterService } from './emby-getter.service';
 import { ValueGetterService } from './getter.service';
@@ -50,7 +50,7 @@ describe('ValueGetterService', () => {
     'passes the run cache to the %s media-server getter',
     async (serverType) => {
       const cache = new ArrLookupCache();
-      const ruleGroup = { id: 1 } as RulesDto;
+      const ruleGroup = { id: 1 } as RuleGroupDto;
       const get =
         serverType === MediaServerType.PLEX
           ? plexGetter.get
@@ -81,7 +81,7 @@ describe('ValueGetterService', () => {
     plexGetter.get.mockResolvedValue(undefined);
 
     await expect(
-      service.get([Application.PLEX, 46], item, { id: 1 } as RulesDto),
+      service.get([Application.PLEX, 46], item, { id: 1 } as RuleGroupDto),
     ).resolves.toBeUndefined();
   });
 });

--- a/apps/server/src/modules/rules/getter/getter.service.ts
+++ b/apps/server/src/modules/rules/getter/getter.service.ts
@@ -8,7 +8,7 @@ import { Injectable } from '@nestjs/common';
 import { MediaServerFactory } from '../../api/media-server/media-server.factory';
 import { Application } from '../constants/rules.constants';
 import { RuleDto } from '../dtos/rule.dto';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 import { EmbyGetterService } from './emby-getter.service';
 import { JellyfinGetterService } from './jellyfin-getter.service';
@@ -49,7 +49,7 @@ export class ValueGetterService {
   async get(
     [val1, val2]: [number, number],
     libItem: MediaItem,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
     dataType?: MediaItemType,
     currentRule?: RuleDto,
     arrLookupCache?: ArrLookupCache,

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.spec.ts
@@ -8,7 +8,7 @@ import {
   WatchRecord,
 } from '@maintainerr/contracts';
 import { Mocked, TestBed } from '@suites/unit';
-import { createRulesDto } from '../../../../test/utils/data';
+import { createRuleGroupDto } from '../../../../test/utils/data';
 
 const LIBRARY_ID = 'lib-1';
 
@@ -135,7 +135,7 @@ describe('JellyfinGetterService', () => {
           STUDIOS_PROP_ID,
           mediaItem,
           'movie',
-          createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+          createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
           cache,
         ),
       ).resolves.toEqual(['Studio One']);
@@ -164,7 +164,7 @@ describe('JellyfinGetterService', () => {
         0, // addDate
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeNull();
@@ -287,7 +287,7 @@ describe('JellyfinGetterService', () => {
           id,
           mediaItem,
           'movie',
-          createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+          createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
         );
 
         expect(response).toEqual(expected);
@@ -319,7 +319,7 @@ describe('JellyfinGetterService', () => {
         11,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Drama', 'Mystery']);
@@ -349,7 +349,7 @@ describe('JellyfinGetterService', () => {
         11,
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Sci-Fi']);
@@ -374,7 +374,7 @@ describe('JellyfinGetterService', () => {
         11,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual([]);
@@ -398,7 +398,7 @@ describe('JellyfinGetterService', () => {
         11,
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual([]);
@@ -421,7 +421,7 @@ describe('JellyfinGetterService', () => {
         44,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(6.9);
@@ -444,7 +444,7 @@ describe('JellyfinGetterService', () => {
         1,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Alice', 'Bob']);
@@ -469,7 +469,7 @@ describe('JellyfinGetterService', () => {
         1,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Bob', 'user-missing', 'Alice']);
@@ -486,7 +486,7 @@ describe('JellyfinGetterService', () => {
         1,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual([]);
@@ -512,7 +512,7 @@ describe('JellyfinGetterService', () => {
         39,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Bob', 'user-missing', 'Alice']);
@@ -549,7 +549,7 @@ describe('JellyfinGetterService', () => {
         40, // sw_favoritedBy
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'episode', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'episode', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Bob']);
@@ -603,7 +603,7 @@ describe('JellyfinGetterService', () => {
         41, // sw_favoritedBy_including_parent
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'episode', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'episode', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Alice', 'Bob', 'Carol', 'Dave']);
@@ -640,7 +640,7 @@ describe('JellyfinGetterService', () => {
         5,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(3);
@@ -661,7 +661,7 @@ describe('JellyfinGetterService', () => {
         JELLYFIN_IS_WATCHED_PROP_ID,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(true);
@@ -680,7 +680,7 @@ describe('JellyfinGetterService', () => {
         JELLYFIN_IS_WATCHED_PROP_ID,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(false);
@@ -712,7 +712,7 @@ describe('JellyfinGetterService', () => {
           title: ' Manual Picks ',
         }),
       ];
-      const ruleGroup = createRulesDto({
+      const ruleGroup = createRuleGroupDto({
         dataType: 'movie',
         libraryId: mediaItem.library.id,
         name: ' movie cleanup ',
@@ -766,7 +766,7 @@ describe('JellyfinGetterService', () => {
         19,
         mediaItem,
         'movie',
-        createRulesDto({
+        createRuleGroupDto({
           dataType: 'movie',
           libraryId: mediaItem.library.id,
           name: ' cleanup a ',
@@ -776,7 +776,7 @@ describe('JellyfinGetterService', () => {
         19,
         mediaItem,
         'movie',
-        createRulesDto({
+        createRuleGroupDto({
           dataType: 'movie',
           libraryId: mediaItem.library.id,
           name: ' cleanup b ',
@@ -838,7 +838,7 @@ describe('JellyfinGetterService', () => {
         },
       );
 
-      const ruleGroup = createRulesDto({
+      const ruleGroup = createRuleGroupDto({
         dataType: 'episode',
         libraryId: episodeItem.library.id,
         name: ' show cleanup ',
@@ -877,7 +877,7 @@ describe('JellyfinGetterService', () => {
         7,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2024-06-15'));
@@ -893,7 +893,7 @@ describe('JellyfinGetterService', () => {
         7,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeNull();
@@ -911,7 +911,7 @@ describe('JellyfinGetterService', () => {
         7,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeUndefined();
@@ -965,7 +965,7 @@ describe('JellyfinGetterService', () => {
         7,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-03-06'));
@@ -1005,7 +1005,7 @@ describe('JellyfinGetterService', () => {
         7,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-03-04'));
@@ -1059,7 +1059,7 @@ describe('JellyfinGetterService', () => {
         12,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Bob']);
@@ -1092,7 +1092,7 @@ describe('JellyfinGetterService', () => {
           propertyId,
           showItem,
           'show',
-          createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+          createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
         );
 
         expect(response).toBeUndefined();
@@ -1136,7 +1136,7 @@ describe('JellyfinGetterService', () => {
         14,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(3);
@@ -1166,7 +1166,7 @@ describe('JellyfinGetterService', () => {
         16,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-01-12'));
@@ -1214,7 +1214,7 @@ describe('JellyfinGetterService', () => {
         27,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-02-08'));
@@ -1253,7 +1253,7 @@ describe('JellyfinGetterService', () => {
         29,
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-03-10'));
@@ -1327,7 +1327,7 @@ describe('JellyfinGetterService', () => {
         13,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-03-06'));
@@ -1380,7 +1380,7 @@ describe('JellyfinGetterService', () => {
         13,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       // ep-2 is the highest-numbered watched episode; its rewatch wins.
@@ -1417,7 +1417,7 @@ describe('JellyfinGetterService', () => {
         13,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeNull();
@@ -1455,7 +1455,7 @@ describe('JellyfinGetterService', () => {
         13,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-02-01'));
@@ -1501,7 +1501,7 @@ describe('JellyfinGetterService', () => {
         13,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(new Date('2026-03-01'));
@@ -1555,7 +1555,7 @@ describe('JellyfinGetterService', () => {
         15, // sw_viewedEpisodes
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(2); // 2 episodes have been watched
@@ -1588,7 +1588,7 @@ describe('JellyfinGetterService', () => {
         15,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(0);
@@ -1635,7 +1635,7 @@ describe('JellyfinGetterService', () => {
         17, // sw_amountOfViews
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(5); // 3 + 2 = 5 total views
@@ -1668,7 +1668,7 @@ describe('JellyfinGetterService', () => {
         17,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(0);
@@ -1698,13 +1698,13 @@ describe('JellyfinGetterService', () => {
         21,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
       const count = await jellyfinGetterService.get(
         20,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(names).toEqual(['Friday Queue']);
@@ -1747,7 +1747,7 @@ describe('JellyfinGetterService', () => {
         21,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Show Queue']);
@@ -1773,7 +1773,7 @@ describe('JellyfinGetterService', () => {
           id,
           mediaItem,
           type,
-          createRulesDto({ dataType: type, libraryId: LIBRARY_ID }),
+          createRuleGroupDto({ dataType: type, libraryId: LIBRARY_ID }),
         );
 
         expect(response).toBe(expected);
@@ -1807,7 +1807,7 @@ describe('JellyfinGetterService', () => {
         id,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(expected);
@@ -1851,7 +1851,7 @@ describe('JellyfinGetterService', () => {
           id,
           seasonItem,
           'season',
-          createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+          createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
         );
 
         expect(response).toBe(expected);
@@ -1881,7 +1881,7 @@ describe('JellyfinGetterService', () => {
         35,
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBe(9.1);
@@ -1900,7 +1900,7 @@ describe('JellyfinGetterService', () => {
         999, // Unknown property ID
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeNull();
@@ -1936,7 +1936,7 @@ describe('JellyfinGetterService', () => {
         SW_WATCHERS_PROP_ID,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Alice', 'Bob']);
@@ -1963,7 +1963,7 @@ describe('JellyfinGetterService', () => {
         SW_WATCHERS_PROP_ID,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual([]);
@@ -1988,7 +1988,7 @@ describe('JellyfinGetterService', () => {
         SW_WATCHERS_PROP_ID,
         seasonItem,
         'season',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Bob']);
@@ -2014,7 +2014,7 @@ describe('JellyfinGetterService', () => {
         SW_WATCHERS_PROP_ID,
         episodeItem,
         'episode',
-        createRulesDto({ dataType: 'episode', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'episode', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['Bob']);
@@ -2045,7 +2045,7 @@ describe('JellyfinGetterService', () => {
         SW_WATCHERS_PROP_ID,
         showItem,
         'show',
-        createRulesDto({ dataType: 'show', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'show', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toEqual(['user-ghost']);
@@ -2061,7 +2061,7 @@ describe('JellyfinGetterService', () => {
         0,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeUndefined();
@@ -2078,7 +2078,7 @@ describe('JellyfinGetterService', () => {
         0,
         mediaItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeUndefined();
@@ -2138,7 +2138,7 @@ describe('JellyfinGetterService', () => {
         COLLECTION_SIBLINGS_PROP_ID,
         libItem,
         'movie',
-        createRulesDto({
+        createRuleGroupDto({
           dataType: 'movie',
           libraryId: libItem.library.id,
           name: 'Movie cleanup',
@@ -2189,7 +2189,10 @@ describe('JellyfinGetterService', () => {
         COLLECTION_SIBLINGS_PROP_ID,
         libItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: libItem.library.id }),
+        createRuleGroupDto({
+          dataType: 'movie',
+          libraryId: libItem.library.id,
+        }),
       );
 
       expect(result).toBeNull();
@@ -2234,7 +2237,7 @@ describe('JellyfinGetterService', () => {
         COLLECTION_SIBLINGS_PROP_ID,
         libItem,
         'movie',
-        createRulesDto({
+        createRuleGroupDto({
           dataType: 'movie',
           libraryId: libItem.library.id,
           name: 'Movie cleanup',
@@ -2271,7 +2274,7 @@ describe('JellyfinGetterService', () => {
           propertyId,
           episodeItem,
           'episode',
-          createRulesDto({ dataType: 'episode', libraryId: LIBRARY_ID }),
+          createRuleGroupDto({ dataType: 'episode', libraryId: LIBRARY_ID }),
         );
 
         expect(response).toEqual(expected);
@@ -2291,7 +2294,7 @@ describe('JellyfinGetterService', () => {
         7,
         movieItem,
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: LIBRARY_ID }),
       );
 
       expect(response).toBeNull();

--- a/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/jellyfin-getter.service.ts
@@ -14,7 +14,7 @@ import {
   Property,
   RuleConstants,
 } from '../constants/rules.constants';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 import {
   filterRuleCollectionNames,
@@ -57,7 +57,7 @@ export class JellyfinGetterService {
     id: number,
     libItem: MediaItem,
     dataType?: MediaItemType,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
     arrLookupCache?: ArrLookupCache,
   ): Promise<RuleValueType> {
     try {
@@ -838,7 +838,7 @@ export class JellyfinGetterService {
   private async getCollectionNames(
     itemId: string,
     libraryId: string,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
   ): Promise<string[]> {
     // Cache the raw collection names (without exclusion filtering)
     // so we can apply different exclusions for different rule groups
@@ -940,7 +940,7 @@ export class JellyfinGetterService {
     parentId: string | undefined,
     grandparentId: string | undefined,
     libraryId: string,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
   ): Promise<number> {
     const names = await this.getCollectionNamesIncludingParent(
       itemId,
@@ -957,7 +957,7 @@ export class JellyfinGetterService {
     parentId: string | undefined,
     grandparentId: string | undefined,
     libraryId: string,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
   ): Promise<string[]> {
     const collections = await this.jellyfinAdapter.getCollections(libraryId);
     const collectionNames: string[] = [];
@@ -986,7 +986,7 @@ export class JellyfinGetterService {
   private async getCollectionSiblingsLastViewedAt(
     itemId: string,
     libraryId: string,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
   ): Promise<Date | null> {
     const collections = await this.jellyfinAdapter.getCollections(libraryId);
     const includedCollectionNames = new Set(

--- a/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.spec.ts
@@ -1,6 +1,9 @@
 import { MediaItem } from '@maintainerr/contracts';
 import { Mocked, TestBed } from '@suites/unit';
-import { createMediaItem, createRulesDto } from '../../../../test/utils/data';
+import {
+  createMediaItem,
+  createRuleGroupDto,
+} from '../../../../test/utils/data';
 import { PlexAdapterService } from '../../api/media-server/plex/plex-adapter.service';
 import {
   PlexCollection,
@@ -178,7 +181,7 @@ describe('PlexGetterService', () => {
         VIEWCOUNT_PROP_ID,
         libItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRuleGroupDto({ dataType: 'movie' }),
       );
 
       expect(result).toBe(7);
@@ -197,7 +200,7 @@ describe('PlexGetterService', () => {
         ISWATCHED_PROP_ID,
         libItem,
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRuleGroupDto({ dataType: 'movie' }),
       );
 
       expect(result).toBe(false);
@@ -271,7 +274,7 @@ describe('PlexGetterService', () => {
         rule.id,
         createMediaItem({ id: metadata.ratingKey, type: 'movie' }),
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRuleGroupDto({ dataType: 'movie' }),
       );
 
       expect(result).toEqual(rule.expected);
@@ -289,7 +292,7 @@ describe('PlexGetterService', () => {
         7,
         createMediaItem({ type: 'movie', lastViewedAt }),
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRuleGroupDto({ dataType: 'movie' }),
       );
 
       expect(result).toEqual(lastViewedAt);
@@ -308,7 +311,7 @@ describe('PlexGetterService', () => {
           lastViewedAt: new Date(1_730_000_000 * 1000),
         }),
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRuleGroupDto({ dataType: 'movie' }),
       );
 
       expect(result).toEqual(new Date(1_740_000_000 * 1000));
@@ -322,7 +325,7 @@ describe('PlexGetterService', () => {
         makeWatchEntry({ viewedAt: 1_710_000_000 }),
       ]);
 
-      const ruleGroup = createRulesDto({ dataType: 'movie' });
+      const ruleGroup = createRuleGroupDto({ dataType: 'movie' });
       const result = await service.get(
         7,
         createMediaItem({ type: 'movie' }),
@@ -354,12 +357,12 @@ describe('PlexGetterService', () => {
         6,
         createMediaItem({ type: 'movie' }),
         'movie',
-        createRulesDto({
+        createRuleGroupDto({
           dataType: 'movie',
           name: ' cleanup group ',
           collection: {
             manualCollectionName: ' Manual Shelf ',
-          } as ReturnType<typeof createRulesDto>['collection'],
+          } as ReturnType<typeof createRuleGroupDto>['collection'],
         }),
       );
 
@@ -381,7 +384,7 @@ describe('PlexGetterService', () => {
         19,
         createMediaItem({ type: 'movie' }),
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRuleGroupDto({ dataType: 'movie' }),
       );
 
       expect(result).toEqual(['Space Saga', 'space saga', 'Space Saga']);
@@ -410,7 +413,7 @@ describe('PlexGetterService', () => {
           11,
           libItem,
           'episode',
-          createRulesDto({ dataType: 'show' }),
+          createRuleGroupDto({ dataType: 'show' }),
         ),
       ).resolves.toEqual(['Mystery']);
       await expect(
@@ -418,7 +421,7 @@ describe('PlexGetterService', () => {
           24,
           libItem,
           'episode',
-          createRulesDto({ dataType: 'show' }),
+          createRuleGroupDto({ dataType: 'show' }),
         ),
       ).resolves.toEqual(['Shared Show Label']);
     });
@@ -455,7 +458,7 @@ describe('PlexGetterService', () => {
         12,
         createMediaItem({ type: 'season' }),
         'season',
-        createRulesDto({ dataType: 'show' }),
+        createRuleGroupDto({ dataType: 'show' }),
       );
 
       expect(result).toEqual(['bob', 'alice']);
@@ -483,7 +486,7 @@ describe('PlexGetterService', () => {
         }),
       ]);
 
-      const ruleGroup = createRulesDto({ dataType: 'show' });
+      const ruleGroup = createRuleGroupDto({ dataType: 'show' });
       const result = await service.get(
         13,
         createMediaItem({ type: 'show' }),
@@ -512,7 +515,7 @@ describe('PlexGetterService', () => {
         13,
         createMediaItem({ type: 'show' }),
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRuleGroupDto({ dataType: 'show' }),
       );
 
       expect(result).toBeNull();
@@ -533,7 +536,7 @@ describe('PlexGetterService', () => {
       );
 
       const libItem = createMediaItem({ type: 'season' });
-      const ruleGroup = createRulesDto({ dataType: 'show' });
+      const ruleGroup = createRuleGroupDto({ dataType: 'show' });
 
       await expect(service.get(14, libItem, 'season', ruleGroup)).resolves.toBe(
         2,
@@ -593,7 +596,7 @@ describe('PlexGetterService', () => {
           16,
           createMediaItem({ id: 'show-1', type: 'show' }),
           'show',
-          createRulesDto({ dataType: 'show' }),
+          createRuleGroupDto({ dataType: 'show' }),
         ),
       ).resolves.toEqual(new Date(1_720_000_000 * 1000));
       await expect(
@@ -601,7 +604,7 @@ describe('PlexGetterService', () => {
           27,
           createMediaItem({ id: 'show-1', type: 'show' }),
           'show',
-          createRulesDto({ dataType: 'show' }),
+          createRuleGroupDto({ dataType: 'show' }),
         ),
       ).resolves.toEqual(new Date('2024-04-17'));
       await expect(
@@ -609,7 +612,7 @@ describe('PlexGetterService', () => {
           29,
           createMediaItem({ id: 'episode-1', type: 'episode' }),
           'episode',
-          createRulesDto({ dataType: 'show' }),
+          createRuleGroupDto({ dataType: 'show' }),
         ),
       ).resolves.toEqual(new Date('2024-04-17'));
     });
@@ -630,7 +633,7 @@ describe('PlexGetterService', () => {
         makeWatchEntry({ accountID: 1 }),
       ]);
 
-      const ruleGroup = createRulesDto({ dataType: 'show' });
+      const ruleGroup = createRuleGroupDto({ dataType: 'show' });
       const result = await service.get(
         18,
         createMediaItem({ type: 'show' }),
@@ -678,7 +681,7 @@ describe('PlexGetterService', () => {
       });
 
       const libItem = createMediaItem({ type: 'show' });
-      const ruleGroup = createRulesDto({ dataType: 'show' });
+      const ruleGroup = createRuleGroupDto({ dataType: 'show' });
 
       await expect(service.get(20, libItem, 'show', ruleGroup)).resolves.toBe(
         3,
@@ -702,7 +705,7 @@ describe('PlexGetterService', () => {
         21,
         createMediaItem({ id: 'movie-1', type: 'movie' }),
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRuleGroupDto({ dataType: 'movie' }),
       );
 
       expect(result).toEqual(['Road Trip', 'Road Trip', 'Finale']);
@@ -743,7 +746,7 @@ describe('PlexGetterService', () => {
       );
 
       const libItem = createMediaItem({ id: 'episode-1', type: 'episode' });
-      const ruleGroup = createRulesDto({ dataType: 'show' });
+      const ruleGroup = createRuleGroupDto({ dataType: 'show' });
 
       await expect(
         service.get(28, libItem, 'episode', ruleGroup),
@@ -774,7 +777,7 @@ describe('PlexGetterService', () => {
       ]);
 
       const libItem = createMediaItem({ id: 'movie-1', type: 'movie' });
-      const ruleGroup = createRulesDto({ dataType: 'movie' });
+      const ruleGroup = createRuleGroupDto({ dataType: 'movie' });
 
       await expect(
         service.get(28, libItem, 'movie', ruleGroup),
@@ -801,7 +804,7 @@ describe('PlexGetterService', () => {
       plexApi.getWatchlistIdsForUser.mockResolvedValue(undefined);
 
       const libItem = createMediaItem({ id: 'movie-1', type: 'movie' });
-      const ruleGroup = createRulesDto({ dataType: 'movie' });
+      const ruleGroup = createRuleGroupDto({ dataType: 'movie' });
 
       await expect(
         service.get(28, libItem, 'movie', ruleGroup),
@@ -840,7 +843,7 @@ describe('PlexGetterService', () => {
       );
 
       const libItem = createMediaItem({ id: 'movie-1', type: 'movie' });
-      const ruleGroup = createRulesDto({ dataType: 'movie' });
+      const ruleGroup = createRuleGroupDto({ dataType: 'movie' });
 
       await expect(
         service.get(28, libItem, 'movie', ruleGroup),
@@ -864,7 +867,7 @@ describe('PlexGetterService', () => {
       plexApi.getWatchlistIdsForUser.mockResolvedValue(null);
 
       const libItem = createMediaItem({ id: 'movie-1', type: 'movie' });
-      const ruleGroup = createRulesDto({ dataType: 'movie' });
+      const ruleGroup = createRuleGroupDto({ dataType: 'movie' });
 
       await expect(
         service.get(28, libItem, 'movie', ruleGroup),
@@ -888,7 +891,7 @@ describe('PlexGetterService', () => {
       );
 
       const libItem = createMediaItem({ id: 'movie-1', type: 'movie' });
-      const ruleGroup = createRulesDto({ dataType: 'movie' });
+      const ruleGroup = createRuleGroupDto({ dataType: 'movie' });
 
       await expect(
         service.get(28, libItem, 'movie', ruleGroup),
@@ -933,7 +936,7 @@ describe('PlexGetterService', () => {
         rule.id,
         createMediaItem({ type: 'movie' }),
         'movie',
-        createRulesDto({ dataType: 'movie' }),
+        createRuleGroupDto({ dataType: 'movie' }),
       );
 
       expect(result).toBe(rule.expected);
@@ -980,7 +983,7 @@ describe('PlexGetterService', () => {
         rule.id,
         createMediaItem({ id: 'episode-1', type: 'episode' }),
         'episode',
-        createRulesDto({ dataType: 'show' }),
+        createRuleGroupDto({ dataType: 'show' }),
       );
 
       expect(result).toBe(rule.expected);
@@ -1001,7 +1004,7 @@ describe('PlexGetterService', () => {
             id,
             createMediaItem({ id: 'show-1', type: 'show' }),
             'show',
-            createRulesDto({ dataType: 'show' }),
+            createRuleGroupDto({ dataType: 'show' }),
           ),
         ).resolves.toBeNull();
       },
@@ -1035,13 +1038,13 @@ describe('PlexGetterService', () => {
         39,
         createMediaItem({ id: 'movie-1', type: 'movie' }),
         'movie',
-        createRulesDto({
+        createRuleGroupDto({
           dataType: 'movie',
           libraryId: 'lib-1',
           name: 'Cleanup Group',
           collection: {
             manualCollectionName: 'manual shelf',
-          } as ReturnType<typeof createRulesDto>['collection'],
+          } as ReturnType<typeof createRuleGroupDto>['collection'],
         }),
       );
 
@@ -1089,7 +1092,7 @@ describe('PlexGetterService', () => {
         40,
         createMediaItem({ id: 'episode-1', type: 'episode' }),
         'episode',
-        createRulesDto({
+        createRuleGroupDto({
           dataType: 'show',
           libraryId: 'lib-1',
           name: ' cleanup group ',
@@ -1138,7 +1141,7 @@ describe('PlexGetterService', () => {
         41,
         createMediaItem({ id: 'episode-1', type: 'episode' }),
         'episode',
-        createRulesDto({ dataType: 'show', libraryId: 'lib-1' }),
+        createRuleGroupDto({ dataType: 'show', libraryId: 'lib-1' }),
       );
 
       // Pre-refactor behaviour (#1630): dedupe runs on the RAW tag, so the
@@ -1175,7 +1178,7 @@ describe('PlexGetterService', () => {
         42,
         createMediaItem({ id: 'movie-1', type: 'movie' }),
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: 'lib-1' }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: 'lib-1' }),
       );
 
       // The exact-equal 'Space Saga' (metadata + smart) collapse; the whitespace
@@ -1209,7 +1212,7 @@ describe('PlexGetterService', () => {
       });
 
       const libItem = createMediaItem({ id: 'episode-1', type: 'episode' });
-      const ruleGroup = createRulesDto({
+      const ruleGroup = createRuleGroupDto({
         dataType: 'show',
         name: 'cleanup group',
       });
@@ -1271,7 +1274,7 @@ describe('PlexGetterService', () => {
       31,
       mediaItem,
       'movie',
-      createRulesDto({ dataType: 'movie' }),
+      createRuleGroupDto({ dataType: 'movie' }),
     );
 
     expect(result).toBe(7.8);
@@ -1308,7 +1311,7 @@ describe('PlexGetterService', () => {
       35,
       mediaItem,
       'episode',
-      createRulesDto({ dataType: 'show' }),
+      createRuleGroupDto({ dataType: 'show' }),
     );
 
     expect(result).toBe(8.2);
@@ -1353,7 +1356,7 @@ describe('PlexGetterService', () => {
       });
 
       const libItem = createMediaItem({ type: 'movie' });
-      const ruleGroup = createRulesDto({
+      const ruleGroup = createRuleGroupDto({
         dataType: 'movie',
         libraryId: 'lib-1',
         name: 'My cleanup group',
@@ -1397,7 +1400,7 @@ describe('PlexGetterService', () => {
         COLLECTION_SIBLINGS_PROP_ID,
         createMediaItem({ type: 'movie' }),
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: 'lib-1' }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: 'lib-1' }),
       );
 
       expect(result).toBeNull();
@@ -1425,7 +1428,7 @@ describe('PlexGetterService', () => {
         COLLECTION_SIBLINGS_PROP_ID,
         createMediaItem({ type: 'movie' }),
         'movie',
-        createRulesDto({ dataType: 'movie', libraryId: 'lib-1' }),
+        createRuleGroupDto({ dataType: 'movie', libraryId: 'lib-1' }),
       );
 
       expect(result).toBeNull();
@@ -1458,7 +1461,7 @@ describe('PlexGetterService', () => {
         COLLECTION_SIBLINGS_PROP_ID,
         createMediaItem({ type: 'movie' }),
         'movie',
-        createRulesDto({
+        createRuleGroupDto({
           dataType: 'movie',
           libraryId: 'lib-1',
           name: 'My cleanup group',
@@ -1499,13 +1502,13 @@ describe('PlexGetterService', () => {
         COLLECTION_SIBLINGS_PROP_ID,
         createMediaItem({ type: 'movie' }),
         'movie',
-        createRulesDto({
+        createRuleGroupDto({
           dataType: 'movie',
           libraryId: 'lib-1',
           name: ' cleanup group ',
           collection: {
             manualCollectionName: ' manual shelf ',
-          } as ReturnType<typeof createRulesDto>['collection'],
+          } as ReturnType<typeof createRuleGroupDto>['collection'],
         }),
       );
 
@@ -1531,7 +1534,7 @@ describe('PlexGetterService', () => {
         makeWatchEntry({ accountID: 2 }),
       ]);
 
-      const ruleGroup = createRulesDto({ dataType: 'movie' });
+      const ruleGroup = createRuleGroupDto({ dataType: 'movie' });
       const result = await service.get(
         SEEN_BY_PROP_ID,
         createMediaItem({ type: 'movie' }),
@@ -1604,7 +1607,7 @@ describe('PlexGetterService', () => {
         SW_LAST_WATCHED_PROP_ID,
         createMediaItem({ type: 'show' }),
         'show',
-        createRulesDto({ dataType: 'show' }),
+        createRuleGroupDto({ dataType: 'show' }),
       );
 
     it('returns the newest watched episode date (highest season, then episode)', async () => {

--- a/apps/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/plex-getter.service.ts
@@ -15,7 +15,7 @@ import {
   Property,
   RuleConstants,
 } from '../constants/rules.constants';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 import {
   countRuleCollectionNames,
@@ -50,7 +50,7 @@ export class PlexGetterService {
     id: number,
     libItem: MediaItem,
     dataType?: MediaItemType,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
     arrLookupCache?: ArrLookupCache,
   ): Promise<RuleValueType> {
     try {

--- a/apps/server/src/modules/rules/getter/radarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.spec.ts
@@ -8,7 +8,7 @@ import {
   createRadarrMovieFile,
   createRadarrQuality,
   createRuleDto,
-  createRulesDto,
+  createRuleGroupDto,
 } from '../../../../test/utils/data';
 import { RadarrApi } from '../../api/servarr-api/helpers/radarr.helper';
 import { RadarrMovie } from '../../api/servarr-api/interfaces/radarr.interface';
@@ -67,7 +67,7 @@ describe('RadarrGetterService', () => {
       const response = await radarrGetterService.get(
         20,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),
@@ -87,7 +87,7 @@ describe('RadarrGetterService', () => {
       const response = await radarrGetterService.get(
         20,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),
@@ -105,7 +105,7 @@ describe('RadarrGetterService', () => {
       const response = await radarrGetterService.get(
         20,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),
@@ -129,7 +129,7 @@ describe('RadarrGetterService', () => {
       const response = await radarrGetterService.get(
         21,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),
@@ -147,7 +147,7 @@ describe('RadarrGetterService', () => {
       const response = await radarrGetterService.get(
         21,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),
@@ -167,7 +167,7 @@ describe('RadarrGetterService', () => {
       const response = await radarrGetterService.get(
         22,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),
@@ -185,7 +185,7 @@ describe('RadarrGetterService', () => {
       const response = await radarrGetterService.get(
         22,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),
@@ -205,7 +205,7 @@ describe('RadarrGetterService', () => {
       const response = await radarrGetterService.get(
         22,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),
@@ -245,7 +245,7 @@ describe('RadarrGetterService', () => {
       const response = await radarrGetterService.get(
         23,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),
@@ -274,7 +274,7 @@ describe('RadarrGetterService', () => {
       const response = await radarrGetterService.get(
         24,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),
@@ -306,7 +306,7 @@ describe('RadarrGetterService', () => {
       radarrGetterService.get(
         0,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),
@@ -370,7 +370,7 @@ describe('RadarrGetterService', () => {
       radarrGetterService.get(
         propertyId,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),
@@ -424,7 +424,7 @@ describe('RadarrGetterService', () => {
       radarrGetterService.get(
         25,
         mediaItem,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'movie',
         }),

--- a/apps/server/src/modules/rules/getter/radarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/radarr-getter.service.ts
@@ -14,7 +14,7 @@ import {
   RuleConstants,
 } from '../constants/rules.constants';
 import { RuleDto } from '../dtos/rule.dto';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 import { evaluateArrDiskspaceGiB } from '../helpers/diskspace.utils';
 
@@ -36,7 +36,7 @@ export class RadarrGetterService {
   async get(
     id: number,
     libItem: MediaItem,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
     rule?: RuleDto,
     arrLookupCache?: ArrLookupCache,
   ) {

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
@@ -5,7 +5,7 @@ import {
   createCollectionMedia,
   createMediaItem,
   createRuleDto,
-  createRulesDto,
+  createRuleGroupDto,
   createSonarrEpisode,
   createSonarrEpisodeFile,
   createSonarrSeries,
@@ -145,7 +145,7 @@ describe('SonarrGetterService', () => {
           13,
           mediaItem,
           type as MediaItemType,
-          createRulesDto({
+          createRuleGroupDto({
             collection: collectionMedia.collection,
             dataType: type as MediaItemType,
           }),
@@ -238,7 +238,7 @@ describe('SonarrGetterService', () => {
             13,
             mediaItem,
             type as MediaItemType,
-            createRulesDto({
+            createRuleGroupDto({
               collection: collectionMedia.collection,
               dataType: type as MediaItemType,
             }),
@@ -311,7 +311,7 @@ describe('SonarrGetterService', () => {
                 parentIndex: type === 'episode' ? seasonNumber : undefined,
               }),
               type as MediaItemType,
-              createRulesDto({
+              createRuleGroupDto({
                 collection: collectionMedia.collection,
                 dataType: type as MediaItemType,
               }),
@@ -352,7 +352,7 @@ describe('SonarrGetterService', () => {
           0,
           showItem,
           'show',
-          createRulesDto({
+          createRuleGroupDto({
             collection: collectionMedia.collection,
             dataType: 'show',
           }),
@@ -470,7 +470,7 @@ describe('SonarrGetterService', () => {
           index: 6,
         }),
         'season',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'season',
         }),
@@ -530,7 +530,7 @@ describe('SonarrGetterService', () => {
           index: 8,
         }),
         'season',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'season',
         }),
@@ -593,7 +593,7 @@ describe('SonarrGetterService', () => {
           grandparentId: 'show-1',
         }),
         'episode',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'episode',
         }),
@@ -646,7 +646,7 @@ describe('SonarrGetterService', () => {
           index: 5,
         }),
         'season',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'season',
         }),
@@ -678,7 +678,7 @@ describe('SonarrGetterService', () => {
           type: 'show',
         }),
         'show',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'show',
         }),
@@ -725,7 +725,7 @@ describe('SonarrGetterService', () => {
           23,
           mediaItem,
           'episode',
-          createRulesDto({
+          createRuleGroupDto({
             collection: collectionMedia.collection,
             dataType: 'episode',
           }),
@@ -750,7 +750,7 @@ describe('SonarrGetterService', () => {
           23,
           mediaItem,
           'episode',
-          createRulesDto({
+          createRuleGroupDto({
             collection: collectionMedia.collection,
             dataType: 'episode',
           }),
@@ -766,7 +766,7 @@ describe('SonarrGetterService', () => {
           23,
           mediaItem,
           'episode',
-          createRulesDto({
+          createRuleGroupDto({
             collection: collectionMedia.collection,
             dataType: 'episode',
           }),
@@ -800,7 +800,7 @@ describe('SonarrGetterService', () => {
           24,
           mediaItem,
           'episode',
-          createRulesDto({
+          createRuleGroupDto({
             collection: collectionMedia.collection,
             dataType: 'episode',
           }),
@@ -816,7 +816,7 @@ describe('SonarrGetterService', () => {
           24,
           mediaItem,
           'episode',
-          createRulesDto({
+          createRuleGroupDto({
             collection: collectionMedia.collection,
             dataType: 'episode',
           }),
@@ -843,7 +843,7 @@ describe('SonarrGetterService', () => {
           26,
           mediaItem,
           'episode',
-          createRulesDto({
+          createRuleGroupDto({
             collection: collectionMedia.collection,
             dataType: 'episode',
           }),
@@ -859,7 +859,7 @@ describe('SonarrGetterService', () => {
           26,
           mediaItem,
           'episode',
-          createRulesDto({
+          createRuleGroupDto({
             collection: collectionMedia.collection,
             dataType: 'episode',
           }),
@@ -884,7 +884,7 @@ describe('SonarrGetterService', () => {
           26,
           mediaItem,
           'episode',
-          createRulesDto({
+          createRuleGroupDto({
             collection: collectionMedia.collection,
             dataType: 'episode',
           }),
@@ -938,7 +938,7 @@ describe('SonarrGetterService', () => {
           25,
           mediaItem,
           type as MediaItemType,
-          createRulesDto({
+          createRuleGroupDto({
             collection: collectionMedia.collection,
             dataType: type as MediaItemType,
           }),
@@ -977,7 +977,7 @@ describe('SonarrGetterService', () => {
         28,
         mediaItem,
         'show',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'show',
         }),
@@ -1007,7 +1007,7 @@ describe('SonarrGetterService', () => {
         29,
         mediaItem,
         'show',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'show',
         }),
@@ -1043,7 +1043,7 @@ describe('SonarrGetterService', () => {
         propId,
         mediaItem,
         'show',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'show',
         }),
@@ -1059,7 +1059,7 @@ describe('SonarrGetterService', () => {
           7, // 'ended' - reaches tryMetadataFallback's resolveIdsFromMediaItem
           mediaItem,
           'show',
-          createRulesDto({
+          createRuleGroupDto({
             collection: collectionMedia.collection,
             dataType: 'show',
           }),
@@ -1253,7 +1253,7 @@ describe('SonarrGetterService', () => {
             : {}),
         }),
         type,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: type,
         }),
@@ -1313,7 +1313,7 @@ describe('SonarrGetterService', () => {
             : {}),
         }),
         type,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: type,
         }),
@@ -1365,7 +1365,7 @@ describe('SonarrGetterService', () => {
           grandparentId: 'show-1',
         }),
         'episode',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'episode',
         }),
@@ -1600,7 +1600,7 @@ describe('SonarrGetterService', () => {
           grandparentId: 'show-1',
         }),
         'episode',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'episode',
         }),
@@ -1633,7 +1633,7 @@ describe('SonarrGetterService', () => {
           grandparentId: 'show-1',
         }),
         'episode',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'episode',
         }),
@@ -1761,7 +1761,7 @@ describe('SonarrGetterService', () => {
           originallyAvailableAt: target.originallyAvailableAt,
         }),
         'episode',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'episode',
         }),
@@ -1949,7 +1949,7 @@ describe('SonarrGetterService', () => {
           parentId: 'show-1',
         }),
         dataType,
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType,
         }),
@@ -2051,7 +2051,7 @@ describe('SonarrGetterService', () => {
         35,
         createMediaItem({ type: 'season', index: 1, parentId: 'show-1' }),
         'season',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'season',
         }),
@@ -2094,7 +2094,7 @@ describe('SonarrGetterService', () => {
           grandparentId: 'show-1',
         }),
         'episode',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'episode',
         }),
@@ -2141,7 +2141,10 @@ describe('SonarrGetterService', () => {
         11,
         createMediaItem(item),
         dataType,
-        createRulesDto({ collection: collectionMedia.collection, dataType }),
+        createRuleGroupDto({
+          collection: collectionMedia.collection,
+          dataType,
+        }),
       );
 
       // `undefined`, not `null`: the comparator reads it as a transport
@@ -2173,7 +2176,7 @@ describe('SonarrGetterService', () => {
         18,
         createMediaItem({ type: 'season', index: 0 }),
         'season',
-        createRulesDto({
+        createRuleGroupDto({
           collection: collectionMedia.collection,
           dataType: 'season',
         }),

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -24,7 +24,7 @@ import {
   RuleConstants,
 } from '../constants/rules.constants';
 import { RuleDto } from '../dtos/rule.dto';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 import { evaluateArrDiskspaceGiB } from '../helpers/diskspace.utils';
 
@@ -53,7 +53,7 @@ export class SonarrGetterService {
     id: number,
     libItem: MediaItem,
     dataType?: MediaItemType,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
     rule?: RuleDto,
     arrLookupCache?: ArrLookupCache,
   ) {

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.spec.ts
@@ -1,5 +1,8 @@
 import { Mocked, TestBed } from '@suites/unit';
-import { createMediaItem, createRulesDto } from '../../../../test/utils/data';
+import {
+  createMediaItem,
+  createRuleGroupDto,
+} from '../../../../test/utils/data';
 import { MediaServerFactory } from '../../api/media-server/media-server.factory';
 import { IMediaServerService } from '../../api/media-server/media-server.interface';
 import { ServarrService } from '../../api/servarr-api/servarr.service';
@@ -60,7 +63,7 @@ describe('SportarrGetterService', () => {
     });
 
   const ruleGroup = () =>
-    createRulesDto({
+    createRuleGroupDto({
       dataType: 'show',
       collection: { title: 'F1', sportarrSettingsId: 1 } as any,
     });
@@ -70,7 +73,7 @@ describe('SportarrGetterService', () => {
       0,
       showItem(),
       'show',
-      createRulesDto({ collection: {} as any }),
+      createRuleGroupDto({ collection: {} as any }),
     );
     expect(result).toBeNull();
   });

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
@@ -12,7 +12,7 @@ import {
   RuleConstants,
 } from '../constants/rules.constants';
 import { RuleDto } from '../dtos/rule.dto';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 
 // Getter for the native Sportarr application. Resolution keys off the tvdb
@@ -43,7 +43,7 @@ export class SportarrGetterService {
     id: number,
     libItem: MediaItem,
     dataType?: MediaItemType,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
     rule?: RuleDto,
     arrLookupCache?: ArrLookupCache,
   ) {

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.spec.ts
@@ -8,7 +8,7 @@ import {
 import { PlexApiService } from '../../api/plex-api/plex-api.service';
 import { TautulliApiService } from '../../api/tautulli-api/tautulli-api.service';
 import { Collection } from '../../collections/entities/collection.entities';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { TautulliGetterService } from './tautulli-getter.service';
 
 const SEEN_BY = 0;
@@ -51,7 +51,7 @@ const createService = (
 };
 
 const showItem: MediaItem = createMediaItem({ type: 'show', id: '1' });
-const ruleGroup = { collection: { id: 1 } } as RulesDto;
+const ruleGroup = { collection: { id: 1 } } as RuleGroupDto;
 
 describe('TautulliGetterService', () => {
   describe('seenBy', () => {

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
@@ -15,7 +15,7 @@ import {
   Property,
   RuleConstants,
 } from '../constants/rules.constants';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 
 @Injectable()
 export class TautulliGetterService {
@@ -39,7 +39,7 @@ export class TautulliGetterService {
     id: number,
     libItem: MediaItem,
     dataType?: MediaItemType,
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
   ) {
     try {
       const prop = this.appProperties.find((el) => el.id === id);

--- a/apps/server/src/modules/rules/getter/tracearr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/tracearr-getter.service.spec.ts
@@ -10,7 +10,7 @@ import {
   TracearrHistoryIndex,
 } from '../../api/tracearr-api/tracearr-api.service';
 import { Collection } from '../../collections/entities/collection.entities';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { TracearrGetterService } from './tracearr-getter.service';
 
 const SEEN_BY = 0;
@@ -80,7 +80,7 @@ const createHistoryIndex = (
   };
 };
 
-const ruleGroup = { collection: { id: 1 } } as RulesDto;
+const ruleGroup = { collection: { id: 1 } } as RuleGroupDto;
 
 const createService = (
   rows: TracearrHistoryItem[],

--- a/apps/server/src/modules/rules/getter/tracearr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/tracearr-getter.service.ts
@@ -17,7 +17,7 @@ import {
   Property,
   RuleConstants,
 } from '../constants/rules.constants';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 
 @Injectable()
 export class TracearrGetterService {
@@ -42,7 +42,7 @@ export class TracearrGetterService {
     ).props;
   }
 
-  async get(id: number, libItem: MediaItem, ruleGroup?: RulesDto) {
+  async get(id: number, libItem: MediaItem, ruleGroup?: RuleGroupDto) {
     try {
       const property = this.appProperties.find((item) => item.id === id);
       if (!property) {
@@ -120,7 +120,7 @@ export class TracearrGetterService {
   }
 
   private async getWatchedPercentOverride(
-    ruleGroup?: RulesDto,
+    ruleGroup?: RuleGroupDto,
     historyIndex?: TracearrHistoryIndex,
   ): Promise<number | null> {
     if (this.historyIndexForWatchedPercentOverrides !== historyIndex) {

--- a/apps/server/src/modules/rules/helpers/collection-exclude.helper.ts
+++ b/apps/server/src/modules/rules/helpers/collection-exclude.helper.ts
@@ -1,4 +1,4 @@
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 
 /**
  * Builds a list of collection names to exclude when counting collections for an item.
@@ -14,7 +14,9 @@ import { RulesDto } from '../dtos/rules.dto';
  * @param ruleGroup - The rule group being evaluated
  * @returns Array of lowercase, trimmed collection names to exclude
  */
-export function buildCollectionExcludeNames(ruleGroup?: RulesDto): string[] {
+export function buildCollectionExcludeNames(
+  ruleGroup?: RuleGroupDto,
+): string[] {
   const excludeNames: string[] = [];
 
   if (ruleGroup?.name) {

--- a/apps/server/src/modules/rules/helpers/rule-property.helper.spec.ts
+++ b/apps/server/src/modules/rules/helpers/rule-property.helper.spec.ts
@@ -1,6 +1,6 @@
 import { type MediaItemType } from '@maintainerr/contracts';
-import { createRulesDto } from '../../../../test/utils/data';
-import { type RulesDto } from '../dtos/rules.dto';
+import { createRuleGroupDto } from '../../../../test/utils/data';
+import { type RuleGroupDto } from '../dtos/ruleGroup.dto';
 import {
   countRuleCollectionNames,
   filterRuleCollectionNames,
@@ -15,12 +15,12 @@ interface TestUser {
   name: string;
 }
 
-const createRuleGroup = (): RulesDto =>
-  createRulesDto({
+const createRuleGroup = (): RuleGroupDto =>
+  createRuleGroupDto({
     name: 'Cleanup Collection',
     collection: {
       manualCollectionName: 'Manual Cleanup',
-    } as RulesDto['collection'],
+    } as RuleGroupDto['collection'],
   });
 
 describe('rule-property.helper', () => {

--- a/apps/server/src/modules/rules/helpers/rule-property.helper.ts
+++ b/apps/server/src/modules/rules/helpers/rule-property.helper.ts
@@ -1,5 +1,5 @@
 import { type MediaItemType } from '@maintainerr/contracts';
-import { type RulesDto } from '../dtos/rules.dto';
+import { type RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { buildCollectionExcludeNames } from './collection-exclude.helper';
 
 type RuleUserId = string | number;
@@ -28,7 +28,7 @@ export function uniqueTrimmedRulePropertyNames(
 
 export function filterRuleCollectionNames(
   collectionNames: readonly string[],
-  ruleGroup?: RulesDto,
+  ruleGroup?: RuleGroupDto,
 ): string[] {
   const excludedCollectionNames = new Set(
     buildCollectionExcludeNames(ruleGroup),
@@ -41,7 +41,7 @@ export function filterRuleCollectionNames(
 
 export function countRuleCollectionNames(
   collectionNames: readonly string[],
-  ruleGroup?: RulesDto,
+  ruleGroup?: RuleGroupDto,
 ): number {
   return filterRuleCollectionNames(collectionNames, ruleGroup).length;
 }

--- a/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/apps/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -17,7 +17,7 @@ import {
 } from '../constants/rules.constants';
 import { RuleDto } from '../dtos/rule.dto';
 import { RuleDbDto } from '../dtos/ruleDb.dto';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { ValueGetterService } from '../getter/getter.service';
 import { ArrLookupCache } from './arr-lookup-cache';
 
@@ -77,7 +77,7 @@ export class RuleComparatorService {
   }
 
   public async executeRulesWithData(
-    rulegroup: RulesDto,
+    rulegroup: RuleGroupDto,
     plexData: MediaItem[],
     onRuleProgress?: (processingRule: number) => void,
     abortSignal?: AbortSignal,
@@ -220,7 +220,7 @@ export class RuleComparatorService {
     });
   }
 
-  private async executeRule(rule: RuleDto, ruleGroup: RulesDto) {
+  private async executeRule(rule: RuleDto, ruleGroup: RuleGroupDto) {
     let data: MediaItem[];
     let firstVal: RuleValueType;
     let secondVal: RuleValueType;
@@ -394,7 +394,7 @@ export class RuleComparatorService {
   private async getSecondValue(
     rule: RuleDto,
     data: MediaItem,
-    rulegroup: RulesDto,
+    rulegroup: RuleGroupDto,
     firstVal: RuleValueType,
   ): Promise<RuleValueType> {
     let secondVal: RuleValueType;
@@ -526,7 +526,7 @@ export class RuleComparatorService {
 
   private logMissingOperand(
     rule: RuleDto,
-    ruleGroup: RulesDto,
+    ruleGroup: RuleGroupDto,
     mediaId: string,
     firstVal: RuleValueType,
     secondVal: RuleValueType,

--- a/apps/server/src/modules/rules/rules.controller.ts
+++ b/apps/server/src/modules/rules/rules.controller.ts
@@ -30,7 +30,7 @@ import { ZodValidationPipe } from 'nestjs-zod';
 import { MaintainerrLogger } from '../logging/logs.service';
 import { CommunityRule } from './dtos/communityRule.dto';
 import { ExclusionAction, ExclusionContextDto } from './dtos/exclusion.dto';
-import { RulesDto } from './dtos/rules.dto';
+import { RuleGroupDto } from './dtos/ruleGroup.dto';
 import { ReturnStatus, RulesService } from './rules.service';
 import { RuleExecutorJobManagerService } from './tasks/rule-executor-job-manager.service';
 import { RuleExecutorSchedulerService } from './tasks/rule-executor-scheduler.service';
@@ -104,7 +104,7 @@ export class RulesController {
   }
 
   @Get('/:id')
-  getRuleGroup(@Param('id', ParseIntPipe) id: number): Promise<RulesDto> {
+  getRuleGroup(@Param('id', ParseIntPipe) id: number): Promise<RuleGroupDto> {
     return this.rulesService.getRuleGroup(id);
   }
 
@@ -270,7 +270,7 @@ export class RulesController {
     status: 503,
     description: 'The configured media server adapter could not initialize.',
   })
-  async setRules(@Body() body: RulesDto): Promise<ReturnStatus> {
+  async setRules(@Body() body: RuleGroupDto): Promise<ReturnStatus> {
     return this.orFail(await this.rulesService.setRules(body));
   }
 
@@ -347,7 +347,7 @@ export class RulesController {
     status: 503,
     description: 'The configured media server adapter could not initialize.',
   })
-  async updateRule(@Body() body: RulesDto): Promise<ReturnStatus> {
+  async updateRule(@Body() body: RuleGroupDto): Promise<ReturnStatus> {
     return this.orFail(await this.rulesService.updateRules(body));
   }
 

--- a/apps/server/src/modules/rules/rules.service.cacheReset.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.cacheReset.spec.ts
@@ -4,7 +4,7 @@ import {
   createMockServarrTagService,
 } from '../../../test/utils/data';
 import cacheManager, { Cache } from '../api/lib/cache';
-import { RulesDto } from './dtos/rules.dto';
+import { RuleGroupDto } from './dtos/ruleGroup.dto';
 import { RulesService } from './rules.service';
 
 /**
@@ -79,7 +79,7 @@ describe('RulesService.resetCacheIfGroupUsesRuleThatRequiresIt', () => {
         }),
       },
     ],
-  } as unknown as RulesDto;
+  } as unknown as RuleGroupDto;
 
   const spyOnCache = (cacheId: 'plextv' | 'plexguid' | 'jellyfin' | 'emby') => {
     const cache = cacheManager.getCache(cacheId) as Cache;

--- a/apps/server/src/modules/rules/rules.service.setRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.setRules.spec.ts
@@ -129,7 +129,7 @@ describe('RulesService.setRules', () => {
 
   // The UI submits the leftover-folder cleanup opt-in on the rule-group payload,
   // so setRules is the only path that can turn it on. It used to be missing from
-  // RulesDto and from the createCollection call, which silently dropped it.
+  // RuleGroupDto and from the createCollection call, which silently dropped it.
   it('persists the leftover-folder cleanup opt-in for an action that strands a folder', async () => {
     const createCollection = jest
       .fn()

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -51,7 +51,7 @@ import { CommunityRule } from './dtos/communityRule.dto';
 import { ExclusionContextDto } from './dtos/exclusion.dto';
 import { RuleDto } from './dtos/rule.dto';
 import { RuleDbDto } from './dtos/ruleDb.dto';
-import { RulesDto } from './dtos/rules.dto';
+import { RuleGroupDto } from './dtos/ruleGroup.dto';
 import { CommunityRuleKarma } from './entities/community-rule-karma.entities';
 import { Exclusion } from './entities/exclusion.entities';
 import { RuleGroup } from './entities/rule-group.entities';
@@ -168,7 +168,7 @@ export class RulesService {
     activeOnly = false,
     libraryId?: string,
     typeId?: number,
-  ): Promise<RulesDto[]> {
+  ): Promise<RuleGroupDto[]> {
     try {
       const queryBuilder = this.connection
         .createQueryBuilder('rule_group', 'rg')
@@ -196,7 +196,7 @@ export class RulesService {
           group.rules = [];
         }
       }
-      return rulegroups as RulesDto[];
+      return rulegroups as RuleGroupDto[];
     } catch (error) {
       this.logger.warn('Rules - Action failed');
       this.logger.debug(error);
@@ -204,7 +204,7 @@ export class RulesService {
     }
   }
 
-  async getRuleGroupsByIds(ids: number[]): Promise<RulesDto[]> {
+  async getRuleGroupsByIds(ids: number[]): Promise<RuleGroupDto[]> {
     if (ids.length === 0) {
       return [];
     }
@@ -226,7 +226,7 @@ export class RulesService {
           group.rules = [];
         }
       }
-      return rulegroups as RulesDto[];
+      return rulegroups as RuleGroupDto[];
     } catch (error) {
       this.logger.warn('Rules - Action failed');
       this.logger.debug(error);
@@ -234,7 +234,7 @@ export class RulesService {
     }
   }
 
-  async getRuleGroup(id: number): Promise<RulesDto> {
+  async getRuleGroup(id: number): Promise<RuleGroupDto> {
     try {
       const rulegroup = await this.connection
         .createQueryBuilder('rule_group', 'rg')
@@ -250,7 +250,7 @@ export class RulesService {
       if (rulegroup && !Array.isArray(rulegroup.rules)) {
         rulegroup.rules = [];
       }
-      return rulegroup as RulesDto;
+      return rulegroup as RuleGroupDto;
     } catch (error) {
       this.logger.warn('Rules - Action failed');
       this.logger.debug(error);
@@ -408,7 +408,7 @@ export class RulesService {
   // defaulting to 'show'.
   private resolveCollectionType(
     libType: MediaItemType,
-    params: RulesDto,
+    params: RuleGroupDto,
   ): MediaItemType {
     if (libType === 'movie') {
       return 'movie';
@@ -416,7 +416,7 @@ export class RulesService {
     return params.dataType !== undefined ? params.dataType : 'show';
   }
 
-  async setRules(params: RulesDto) {
+  async setRules(params: RuleGroupDto) {
     try {
       const managerState = this.validateSingleShowManager(params);
       if (managerState.code !== 1) {
@@ -537,7 +537,7 @@ export class RulesService {
     }
   }
 
-  async updateRules(params: RulesDto) {
+  async updateRules(params: RuleGroupDto) {
     try {
       // Without one there is nothing to update, and TypeORM drops an undefined
       // id from the where clause rather than rejecting it.
@@ -1844,7 +1844,7 @@ export class RulesService {
   // The UI enforces this via the "Managed by" selector; this guards the raw
   // API path, where a payload with both set would otherwise dispatch the
   // Sonarr handler against a sports library.
-  private validateSingleShowManager(params: RulesDto): ReturnStatus {
+  private validateSingleShowManager(params: RuleGroupDto): ReturnStatus {
     if (params.sonarrSettingsId != null && params.sportarrSettingsId != null) {
       return this.createReturnStatus(
         false,
@@ -2258,7 +2258,7 @@ export class RulesService {
       const ruleComparator = this.ruleComparatorServiceFactory.create();
       try {
         const result = await ruleComparator.executeRulesWithData(
-          group as RulesDto,
+          group as RuleGroupDto,
           [mediaResp],
         );
         return { code: 1, result: result.stats };
@@ -2274,11 +2274,11 @@ export class RulesService {
   /**
    * Reset the media server cache if any rule in the rule group requires it.
    *
-   * @param {RulesDto} rulegroup - The rule group to check for cache reset requirement.
+   * @param {RuleGroupDto} rulegroup - The rule group to check for cache reset requirement.
    * @return {Promise<boolean>} Whether the media server cache was reset.
    */
   public async resetCacheIfGroupUsesRuleThatRequiresIt(
-    rulegroup: RulesDto,
+    rulegroup: RuleGroupDto,
   ): Promise<boolean> {
     try {
       let result = false;

--- a/apps/server/src/modules/rules/tasks/rule-executor-scheduler.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor-scheduler.service.ts
@@ -10,7 +10,7 @@ import { CronJob, CronTime } from 'cron';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { Settings } from '../../settings/entities/settings.entities';
 import { SettingsDataService } from '../../settings/settings-data.service';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { RuleGroup } from '../entities/rule-group.entities';
 import { RulesService } from '../rules.service';
 import { RuleExecutorJobManagerService } from './rule-executor-job-manager.service';
@@ -179,7 +179,7 @@ export class RuleExecutorSchedulerService
     globalJob.setTime(new CronTime(data.settings.rules_handler_job_cron));
   }
 
-  private createRuleGroupCronJob(ruleGroup: RulesDto) {
+  private createRuleGroupCronJob(ruleGroup: RuleGroupDto) {
     const jobName = this.getJobNameForRuleGroup(ruleGroup.id);
     if (!ruleGroup.ruleHandlerCronSchedule) {
       this.logger.warn(

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -34,7 +34,7 @@ import { MaintainerrLogger } from '../../logging/logs.service';
 import { SettingsDataService } from '../../settings/settings-data.service';
 import { Application, RuleConstants } from '../constants/rules.constants';
 import { RuleDto } from '../dtos/rule.dto';
-import { RulesDto } from '../dtos/rules.dto';
+import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { RuleGroup } from '../entities/rule-group.entities';
 import {
   buildExclusionCascadeSets,
@@ -125,7 +125,7 @@ export class RuleExecutorService {
     return this.mediaServerFactory.getService();
   }
 
-  private usesTracearr(ruleGroup: RulesDto): boolean {
+  private usesTracearr(ruleGroup: RuleGroupDto): boolean {
     return ruleGroup.rules.some((rule) => {
       const parsedRule = (
         'ruleJson' in rule ? JSON.parse(rule.ruleJson) : rule
@@ -139,7 +139,7 @@ export class RuleExecutorService {
 
   /** Both sides of a rule count: a Seerr date compared against a Tautulli one needs both. */
   private async findUnavailableApplications(
-    ruleGroup: RulesDto,
+    ruleGroup: RuleGroupDto,
   ): Promise<string[]> {
     const referenced = new Set<Application>();
     for (const rule of ruleGroup.rules) {
@@ -1220,7 +1220,7 @@ export class RuleExecutorService {
     }
   }
 
-  private async getAllActiveRuleGroups(): Promise<RulesDto[]> {
+  private async getAllActiveRuleGroups(): Promise<RuleGroupDto[]> {
     return await this.rulesService.getRuleGroups(true);
   }
 

--- a/apps/server/src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts
+++ b/apps/server/src/modules/rules/tests/rule.comparator.service.executeRulesWithData.spec.ts
@@ -1,5 +1,8 @@
 import { Mocked, TestBed } from '@suites/unit';
-import { createMediaItem, createRulesDto } from '../../../../test/utils/data';
+import {
+  createMediaItem,
+  createRuleGroupDto,
+} from '../../../../test/utils/data';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { RuleConstanstService } from '../constants/constants.service';
 import {
@@ -157,7 +160,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
 
     await expect(
       ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [mediaItem],
       ),
     ).rejects.toThrow('boom');
@@ -178,7 +181,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
     mockGetterSequence(null);
 
     const result = await ruleComparatorService.executeRulesWithData(
-      createRulesDto({ dataType: 'movie', rules }),
+      createRuleGroupDto({ dataType: 'movie', rules }),
       [mediaItem],
     );
 
@@ -219,7 +222,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
     mockGetterSequence(10, null);
 
     const result = await ruleComparatorService.executeRulesWithData(
-      createRulesDto({ dataType: 'movie', rules }),
+      createRuleGroupDto({ dataType: 'movie', rules }),
       [mediaItem],
     );
 
@@ -249,7 +252,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
     mockGetterSequence('HEVC 1080p');
 
     const result = await ruleComparatorService.executeRulesWithData(
-      createRulesDto({ dataType: 'movie', rules }),
+      createRuleGroupDto({ dataType: 'movie', rules }),
       [mediaItem],
     );
 
@@ -283,7 +286,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
     mockGetterSequence(null);
 
     const result = await ruleComparatorService.executeRulesWithData(
-      createRulesDto({ dataType: 'movie', rules }),
+      createRuleGroupDto({ dataType: 'movie', rules }),
       [mediaItem],
     );
 
@@ -321,7 +324,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
     mockGetterSequence(null);
 
     const result = await ruleComparatorService.executeRulesWithData(
-      createRulesDto({ dataType: 'movie', rules }),
+      createRuleGroupDto({ dataType: 'movie', rules }),
       [mediaItem],
     );
 
@@ -355,7 +358,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
     const startedAt = Date.now();
 
     const result = await ruleComparatorService.executeRulesWithData(
-      createRulesDto({ dataType: 'movie', rules }),
+      createRuleGroupDto({ dataType: 'movie', rules }),
       [mediaItem],
     );
 
@@ -388,7 +391,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
     mockGetterSequence(null);
 
     const result = await ruleComparatorService.executeRulesWithData(
-      createRulesDto({ dataType: 'movie', rules }),
+      createRuleGroupDto({ dataType: 'movie', rules }),
       [mediaItem],
     );
 
@@ -416,7 +419,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
     const startedAt = Date.now();
 
     const result = await ruleComparatorService.executeRulesWithData(
-      createRulesDto({ dataType: 'movie', rules }),
+      createRuleGroupDto({ dataType: 'movie', rules }),
       [mediaItem],
     );
 
@@ -448,7 +451,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
     mockGetterSequence('HEVC 1080p', null);
 
     const result = await ruleComparatorService.executeRulesWithData(
-      createRulesDto({ dataType: 'movie', rules }),
+      createRuleGroupDto({ dataType: 'movie', rules }),
       [mediaItem],
     );
 
@@ -484,7 +487,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(null);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [mediaItem],
       );
 
@@ -505,7 +508,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(undefined);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [mediaItem],
       );
 
@@ -530,7 +533,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(value);
 
       await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [createSingleMedia()],
       );
 
@@ -568,7 +571,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(undefined);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [mediaItem],
       );
 
@@ -633,7 +636,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(0, 0);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [mediaItem],
       );
 
@@ -649,7 +652,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(5, 5);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [mediaItem],
       );
 
@@ -665,7 +668,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(null, null);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [mediaItem],
       );
 
@@ -710,7 +713,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(0, 0);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules: overlappingRules }),
+        createRuleGroupDto({ dataType: 'movie', rules: overlappingRules }),
         [mediaItem],
       );
 
@@ -756,7 +759,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(1, 0, 2);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [matchedByFirstRule, matchedBySecondRule],
       );
 
@@ -822,7 +825,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(5, 15, 5, 15);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules: andRules }),
+        createRuleGroupDto({ dataType: 'movie', rules: andRules }),
         [inRange, tooHigh],
       );
 
@@ -849,7 +852,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(undefined);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [mediaItem],
       );
 
@@ -871,7 +874,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(null);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [mediaItem],
       );
 
@@ -893,7 +896,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(10, undefined);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [mediaItem],
       );
 
@@ -915,7 +918,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       mockGetterSequence(5);
 
       const result = await ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         [mediaItem],
       );
 
@@ -961,7 +964,7 @@ describe('RuleComparatorService.executeRulesWithData', () => {
       );
 
       const resultPromise = ruleComparatorService.executeRulesWithData(
-        createRulesDto({ dataType: 'movie', rules }),
+        createRuleGroupDto({ dataType: 'movie', rules }),
         mediaItems,
       );
 

--- a/apps/server/test/utils/data.ts
+++ b/apps/server/test/utils/data.ts
@@ -43,7 +43,7 @@ import {
   ResolvedMediaIds,
 } from '../../src/modules/metadata/interfaces/metadata.types';
 import { RuleDto } from '../../src/modules/rules/dtos/rule.dto';
-import { RulesDto } from '../../src/modules/rules/dtos/rules.dto';
+import { RuleGroupDto } from '../../src/modules/rules/dtos/ruleGroup.dto';
 
 export const createCollection = (
   properties: Partial<Collection> = {},
@@ -597,9 +597,9 @@ export const createSonarrEpisodeFile = (
   ...properties,
 });
 
-export const createRulesDto = (
-  properties: Partial<RulesDto> = {},
-): RulesDto => ({
+export const createRuleGroupDto = (
+  properties: Partial<RuleGroupDto> = {},
+): RuleGroupDto => ({
   id: faker.number.int(),
   libraryId: faker.number.int().toString(),
   dataType: faker.helpers.arrayElement([


### PR DESCRIPTION
`RulesDto` is a rule group - library, collection, notifications, arr action - not a set of rules, and it sat one letter away from `RuleDto`, the single rule. Reading a getter that imports both told you nothing about which was which.

Renames it to `RuleGroupDto`, the file to `ruleGroup.dto.ts`, and the test helper to `createRuleGroupDto`. Mechanical, no behaviour change.