### PR TITLE
feat(rules): scope watch statistics to one user

### DIFF
--- a/apps/server/src/modules/api/tautulli-api/tautulli-api.service.ts
+++ b/apps/server/src/modules/api/tautulli-api/tautulli-api.service.ts
@@ -55,9 +55,11 @@ interface TautulliHistoryItem {
   rating_key: number;
   media_index: number;
   parent_media_index: number;
-  // Seconds actually played: Tautulli computes it as (stopped - started) minus
-  // the paused counter. `duration` is the same value under its older name.
-  play_duration: number;
+  // Seconds actually played: (stopped - started) minus the paused counter.
+  // Tautulli renamed `duration` to `play_duration` in 2.12.3 and kept both
+  // since; older versions answer only the original name.
+  play_duration?: number;
+  duration?: number;
 }
 
 export interface TautulliHistoryRequestOptions {

--- a/apps/server/src/modules/api/tautulli-api/tautulli-api.service.ts
+++ b/apps/server/src/modules/api/tautulli-api/tautulli-api.service.ts
@@ -55,6 +55,9 @@ interface TautulliHistoryItem {
   rating_key: number;
   media_index: number;
   parent_media_index: number;
+  // Seconds actually played: Tautulli computes it as (stopped - started) minus
+  // the paused counter. `duration` is the same value under its older name.
+  play_duration: number;
 }
 
 export interface TautulliHistoryRequestOptions {

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -115,6 +115,57 @@ describe('TracearrApiService', () => {
     ]);
   });
 
+  // A username that maps to no Tracearr user means "unknown user" to the
+  // per-user properties, so users without history must still be mapped.
+  it('maps every Tracearr user, under both the media server and Tracearr names', async () => {
+    const OTHER_USER_ID = '55555555-5555-4555-8555-555555555555';
+    apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/history') {
+        return {
+          data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
+          meta: { nextCursor: null, pageSize: 100 },
+        };
+      }
+      return {
+        data: [
+          {
+            id: USER_ID,
+            accounts: [
+              {
+                server_id: SERVER_ID,
+                server_type: 'plex',
+                external_user_id: 'account-1',
+                username: 'alice.on.plex.tv',
+              },
+            ],
+          },
+          {
+            id: OTHER_USER_ID,
+            accounts: [
+              {
+                server_id: SERVER_ID,
+                server_type: 'plex',
+                external_user_id: 'account-2',
+                username: 'bob',
+              },
+            ],
+          },
+        ],
+        meta: { nextCursor: null, pageSize: 100 },
+      };
+    });
+
+    await service.prefetchHistory();
+
+    expect(service.getUsernamesByTracearrUserId()?.get(USER_ID)).toEqual([
+      'alice',
+      'alice.on.plex.tv',
+    ]);
+    expect(service.getUsernamesByTracearrUserId()?.get(OTHER_USER_ID)).toEqual([
+      'bob',
+    ]);
+  });
+
   it('invalidates a prefetched history snapshot', async () => {
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
       if (endpoint === '/history') {

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -166,6 +166,41 @@ describe('TracearrApiService', () => {
     ]);
   });
 
+  // Tracearr keeps a departed account in the identity, flagged with removed_at.
+  // Resolving it would let a per-user rule read "watched nothing" for someone
+  // the server no longer has, instead of skipping the item.
+  it('does not resolve an account Tracearr marks as removed', async () => {
+    apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/history') {
+        return {
+          data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
+          meta: { nextCursor: null, pageSize: 100 },
+        };
+      }
+      return {
+        data: [
+          {
+            id: USER_ID,
+            accounts: [
+              {
+                server_id: SERVER_ID,
+                server_type: 'plex',
+                external_user_id: 'account-1',
+                username: 'alice',
+                removed_at: '2026-08-01T00:00:00.000Z',
+              },
+            ],
+          },
+        ],
+        meta: { nextCursor: null, pageSize: 100 },
+      };
+    });
+
+    await service.prefetchHistory();
+
+    expect(service.getUsernamesByTracearrUserId()?.has(USER_ID)).toBe(false);
+  });
+
   it('invalidates a prefetched history snapshot', async () => {
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
       if (endpoint === '/history') {

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -245,7 +245,7 @@ export class TracearrApiService {
     this.logger.log(
       `Tracearr history starts at ${new Date(historyIndex.earliestStartedAt).toISOString()}. Earlier unobserved media is skipped.`,
     );
-    const usernames = await this.fetchUsernamesByTracearrUserId(historyIndex);
+    const usernames = await this.fetchUsernamesByTracearrUserId();
     if (!usernames) {
       this.logger.warn(
         'Tracearr media-server user lookup did not complete. Tracearr username rule values are unavailable for this run.',
@@ -256,6 +256,11 @@ export class TracearrApiService {
     this.activeUsernamesByTracearrUserId = usernames;
   }
 
+  /**
+   * Tracearr's public history only returns a play once one of its segments ran
+   * for 2 minutes or more, so every Tracearr rule property counts sustained
+   * plays only.
+   */
   private async refreshHistoryIndex(): Promise<
     TracearrHistoryIndex | undefined
   > {
@@ -455,9 +460,9 @@ export class TracearrApiService {
     return name || id;
   }
 
-  private async fetchUsernamesByTracearrUserId(
-    historyIndex: TracearrHistoryIndex,
-  ): Promise<Map<string, string[]> | undefined> {
+  private async fetchUsernamesByTracearrUserId(): Promise<
+    Map<string, string[]> | undefined
+  > {
     const api = this.api;
     const serverId = this.settings.tracearr_server_id;
     if (!api || !serverId) {
@@ -472,9 +477,6 @@ export class TracearrApiService {
 
     const usernamesByAccountId = new Map(
       mediaUsers.map((user) => [user.id, user.name]),
-    );
-    const historyUserIds = new Set(
-      [...historyIndex.rowsById.values()].map((row) => row.user.id),
     );
     const usernamesByTracearrUserId = new Map<string, string[]>();
     const cursors = new Set<string>();
@@ -499,14 +501,22 @@ export class TracearrApiService {
       }
 
       for (const user of parsed.data.data) {
-        if (!historyUserIds.has(user.id)) {
-          continue;
-        }
-
-        const usernames = user.accounts
-          .filter((account) => account.server_id === serverId)
-          .map((account) => usernamesByAccountId.get(account.external_user_id))
-          .filter((username): username is string => Boolean(username));
+        // Mapped whether or not they appear in the swept history: absence has
+        // to mean "Tracearr has no such user" so the per-user properties can
+        // skip rather than read an unknown user as "watched nothing" (#3387
+        // fails closed). Both spellings are kept because the media server and
+        // Tracearr can name the same Plex account differently.
+        const usernames = [
+          ...new Set(
+            user.accounts
+              .filter((account) => account.server_id === serverId)
+              .flatMap((account) => [
+                usernamesByAccountId.get(account.external_user_id),
+                account.username,
+              ])
+              .filter((username): username is string => Boolean(username)),
+          ),
+        ];
         if (usernames.length > 0) {
           usernamesByTracearrUserId.set(user.id, usernames);
         }

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -509,7 +509,10 @@ export class TracearrApiService {
         const usernames = [
           ...new Set(
             user.accounts
-              .filter((account) => account.server_id === serverId)
+              .filter(
+                (account) =>
+                  account.server_id === serverId && !account.removed_at,
+              )
               .flatMap((account) => [
                 usernamesByAccountId.get(account.external_user_id),
                 account.username,

--- a/apps/server/src/modules/rules/constants/rules.constants.ts
+++ b/apps/server/src/modules/rules/constants/rules.constants.ts
@@ -1238,6 +1238,28 @@ export class RuleConstants {
           type: RuleType.TEXT_LIST, // return usernames []
           showType: ['show', 'season', 'episode'],
         },
+        // Scoped to the rule's user; same names as the other two companions.
+        {
+          id: 9,
+          name: 'viewCountByUser',
+          humanName: 'Times viewed by user',
+          mediaType: MediaType.BOTH,
+          type: RuleType.NUMBER,
+        },
+        {
+          id: 10,
+          name: 'watchTimeByUser',
+          humanName: 'Watch time by user (minutes)',
+          mediaType: MediaType.BOTH,
+          type: RuleType.NUMBER,
+        },
+        {
+          id: 11,
+          name: 'lastViewedAtByUser',
+          humanName: 'Last view date by user',
+          mediaType: MediaType.BOTH,
+          type: RuleType.DATE,
+        },
       ],
     },
     {
@@ -1306,6 +1328,28 @@ export class RuleConstants {
           mediaType: MediaType.SHOW,
           type: RuleType.TEXT_LIST,
           showType: ['show', 'season', 'episode'],
+        },
+        // Scoped to the rule's user; same names as the other two companions.
+        {
+          id: 9,
+          name: 'viewCountByUser',
+          humanName: 'Times viewed by user',
+          mediaType: MediaType.BOTH,
+          type: RuleType.NUMBER,
+        },
+        {
+          id: 10,
+          name: 'watchTimeByUser',
+          humanName: 'Watch time by user (minutes)',
+          mediaType: MediaType.BOTH,
+          type: RuleType.NUMBER,
+        },
+        {
+          id: 11,
+          name: 'lastViewedAtByUser',
+          humanName: 'Last view date by user',
+          mediaType: MediaType.BOTH,
+          type: RuleType.DATE,
         },
       ],
     },
@@ -1710,6 +1754,32 @@ export class RuleConstants {
           mediaType: MediaType.SHOW,
           type: RuleType.TEXT_LIST, // returns usernames []
           showType: ['season', 'episode'],
+        },
+        // Scoped to the rule's user. Streamystats aggregates a show from its
+        // episodes but holds no session against a season, so seasons are out.
+        {
+          id: 4,
+          name: 'viewCountByUser',
+          humanName: 'Times viewed by user',
+          mediaType: MediaType.BOTH,
+          type: RuleType.NUMBER,
+          showType: ['show', 'episode'],
+        },
+        {
+          id: 5,
+          name: 'watchTimeByUser',
+          humanName: 'Watch time by user (minutes)',
+          mediaType: MediaType.BOTH,
+          type: RuleType.NUMBER,
+          showType: ['show', 'episode'],
+        },
+        {
+          id: 6,
+          name: 'lastViewedAtByUser',
+          humanName: 'Last view date by user',
+          mediaType: MediaType.BOTH,
+          type: RuleType.DATE,
+          showType: ['show', 'episode'],
         },
       ],
     },

--- a/apps/server/src/modules/rules/dtos/rule.dto.ts
+++ b/apps/server/src/modules/rules/dtos/rule.dto.ts
@@ -18,5 +18,12 @@ export class RuleDto {
    * Undefined means aggregate all reported paths.
    */
   arrDiskPath?: string;
+  /**
+   * Media-server user the PER_USER_PROPERTIES read; unused by every other one.
+   * Held as a username because the companions key history on their own user
+   * ids and agree only on this - Tautulli reports the plex.tv account id where
+   * the media server reports its local one.
+   */
+  username?: string;
   section: number;
 }

--- a/apps/server/src/modules/rules/getter/getter.service.ts
+++ b/apps/server/src/modules/rules/getter/getter.service.ts
@@ -122,13 +122,19 @@ export class ValueGetterService {
           libItem,
           dataType,
           ruleGroup,
+          currentRule,
         );
       }
       case Application.STREAMYSTATS: {
-        return await this.streamystatsGetter.get(val2, libItem);
+        return await this.streamystatsGetter.get(val2, libItem, currentRule);
       }
       case Application.TRACEARR: {
-        return await this.tracearrGetter.get(val2, libItem, ruleGroup);
+        return await this.tracearrGetter.get(
+          val2,
+          libItem,
+          ruleGroup,
+          currentRule,
+        );
       }
       default: {
         return null;

--- a/apps/server/src/modules/rules/getter/streamystats-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/streamystats-getter.service.spec.ts
@@ -10,6 +10,38 @@ const IS_IN_WATCHLIST_PROP_ID = 0;
 const WATCHLISTED_BY_USERS_PROP_ID = 1;
 const IS_IN_WATCHLIST_INCLUDING_PARENT_PROP_ID = 2;
 const WATCHLISTED_BY_USERS_INCLUDING_PARENT_PROP_ID = 3;
+const VIEW_COUNT_BY_USER_PROP_ID = 4;
+const WATCH_TIME_BY_USER_PROP_ID = 5;
+const LAST_VIEWED_AT_BY_USER_PROP_ID = 6;
+
+const itemDetailsOf = (
+  usersWatched: {
+    name: string;
+    watchCount: number;
+    totalWatchTime: number;
+    lastWatched: string | null;
+  }[],
+) =>
+  ({
+    item: { id: 'item-1' },
+    totalViews: 0,
+    totalWatchTime: 0,
+    completionRate: 0,
+    firstWatched: null,
+    lastWatched: null,
+    watchHistory: [],
+    watchCountByMonth: [],
+    usersWatched: usersWatched.map(
+      ({ name, watchCount, totalWatchTime, lastWatched }) => ({
+        user: { id: `id-${name}`, name },
+        watchCount,
+        totalWatchTime,
+        completionRate: 0,
+        firstWatched: null,
+        lastWatched,
+      }),
+    ),
+  }) as never;
 
 const membershipOf = (
   entries: Record<string, string[]>,
@@ -26,6 +58,7 @@ describe('StreamystatsGetterService', () => {
   ) => {
     const streamystatsApi = {
       getWatchlistMembership: jest.fn(),
+      getItemDetails: jest.fn(),
     } as unknown as jest.Mocked<StreamystatsApiService>;
 
     const getMetadata = jest.fn(async (id: string) =>
@@ -299,6 +332,108 @@ describe('StreamystatsGetterService', () => {
           season,
         ),
       ).toEqual([]);
+    });
+  });
+
+  describe('per-user properties (ids 4-6)', () => {
+    const alice = { id: 'user-a', name: 'alice' };
+    const rule = { username: 'alice' } as never;
+
+    it('reads the picked user out of the item statistics', async () => {
+      const { service, streamystatsApi } = createService([alice]);
+      const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+      streamystatsApi.getItemDetails.mockResolvedValue(
+        itemDetailsOf([
+          {
+            name: 'alice',
+            watchCount: 3,
+            totalWatchTime: 5400,
+            lastWatched: '2026-05-01T10:00:00.000Z',
+          },
+          {
+            name: 'bob',
+            watchCount: 9,
+            totalWatchTime: 60,
+            lastWatched: '2026-06-01T10:00:00.000Z',
+          },
+        ]),
+      );
+
+      expect(await service.get(VIEW_COUNT_BY_USER_PROP_ID, libItem, rule)).toBe(
+        3,
+      );
+      // Streamystats reports seconds; the property is minutes.
+      expect(await service.get(WATCH_TIME_BY_USER_PROP_ID, libItem, rule)).toBe(
+        90,
+      );
+      expect(
+        await service.get(LAST_VIEWED_AT_BY_USER_PROP_ID, libItem, rule),
+      ).toEqual(new Date('2026-05-01T10:00:00.000Z'));
+    });
+
+    it('answers zero and no date for a known user who never watched the item', async () => {
+      const { service, streamystatsApi } = createService([alice]);
+      const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+      streamystatsApi.getItemDetails.mockResolvedValue(itemDetailsOf([]));
+
+      expect(await service.get(VIEW_COUNT_BY_USER_PROP_ID, libItem, rule)).toBe(
+        0,
+      );
+      expect(await service.get(WATCH_TIME_BY_USER_PROP_ID, libItem, rule)).toBe(
+        0,
+      );
+      expect(
+        await service.get(LAST_VIEWED_AT_BY_USER_PROP_ID, libItem, rule),
+      ).toBeNull();
+    });
+
+    // Zero here would read as "this user never watched it" and let a rule that
+    // protects rewatched media sweep it instead.
+    it.each([
+      { when: 'the rule has no user', users: [alice], ruleDto: {} as never },
+      {
+        when: 'the media server has no such user',
+        users: [{ id: 'user-b', name: 'bob' }],
+        ruleDto: rule,
+      },
+      { when: 'the media server user lookup failed', users: [], ruleDto: rule },
+    ])('skips the item when $when', async ({ users, ruleDto }) => {
+      const { service, streamystatsApi } = createService(users);
+      const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+      streamystatsApi.getItemDetails.mockResolvedValue(
+        itemDetailsOf([
+          {
+            name: 'alice',
+            watchCount: 3,
+            totalWatchTime: 60,
+            lastWatched: null,
+          },
+        ]),
+      );
+
+      expect(
+        await service.get(VIEW_COUNT_BY_USER_PROP_ID, libItem, ruleDto),
+      ).toBeUndefined();
+    });
+
+    it('skips the item when Streamystats has no statistics for it', async () => {
+      const { service, streamystatsApi } = createService([alice]);
+      const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+      streamystatsApi.getItemDetails.mockResolvedValue(null);
+
+      expect(
+        await service.get(VIEW_COUNT_BY_USER_PROP_ID, libItem, rule),
+      ).toBeUndefined();
+    });
+
+    it('answers null for a season without reading Streamystats', async () => {
+      const { service, streamystatsApi } = createService([alice]);
+      const season = createMediaItem({ type: 'season', id: 'season-1' });
+
+      expect(
+        await service.get(VIEW_COUNT_BY_USER_PROP_ID, season, rule),
+      ).toBeNull();
+      expect(streamystatsApi.getItemDetails).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/modules/rules/getter/streamystats-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/streamystats-getter.service.ts
@@ -1,4 +1,4 @@
-import { MediaItem } from '@maintainerr/contracts';
+import { isPerUserProperty, MediaItem } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import { MediaServerFactory } from '../../api/media-server/media-server.factory';
 import { StreamystatsApiService } from '../../api/streamystats-api/streamystats-api.service';
@@ -8,6 +8,7 @@ import {
   Property,
   RuleConstants,
 } from '../constants/rules.constants';
+import { RuleDto } from '../dtos/rule.dto';
 import { definedUniqueValues } from '../helpers/rule-property.helper';
 
 /**
@@ -37,11 +38,15 @@ export class StreamystatsGetterService {
     ).props;
   }
 
-  async get(id: number, libItem: MediaItem) {
+  async get(id: number, libItem: MediaItem, currentRule?: RuleDto) {
     try {
       const prop = this.appProperties.find((el) => el.id === id);
       if (!prop) {
         return null;
+      }
+
+      if (isPerUserProperty(prop.name)) {
+        return await this.getUserStat(prop.name, libItem, currentRule);
       }
 
       const membership = await this.streamystatsApi.getWatchlistMembership();
@@ -89,6 +94,73 @@ export class StreamystatsGetterService {
         error,
       );
       return undefined;
+    }
+  }
+
+  /**
+   * Per-user statistics for the rule's user. Streamystats counts every
+   * recorded session, so an abandoned play counts as a view here - it exposes
+   * no completion filter, unlike Tautulli and Tracearr.
+   *
+   * A show aggregates its episodes, but a season holds no session of its own,
+   * so seasons answer `null` (no value) rather than a zero reading as "never
+   * watched" - the distinction #3402 drew. An unknown user is `undefined`
+   * (skip) for the same reason.
+   */
+  private async getUserStat(
+    propName: string,
+    libItem: MediaItem,
+    currentRule?: RuleDto,
+  ): Promise<number | Date | null | undefined> {
+    const username = currentRule?.username;
+    if (!username) {
+      this.logger.warn(
+        `Streamystats-Getter - Skipping '${propName}': the rule has no user selected.`,
+      );
+      return undefined;
+    }
+
+    if (libItem.type === 'season') {
+      return null;
+    }
+
+    const mediaServer = await this.mediaServerFactory.getService();
+    // Fail-closed ([] on error) and cached, so not a per-item request.
+    const users = await mediaServer.getUsers();
+    if (users.length === 0) {
+      return undefined;
+    }
+    if (!users.some((user) => user.name === username)) {
+      this.logger.warn(
+        `Streamystats-Getter - Skipping '${propName}': the media server has no user named '${username}'.`,
+      );
+      return undefined;
+    }
+
+    // Null covers both an unsynced item and a failed read, so treat it as
+    // transient rather than sweeping on statistics that were never available.
+    const details = await this.streamystatsApi.getItemDetails(libItem.id);
+    if (!details) {
+      return undefined;
+    }
+
+    const userStats = details.usersWatched.find(
+      (entry) => entry.user.name === username,
+    );
+
+    switch (propName) {
+      case 'viewCountByUser': {
+        return userStats?.watchCount ?? 0;
+      }
+      case 'watchTimeByUser': {
+        return Math.round((userStats?.totalWatchTime ?? 0) / 60);
+      }
+      case 'lastViewedAtByUser': {
+        return userStats?.lastWatched ? new Date(userStats.lastWatched) : null;
+      }
+      default: {
+        return null;
+      }
     }
   }
 

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.spec.ts
@@ -13,6 +13,9 @@ import { TautulliGetterService } from './tautulli-getter.service';
 
 const SEEN_BY = 0;
 const SW_LAST_WATCHED = 7;
+const VIEW_COUNT_BY_USER = 9;
+const WATCH_TIME_BY_USER = 10;
+const LAST_VIEWED_AT_BY_USER = 11;
 
 // Tautulli grades watched_status as 0 | 0.25 | 0.5 | 0.75 | 1; only 1 means the
 // item crossed the configured watched percent.
@@ -22,7 +25,13 @@ const historyItem = (props: {
   parent_media_index: number;
   media_index: number;
   stopped: number;
-}) => ({ user_id: 1, user: 'user', rating_key: 1, ...props });
+}) => ({
+  user_id: 1,
+  user: 'user',
+  rating_key: 1,
+  play_duration: 0,
+  ...props,
+});
 
 const createService = (
   history: ReturnType<typeof historyItem>[],
@@ -181,6 +190,107 @@ describe('TautulliGetterService', () => {
       await expect(
         service.get(SW_LAST_WATCHED, showItem, undefined, ruleGroup),
       ).resolves.toEqual(new Date(1_700_000_000 * 1000));
+    });
+  });
+
+  describe('per-user properties', () => {
+    const rule = { username: 'alice' } as never;
+    const correctedUsers = {
+      getCorrectedUsers: jest.fn().mockResolvedValue([
+        { plexId: 1, username: 'alice' },
+        { plexId: 2, username: 'bob' },
+      ]),
+    };
+    const play = (
+      user_id: number,
+      watched_status: number,
+      play_duration: number,
+      stopped: number,
+    ) => ({
+      ...historyItem({
+        watched_status,
+        percent_complete: watched_status === 1 ? 100 : 30,
+        parent_media_index: 1,
+        media_index: 1,
+        stopped,
+      }),
+      user_id,
+      play_duration,
+    });
+
+    const history = [
+      play(1, 1, 1800, 1_700_000_000),
+      play(1, 0.25, 900, 1_700_000_500),
+      play(2, 1, 3600, 1_700_100_000),
+    ];
+
+    it('counts only the picked user, and only their watched plays', async () => {
+      const service = createService(history, null, correctedUsers);
+
+      await expect(
+        service.get(VIEW_COUNT_BY_USER, showItem, undefined, ruleGroup, rule),
+      ).resolves.toBe(1);
+      await expect(
+        service.get(
+          LAST_VIEWED_AT_BY_USER,
+          showItem,
+          undefined,
+          ruleGroup,
+          rule,
+        ),
+      ).resolves.toEqual(new Date(1_700_000_000 * 1000));
+    });
+
+    it('sums every play of the picked user, in minutes', async () => {
+      const service = createService(history, null, correctedUsers);
+
+      await expect(
+        service.get(WATCH_TIME_BY_USER, showItem, undefined, ruleGroup, rule),
+      ).resolves.toBe(45);
+    });
+
+    it('honours the collection watched-percent override for the view count', async () => {
+      const service = createService(history, 20, correctedUsers);
+
+      await expect(
+        service.get(VIEW_COUNT_BY_USER, showItem, undefined, ruleGroup, rule),
+      ).resolves.toBe(2);
+    });
+
+    // Zero here would read as "this user never watched it" and let a rule that
+    // protects rewatched media sweep it instead.
+    it.each([
+      {
+        when: 'the rule has no user',
+        ruleDto: {} as never,
+        plexApi: correctedUsers,
+      },
+      {
+        when: 'Plex no longer has the user',
+        ruleDto: rule,
+        plexApi: { getCorrectedUsers: jest.fn().mockResolvedValue([]) },
+      },
+      {
+        when: 'plex.tv could not be reached',
+        ruleDto: rule,
+        plexApi: {
+          getCorrectedUsers: jest
+            .fn()
+            .mockRejectedValue(new Error('plex.tv user data unavailable')),
+        },
+      },
+    ])('skips the item when $when', async ({ ruleDto, plexApi }) => {
+      const service = createService(history, null, plexApi);
+
+      await expect(
+        service.get(
+          VIEW_COUNT_BY_USER,
+          showItem,
+          undefined,
+          ruleGroup,
+          ruleDto,
+        ),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.spec.ts
@@ -241,6 +241,24 @@ describe('TautulliGetterService', () => {
       ).resolves.toEqual(new Date(1_700_000_000 * 1000));
     });
 
+    // Tautulli only renamed `duration` to `play_duration` in 2.12.3, so an
+    // older install answers with the original key alone.
+    it('reads the watch time of a Tautulli older than 2.12.3', async () => {
+      const legacyHistory = history.map(({ play_duration, ...row }) => ({
+        ...row,
+        duration: play_duration,
+      }));
+      const service = createService(
+        legacyHistory as never,
+        null,
+        correctedUsers,
+      );
+
+      await expect(
+        service.get(WATCH_TIME_BY_USER, showItem, undefined, ruleGroup, rule),
+      ).resolves.toBe(45);
+    });
+
     it('sums every play of the picked user, in minutes', async () => {
       const service = createService(history, null, correctedUsers);
 

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
@@ -1,4 +1,8 @@
-import { MediaItem, MediaItemType } from '@maintainerr/contracts';
+import {
+  isPerUserProperty,
+  MediaItem,
+  MediaItemType,
+} from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -15,6 +19,7 @@ import {
   Property,
   RuleConstants,
 } from '../constants/rules.constants';
+import { RuleDto } from '../dtos/rule.dto';
 import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 
 @Injectable()
@@ -40,6 +45,7 @@ export class TautulliGetterService {
     libItem: MediaItem,
     dataType?: MediaItemType,
     ruleGroup?: RuleGroupDto,
+    currentRule?: RuleDto,
   ) {
     try {
       const prop = this.appProperties.find((el) => el.id === id);
@@ -57,6 +63,15 @@ export class TautulliGetterService {
       });
       const tautulliWatchedPercentOverride =
         collection.tautulliWatchedPercentOverride;
+
+      if (isPerUserProperty(prop.name)) {
+        return await this.getUserStat(
+          prop.name,
+          metadata,
+          currentRule,
+          tautulliWatchedPercentOverride,
+        );
+      }
 
       switch (prop.name) {
         // At season/show level `sw_watchers` returns the UNION of users that
@@ -219,6 +234,68 @@ export class TautulliGetterService {
       );
       return undefined;
     }
+  }
+
+  /**
+   * Per-user statistics for the rule's user. Views and the last view date
+   * count watched plays only, honouring the collection's watched-percent
+   * override like the whole-item properties; watch time counts every play,
+   * since an abandoned one still ran for its minutes.
+   *
+   * Resolves the username through the plex.tv-corrected list the rule editor
+   * offers, and answers `undefined` when it cannot: zero would read as "this
+   * user watched nothing" after a rename or a plex.tv outage.
+   */
+  private async getUserStat(
+    propName: string,
+    metadata: TautulliMetadata,
+    currentRule: RuleDto | undefined,
+    tautulliWatchedPercentOverride: number | null,
+  ): Promise<number | Date | null | undefined> {
+    const username = currentRule?.username;
+    if (!username) {
+      this.logger.warn(
+        `Tautulli-Getter - Skipping '${propName}': the rule has no user selected.`,
+      );
+      return undefined;
+    }
+
+    const plexUsers = await this.plexApi.getCorrectedUsers();
+    const plexUser = plexUsers.find((user) => user.username === username);
+    if (!plexUser) {
+      this.logger.warn(
+        `Tautulli-Getter - Skipping '${propName}': Plex has no user named '${username}'.`,
+      );
+      return undefined;
+    }
+
+    const history = (await this.getHistoryForMetadata(metadata)).filter(
+      (el) => el.user_id === plexUser.plexId,
+    );
+
+    if (propName === 'watchTimeByUser') {
+      const seconds = history.reduce(
+        (total, el) => total + (el.play_duration ?? 0),
+        0,
+      );
+      return Math.round(seconds / 60);
+    }
+
+    const watchedHistory = history.filter((el) =>
+      tautulliWatchedPercentOverride != null
+        ? el.percent_complete >= tautulliWatchedPercentOverride
+        : el.watched_status == 1,
+    );
+
+    if (propName === 'viewCountByUser') {
+      return watchedHistory.length;
+    }
+
+    const lastStopped = watchedHistory.reduce(
+      (latest, el) => (el.stopped > latest ? el.stopped : latest),
+      0,
+    );
+    return lastStopped > 0 ? new Date(lastStopped * 1000) : null;
   }
 
   private async getHistoryForMetadata(metadata: TautulliMetadata) {

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
@@ -275,7 +275,7 @@ export class TautulliGetterService {
 
     if (propName === 'watchTimeByUser') {
       const seconds = history.reduce(
-        (total, el) => total + (el.play_duration ?? 0),
+        (total, el) => total + (el.play_duration ?? el.duration ?? 0),
         0,
       );
       return Math.round(seconds / 60);

--- a/apps/server/src/modules/rules/getter/tracearr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/tracearr-getter.service.spec.ts
@@ -21,6 +21,9 @@ const AMOUNT_OF_VIEWS = 5;
 const VIEWED_EPISODES = 6;
 const LAST_WATCHED = 7;
 const WATCHERS = 8;
+const VIEW_COUNT_BY_USER = 9;
+const WATCH_TIME_BY_USER = 10;
+const LAST_VIEWED_AT_BY_USER = 11;
 
 const USER_ID = '22222222-2222-4222-8222-222222222222';
 
@@ -140,6 +143,94 @@ describe('TracearrGetterService', () => {
     parentId: 'season-1',
     grandparentId: 'show-1',
     addedAt: new Date('2026-01-02T00:00:00.000Z'),
+  });
+
+  describe('per-user properties', () => {
+    const OTHER_USER_ID = '44444444-4444-4444-8444-444444444444';
+    const rule = { username: 'alice' } as never;
+    const movieRow = (
+      id: string,
+      properties: Partial<TracearrHistoryItem> = {},
+    ) =>
+      historyItem(id, {
+        media_type: 'movie',
+        rating_key: 'movie-1',
+        grandparent_rating_key: null,
+        season_number: null,
+        episode_number: null,
+        ...properties,
+      });
+
+    const rows = [
+      movieRow('33333333-3333-4333-8333-333333333333', {
+        duration_ms: 1_800_000,
+      }),
+      movieRow('55555555-5555-4555-8555-555555555555', {
+        watched: false,
+        percent_complete: 30,
+        duration_ms: 900_000,
+      }),
+      movieRow('66666666-6666-4666-8666-666666666666', {
+        user: { id: OTHER_USER_ID },
+        duration_ms: 3_600_000,
+      }),
+    ];
+
+    const withUsers = (
+      usernamesByTracearrUserId: Map<string, string[]> | undefined,
+    ) => {
+      const created = createService(rows);
+      (
+        created.tracearrApi.getUsernamesByTracearrUserId as jest.Mock
+      ).mockReturnValue(usernamesByTracearrUserId);
+      return created.service;
+    };
+
+    const users = new Map([
+      [USER_ID, ['alice']],
+      [OTHER_USER_ID, ['bob']],
+    ]);
+
+    it('counts only the picked user, and only their watched plays', async () => {
+      const service = withUsers(users);
+
+      await expect(
+        service.get(VIEW_COUNT_BY_USER, movie, ruleGroup, rule),
+      ).resolves.toBe(1);
+      await expect(
+        service.get(LAST_VIEWED_AT_BY_USER, movie, ruleGroup, rule),
+      ).resolves.toEqual(new Date('2026-01-01T01:00:00.000Z'));
+    });
+
+    it('sums every play of the picked user, in minutes', async () => {
+      const service = withUsers(users);
+
+      await expect(
+        service.get(WATCH_TIME_BY_USER, movie, ruleGroup, rule),
+      ).resolves.toBe(45);
+    });
+
+    // Zero here would read as "this user never watched it" and let a rule that
+    // protects rewatched media sweep it instead.
+    it.each([
+      { when: 'the rule has no user', ruleDto: {} as never, usernames: users },
+      {
+        when: 'Tracearr has no account for the user',
+        ruleDto: rule,
+        usernames: new Map(),
+      },
+      {
+        when: 'the Tracearr user lookup failed',
+        ruleDto: rule,
+        usernames: undefined,
+      },
+    ])('skips the item when $when', async ({ ruleDto, usernames }) => {
+      const service = withUsers(usernames);
+
+      await expect(
+        service.get(VIEW_COUNT_BY_USER, movie, ruleGroup, ruleDto),
+      ).resolves.toBeUndefined();
+    });
   });
 
   it('returns usernames for seenBy', async () => {

--- a/apps/server/src/modules/rules/getter/tracearr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/tracearr-getter.service.ts
@@ -1,4 +1,5 @@
 import {
+  isPerUserProperty,
   MediaItem,
   MediaType,
   TracearrHistoryItem,
@@ -17,6 +18,7 @@ import {
   Property,
   RuleConstants,
 } from '../constants/rules.constants';
+import { RuleDto } from '../dtos/rule.dto';
 import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 
 @Injectable()
@@ -42,7 +44,12 @@ export class TracearrGetterService {
     ).props;
   }
 
-  async get(id: number, libItem: MediaItem, ruleGroup?: RuleGroupDto) {
+  async get(
+    id: number,
+    libItem: MediaItem,
+    ruleGroup?: RuleGroupDto,
+    currentRule?: RuleDto,
+  ) {
     try {
       const property = this.appProperties.find((item) => item.id === id);
       if (!property) {
@@ -83,6 +90,15 @@ export class TracearrGetterService {
       const watchedHistory = history.filter((item) =>
         this.isWatched(item, watchedPercentOverride),
       );
+
+      if (isPerUserProperty(property.name)) {
+        return this.getUserStat(
+          property.name,
+          currentRule,
+          history,
+          watchedHistory,
+        );
+      }
 
       switch (property.name) {
         case 'seenBy':
@@ -206,6 +222,63 @@ export class TracearrGetterService {
   ): boolean {
     const addedAt = libItem.addedAt.getTime();
     return Number.isNaN(addedAt) || addedAt < historyIndex.earliestStartedAt;
+  }
+
+  /**
+   * Per-user statistics for the rule's user. Views and the last view date
+   * count watched plays only, honouring the collection's watched-percent
+   * override like the whole-item properties; watch time counts every play,
+   * since an abandoned one still ran for its minutes.
+   *
+   * A username Tracearr has no account for answers `undefined`: zero would
+   * read as "this user watched nothing" after a rename or an unlink.
+   */
+  private getUserStat(
+    propName: string,
+    currentRule: RuleDto | undefined,
+    history: TracearrHistoryItem[],
+    watchedHistory: TracearrHistoryItem[],
+  ): number | Date | null | undefined {
+    const username = currentRule?.username;
+    if (!username) {
+      this.logger.warn(
+        `Tracearr-Getter - Skipping '${propName}': the rule has no user selected.`,
+      );
+      return undefined;
+    }
+
+    const usernamesByTracearrUserId =
+      this.tracearrApi.getUsernamesByTracearrUserId();
+    if (!usernamesByTracearrUserId) {
+      return undefined;
+    }
+
+    const tracearrUserIds = new Set(
+      [...usernamesByTracearrUserId.entries()]
+        .filter(([, usernames]) => usernames.includes(username))
+        .map(([tracearrUserId]) => tracearrUserId),
+    );
+    if (tracearrUserIds.size === 0) {
+      this.logger.warn(
+        `Tracearr-Getter - Skipping '${propName}': Tracearr has no account for user '${username}'.`,
+      );
+      return undefined;
+    }
+
+    if (propName === 'watchTimeByUser') {
+      const milliseconds = history
+        .filter((item) => tracearrUserIds.has(item.user.id))
+        .reduce((total, item) => total + (item.duration_ms ?? 0), 0);
+      return Math.round(milliseconds / 60000);
+    }
+
+    const userHistory = watchedHistory.filter((item) =>
+      tracearrUserIds.has(item.user.id),
+    );
+
+    return propName === 'viewCountByUser'
+      ? userHistory.length
+      : this.getLatestViewedAt(userHistory);
   }
 
   private getUsernames(history: TracearrHistoryItem[]): string[] | undefined {

--- a/apps/server/src/modules/rules/helpers/yaml.service.spec.ts
+++ b/apps/server/src/modules/rules/helpers/yaml.service.spec.ts
@@ -199,6 +199,28 @@ describe('RuleYamlService', () => {
     expect(rules[1].operator).toBe(RuleOperators.AND); // section boundary, not OR
   });
 
+  it('round-trips the user a per-user property is scoped to', () => {
+    const encoded = service.encode(
+      [
+        {
+          operator: null,
+          action: RulePossibility.BIGGER,
+          firstVal: [4, 9],
+          customVal: { ruleTypeId: 0, value: '3' },
+          username: 'alice',
+          section: 0,
+        },
+      ],
+      'movie',
+    );
+
+    expect(YAML.parse(encoded.result).rules[0][0][0].username).toBe('alice');
+
+    const decoded = service.decode(encoded.result, 'movie');
+
+    expect(JSON.parse(decoded.result).rules[0].username).toBe('alice');
+  });
+
   it('returns a clear, structured message when the YAML is not valid', () => {
     // Malformed YAML (an unterminated flow sequence) makes the parser throw,
     // which the decoder catches and reports as a structured failure.

--- a/apps/server/src/modules/rules/helpers/yaml.service.ts
+++ b/apps/server/src/modules/rules/helpers/yaml.service.ts
@@ -31,6 +31,7 @@ interface IRuleYaml {
   lastValue?: string;
   customValue?: ICustomIdentifier;
   arrDiskPath?: string;
+  username?: string;
 }
 
 @Injectable()
@@ -102,6 +103,11 @@ export class RuleYamlService {
           ...(rule.arrDiskPath
             ? {
                 arrDiskPath: rule.arrDiskPath,
+              }
+            : {}),
+          ...(rule.username
+            ? {
+                username: rule.username,
               }
             : {}),
         });
@@ -228,6 +234,11 @@ export class RuleYamlService {
             ...(rule.arrDiskPath
               ? {
                   arrDiskPath: rule.arrDiskPath,
+                }
+              : {}),
+            ...(rule.username
+              ? {
+                  username: rule.username,
                 }
               : {}),
           });

--- a/apps/server/src/modules/rules/rule-users.service.spec.ts
+++ b/apps/server/src/modules/rules/rule-users.service.spec.ts
@@ -1,0 +1,58 @@
+import { MediaServerType } from '@maintainerr/contracts';
+import { Mocked, TestBed } from '@suites/unit';
+import { MediaServerFactory } from '../api/media-server/media-server.factory';
+import { PlexApiService } from '../api/plex-api/plex-api.service';
+import { RuleUsersService } from './rule-users.service';
+
+describe('RuleUsersService', () => {
+  let service: RuleUsersService;
+  let mediaServerFactory: Mocked<MediaServerFactory>;
+  let plexApi: Mocked<PlexApiService>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(RuleUsersService).compile();
+    service = unit;
+    mediaServerFactory = unitRef.get(MediaServerFactory);
+    plexApi = unitRef.get(PlexApiService);
+  });
+
+  const withServer = (serverType: MediaServerType, users: unknown[] = []) => {
+    mediaServerFactory.getConfiguredServerType.mockResolvedValue(serverType);
+    mediaServerFactory.getService.mockResolvedValue({
+      getUsers: jest.fn().mockResolvedValue(users),
+    } as never);
+  };
+
+  it('names Jellyfin users as the media server does, sorted and deduplicated', async () => {
+    withServer(MediaServerType.JELLYFIN, [
+      { id: '2', name: 'bob' },
+      { id: '1', name: 'alice' },
+      { id: '3', name: 'alice' },
+      { id: '4', name: '' },
+    ]);
+
+    await expect(service.getUsernames()).resolves.toEqual(['alice', 'bob']);
+  });
+
+  // The Tautulli getter maps history rows to plex.tv-corrected usernames, so
+  // offering the server's local account names would hand out names that then
+  // match nothing.
+  it('names Plex users as plex.tv does', async () => {
+    withServer(MediaServerType.PLEX, [{ id: '1', name: 'local-name' }]);
+    plexApi.getCorrectedUsers.mockResolvedValue([
+      { plexId: 1, username: 'alice' },
+    ]);
+
+    await expect(service.getUsernames()).resolves.toEqual(['alice']);
+  });
+
+  it('offers no user at all when plex.tv cannot be reached', async () => {
+    withServer(MediaServerType.PLEX, [{ id: '1', name: 'local-name' }]);
+    plexApi.getCorrectedUsers.mockRejectedValue(
+      new Error('plex.tv user data unavailable'),
+    );
+
+    await expect(service.getUsernames()).resolves.toEqual([]);
+  });
+});

--- a/apps/server/src/modules/rules/rule-users.service.ts
+++ b/apps/server/src/modules/rules/rule-users.service.ts
@@ -1,0 +1,48 @@
+import { MediaServerType } from '@maintainerr/contracts';
+import { Injectable } from '@nestjs/common';
+import { MediaServerFactory } from '../api/media-server/media-server.factory';
+import { PlexApiService } from '../api/plex-api/plex-api.service';
+import { MaintainerrLogger } from '../logging/logs.service';
+
+/**
+ * The users a rule can be scoped to (see PER_USER_PROPERTIES), named as the
+ * getters resolve them. On Plex that is the plex.tv-corrected list the
+ * Tautulli getter maps history rows to, which can spell an account
+ * differently from the server's own account list.
+ */
+@Injectable()
+export class RuleUsersService {
+  constructor(
+    private readonly mediaServerFactory: MediaServerFactory,
+    private readonly plexApi: PlexApiService,
+    private readonly logger: MaintainerrLogger,
+  ) {
+    logger.setContext(RuleUsersService.name);
+  }
+
+  async getUsernames(): Promise<string[]> {
+    try {
+      const serverType =
+        await this.mediaServerFactory.getConfiguredServerType();
+
+      const usernames =
+        serverType === MediaServerType.PLEX
+          ? (await this.plexApi.getCorrectedUsers()).map(
+              (user) => user.username,
+            )
+          : (await (await this.mediaServerFactory.getService()).getUsers()).map(
+              (user) => user.name,
+            );
+
+      return [...new Set(usernames.filter(Boolean))].sort((left, right) =>
+        left.localeCompare(right),
+      );
+    } catch (error) {
+      // Offer nothing rather than the local names getCorrectedUsers falls back
+      // to, which the getters would then fail to match.
+      this.logger.warn('Rules - Could not resolve media server usernames');
+      this.logger.debug(error);
+      return [];
+    }
+  }
+}

--- a/apps/server/src/modules/rules/rules.controller.spec.ts
+++ b/apps/server/src/modules/rules/rules.controller.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException } from '@nestjs/common';
 import { MaintainerrLogger } from '../logging/logs.service';
+import { RuleUsersService } from './rule-users.service';
 import { RulesController } from './rules.controller';
 import { RulesService } from './rules.service';
 import { RuleExecutorJobManagerService } from './tasks/rule-executor-job-manager.service';
@@ -19,6 +20,7 @@ describe('RulesController', () => {
     {} as jest.Mocked<RuleExecutorSchedulerService>;
   const ruleExecutorJobManagerService =
     {} as jest.Mocked<RuleExecutorJobManagerService>;
+  const ruleUsersService = {} as jest.Mocked<RuleUsersService>;
 
   const logger = {
     setContext: jest.fn(),
@@ -32,6 +34,7 @@ describe('RulesController', () => {
       rulesService,
       ruleExecutorSchedulerService,
       ruleExecutorJobManagerService,
+      ruleUsersService,
       logger,
     );
   });

--- a/apps/server/src/modules/rules/rules.controller.ts
+++ b/apps/server/src/modules/rules/rules.controller.ts
@@ -31,6 +31,7 @@ import { MaintainerrLogger } from '../logging/logs.service';
 import { CommunityRule } from './dtos/communityRule.dto';
 import { ExclusionAction, ExclusionContextDto } from './dtos/exclusion.dto';
 import { RuleGroupDto } from './dtos/ruleGroup.dto';
+import { RuleUsersService } from './rule-users.service';
 import { ReturnStatus, RulesService } from './rules.service';
 import { RuleExecutorJobManagerService } from './tasks/rule-executor-job-manager.service';
 import { RuleExecutorSchedulerService } from './tasks/rule-executor-scheduler.service';
@@ -41,6 +42,7 @@ export class RulesController {
     private readonly rulesService: RulesService,
     private readonly ruleExecutorSchedulerService: RuleExecutorSchedulerService,
     private readonly ruleExecutorJobManagerService: RuleExecutorJobManagerService,
+    private readonly ruleUsersService: RuleUsersService,
     private readonly logger: MaintainerrLogger,
   ) {
     this.logger.setContext(RulesController.name);
@@ -49,6 +51,11 @@ export class RulesController {
   @Get('/constants')
   async getRuleConstants() {
     return await this.rulesService.getRuleConstants();
+  }
+
+  @Get('/users')
+  async getRuleUsernames(): Promise<string[]> {
+    return await this.ruleUsersService.getUsernames();
   }
 
   @Get('/community')

--- a/apps/server/src/modules/rules/rules.module.ts
+++ b/apps/server/src/modules/rules/rules.module.ts
@@ -31,6 +31,7 @@ import { PlexGetterService } from './getter/plex-getter.service';
 import { RadarrGetterService } from './getter/radarr-getter.service';
 import { SonarrGetterService } from './getter/sonarr-getter.service';
 import { SportarrGetterService } from './getter/sportarr-getter.service';
+import { RuleUsersService } from './rule-users.service';
 import { StreamystatsGetterService } from './getter/streamystats-getter.service';
 import { TautulliGetterService } from './getter/tautulli-getter.service';
 import { TracearrGetterService } from './getter/tracearr-getter.service';
@@ -92,6 +93,7 @@ import { RuleMaintenanceService } from './tasks/rule-maintenance.service';
     SeerrGetterService,
     TautulliGetterService,
     StreamystatsGetterService,
+    RuleUsersService,
     TracearrGetterService,
     ValueGetterService,
     RuleYamlService,

--- a/apps/server/src/modules/rules/rules.service.cacheReset.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.cacheReset.spec.ts
@@ -41,6 +41,7 @@ describe('RulesService.resetCacheIfGroupUsesRuleThatRequiresIt', () => {
       createMockServarrTagService() as any,
       logger as any,
       {} as any,
+      { getUsernames: jest.fn().mockResolvedValue([]) } as any,
     );
 
   const stubGetRuleConstants = (service: RulesService) => {

--- a/apps/server/src/modules/rules/rules.service.deleteRuleGroup.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.deleteRuleGroup.spec.ts
@@ -57,7 +57,8 @@ describe('RulesService.deleteRuleGroup', () => {
       eventEmitter as any,
       servarrTagService as any,
       logger as any,
-      {} as any, // tracearrApi
+      {} as any, // tracearrApi,
+      { getUsernames: jest.fn().mockResolvedValue([]) } as any,
     );
 
     return {
@@ -313,7 +314,8 @@ describe('RulesService.removeExclusion', () => {
       {} as any, // eventEmitter
       createMockServarrTagService() as any,
       logger as any,
-      {} as any, // tracearrApi
+      {} as any, // tracearrApi,
+      { getUsernames: jest.fn().mockResolvedValue([]) } as any,
     );
 
     return {

--- a/apps/server/src/modules/rules/rules.service.exclusion-scoping.integration.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.exclusion-scoping.integration.spec.ts
@@ -63,7 +63,8 @@ describe('Exclusion scoping (real DB) - excluded-in-A item is added in B', () =>
       { emit: jest.fn() } as any, // eventEmitter
       createMockServarrTagService() as any,
       createMockLogger() as any,
-      {} as any, // tracearrApi
+      {} as any, // tracearrApi,
+      { getUsernames: jest.fn().mockResolvedValue([]) } as any,
     );
 
   beforeAll(async () => {

--- a/apps/server/src/modules/rules/rules.service.exclusions.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.exclusions.spec.ts
@@ -68,7 +68,8 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
       {} as any, // eventEmitter
       servarrTagService as any,
       logger as any,
-      {} as any, // tracearrApi
+      {} as any, // tracearrApi,
+      { getUsernames: jest.fn().mockResolvedValue([]) } as any,
     );
 
     return {

--- a/apps/server/src/modules/rules/rules.service.getRuleConstants.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.getRuleConstants.spec.ts
@@ -49,7 +49,8 @@ describe('RulesService.getRuleConstants', () => {
       {} as any, // eventEmitter
       createMockServarrTagService() as any,
       logger as any,
-      {} as any, // tracearrApi
+      {} as any, // tracearrApi,
+      { getUsernames: jest.fn().mockResolvedValue([]) } as any,
     );
 
   const applicationIds = async (service: RulesService) =>

--- a/apps/server/src/modules/rules/rules.service.setRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.setRules.spec.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import {
   createMockLogger,
   createMockServarrTagService,
@@ -27,6 +28,7 @@ describe('RulesService.setRules', () => {
       ruleComparatorServiceFactory: unknown;
       ruleMigrationService: unknown;
       eventEmitter: unknown;
+      ruleUsersService: unknown;
     }> = {},
   ) =>
     new RulesService(
@@ -49,6 +51,9 @@ describe('RulesService.setRules', () => {
       createMockServarrTagService() as any,
       logger as any,
       {} as any,
+      (overrides.ruleUsersService ?? {
+        getUsernames: jest.fn().mockResolvedValue([]),
+      }) as any,
     );
 
   // A minimal, valid single-rule section (Plex "date added" EXISTS). EXISTS is
@@ -93,6 +98,131 @@ describe('RulesService.setRules', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  // Without the user, a saved rule would skip every item at run time.
+  // The community list is public and shared between installs; a rule must not
+  // carry the uploader's media-server user into it.
+  it('uploads a per-user rule without the user it was scoped to', async () => {
+    const patch = jest.fn().mockResolvedValue({});
+    jest.spyOn(axios, 'patch').mockImplementation(patch);
+    const service = createRulesService();
+    jest.spyOn(service, 'getCommunityRules').mockResolvedValue([]);
+
+    await service.addToCommunityRules({
+      name: 'Rewatched by a user',
+      description: 'keeps what one user rewatches',
+      JsonRules: [
+        {
+          operator: null,
+          action: RulePossibility.BIGGER,
+          firstVal: [Application.TAUTULLI, 9],
+          customVal: { ruleTypeId: 0, value: '3' },
+          username: 'alice',
+          section: 0,
+        },
+      ],
+    } as never);
+
+    const uploaded = patch.mock.calls[0][1][0].value;
+    expect(uploaded.JsonRules[0]).not.toHaveProperty('username');
+    expect(uploaded.JsonRules[0]).toMatchObject({
+      firstVal: [Application.TAUTULLI, 9],
+      customVal: { ruleTypeId: 0, value: '3' },
+    });
+  });
+
+  describe('per-user property validation', () => {
+    const perUserRule = (username?: string) => [
+      {
+        operator: null,
+        action: RulePossibility.BIGGER,
+        firstVal: [Application.TAUTULLI, 9],
+        customVal: { ruleTypeId: 0, value: '3' },
+        section: 0,
+        ...(username != null ? { username } : {}),
+      },
+    ];
+
+    const saveRules = (rules: unknown[], knownUsernames = ['alice']) => {
+      const service = createRulesService({
+        ruleUsersService: {
+          getUsernames: jest.fn().mockResolvedValue(knownUsernames),
+        },
+        rulesRepository: { save: jest.fn().mockResolvedValue(undefined) },
+        collectionService: {
+          createCollection: jest
+            .fn()
+            .mockResolvedValue({ dbCollection: { id: 9 } }),
+        },
+        mediaServerFactory: createMediaServerFactory(),
+      });
+      jest.spyOn(service as any, 'createOrUpdateGroup').mockResolvedValue(7);
+
+      return service.setRules({
+        libraryId: '1',
+        name: 'Per-user group',
+        description: '',
+        useRules: true,
+        isActive: true,
+        rules,
+        collection: { keepLogsForMonths: 6 },
+      } as any);
+    };
+
+    it('rejects a per-user property saved without a user', async () => {
+      await expect(saveRules(perUserRule())).resolves.toEqual({
+        code: 0,
+        result: 'Select a user for properties that are scoped to one user',
+        message: 'Select a user for properties that are scoped to one user',
+      });
+    });
+
+    it('rejects a blank user as no user at all', async () => {
+      await expect(saveRules(perUserRule('   '))).resolves.toEqual({
+        code: 0,
+        result: 'Select a user for properties that are scoped to one user',
+        message: 'Select a user for properties that are scoped to one user',
+      });
+    });
+
+    it('rejects a user picked for a property that ignores it', async () => {
+      const rules = [{ ...validRules[0], username: 'alice' }];
+
+      await expect(saveRules(rules)).resolves.toEqual({
+        code: 0,
+        result:
+          'A user can only be selected for properties that are scoped to one user',
+        message:
+          'A user can only be selected for properties that are scoped to one user',
+      });
+    });
+
+    it('accepts a per-user property with a user', async () => {
+      await expect(saveRules(perUserRule('alice'))).resolves.toEqual({
+        code: 1,
+        result: 'Success',
+        message: 'Success',
+      });
+    });
+
+    // A YAML or community import carries the user of the install it came from,
+    // and never passes through the editor's picker.
+    it('rejects a user the media server does not have', async () => {
+      await expect(saveRules(perUserRule('bob'))).resolves.toEqual({
+        code: 0,
+        result: "The media server has no user named 'bob'",
+        message: "The media server has no user named 'bob'",
+      });
+    });
+
+    it('saves anyway when the media server cannot list its users', async () => {
+      await expect(saveRules(perUserRule('bob'), [])).resolves.toEqual({
+        code: 1,
+        result: 'Success',
+        message: 'Success',
+      });
+    });
   });
 
   it('persists a valid rule group and reports success', async () => {

--- a/apps/server/src/modules/rules/rules.service.testMedia.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.testMedia.spec.ts
@@ -61,6 +61,7 @@ describe('RulesService Test Media Tracearr freshness', () => {
       createMockServarrTagService() as never,
       createMockLogger() as never,
       tracearrApi,
+      { getUsernames: jest.fn().mockResolvedValue([]) } as any,
     );
 
     return { service, tracearrApi, comparator };

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -2,6 +2,7 @@ import {
   type BulkMediaItemResult,
   type BulkMediaResponse,
   ECollectionLogType,
+  isPerUserProperty,
   leftoverCleanupScope,
   MaintainerrEvent,
   MediaItemType,
@@ -51,6 +52,7 @@ import { CommunityRule } from './dtos/communityRule.dto';
 import { ExclusionContextDto } from './dtos/exclusion.dto';
 import { RuleDto } from './dtos/rule.dto';
 import { RuleDbDto } from './dtos/ruleDb.dto';
+import { RuleUsersService } from './rule-users.service';
 import { RuleGroupDto } from './dtos/ruleGroup.dto';
 import { CommunityRuleKarma } from './entities/community-rule-karma.entities';
 import { Exclusion } from './entities/exclusion.entities';
@@ -106,6 +108,7 @@ export class RulesService {
     private readonly servarrTagService: ServarrTagService,
     private readonly logger: MaintainerrLogger,
     private readonly tracearrApi: TracearrApiService,
+    private readonly ruleUsersService: RuleUsersService,
   ) {
     logger.setContext(RulesService.name);
     this.ruleConstants = new RuleConstants();
@@ -423,6 +426,9 @@ export class RulesService {
         return managerState;
       }
       let state: ReturnStatus = this.createReturnStatus(true, 'Success');
+      const knownUsernames = await this.getKnownUsernames(
+        params.rules as RuleDto[],
+      );
       for (const [index, rule] of (params.rules as RuleDto[]).entries()) {
         if (state.code === 1 && index > 0 && rule.operator == null) {
           state = this.createReturnStatus(
@@ -431,6 +437,7 @@ export class RulesService {
           );
         }
         this.normalizeRuleDiskPath(rule);
+        this.normalizeRuleUsername(rule);
         if (state.code === 1) {
           state = this.validateRule(rule);
         }
@@ -444,6 +451,9 @@ export class RulesService {
         }
         if (state.code === 1) {
           state = this.validateRuleDiskPath(rule);
+        }
+        if (state.code === 1) {
+          state = this.validateRuleUsername(rule, knownUsernames);
         }
       }
 
@@ -550,6 +560,9 @@ export class RulesService {
         return managerState;
       }
       let state: ReturnStatus = this.createReturnStatus(true, 'Success');
+      const knownUsernames = await this.getKnownUsernames(
+        params.rules as RuleDto[],
+      );
       for (const [index, rule] of (params.rules as RuleDto[]).entries()) {
         if (state.code === 1 && index > 0 && rule.operator == null) {
           state = this.createReturnStatus(
@@ -558,6 +571,7 @@ export class RulesService {
           );
         }
         this.normalizeRuleDiskPath(rule);
+        this.normalizeRuleUsername(rule);
         if (state.code === 1) {
           state = this.validateRule(rule);
         }
@@ -571,6 +585,9 @@ export class RulesService {
         }
         if (state.code === 1) {
           state = this.validateRuleDiskPath(rule);
+        }
+        if (state.code === 1) {
+          state = this.validateRuleUsername(rule, knownUsernames);
         }
       }
 
@@ -1887,6 +1904,75 @@ export class RulesService {
     return this.createReturnStatus(true, 'Success');
   }
 
+  private normalizeRuleUsername(rule: RuleDto) {
+    if (rule.username == null) {
+      return;
+    }
+
+    const username = rule.username.trim();
+    rule.username = username.length > 0 ? username : undefined;
+  }
+
+  /**
+   * Resolved once per save, and only when a rule names a user: imports and API
+   * clients never see the editor's picker.
+   */
+  private async getKnownUsernames(rules: RuleDto[]): Promise<string[]> {
+    return rules.some((rule) => rule.username?.trim())
+      ? await this.ruleUsersService.getUsernames()
+      : [];
+  }
+
+  /** Rejected here rather than skipping every item at execution time. */
+  private validateRuleUsername(
+    rule: RuleDto,
+    knownUsernames: string[],
+  ): ReturnStatus {
+    const usesPerUserProperty = [rule.firstVal, rule.lastVal].some((value) =>
+      isPerUserProperty(this.findRuleProperty(value)?.name),
+    );
+
+    if (usesPerUserProperty && !rule.username) {
+      return this.createReturnStatus(
+        false,
+        'Select a user for properties that are scoped to one user',
+      );
+    }
+
+    if (!usesPerUserProperty && rule.username) {
+      return this.createReturnStatus(
+        false,
+        'A user can only be selected for properties that are scoped to one user',
+      );
+    }
+
+    // An empty list means the media server could not be reached, which must not
+    // block a save; a populated one that lacks the user means the rule would
+    // skip every item, so reject it here instead.
+    if (
+      rule.username &&
+      knownUsernames.length > 0 &&
+      !knownUsernames.includes(rule.username)
+    ) {
+      return this.createReturnStatus(
+        false,
+        `The media server has no user named '${rule.username}'`,
+      );
+    }
+
+    return this.createReturnStatus(true, 'Success');
+  }
+
+  private findRuleProperty(value?: [number, number]): Property | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    return this.ruleConstants.applications
+      .find((el) => el.id === value[0])
+      ?.props.find((el) => el.id === value[1]);
+  }
+
   private normalizeRuleDiskPath(rule: RuleDto) {
     if (rule.arrDiskPath == null) {
       return;
@@ -2038,6 +2124,27 @@ export class RulesService {
     return Array.isArray(response) ? response.length : 0;
   }
 
+  /**
+   * The community list is public and shared between installs, so a rule leaves
+   * without the user it was scoped to: that name identifies someone's
+   * household, and it would resolve to nobody on the install that imports it.
+   * The importer picks their own user, which the editor already demands.
+   */
+  private withoutLocalUsers(rules: CommunityRule['JsonRules']) {
+    if (!Array.isArray(rules)) {
+      return rules;
+    }
+
+    return rules.map((rule) => {
+      if (!rule || typeof rule !== 'object' || !('username' in rule)) {
+        return rule;
+      }
+      const withoutUser: RuleDto = { ...(rule as RuleDto) };
+      delete withoutUser.username;
+      return withoutUser;
+    });
+  }
+
   public async addToCommunityRules(rule: CommunityRule): Promise<ReturnStatus> {
     const rules = await this.getCommunityRules();
     const appVersion = process.env.npm_package_version
@@ -2066,6 +2173,7 @@ export class RulesService {
             appVersion: appVersion,
             hasRules,
             ...rule,
+            JsonRules: this.withoutLocalUsers(rule.JsonRules),
           },
         },
       ])
@@ -2238,6 +2346,7 @@ export class RulesService {
     // it from a fresh /request sweep and agrees with a full run (#3152).
     cacheManager.getCache('seerrrequests').data.flushAll();
     cacheManager.getCache('tautulli').data.flushAll();
+    cacheManager.getCache('streamystats').data.flushAll();
     cacheManager
       .getCachesByType('radarr')
       .forEach((cache) => cache.data.flushAll());

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -560,9 +560,10 @@ export class RulesService {
         return managerState;
       }
       let state: ReturnStatus = this.createReturnStatus(true, 'Success');
-      const knownUsernames = await this.getKnownUsernames(
-        params.rules as RuleDto[],
-      );
+      const knownUsernames = [
+        ...(await this.getKnownUsernames(params.rules as RuleDto[])),
+        ...(await this.getSavedUsernames(params.id)),
+      ];
       for (const [index, rule] of (params.rules as RuleDto[]).entries()) {
         if (state.code === 1 && index > 0 && rule.operator == null) {
           state = this.createReturnStatus(
@@ -1921,6 +1922,30 @@ export class RulesService {
     return rules.some((rule) => rule.username?.trim())
       ? await this.ruleUsersService.getUsernames()
       : [];
+  }
+
+  /**
+   * Users this group already reads. An account that has since been renamed or
+   * deleted leaves the rule paused at execution time, which is the point - but
+   * it must not block every later edit to the group it sits in.
+   */
+  private async getSavedUsernames(ruleGroupId: number): Promise<string[]> {
+    const rules = (await this.getRules(ruleGroupId)) ?? [];
+
+    return rules.reduce((usernames, rule) => {
+      try {
+        const username = (
+          JSON.parse(rule.ruleJson) as RuleDto
+        ).username?.trim();
+        if (username) {
+          usernames.push(username);
+        }
+      } catch {
+        // A rule row that no longer parses is the executor's problem, not this
+        // validation's.
+      }
+      return usernames;
+    }, [] as string[]);
   }
 
   /** Rejected here rather than skipping every item at execution time. */

--- a/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
@@ -54,6 +54,7 @@ describe('RulesService.updateRules', () => {
       (overrides.servarrTagService ?? createMockServarrTagService()) as any,
       logger as any,
       {} as any,
+      { getUsernames: jest.fn().mockResolvedValue([]) } as any,
     );
 
   // Let the fire-and-forget membership reconcile settle before asserting on it.

--- a/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
@@ -32,6 +32,7 @@ describe('RulesService.updateRules', () => {
       ruleMigrationService: unknown;
       eventEmitter: unknown;
       servarrTagService: unknown;
+      ruleUsersService: unknown;
     }> = {},
   ) =>
     new RulesService(
@@ -54,7 +55,9 @@ describe('RulesService.updateRules', () => {
       (overrides.servarrTagService ?? createMockServarrTagService()) as any,
       logger as any,
       {} as any,
-      { getUsernames: jest.fn().mockResolvedValue([]) } as any,
+      (overrides.ruleUsersService ?? {
+        getUsernames: jest.fn().mockResolvedValue([]),
+      }) as any,
     );
 
   // Let the fire-and-forget membership reconcile settle before asserting on it.
@@ -860,5 +863,68 @@ describe('RulesService.updateRules', () => {
       [],
       [{ mediaServerId: 'm1', tmdbId: 1, tvdbId: null }],
     );
+  });
+
+  // A per-user rule keeps working on the items it can still resolve and pauses
+  // on the rest, so an account that has since gone must not block every later
+  // edit to the group it sits in.
+  describe('a user the media server no longer reports', () => {
+    const perUserRule = (username: string) => ({
+      operator: null,
+      action: RulePossibility.BIGGER,
+      firstVal: [Application.TAUTULLI, 9],
+      customVal: { ruleTypeId: 0, value: '3' },
+      username,
+      section: 0,
+    });
+
+    const updateWith = (username: string, savedUsername?: string) => {
+      const service = createRulesService({
+        ruleGroupRepository: {
+          findOne: jest.fn().mockResolvedValue({ id: 1, collectionId: 1 }),
+        },
+        ruleUsersService: {
+          getUsernames: jest.fn().mockResolvedValue(['alice']),
+        },
+      });
+      jest
+        .spyOn(service, 'getRules')
+        .mockResolvedValue(
+          savedUsername
+            ? ([
+                { ruleJson: JSON.stringify(perUserRule(savedUsername)) },
+              ] as never)
+            : ([] as never),
+        );
+
+      return service.updateRules({
+        id: 1,
+        libraryId: '1',
+        name: 'Per-user group',
+        description: '',
+        useRules: true,
+        isActive: true,
+        rules: [perUserRule(username)],
+        collection: { keepLogsForMonths: 6 },
+      } as never);
+    };
+
+    it('keeps a user the group already saved', async () => {
+      // The save itself runs past validation into repositories this test does
+      // not stand up, so assert only on what is under test: it is not the
+      // username that stops it.
+      const outcome = await updateWith('bob', 'bob').catch((error) => error);
+
+      expect(outcome).not.toMatchObject({
+        result: "The media server has no user named 'bob'",
+      });
+    });
+
+    it('still rejects one the group never had', async () => {
+      await expect(updateWith('bob')).resolves.toMatchObject({
+        code: 0,
+        result: "The media server has no user named 'bob'",
+      });
+    });
   });
 });

--- a/apps/server/src/modules/settings/rule-migration.service.spec.ts
+++ b/apps/server/src/modules/settings/rule-migration.service.spec.ts
@@ -360,6 +360,60 @@ describe('RuleMigrationService', () => {
       expect(result.rules[0].firstVal?.[0]).toBe(6); // 6 = JELLYFIN
     });
 
+    // The migration rewrites the property slots; everything else that gives a
+    // rule its meaning has to survive a server switch untouched.
+    it('keeps the per-rule fields when it rewrites a property', () => {
+      const rules: RuleDto[] = [
+        {
+          operator: null,
+          action: RulePossibility.BIGGER,
+          firstVal: [Application.PLEX, 0],
+          customVal: { ruleTypeId: 0, value: '3' },
+          username: 'alice',
+          arrDiskPath: '/movies',
+          section: 0,
+        },
+      ];
+
+      const result = service.migrateImportedRuleDtos(
+        rules,
+        MediaServerType.JELLYFIN,
+      );
+
+      expect(result.rules[0]).toMatchObject({
+        firstVal: [Application.JELLYFIN, 0],
+        customVal: { ruleTypeId: 0, value: '3' },
+        username: 'alice',
+        arrDiskPath: '/movies',
+      });
+    });
+
+    // Tautulli, Streamystats and Tracearr rules are carried across a server
+    // change untouched; the executor warns when the companion is unavailable.
+    it('leaves a companion per-user rule alone', () => {
+      const rules: RuleDto[] = [
+        {
+          operator: null,
+          action: RulePossibility.BIGGER,
+          firstVal: [Application.TAUTULLI, 9],
+          customVal: { ruleTypeId: 0, value: '1' },
+          username: 'alice',
+          section: 0,
+        },
+      ];
+
+      const result = service.migrateImportedRuleDtos(
+        rules,
+        MediaServerType.JELLYFIN,
+      );
+
+      expect(result.skippedRules).toBe(0);
+      expect(result.rules[0]).toMatchObject({
+        firstVal: [Application.TAUTULLI, 9],
+        username: 'alice',
+      });
+    });
+
     it('backfills an unset within-section operator to OR (pre-explicit-operator community rule)', () => {
       // Mirrors a real community rule (appVersion 2.19.0): three rules in one
       // section with the third operator left unset. reassert only fixes section

--- a/apps/server/test/rules-test-matrix.e2e.ts
+++ b/apps/server/test/rules-test-matrix.e2e.ts
@@ -46,6 +46,10 @@ import { RuleExecutorSchedulerService } from '../src/modules/rules/tasks/rule-ex
 import { RadarrSettings } from '../src/modules/settings/entities/radarr_settings.entities';
 import { Settings } from '../src/modules/settings/entities/settings.entities';
 import { SonarrSettings } from '../src/modules/settings/entities/sonarr_settings.entities';
+import { SportarrSettings } from '../src/modules/settings/entities/sportarr_settings.entities';
+import { RuleUsersService } from '../src/modules/rules/rule-users.service';
+import { TracearrApiService } from '../src/modules/api/tracearr-api/tracearr-api.service';
+import { ServarrTagService } from '../src/modules/actions/servarr-tag.service';
 import { RuleMigrationService } from '../src/modules/settings/rule-migration.service';
 import { createMediaItem } from './utils/data';
 
@@ -112,6 +116,7 @@ const mediaServerFactory = {
 
 const valueGetter = {
   get: async () => (state.values.length > 0 ? state.values.shift() : null),
+  getConfiguredServerType: async () => null,
 };
 
 function createStoredRule(
@@ -835,6 +840,22 @@ async function bootstrapApp(): Promise<INestApplication> {
       {
         provide: getRepositoryToken(SonarrSettings),
         useValue: { exists: async () => false },
+      },
+      {
+        provide: getRepositoryToken(SportarrSettings),
+        useValue: { exists: async () => false },
+      },
+      {
+        provide: ServarrTagService,
+        useValue: {},
+      },
+      {
+        provide: TracearrApiService,
+        useValue: { invalidateHistory: () => undefined },
+      },
+      {
+        provide: RuleUsersService,
+        useValue: { getUsernames: async () => [] },
       },
       {
         provide: 'CollectionMediaRepository',

--- a/apps/ui/src/api/rules.ts
+++ b/apps/ui/src/api/rules.ts
@@ -190,6 +190,27 @@ export const useRuleConstants = (options?: UseRuleConstantsOptions) => {
 
 export type UseRuleConstants = ReturnType<typeof useRuleConstants>
 
+type UseRuleUsernamesQueryKey = ['rules', 'users']
+
+type UseRuleUsernamesOptions = Omit<
+  UseQueryOptions<string[], Error, string[], UseRuleUsernamesQueryKey>,
+  'queryKey' | 'queryFn'
+>
+
+/**
+ * Users a rule can be scoped to, named as the rule getters resolve them.
+ */
+export const useRuleUsernames = (options?: UseRuleUsernamesOptions) => {
+  return useQuery<string[], Error, string[], UseRuleUsernamesQueryKey>({
+    queryKey: ['rules', 'users'],
+    queryFn: async () => {
+      return await GetApiHandler<string[]>('/rules/users')
+    },
+    staleTime: 60000,
+    ...options,
+  })
+}
+
 export type { ArrDiskspaceResource } from '@maintainerr/contracts'
 
 type UseArrDiskspaceQueryKey = [

--- a/apps/ui/src/components/Forms/DatalistInput.tsx
+++ b/apps/ui/src/components/Forms/DatalistInput.tsx
@@ -1,0 +1,37 @@
+import { ChevronDownIcon } from '@heroicons/react/solid'
+import clsx from 'clsx'
+import { InputHTMLAttributes, Ref } from 'react'
+import { Input } from './Input'
+
+type DatalistInputProps = {
+  name: string
+  /** Id of the `<datalist>` holding the options. */
+  list: string
+  className?: string
+  error?: boolean
+  ref?: Ref<HTMLInputElement>
+} & InputHTMLAttributes<HTMLInputElement>
+
+/**
+ * A picker for lists too long to scroll: it reads as a `Select` (same field
+ * styling, same chevron) but filters as you type, and its options live in one
+ * shared `<datalist>` instead of being repeated in every field.
+ */
+export const DatalistInput = ({
+  className,
+  ref,
+  ...props
+}: DatalistInputProps) => {
+  return (
+    <div className="relative w-full">
+      <Input
+        {...props}
+        ref={ref}
+        type="text"
+        autoComplete="off"
+        className={clsx('pr-9', className)}
+      />
+      <ChevronDownIcon className="pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+    </div>
+  )
+}

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.spec.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.spec.tsx
@@ -6,11 +6,13 @@ import RuleInput from './index'
 const useRuleConstantsMock = vi.fn()
 const useRadarrDiskspaceMock = vi.fn()
 const useSonarrDiskspaceMock = vi.fn()
+const useRuleUsernamesMock = vi.fn()
 
 vi.mock('../../../../../api/rules', () => ({
   useRuleConstants: () => useRuleConstantsMock(),
   useRadarrDiskspace: (...args: unknown[]) => useRadarrDiskspaceMock(...args),
   useSonarrDiskspace: (...args: unknown[]) => useSonarrDiskspaceMock(...args),
+  useRuleUsernames: (...args: unknown[]) => useRuleUsernamesMock(...args),
 }))
 
 vi.mock('../../../../../hooks/useMediaServerType', () => ({
@@ -29,6 +31,8 @@ const onIncomplete = vi.fn()
 const onDelete = vi.fn()
 
 const listPropertyId = 101
+const numberPropertyId = 102
+const perUserPropertyId = 9
 
 const ruleConstants = {
   applications: [
@@ -45,6 +49,33 @@ const ruleConstants = {
           type: {
             key: '4',
             possibilities: [RulePossibility.NOT_EQUALS, RulePossibility.EXISTS],
+          },
+        },
+        {
+          id: numberPropertyId,
+          name: 'viewCount',
+          humanName: 'Times viewed',
+          mediaType: MediaType.BOTH,
+          type: {
+            key: '0',
+            possibilities: [RulePossibility.BIGGER, RulePossibility.EXISTS],
+          },
+        },
+      ],
+    },
+    {
+      id: Application.TAUTULLI,
+      name: 'Tautulli',
+      mediaType: MediaType.BOTH,
+      props: [
+        {
+          id: perUserPropertyId,
+          name: 'viewCountByUser',
+          humanName: 'Times viewed by user',
+          mediaType: MediaType.BOTH,
+          type: {
+            key: '0',
+            possibilities: [RulePossibility.BIGGER, RulePossibility.EXISTS],
           },
         },
       ],
@@ -67,6 +98,11 @@ describe('RuleInput', () => {
     })
     useRadarrDiskspaceMock.mockReturnValue({ data: [], isLoading: false })
     useSonarrDiskspaceMock.mockReturnValue({ data: [], isLoading: false })
+    useRuleUsernamesMock.mockReset()
+    useRuleUsernamesMock.mockReturnValue({
+      data: ['alice', 'bob'],
+      isLoading: false,
+    })
   })
 
   afterEach(() => {
@@ -194,6 +230,149 @@ describe('RuleInput', () => {
       expect(onIncomplete).toHaveBeenCalled()
     })
     expect(onCommit).not.toHaveBeenCalled()
+  })
+
+  describe('per-user properties', () => {
+    const renderPerUserRule = () => {
+      render(
+        <RuleInput
+          id={1}
+          mediaType={MediaType.MOVIE}
+          onCommit={onCommit}
+          onIncomplete={onIncomplete}
+          onDelete={onDelete}
+        />,
+      )
+
+      fireEvent.change(screen.getByLabelText('First Value'), {
+        target: {
+          value: JSON.stringify([Application.TAUTULLI, perUserPropertyId]),
+        },
+      })
+      fireEvent.change(screen.getByLabelText('Action'), {
+        target: { value: String(RulePossibility.EXISTS) },
+      })
+    }
+
+    it('asks for a user and reports the rule incomplete until one is picked', async () => {
+      renderPerUserRule()
+
+      expect(screen.getByLabelText('User')).toBeTruthy()
+      await waitFor(() => {
+        expect(onIncomplete).toHaveBeenCalled()
+      })
+      expect(onCommit).not.toHaveBeenCalled()
+    })
+
+    it('commits the picked user with the rule', async () => {
+      renderPerUserRule()
+
+      fireEvent.change(screen.getByLabelText('User'), {
+        target: { value: 'alice' },
+      })
+
+      await waitFor(() => {
+        expect(onCommit.mock.calls.at(-1)?.[0]).toMatchObject({
+          firstVal: [Application.TAUTULLI, perUserPropertyId],
+          username: 'alice',
+        })
+      })
+    })
+
+    // The field takes typed input, so a name the media server does not report
+    // must not save a rule that would then skip every item.
+    it('stays incomplete for a user the media server does not report', async () => {
+      renderPerUserRule()
+
+      fireEvent.change(screen.getByLabelText('User'), {
+        target: { value: 'alicia' },
+      })
+
+      await waitFor(() => {
+        expect(onIncomplete).toHaveBeenCalled()
+      })
+      expect(onCommit).not.toHaveBeenCalled()
+    })
+
+    it('keeps a saved user that the media server no longer reports', async () => {
+      render(
+        <RuleInput
+          id={1}
+          mediaType={MediaType.MOVIE}
+          editData={{
+            rule: {
+              operator: null,
+              firstVal: [Application.TAUTULLI, perUserPropertyId],
+              action: RulePossibility.EXISTS,
+              username: 'carol',
+            } as never,
+          }}
+          onCommit={onCommit}
+          onIncomplete={onIncomplete}
+          onDelete={onDelete}
+        />,
+      )
+
+      await waitFor(() => {
+        expect(onCommit.mock.calls.at(-1)?.[0]).toMatchObject({
+          username: 'carol',
+        })
+      })
+    })
+
+    // The rule's user applies to whichever side holds the property, so the
+    // second value has to raise the field too.
+    it('asks for a user when only the second value is scoped to one', () => {
+      render(
+        <RuleInput
+          id={1}
+          mediaType={MediaType.MOVIE}
+          radarrSettingsId={1}
+          onCommit={onCommit}
+          onIncomplete={onIncomplete}
+          onDelete={onDelete}
+        />,
+      )
+
+      fireEvent.change(screen.getByLabelText('First Value'), {
+        target: {
+          value: JSON.stringify([Application.RADARR, numberPropertyId]),
+        },
+      })
+
+      fireEvent.change(screen.getByLabelText('Action'), {
+        target: { value: String(RulePossibility.BIGGER) },
+      })
+
+      expect(screen.queryByLabelText('User')).toBeNull()
+
+      fireEvent.change(screen.getByLabelText('Second Value'), {
+        target: {
+          value: JSON.stringify([Application.TAUTULLI, perUserPropertyId]),
+        },
+      })
+
+      expect(screen.getByLabelText('User')).toBeTruthy()
+    })
+
+    it('offers no user for a property that is not scoped to one', () => {
+      render(
+        <RuleInput
+          id={1}
+          mediaType={MediaType.MOVIE}
+          radarrSettingsId={1}
+          onCommit={onCommit}
+          onIncomplete={onIncomplete}
+          onDelete={onDelete}
+        />,
+      )
+
+      fireEvent.change(screen.getByLabelText('First Value'), {
+        target: { value: JSON.stringify([Application.RADARR, listPropertyId]) },
+      })
+
+      expect(screen.queryByLabelText('User')).toBeNull()
+    })
   })
 
   describe('application filtering', () => {

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
@@ -4,6 +4,7 @@ import {
   type ArrDiskspaceResource,
   DISKSPACE_REMAINING_PROPERTY,
   DISKSPACE_TOTAL_PROPERTY,
+  isPerUserProperty,
   type MediaItemType,
   MediaType,
   normalizeDiskPath,
@@ -15,6 +16,7 @@ import { IRule } from '../'
 import {
   useRadarrDiskspace,
   useRuleConstants,
+  useRuleUsernames,
   useSonarrDiskspace,
 } from '../../../../../api/rules'
 import {
@@ -23,8 +25,14 @@ import {
 } from '../../../../../contexts/constants-context'
 import { useMediaServerType } from '../../../../../hooks/useMediaServerType'
 import LoadingSpinner from '../../../../Common/LoadingSpinner'
+import { DatalistInput } from '../../../../Forms/DatalistInput'
 import { Input } from '../../../../Forms/Input'
 import { Select } from '../../../../Forms/Select'
+
+// One shared list of users for every rule card: the options are rendered once
+// by the rule creator, not per card, so a server with thousands of users does
+// not multiply them across the editor.
+export const RULE_USERNAMES_DATALIST_ID = 'rule-usernames'
 
 enum RuleType {
   NUMBER,
@@ -204,6 +212,14 @@ const getPropFromTuple = (
   return application?.props.find((el) => el.id === +parsed[1])
 }
 
+const getPropFromValue = (
+  value: string | undefined,
+  constants: IConstants | undefined,
+): IProperty | undefined => {
+  // The second value holds either a property tuple or a CustomParams marker.
+  return value?.startsWith('[') ? getPropFromTuple(value, constants) : undefined
+}
+
 interface InitialRuleState {
   operator: string | undefined
   firstVal: string | undefined
@@ -211,6 +227,7 @@ interface InitialRuleState {
   secondVal: string | undefined
   customVal: string | undefined
   arrDiskPath: string
+  username: string
   ruleType: RuleType
 }
 
@@ -225,6 +242,7 @@ const getInitialRuleState = (props: IRuleInput): InitialRuleState => {
       secondVal: undefined,
       customVal: undefined,
       arrDiskPath: '',
+      username: '',
       ruleType: RuleType.NUMBER,
     }
   }
@@ -236,6 +254,7 @@ const getInitialRuleState = (props: IRuleInput): InitialRuleState => {
     secondVal: undefined,
     customVal: undefined,
     arrDiskPath: rule.arrDiskPath ? normalizeDiskPath(rule.arrDiskPath) : '',
+    username: rule.username ?? '',
     ruleType: RuleType.NUMBER,
   }
 
@@ -295,6 +314,7 @@ const RuleInput = (props: IRuleInput) => {
   const [arrDiskPath, setArrDiskPath] = useState<string>(
     initialRuleState.arrDiskPath,
   )
+  const [username, setUsername] = useState<string>(initialRuleState.username)
 
   const { data: constants, isLoading: constantsLoading } = useRuleConstants()
   const { isPlex, isJellyfin, isEmby } = useMediaServerType()
@@ -374,6 +394,23 @@ const RuleInput = (props: IRuleInput) => {
     (selectedFirstValueAppId === Application.RADARR ||
       selectedFirstValueAppId === Application.SONARR) &&
     isArrDiskspaceProperty(selectedFirstValueProp)
+
+  // Either side can hold a per-user property; both read the one user here.
+  const isSelectedPerUserRule =
+    isPerUserProperty(selectedFirstValueProp?.name) ||
+    isPerUserProperty(getPropFromValue(secondVal, constants)?.name)
+
+  const { data: ruleUsernames = [], isLoading: ruleUsernamesLoading } =
+    useRuleUsernames({ enabled: isSelectedPerUserRule })
+
+  // A typo would save a rule that then skips every item, so only a known user
+  // counts - or the one already saved, which keeps a rule editable after the
+  // account is gone.
+  const isUsernameUsable =
+    !!username &&
+    (ruleUsernames.length === 0 ||
+      ruleUsernames.includes(username) ||
+      username === initialRuleState.username)
 
   const { data: radarrDiskspace = [], isLoading: radarrDiskspaceLoading } =
     useRadarrDiskspace(props.radarrSettingsId, {
@@ -473,6 +510,13 @@ const RuleInput = (props: IRuleInput) => {
     if (!isArrDiskspaceProperty(nextProp)) {
       setArrDiskPath('')
     }
+
+    if (
+      !isPerUserProperty(nextProp?.name) &&
+      !isPerUserProperty(getPropFromValue(secondVal, constants)?.name)
+    ) {
+      setUsername('')
+    }
   }
 
   const updateSecondValue = (event: { target: { value: string } }) => {
@@ -499,6 +543,14 @@ const RuleInput = (props: IRuleInput) => {
     } else {
       setCustomVal(event.target.value)
     }
+  }
+
+  // Unique per card: every rule renders this field, and a shared id would bind
+  // all their labels to the first one.
+  const usernameFieldId = `username_${props.section ?? 0}_${props.id ?? 0}`
+
+  const updateUsername = (event: { target: { value: string } }) => {
+    setUsername(event.target.value)
   }
 
   const updateArrDiskPath = (event: { target: { value: string } }) => {
@@ -556,7 +608,8 @@ const RuleInput = (props: IRuleInput) => {
       validFirstVal &&
       action != null &&
       (!requiresSecondValue || hasSecondValue || !!customVal) &&
-      (!operatorRequired || !!operator)
+      (!operatorRequired || !!operator) &&
+      (!isSelectedPerUserRule || isUsernameUsable)
     ) {
       const ruleValues = {
         operator: operator ? operator : null,
@@ -564,6 +617,7 @@ const RuleInput = (props: IRuleInput) => {
         action,
         section: props.section ? props.section - 1 : 0,
         ...(isSelectedArrDiskspaceRule && arrDiskPath ? { arrDiskPath } : {}),
+        ...(isSelectedPerUserRule && username ? { username } : {}),
       }
       if (!requiresSecondValue) {
         props.onCommit(ruleValues)
@@ -618,9 +672,12 @@ const RuleInput = (props: IRuleInput) => {
     customVal,
     validFirstVal,
     isSelectedArrDiskspaceRule,
+    isSelectedPerUserRule,
+    isUsernameUsable,
     operator,
     ruleType,
     secondVal,
+    username,
   ])
 
   if (!constants || constantsLoading) {
@@ -814,6 +871,32 @@ const RuleInput = (props: IRuleInput) => {
                 ) : undefined
               })}
             </Select>
+          </div>
+        ) : null}
+
+        {isSelectedPerUserRule ? (
+          <div>
+            <label
+              htmlFor={usernameFieldId}
+              className="mb-1 block text-sm font-medium"
+            >
+              User
+            </label>
+            <DatalistInput
+              name="username"
+              id={usernameFieldId}
+              list={RULE_USERNAMES_DATALIST_ID}
+              placeholder={
+                ruleUsernamesLoading ? 'Loading users...' : 'Select a user'
+              }
+              onChange={updateUsername}
+              value={username}
+            />
+            {!ruleUsernamesLoading && ruleUsernames.length === 0 ? (
+              <p className="mt-1 text-xs text-zinc-400">
+                No users reported by the media server
+              </p>
+            ) : null}
           </div>
         ) : null}
 

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/index.spec.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/index.spec.tsx
@@ -56,7 +56,12 @@ vi.mock('react-movable', () => {
   return { List, arrayMove }
 })
 
+vi.mock('../../../../api/rules', () => ({
+  useRuleUsernames: () => ({ data: ['alice', 'bob'], isLoading: false }),
+}))
+
 vi.mock('./RuleInput', () => ({
+  RULE_USERNAMES_DATALIST_ID: 'rule-usernames',
   default: ({
     tagId,
     section,

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/index.tsx
@@ -13,10 +13,11 @@ import {
   useState,
 } from 'react'
 import { arrayMove, List } from 'react-movable'
+import { useRuleUsernames } from '../../../../api/rules'
 import AddButton from '../../../Common/AddButton'
 import Alert from '../../../Common/Alert'
 import SectionHeading from '../../../Common/SectionHeading'
-import RuleInput from './RuleInput'
+import RuleInput, { RULE_USERNAMES_DATALIST_ID } from './RuleInput'
 
 export interface IRule {
   operator: string | null
@@ -25,6 +26,7 @@ export interface IRule {
   section?: number
   customVal?: { ruleTypeId: number; value: string | number }
   arrDiskPath?: string
+  username?: string
   action: number
 }
 
@@ -100,6 +102,8 @@ const RuleCreator = (props: iRuleCreator) => {
     buildInitialSections(props.editData),
   )
   const didMountRef = useRef(false)
+  // Reads the cache only: a rule card that needs users is what fetches them.
+  const { data: ruleUsernames = [] } = useRuleUsernames({ enabled: false })
 
   const emitUpdate = useEffectEvent(() => {
     props.onUpdate(flattenSections(sections))
@@ -214,6 +218,11 @@ const RuleCreator = (props: iRuleCreator) => {
 
   return (
     <div className="text-zinc-100">
+      <datalist id={RULE_USERNAMES_DATALIST_ID}>
+        {ruleUsernames.map((username) => (
+          <option key={username} value={username} />
+        ))}
+      </datalist>
       <List
         lockVertically
         values={sections}

--- a/packages/contracts/src/rules/constants.ts
+++ b/packages/contracts/src/rules/constants.ts
@@ -103,3 +103,20 @@ export enum RequestMediaStatus {
 
 export const DISKSPACE_REMAINING_PROPERTY = 'diskspace_remaining_gb'
 export const DISKSPACE_TOTAL_PROPERTY = 'diskspace_total_gb'
+
+/**
+ * Properties scoped to the single user named by the rule's `username`. Shared
+ * by the watch-history companions (Streamystats, Tautulli, Tracearr).
+ */
+export const PER_USER_PROPERTIES = [
+  'viewCountByUser',
+  'watchTimeByUser',
+  'lastViewedAtByUser',
+] as const
+
+export type PerUserProperty = (typeof PER_USER_PROPERTIES)[number]
+
+export const isPerUserProperty = (
+  property: string | undefined,
+): property is PerUserProperty =>
+  PER_USER_PROPERTIES.includes(property as PerUserProperty)

--- a/packages/contracts/src/tracearr/history.ts
+++ b/packages/contracts/src/tracearr/history.ts
@@ -11,6 +11,8 @@ export const tracearrHistoryItemSchema = z.object({
   season_number: z.number().int().nullable(),
   episode_number: z.number().int().nullable(),
   percent_complete: z.number().nullable(),
+  // Milliseconds played, summed across the play's segments.
+  duration_ms: z.number().nullable().optional(),
   watched: z.boolean(),
   started_at: z.iso.datetime(),
   stopped_at: z.iso.datetime().nullable(),

--- a/packages/contracts/src/tracearr/users.ts
+++ b/packages/contracts/src/tracearr/users.ts
@@ -12,6 +12,8 @@ export const tracearrUsersPageSchema = z.object({
           // Tracearr's own copy of the account name, which can differ from
           // the media server's for the same Plex account.
           username: z.string().min(1).nullish(),
+          // Set once the account is gone from the media server.
+          removed_at: z.iso.datetime().nullish(),
         }),
       ),
     }),

--- a/packages/contracts/src/tracearr/users.ts
+++ b/packages/contracts/src/tracearr/users.ts
@@ -9,6 +9,9 @@ export const tracearrUsersPageSchema = z.object({
           server_id: z.uuid(),
           server_type: z.string().min(1),
           external_user_id: z.string().min(1),
+          // Tracearr's own copy of the account name, which can differ from
+          // the media server's for the same Plex account.
+          username: z.string().min(1).nullish(),
         }),
       ),
     }),


### PR DESCRIPTION
Rules can only ask what the whole household did. This adds three properties to each watch-history integration, so a rule can ask about one person: "keep anything alice watched more than twice". [Feature request 224](https://features.maintainerr.info/posts/224/streamystats-per-user-rules) asked for it on Streamystats; the other two answer the same question from their own history, so all three use the same names.

| Property | Streamystats | Tautulli | Tracearr |
| --- | --- | --- | --- |
| Times viewed by user | yes | yes | yes |
| Watch time by user (minutes) | yes | yes | yes |
| Last view date by user | yes | yes | yes |

The user is picked on the rule itself, next to the property, the same way ARR disk targets are. Rules are stored as JSON, so there is no database migration.

### Why a username and not a user id

Tautulli reports the plex.tv account id, the media server reports its own local one, and nothing maps cleanly between all three. Every other user-facing rule property already compares usernames. The picker offers the same list the rules resolve against (the plex.tv-corrected one on Plex) and filters as you type, so a server with a thousand users does not put a thousand options in every rule card.

### What happens when a user cannot be resolved

| Situation | Behaviour |
| --- | --- |
| Name is not one the media server reports | Save is rejected, with the name in the message |
| User exists but never watched the item | 0 plays, no date |
| User is renamed or deleted after the rule is saved | Rule pauses on those items, never reads as "watched nothing" |
| Rule is uploaded to the community list | Username is stripped, since it names someone's household |

### What counts

| Property | Counts |
| --- | --- |
| Times viewed, last view date | Watched plays only, honouring the collection's watched-percent override |
| Watch time | Every play, since an abandoned one still ran for its minutes |

Streamystats has no completion filter to apply, and keeps no session against a season, so seasons answer no value rather than a zero that would read as never watched.

Verified against the real dev stack rather than mocks: all three integrations with real playback, a full rule run, and the editor at 1003 users.

Also here: the rules regression matrix (`yarn workspace @maintainerr/server test:e2e`) could not start any more, because it builds `RulesService` and never gained the dependencies that service picked up since. Fixed, and all 107 scenarios produce results again.
