### PR TITLE
fix(seerr): only report a removal or a sync that actually happened

### DIFF
--- a/apps/server/src/modules/api/external-api/external-api.service.ts
+++ b/apps/server/src/modules/api/external-api/external-api.service.ts
@@ -87,11 +87,17 @@ export class ExternalApiService {
   public async delete<T>(
     endpoint: string,
     config?: RawAxiosRequestConfig,
+    options?: { rethrow?: boolean },
   ): Promise<T> {
     try {
       const response = await this.axios.delete<T>(endpoint, config);
       return response.data;
     } catch (error) {
+      // Same escape hatch as post(): a 204 answers an empty body, so a caller
+      // cannot tell success from failure by the return value.
+      if (options?.rethrow) {
+        throw error;
+      }
       this.logRequestFailure('DELETE', endpoint, config, error);
       return undefined;
     }

--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
@@ -546,23 +546,50 @@ export class SeerrApiService {
     }
   }
 
-  public async removeSeasonRequest(tmdbid: string | number, season: number) {
+  /**
+   * Whether the season's requests were removed. `undefined` when that could not
+   * be established, the same contract as {@link hasRemainingSeasonRequests}, so
+   * a caller never reports a removal that did not happen. The writes rethrow
+   * rather than answering their body: a 204 carries an empty one, so success
+   * and failure are both falsy.
+   */
+  public async removeSeasonRequest(
+    tmdbid: string | number,
+    season: number,
+  ): Promise<boolean | undefined> {
     try {
       const media = await this.getShow(tmdbid);
 
-      if (media?.mediaInfo) {
-        const requests = (media.mediaInfo.requests ?? []).filter((el) =>
-          el.seasons.find((s) => s.seasonNumber === season),
-        );
-        if (requests.length > 0) {
-          for (const el of requests) {
-            await this.deleteRequest(el.id.toString());
-          }
-        } else {
-          // no requests? clear data and let Seerr refetch.
-          await this.api.delete(`/media/${media.id}`);
-        }
+      // getShow returns undefined only on communication failure or falsy id;
+      // the show being untracked still yields a response with mediaInfo == null.
+      if (!media) {
+        return undefined;
       }
+
+      if (!media.mediaInfo) {
+        return false;
+      }
+
+      const requests = (media.mediaInfo.requests ?? []).filter((el) =>
+        el.seasons.find((s) => s.seasonNumber === season),
+      );
+      if (requests.length > 0) {
+        for (const el of requests) {
+          await this.api.delete(`/request/${el.id}`, undefined, {
+            rethrow: true,
+          });
+        }
+      } else {
+        // No requests? Clear the media record and let Seerr refetch. Keyed on
+        // Seerr's own media id, not `media.id`, which is the TMDB id: Seerr
+        // answers 204 for an id it does not hold, so the wrong one was a no-op
+        // that reported success.
+        await this.api.delete(`/media/${media.mediaInfo.id}`, undefined, {
+          rethrow: true,
+        });
+      }
+
+      return true;
     } catch (error) {
       this.logger.warn(
         'Seerr communication failed. Is the application running?',
@@ -638,30 +665,31 @@ export class SeerrApiService {
     }
   }
 
-  public async removeMediaByTmdbId(id: string | number, type: 'movie' | 'tv') {
+  /** Whether the media record was cleared, with the same contract as
+   * {@link removeSeasonRequest}. */
+  public async removeMediaByTmdbId(
+    id: string | number,
+    type: 'movie' | 'tv',
+  ): Promise<boolean | undefined> {
     try {
-      let media: SeerrMovieResponse | SeerrTVResponse;
-      if (type === 'movie') {
-        media = await this.getMovie(id);
-      } else {
-        media = await this.getShow(id);
-      }
+      const media: SeerrMovieResponse | SeerrTVResponse =
+        type === 'movie' ? await this.getMovie(id) : await this.getShow(id);
 
-      if (!media.mediaInfo?.id) {
+      // Reading through an undefined media used to throw, which the catch
+      // below then reported as a communication failure. Answer it directly.
+      if (!media) {
         return undefined;
       }
 
-      try {
-        await this.deleteMediaItem(media.mediaInfo.id.toString());
-      } catch (error) {
-        this.logger.log(
-          `Couldn't delete media by TMDB ID ${id}. Does it exist in Seerr?`,
-        );
-        this.logger.debug(
-          `Couldn't delete media by TMDB ID ${id}. Does it exist in Seerr?`,
-          error,
-        );
+      if (!media.mediaInfo?.id) {
+        return false;
       }
+
+      await this.api.delete(`/media/${media.mediaInfo.id}`, undefined, {
+        rethrow: true,
+      });
+
+      return true;
     } catch (error) {
       this.logger.warn(
         'Seerr communication failed. Is the application running?',

--- a/apps/server/src/modules/collections/collection-handler.spec.ts
+++ b/apps/server/src/modules/collections/collection-handler.spec.ts
@@ -11,6 +11,7 @@ import { SonarrActionHandler } from '../actions/sonarr-action-handler';
 import { MediaServerFactory } from '../api/media-server/media-server.factory';
 import { IMediaServerService } from '../api/media-server/media-server.interface';
 import { SeerrApiService } from '../api/seerr-api/seerr-api.service';
+import { MaintainerrLogger } from '../logging/logs.service';
 import { MetadataService } from '../metadata/metadata.service';
 import { SettingsDataService } from '../settings/settings-data.service';
 import { CollectionHandler } from './collection-handler';
@@ -29,6 +30,7 @@ describe('CollectionHandler', () => {
   let settings: Mocked<SettingsDataService>;
   let metadataService: Mocked<MetadataService>;
   let recentlyHandledMedia: Mocked<RecentlyHandledMediaService>;
+  let logger: Mocked<MaintainerrLogger>;
 
   beforeEach(async () => {
     const { unit, unitRef } =
@@ -43,11 +45,16 @@ describe('CollectionHandler', () => {
     settings = unitRef.get(SettingsDataService);
     metadataService = unitRef.get(MetadataService);
     recentlyHandledMedia = unitRef.get(RecentlyHandledMediaService);
+    logger = unitRef.get(MaintainerrLogger);
 
     metadataService.resolveIdsForService.mockResolvedValue(undefined);
     // The sibling-prune cascade returns the collection ids it pruned; default
     // to none so the disk-freeing tests don't iterate `undefined`.
     collectionsService.removeMediaFromOtherCollections.mockResolvedValue([]);
+    // Default the Seerr removals to a confirmed removal; the unreachable tests
+    // override with undefined.
+    seerrApi.removeSeasonRequest.mockResolvedValue(true);
+    seerrApi.removeMediaByTmdbId.mockResolvedValue(true);
 
     // Setup media server mock. `itemExists` defaults to true (item present) so
     // the action-failure tests exercise the retryable path; the gone-item test
@@ -597,6 +604,43 @@ describe('CollectionHandler', () => {
       }),
     );
   });
+
+  // #3427: a removal that never reached Seerr logged as though it had, so a run
+  // against an unreachable Seerr read as fully successful.
+  it.each([
+    { title: 'a season', type: 'season' as const, index: 1 },
+    { title: 'a movie', type: 'movie' as const, index: undefined },
+  ])(
+    'warns instead of claiming the Seerr removal for $title',
+    async ({ type, index }) => {
+      const collection = createCollection({
+        arrAction: ServarrAction.DELETE,
+        forceSeerr: true,
+        type,
+      });
+      const collectionMedia = createCollectionMedia(collection);
+
+      settings.seerrConfigured.mockReturnValue(true);
+      seerrApi.removeSeasonRequest.mockResolvedValue(undefined);
+      seerrApi.removeMediaByTmdbId.mockResolvedValue(undefined);
+      mockMediaServerMetadata({ index } as MediaItem);
+      mediaServer.getLibraries.mockResolvedValue(
+        createMediaLibraries({
+          id: collection.libraryId.toString(),
+          type: type === 'season' ? 'show' : 'movie',
+        }),
+      );
+
+      await collectionHandler.handleMedia(collection, collectionMedia);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("[Seerr] Couldn't remove"),
+      );
+      expect(logger.log).not.toHaveBeenCalledWith(
+        expect.stringContaining('[Seerr] Removed'),
+      );
+    },
+  );
 
   it('should call removeMediaByTmdbId for movies', async () => {
     const collection = createCollection({

--- a/apps/server/src/modules/collections/collection-handler.ts
+++ b/apps/server/src/modules/collections/collection-handler.ts
@@ -183,14 +183,20 @@ export class CollectionHandler {
               );
 
               if (mediaDataSeason?.index !== undefined) {
-                await this.seerrApi.removeSeasonRequest(
+                const removed = await this.seerrApi.removeSeasonRequest(
                   tmdbId,
                   mediaDataSeason.index,
                 );
 
-                this.logger.log(
-                  `[Seerr] Removed request of season ${mediaDataSeason.index} from show with TMDB ID '${tmdbId}'`,
-                );
+                if (removed === undefined) {
+                  this.logger.warn(
+                    `[Seerr] Couldn't remove the request of season ${mediaDataSeason.index} from show with TMDB ID '${tmdbId}'`,
+                  );
+                } else if (removed) {
+                  this.logger.log(
+                    `[Seerr] Removed request of season ${mediaDataSeason.index} from show with TMDB ID '${tmdbId}'`,
+                  );
+                }
               }
               break;
             }
@@ -214,13 +220,20 @@ export class CollectionHandler {
               // numbers movies and shows independently, so that sends a show's
               // id to the movie endpoint, where it can resolve to an unrelated
               // film whose Seerr record is then deleted.
-              await this.seerrApi.removeMediaByTmdbId(
+              const removed = await this.seerrApi.removeMediaByTmdbId(
                 tmdbId,
                 collection.type === 'show' ? 'tv' : 'movie',
               );
-              this.logger.log(
-                `[Seerr] Removed requests of media with TMDB ID '${tmdbId}'`,
-              );
+
+              if (removed === undefined) {
+                this.logger.warn(
+                  `[Seerr] Couldn't remove the requests of media with TMDB ID '${tmdbId}'`,
+                );
+              } else if (removed) {
+                this.logger.log(
+                  `[Seerr] Removed requests of media with TMDB ID '${tmdbId}'`,
+                );
+              }
               break;
           }
         }

--- a/apps/server/src/modules/collections/collection-worker.service.ts
+++ b/apps/server/src/modules/collections/collection-worker.service.ts
@@ -342,8 +342,12 @@ export class CollectionWorkerService extends TaskBase {
         if (this.settings.seerrConfigured()) {
           await delay(7000, async () => {
             try {
+              // rethrow, or post() answers undefined and this catch never runs.
               await this.seerrApi.api.post(
                 '/settings/jobs/availability-sync/run',
+                undefined,
+                undefined,
+                { rethrow: true },
               );
 
               this.logger.log(


### PR DESCRIPTION
Fixes #3427.

The forced Seerr cleanup logged success unconditionally. A `getShow` that could not be answered left `removeSeasonRequest` a silent no-op, and the availability sync called `post()` without `rethrow`, so its catch never ran. A run against an unreachable Seerr therefore read as fully successful while its requests and stale availability stayed behind, with nothing above debug to say otherwise.

Reproduced against the reporter's exact `ENOTFOUND` hostname: `removeSeasonRequest` answered nothing and logged nothing at INFO, and the sync post was swallowed.

The removals now answer whether they were carried out, using the same contract as `hasRemainingSeasonRequests`: `undefined` when it could not be established, `false` when Seerr tracks nothing to remove. The handler warns on the first and keeps its existing line for a real removal. The sync passes the `rethrow` option `post()` already has, which is all its existing catch needed.

The removal writes rethrow instead of answering their body, because a 204 carries an empty one and success and failure are both falsy. Verified against a live Seerr: a successful `DELETE /request/{id}` answers `""` and a failed one `undefined`, so a truthiness check would have inverted the result.

One more defect in the same path: the season fallback cleared the media record by TMDB id where Seerr wants its own media id. Seerr answers 204 for an id it does not hold, so that branch never did anything and still reported success.