### PR TITLE
fix(plex): read collection children ids from the listing, not per child

### DIFF
--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -12,6 +12,7 @@ import { MaintainerrLogger } from '../../../logging/logs.service';
 import type { PlexStatusResponse } from '../../plex-api/interfaces/server.interface';
 import { PlexApiService } from '../../plex-api/plex-api.service';
 import { PlexAdapterService } from './plex-adapter.service';
+import { PLEX_BATCH_SIZE } from './plex.constants';
 
 describe('PlexAdapterService', () => {
   let service: PlexAdapterService;
@@ -639,43 +640,200 @@ describe('PlexAdapterService', () => {
   });
 
   describe('getCollectionChildren', () => {
-    it('refreshes incomplete Plex collection children via full metadata lookups', async () => {
+    it('reads no metadata at all when the listing carries provider ids', async () => {
       plexApi.getCollectionChildren.mockResolvedValue([
         createPlexLibraryItem('movie', {
           ratingKey: 'movie-1',
-          Guid: undefined,
-        }),
-      ]);
-      plexApi.getMetadata.mockResolvedValue(
-        createPlexMetadata({
-          ratingKey: 'movie-1',
-          type: 'movie',
           Guid: [{ id: 'tmdb://321' }],
         }),
-      );
+      ]);
 
       const children = await service.getCollectionChildren('col123');
 
       expect(plexApi.getCollectionChildren).toHaveBeenCalledWith('col123');
-      expect(plexApi.getMetadata).toHaveBeenCalledWith('movie-1');
+      expect(plexApi.getMetadataBatch).not.toHaveBeenCalled();
       expect(children[0].providerIds.tmdb).toEqual(['321']);
     });
 
-    it('keeps the original collection child when the metadata refresh is unavailable', async () => {
+    it('looks up the ids Plex withheld from the listing in one batch', async () => {
+      plexApi.getCollectionChildren.mockResolvedValue([
+        createPlexLibraryItem('episode', {
+          ratingKey: 'episode-1',
+          Guid: undefined,
+        }),
+        createPlexLibraryItem('episode', {
+          ratingKey: 'episode-2',
+          Guid: undefined,
+        }),
+      ]);
+      plexApi.getMetadataBatch.mockResolvedValue([
+        createPlexMetadata({
+          ratingKey: 'episode-1',
+          type: 'episode',
+          Guid: [{ id: 'tmdb://321' }],
+        }),
+        createPlexMetadata({
+          ratingKey: 'episode-2',
+          type: 'episode',
+          Guid: [{ id: 'tmdb://654' }],
+        }),
+      ]);
+
+      const children = await service.getCollectionChildren('col123');
+
+      expect(plexApi.getMetadataBatch).toHaveBeenCalledTimes(1);
+      expect(plexApi.getMetadataBatch).toHaveBeenCalledWith([
+        'episode-1',
+        'episode-2',
+      ]);
+      expect(children[0].providerIds.tmdb).toEqual(['321']);
+      expect(children[1].providerIds.tmdb).toEqual(['654']);
+    });
+
+    it('splits the lookup so the request line cannot grow without bound', async () => {
+      const childCount = PLEX_BATCH_SIZE.METADATA_LOOKUP * 2 + 3;
+      plexApi.getCollectionChildren.mockResolvedValue(
+        Array.from({ length: childCount }, (_, index) =>
+          createPlexLibraryItem('movie', {
+            ratingKey: `movie-${index}`,
+            Guid: undefined,
+          }),
+        ),
+      );
+      plexApi.getMetadataBatch.mockImplementation(async (keys: string[]) =>
+        keys.map((ratingKey) =>
+          createPlexMetadata({
+            ratingKey,
+            type: 'movie',
+            Guid: [{ id: 'tmdb://321' }],
+          }),
+        ),
+      );
+
+      const children = await service.getCollectionChildren('col123');
+
+      expect(plexApi.getMetadataBatch).toHaveBeenCalledTimes(3);
+      expect(
+        plexApi.getMetadataBatch.mock.calls.every(
+          ([keys]) => keys.length <= PLEX_BATCH_SIZE.METADATA_LOOKUP,
+        ),
+      ).toBe(true);
+      expect(children.every((child) => child.providerIds.tmdb.length > 0)).toBe(
+        true,
+      );
+    });
+
+    // Plex sends no rating at all on an episode or season listing row and puts
+    // the audience score in Rating[], which only the per-item read returns. The
+    // rating sort compares it, so it has to survive the merge.
+    it('takes the ratings the listing row does not carry', async () => {
+      plexApi.getCollectionChildren.mockResolvedValue([
+        createPlexLibraryItem('episode', {
+          ratingKey: 'episode-1',
+          Guid: undefined,
+          rating: undefined,
+          audienceRating: undefined,
+        }),
+      ]);
+      plexApi.getMetadataBatch.mockResolvedValue([
+        createPlexMetadata({
+          ratingKey: 'episode-1',
+          type: 'episode',
+          Guid: [{ id: 'tmdb://321' }],
+          Rating: [
+            { image: 'imdb://image.rating', value: 6.5, type: 'audience' },
+          ],
+        }),
+      ]);
+
+      const children = await service.getCollectionChildren('col123');
+
+      expect(children[0].ratings).toEqual([
+        { source: 'imdb://image.rating', value: 6.5, type: 'audience' },
+      ]);
+    });
+
+    // A movie listing row carries audienceRating, and the metadata read dedupes
+    // Rating[] by type behind it, so the listing value must not be replaced.
+    it('keeps the rating the listing row already carried', async () => {
       plexApi.getCollectionChildren.mockResolvedValue([
         createPlexLibraryItem('movie', {
           ratingKey: 'movie-1',
           Guid: undefined,
+          audienceRating: 5.4,
         }),
       ]);
-      plexApi.getMetadata.mockResolvedValue(undefined);
+      plexApi.getMetadataBatch.mockResolvedValue([
+        createPlexMetadata({
+          ratingKey: 'movie-1',
+          type: 'movie',
+          Guid: [{ id: 'tmdb://321' }],
+          audienceRating: 5.4,
+        }),
+      ]);
 
       const children = await service.getCollectionChildren('col123');
 
-      expect(children[0].id).toBe('movie-1');
+      expect(children[0].ratings).toEqual([
+        { source: 'audience', value: 5.4, type: 'audience' },
+      ]);
+    });
+
+    it('keeps the listing entry, and only its ids change, when a lookup resolves', async () => {
+      plexApi.getCollectionChildren.mockResolvedValue([
+        createPlexLibraryItem('episode', {
+          ratingKey: 'episode-1',
+          Guid: undefined,
+          librarySectionID: 7,
+          librarySectionTitle: 'Shows',
+          grandparentTitle: 'Sample Series',
+        }),
+      ]);
+      plexApi.getMetadataBatch.mockResolvedValue([
+        createPlexMetadata({
+          ratingKey: 'episode-1',
+          type: 'episode',
+          Guid: [{ id: 'tmdb://321' }],
+        }),
+      ]);
+
+      const children = await service.getCollectionChildren('col123');
+
+      expect(children[0].providerIds.tmdb).toEqual(['321']);
+      expect(children[0].grandparentTitle).toBe('Sample Series');
+      expect(children[0].library).toEqual({ id: '7', title: 'Shows' });
+    });
+
+    it('counts the children Plex holds no ids for instead of logging each one', async () => {
+      plexApi.getCollectionChildren.mockResolvedValue([
+        createPlexLibraryItem('episode', {
+          ratingKey: 'episode-1',
+          Guid: undefined,
+        }),
+        createPlexLibraryItem('episode', {
+          ratingKey: 'episode-2',
+          Guid: undefined,
+        }),
+      ]);
+      // An item answered with no ids counts the same as one never answered for.
+      plexApi.getMetadataBatch.mockResolvedValue([
+        createPlexMetadata({
+          ratingKey: 'episode-1',
+          type: 'episode',
+          Guid: undefined,
+        }),
+      ]);
+
+      const children = await service.getCollectionChildren('col123');
+
+      expect(children[0].id).toBe('episode-1');
       expect(children[0].providerIds.tmdb).toEqual([]);
       expect(children[0].providerIds.tvdb).toEqual([]);
       expect(children[0].providerIds.imdb).toEqual([]);
+      expect(logger.debug).toHaveBeenCalledWith(
+        'No external ids resolved for 2 of 2 children of Plex collection col123',
+      );
+      expect(logger.debug).toHaveBeenCalledTimes(1);
     });
 
     it('propagates enumeration failures so callers never mistake a failed read for an empty collection', async () => {

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -7,6 +7,7 @@ import {
   MediaItemType,
   MediaLibrary,
   MediaPlaylist,
+  MediaProviderIds,
   MediaServerFeature,
   MediaServerStatus,
   MediaServerType,
@@ -17,6 +18,7 @@ import {
   WatchRecord,
 } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
+import { chunk } from 'lodash';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { EPlexDataType } from '../../plex-api/enums/plex-data-type-enum';
 import { PlexLibraryItem } from '../../plex-api/interfaces/library.interfaces';
@@ -492,13 +494,11 @@ export class PlexAdapterService implements IMediaServerService {
     );
   }
 
-  private hasUsableProviderIds(mediaItem: MediaItem | undefined): boolean {
-    if (!mediaItem) {
-      return false;
-    }
-
-    return Object.values(mediaItem.providerIds ?? {}).some((values) =>
-      Array.isArray(values) ? values.length > 0 : false,
+  private hasUsableProviderIds(
+    providerIds: MediaProviderIds | undefined,
+  ): boolean {
+    return Object.values(providerIds ?? {}).some(
+      (values) => Array.isArray(values) && values.length > 0,
     );
   }
 
@@ -508,43 +508,62 @@ export class PlexAdapterService implements IMediaServerService {
     const children = await this.plexApi.getCollectionChildren(collectionId);
 
     const mappedChildren = children.map(PlexMapper.toMediaItem);
-    const incompleteChildren = mappedChildren.filter(
-      (child) => !this.hasUsableProviderIds(child),
-    );
+    const idsWithoutProviderIds = mappedChildren
+      .filter((child) => !this.hasUsableProviderIds(child.providerIds))
+      .map((child) => child.id)
+      .filter((id): id is string => Boolean(id));
 
-    if (incompleteChildren.length === 0) {
+    if (idsWithoutProviderIds.length === 0) {
       return mappedChildren;
     }
 
-    const refreshedMetadataResults = await Promise.allSettled(
-      incompleteChildren.map(async (child) => ({
-        id: child.id,
-        mediaItem: await this.getMetadata(child.id),
-      })),
-    );
+    // The listing asks for guids, but Plex withholds the Guid array anyway for
+    // episodes and seasons, and for any library whose agent publishes none. In
+    // id batches, never one request per child: that is what a Plex host answers
+    // with 503s.
+    const resolvedById = new Map<string, MediaItem>();
 
-    const refreshedMetadataById = new Map<string, MediaItem>();
-
-    refreshedMetadataResults.forEach((result, index) => {
-      const child = incompleteChildren[index];
-
-      if (result.status === 'fulfilled' && result.value.mediaItem) {
-        refreshedMetadataById.set(result.value.id, result.value.mediaItem);
-        return;
+    for (const idBatch of chunk(
+      idsWithoutProviderIds,
+      PLEX_BATCH_SIZE.METADATA_LOOKUP,
+    )) {
+      for (const metadata of await this.plexApi.getMetadataBatch(idBatch)) {
+        resolvedById.set(
+          metadata.ratingKey,
+          PlexMapper.metadataToMediaItem(metadata),
+        );
       }
+    }
 
+    const unresolved = idsWithoutProviderIds.filter(
+      (id) => !this.hasUsableProviderIds(resolvedById.get(id)?.providerIds),
+    ).length;
+
+    if (unresolved > 0) {
+      // Counted, not one line each: an unmatched collection is normal. Says
+      // unresolved rather than absent, since a failed batch lands here too.
       this.logger.debug(
-        `Failed to refresh complete metadata for Plex collection child ${child?.id}`,
+        `No external ids resolved for ${unresolved} of ${mappedChildren.length} children of Plex collection ${collectionId}`,
       );
+    }
 
-      if (result.status === 'rejected') {
-        this.logger.debug(result.reason);
+    // The listing entry stays the record: it carries fields the metadata one
+    // does not (library, parent guids, watch counts). Ratings come across too,
+    // because Plex sends none at all on an episode or season listing row and
+    // the rating sort compares them.
+    return mappedChildren.map((child) => {
+      const resolved = resolvedById.get(child.id);
+
+      if (!resolved) {
+        return child;
       }
-    });
 
-    return mappedChildren.map(
-      (child) => refreshedMetadataById.get(child.id) ?? child,
-    );
+      return {
+        ...child,
+        providerIds: resolved.providerIds,
+        ...(resolved.ratings.length > 0 ? { ratings: resolved.ratings } : {}),
+      };
+    });
   }
 
   private ensureMutationSucceeded(

--- a/apps/server/src/modules/api/media-server/plex/plex.constants.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.constants.ts
@@ -5,6 +5,9 @@ import {
 
 export const PLEX_BATCH_SIZE = {
   COLLECTION_MUTATION: 4,
+  // PMS applies no container cap to /library/metadata (240 ids in one response
+  // on 1.43.3), so this bounds only the request line: ~800 characters.
+  METADATA_LOOKUP: 100,
 } as const;
 
 const PLEX_SORT_FIELDS: Partial<Record<MediaLibrarySortField, string>> = {

--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
@@ -203,7 +203,7 @@ export class PlexMapper {
       grandparentId: plex.grandparentRatingKey,
       title: plex.title,
       parentTitle: plex.parentTitle,
-      grandparentTitle: undefined, // Not available on PlexLibraryItem
+      grandparentTitle: plex.grandparentTitle,
       guid: plex.guid,
       parentGuid: plex.parentGuid,
       grandparentGuid: plex.grandparentGuid,

--- a/apps/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
+++ b/apps/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
@@ -7,6 +7,7 @@ export interface PlexLibraryItem {
   grandparentRatingKey?: string;
   title: string;
   parentTitle?: string;
+  grandparentTitle?: string;
   guid: string;
   parentGuid?: string;
   grandparentGuid?: string;

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -198,6 +198,49 @@ describe('PlexApiService.getMetadata', () => {
     expect(await service.getCollectionChildren('col-1')).toEqual([]);
   });
 
+  it('asks for external guids so children arrive with provider ids', async () => {
+    const queryAll = jest.fn().mockResolvedValue({
+      MediaContainer: { Metadata: [{ ratingKey: '1' }] },
+    });
+
+    (service as any).plexClient = { queryAll };
+
+    await service.getCollectionChildren('col-1');
+
+    expect(queryAll).toHaveBeenCalledWith(
+      { uri: '/library/collections/col-1/children?includeGuids=1' },
+      true,
+    );
+  });
+
+  it('reads a batch of ids in one guid-carrying metadata request', async () => {
+    const query = jest.fn().mockResolvedValue({
+      MediaContainer: { Metadata: [{ ratingKey: '1' }, { ratingKey: '2' }] },
+    });
+
+    (service as any).plexClient = { query };
+
+    expect(await service.getMetadataBatch(['1', '2'])).toHaveLength(2);
+    expect(query).toHaveBeenCalledWith('/library/metadata/1,2?includeGuids=1');
+  });
+
+  it('makes no request for an empty batch', async () => {
+    const query = jest.fn();
+
+    (service as any).plexClient = { query };
+
+    expect(await service.getMetadataBatch([])).toEqual([]);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('reports no ids rather than failing the caller when a batch read fails', async () => {
+    const query = jest.fn().mockRejectedValue(new Error('boom'));
+
+    (service as any).plexClient = { query };
+
+    expect(await service.getMetadataBatch(['1'])).toEqual([]);
+  });
+
   it('re-throws children query failures instead of reporting an empty collection', async () => {
     const queryAll = jest.fn().mockRejectedValue(new Error('boom'));
 
@@ -1733,6 +1776,23 @@ describe('PlexApiService.resetMetadataCache', () => {
       [
         key('/library/metadata/12/children'),
         key('/library/metadata/123'),
+      ].sort(),
+    );
+  });
+
+  // A batch caches a whole id list under one key, which matching the uri as a
+  // whole never found.
+  it('drops a batched entry that holds the item among its ids', () => {
+    cache.set(key('/library/metadata/9,12,15?includeGuids=1'), 'batched');
+    cache.set(key('/library/metadata/9,15?includeGuids=1'), 'without the item');
+    cache.set(key('/library/metadata/121,123?includeGuids=1'), 'longer ids');
+
+    service.resetMetadataCache('12');
+
+    expect(cache.keys().sort()).toEqual(
+      [
+        key('/library/metadata/9,15?includeGuids=1'),
+        key('/library/metadata/121,123?includeGuids=1'),
       ].sort(),
     );
   });

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -669,6 +669,30 @@ export class PlexApiService {
     }
   }
 
+  /**
+   * Guid arrays for many items in one request. Verified on PMS 1.43.3: 240 ids
+   * answer in one response, and an unresolvable id is left out of it rather
+   * than failing the batch.
+   */
+  public async getMetadataBatch(keys: string[]): Promise<PlexMetadata[]> {
+    if (keys.length === 0) {
+      return [];
+    }
+
+    try {
+      const response = await this.plexClient.query<PlexMetadataResponse>(
+        `/library/metadata/${keys.join(',')}?includeGuids=1`,
+      );
+      return response?.MediaContainer?.Metadata ?? [];
+    } catch (error) {
+      this.logger.error(
+        'Plex api communication failure.. Is the application running?',
+      );
+      this.logger.debug(error);
+      return [];
+    }
+  }
+
   public resetMetadataCache(mediaId: string) {
     // getMetadata appends the caller's options to the uri, and the rule getter
     // always passes includeExternalMedia - so its entries are cached under
@@ -677,17 +701,28 @@ export class PlexApiService {
     // the one path that caches, and served pre-change metadata for the TTL.
     // Drop every option variant for this id instead.
     const cache = cacheManager.getCache('plexguid').data;
-    const uri = `/library/metadata/${mediaId}`;
+    const metadataUriPrefix = '/library/metadata/';
     // Watch state goes too, like the Jellyfin and Emby resets already do.
     // History entries are keyed by leaf ratingKey - a show or season test
     // reads its episodes' entries, not the id passed here - so the whole
     // history namespace is dropped rather than one id's key.
     const historyUri = '/status/sessions/history/all';
 
+    // Matched against the id list a uri reads, not the uri: a batch entry
+    // holding this id would otherwise keep serving its old copy. Comparing list
+    // members also keeps id 12 from matching id 123.
+    const readsMediaId = (cachedUri: string): boolean =>
+      cachedUri.startsWith(metadataUriPrefix) &&
+      cachedUri
+        .slice(metadataUriPrefix.length)
+        .split('?', 1)[0]
+        .split(',')
+        .includes(mediaId);
+
     for (const key of cache.keys()) {
       // Keys are the serialized request options, so read the uri back out
       // rather than matching on the raw key - options other than the uri end up
-      // in there too. The `?` boundary keeps id 12 from matching id 123.
+      // in there too.
       let cachedUri: string | undefined;
       try {
         cachedUri = (JSON.parse(key) as { uri?: string }).uri;
@@ -696,9 +731,8 @@ export class PlexApiService {
       }
 
       if (
-        cachedUri === uri ||
-        cachedUri?.startsWith(`${uri}?`) ||
-        cachedUri?.startsWith(historyUri)
+        cachedUri !== undefined &&
+        (readsMediaId(cachedUri) || cachedUri.startsWith(historyUri))
       ) {
         cache.del(key);
       }
@@ -1402,7 +1436,10 @@ export class PlexApiService {
       const response: PlexLibraryResponse =
         await this.plexClient.queryAll<PlexLibraryResponse>(
           {
-            uri: `/library/collections/${collectionId}/children`,
+            // Without it Plex sends only its own `plex://` guid, which carries
+            // no imdb/tmdb/tvdb id. Undocumented on this endpoint but honoured,
+            // verified on PMS 1.43.3.
+            uri: `/library/collections/${collectionId}/children?includeGuids=1`,
           },
           useCache,
         );


### PR DESCRIPTION
Opening a large Plex collection could bury a run in `503`s and leave every item
without a poster.

`/library/collections/{id}/children` was the one listing in the Plex module
requested without `includeGuids=1`, so Plex sent only its own `plex://` guid,
which carries no imdb/tmdb/tvdb id. Every child therefore read as incomplete and
the adapter re-read all of them one by one, at once: a 6000 item collection
opened 6000 simultaneous requests, which a Plex host answers with `503`s once
its own request queue saturates. The reporter's stack trace shows it directly -
`Promise.allSettled (index 5055)`.

Measured against a counting proxy in front of a live PMS 1.43.3, before and
after, same collections:

| | before | after |
|---|---|---|
| 5 movie collection | 5 requests | 1 |
| 24 episode collection | 25 requests | 2 |
| same, proxy refusing above 2 concurrent | 62 requests, 37 x 503 | 2 requests, 0 x 503 |

The 62-for-24 case is the amplification `axios-retry` adds on top. Returned
data is identical in every case.

The per-item read could not simply be deleted. Plex withholds the `Guid` array
from some listings whatever you ask for - episodes and seasons always, and
everything in a library whose agent publishes none - and answers per item for
the same item. Verified on a live server, same item queried both ways:

| library agent | type | listing + `includeGuids=1` | `/library/metadata` |
|---|---|---|---|
| `tv.plex.agents.movie` | movie | yes | yes |
| `tv.plex.agents.nfo.series` | show, season | yes | yes |
| `tv.plex.agents.none` | show, season, episode | no | yes, full triple |
| any | episode | no | agent dependent |

So the fallback stays, but reads an id list instead of one item per request.
`/library/metadata` takes a comma-separated list: 240 ids answered in one
response on 1.43.3, and an id it cannot resolve is left out rather than failing
the batch.

The listing entry stays the record, because it carries fields the metadata one
does not (`library`, parent guids, watch counts) - substituting the whole record
was dropping those. Ratings are taken from the per-item read as well: Plex sends
no rating at all on an episode or season listing row and puts the audience score
in `Rating[]`, which only the per-item read returns, so keeping none of it would
have silently flattened the `rating` sort on episode collections to its title
fallback. Verified on live data: five episodes, listing `rating`/`audienceRating`
both null, per-item `Rating[]` carrying 6.4 / 6.5 / 8.9 / 7.9 / 9.0.

`grandparentTitle` is now mapped from the listing. Plex sends it for episodes in
every listing shape and the value equals the show's own title (verified); the
mapper hardcoded `undefined` because `PlexLibraryItem` never declared the field.
That fixes two latent bugs beyond the request count: the title sort used
`parentTitle` for Plex episodes, so title-sorted episode lists grouped by
`"Season 1"` across different shows, and episode cards were titled `"Season 1"`
instead of the show name.

`resetMetadataCache` matched a cached uri as a whole, which no longer finds a
batched entry holding the item, so it now matches against the ids that uri
reads.

Also verified: a full rule run issues zero per-item metadata reads and syncs
cleanly; live Jellyfin and Emby already return provider ids in their collection
listings and make no per-item calls, so neither needs an equivalent change and
neither is touched here.
