### PR TITLE
fix(collections): keep the enrichment reads under SQLite's parameter cap

### DIFF
--- a/apps/server/src/modules/api/media-server/media-item-enrichment.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-item-enrichment.service.spec.ts
@@ -1,12 +1,15 @@
 import { type MediaItem } from '@maintainerr/contracts';
-import { Repository } from 'typeorm';
+import { FindOperator, Repository } from 'typeorm';
 import {
   CollectionMedia,
   CollectionMediaManualMembershipSource,
 } from '../../collections/entities/collection_media.entities';
 import { Exclusion } from '../../rules/entities/exclusion.entities';
 import { RuleGroup } from '../../rules/entities/rule-group.entities';
-import { MediaItemEnrichmentService } from './media-item-enrichment.service';
+import {
+  ENRICHMENT_ID_CHUNK,
+  MediaItemEnrichmentService,
+} from './media-item-enrichment.service';
 
 describe('MediaItemEnrichmentService', () => {
   let service: MediaItemEnrichmentService;
@@ -171,6 +174,101 @@ describe('MediaItemEnrichmentService', () => {
     collectionMediaRepo.find.mockResolvedValue([]);
 
     await expect(service.enrichItems([movie])).resolves.toEqual([movie]);
+  });
+
+  // One IN list for every id would pass SQLite's 32766 parameter ceiling.
+  it('reads long id lists in chunks and merges what each returns', async () => {
+    const lastIndex = ENRICHMENT_ID_CHUNK * 2;
+    const items = Array.from(
+      { length: lastIndex + 1 },
+      (unused, index) =>
+        ({
+          id: `movie-${index}`,
+          title: `Movie ${index}`,
+          guid: `movie-guid-${index}`,
+          type: 'movie',
+          addedAt: new Date(),
+          providerIds: {},
+          mediaSources: [],
+          library: { id: 'library-1', title: 'Movies' },
+        }) satisfies MediaItem,
+    );
+
+    exclusionRepo.find.mockResolvedValue([]);
+    collectionMediaRepo.find.mockImplementation(async (options) => {
+      const ids = (
+        (options?.where as { mediaServerId: unknown })
+          .mediaServerId as FindOperator<string>
+      ).value as unknown as string[];
+      expect(ids.length).toBeLessThanOrEqual(ENRICHMENT_ID_CHUNK);
+      // Only the last chunk answers, so a dropped chunk shows up as a failure.
+      return ids.includes(`movie-${lastIndex}`)
+        ? ([
+            {
+              mediaServerId: `movie-${lastIndex}`,
+              manualMembershipSource:
+                CollectionMediaManualMembershipSource.LOCAL,
+            },
+          ] as CollectionMedia[])
+        : [];
+    });
+
+    const enriched = await service.enrichItems(items);
+
+    expect(collectionMediaRepo.find).toHaveBeenCalledTimes(3);
+    expect(exclusionRepo.find).toHaveBeenCalledTimes(3);
+    expect(enriched[lastIndex].maintainerrIsManual).toBe(true);
+    expect(enriched[0].maintainerrIsManual).toBeUndefined();
+  });
+
+  // One exclusion row can match one batch on mediaServerId and another on
+  // parent, so it comes back twice. Both of its ids still have to resolve.
+  it('resolves an exclusion whose two ids fall in different batches', async () => {
+    const item = (id: string, type: 'movie' | 'show') =>
+      ({
+        id,
+        title: id,
+        guid: `${id}-guid`,
+        type,
+        addedAt: new Date(),
+        providerIds: {},
+        mediaSources: [],
+        library: { id: 'library-1', title: 'Library' },
+      }) satisfies MediaItem;
+    // Enough items between them that 'first' and 'last' cannot share a batch.
+    const items = [
+      item('first', 'movie'),
+      ...Array.from({ length: ENRICHMENT_ID_CHUNK }, (unused, index) =>
+        item(`filler-${index}`, 'movie'),
+      ),
+      item('last', 'show'),
+    ];
+
+    collectionMediaRepo.find.mockResolvedValue([]);
+    exclusionRepo.find.mockImplementation(async (options) => {
+      const ids = (
+        (options?.where as [{ mediaServerId: unknown }])[0]
+          .mediaServerId as FindOperator<string>
+      ).value as unknown as string[];
+      // The one row Plex-side ids straddle: matched by mediaServerId in one
+      // batch and by parent in the other, so it is returned by both.
+      return ids.includes('first') || ids.includes('last')
+        ? ([
+            {
+              id: 7,
+              mediaServerId: 'first',
+              parent: 'last',
+              ruleGroupId: null,
+            },
+          ] as Exclusion[])
+        : [];
+    });
+
+    const enriched = await service.enrichItems(items);
+
+    expect(exclusionRepo.find.mock.calls.length).toBeGreaterThan(1);
+    expect(enriched[0].maintainerrExclusionId).toBe(7);
+    expect(enriched[enriched.length - 1].maintainerrExclusionId).toBe(7);
   });
 
   it('does not inherit manual state from parent or grandparent relations', async () => {

--- a/apps/server/src/modules/api/media-server/media-item-enrichment.service.ts
+++ b/apps/server/src/modules/api/media-server/media-item-enrichment.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { chunk } from 'lodash';
 import { In, IsNull, Not, Repository } from 'typeorm';
 import { CollectionMedia } from '../../collections/entities/collection_media.entities';
 import { Exclusion } from '../../rules/entities/exclusion.entities';
@@ -19,6 +20,12 @@ interface CollectionMembership {
   manuallyIncludedIds: Set<string>;
   collectionTitles: Map<string, string[]>;
 }
+
+// SQLite binds at most 32766 parameters, and a status-sorted sweep reaches
+// thousands of ids: three relation ids per item, and the exclusion read binds
+// each of them twice. 2048 leaves that widest read 8x of headroom, and measured
+// flat against 500 through 16000 - the sweep costs per row, not per query.
+export const ENRICHMENT_ID_CHUNK = 2048;
 
 @Injectable()
 export class MediaItemEnrichmentService {
@@ -133,9 +140,18 @@ export class MediaItemEnrichmentService {
   private async fetchExclusionMap(
     ids: string[],
   ): Promise<Map<string, ExclusionState>> {
-    const exclusions = await this.exclusionRepo.find({
-      where: [{ mediaServerId: In(ids) }, { parent: In(ids) }],
-    });
+    const exclusions: Exclusion[] = [];
+
+    for (const idBatch of chunk(ids, ENRICHMENT_ID_CHUNK)) {
+      exclusions.push(
+        // A row can match one batch on mediaServerId and another on parent. The
+        // map below is written per id, so the repeat is a no-op.
+        ...(await this.exclusionRepo.find({
+          where: [{ mediaServerId: In(idBatch) }, { parent: In(idBatch) }],
+        })),
+      );
+    }
+
     const map = new Map<string, ExclusionState>();
 
     exclusions.forEach((exclusion) => {
@@ -161,10 +177,17 @@ export class MediaItemEnrichmentService {
   private async fetchCollectionMembership(
     ids: string[],
   ): Promise<CollectionMembership> {
-    const collectionMedia = await this.collectionMediaRepo.find({
-      where: { mediaServerId: In(ids) },
-      relations: { collection: true },
-    });
+    const collectionMedia: CollectionMedia[] = [];
+
+    for (const idBatch of chunk(ids, ENRICHMENT_ID_CHUNK)) {
+      collectionMedia.push(
+        ...(await this.collectionMediaRepo.find({
+          where: { mediaServerId: In(idBatch) },
+          relations: { collection: true },
+        })),
+      );
+    }
+
     const manuallyIncludedIds = new Set<string>();
     const collectionTitles = new Map<string, string[]>();
 


### PR DESCRIPTION
The exclusion and collection-membership reads in `MediaItemEnrichmentService`
bind one parameter per id, and a status-sorted sweep can hand them thousands at
once: the library controller caps at 15000 items, times three relation ids, and
the exclusion read binds each id twice because it ORs two columns. SQLite binds
at most 32766, past which it throws `too many SQL variables`.

The id lists are read in chunks of 2048. Measured over a 45000 id sweep against
the bundled 3.53.4: 16383 ids is the real ceiling for that widest read, and total
time is flat from 500 through 16000 because the sweep costs per row rather than
per query - so the chunk size is chosen for headroom, not throughput.

A row can match one chunk on `mediaServerId` and another on `parent`, so it comes
back twice. The map is written per id, so the repeat is a no-op, and a test covers
an exclusion whose two ids fall in different chunks.

Needed by #3430, which routes a whole collection's items through these reads for
its status sorts.
