### PR TITLE
feat(media-server): read metadata for many items in one request

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -1,4 +1,6 @@
 import { AxiosError } from 'axios';
+import { batchIdsByRequestCost } from '../metadata-batch.util';
+import { EMBY_METADATA_FIELDS } from './emby-adapter.service';
 import { EMBY_CACHE_TTL } from './emby.constants';
 import { EmbyAdapterService } from './emby-adapter.service';
 
@@ -146,6 +148,161 @@ describe('EmbyAdapterService', () => {
 
       await expect(service.getMetadata('item-1')).resolves.toBeUndefined();
       expect(embyCacheMocks.data.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getMetadataBatch', () => {
+    it('reads a whole id list in one user-scoped request and caches each item', async () => {
+      http.get.mockResolvedValue({
+        data: {
+          Items: [
+            { Id: 'movie-1', Type: 'Movie', Name: 'One' },
+            { Id: 'movie-2', Type: 'Movie', Name: 'Two' },
+          ],
+        },
+      });
+
+      const items = await service.getMetadataBatch(['movie-1', 'movie-2']);
+
+      expect(http.get).toHaveBeenCalledTimes(1);
+      expect(http.get).toHaveBeenCalledWith(
+        '/Items',
+        expect.objectContaining({
+          params: expect.objectContaining({ Ids: 'movie-1,movie-2' }),
+        }),
+      );
+      expect(items.map((item) => item.id)).toEqual(['movie-1', 'movie-2']);
+      expect(embyCacheMocks.data.set).toHaveBeenCalledWith(
+        'emby:metadata:movie-1',
+        expect.objectContaining({ id: 'movie-1' }),
+        EMBY_CACHE_TTL.METADATA,
+      );
+    });
+
+    it('splits a long id list', async () => {
+      http.get.mockResolvedValue({ data: { Items: [] } });
+      const itemIds = Array.from(
+        { length: 1500 },
+        (unused, index) => `movie-${index}`,
+      );
+
+      await service.getMetadataBatch(itemIds);
+
+      // The shared helper decides the split from the ids themselves.
+      expect(http.get).toHaveBeenCalledTimes(
+        batchIdsByRequestCost(itemIds, 1).length,
+      );
+      expect(http.get.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it('keeps only the ids it was asked for', async () => {
+      http.get.mockResolvedValue({
+        data: {
+          Items: [
+            { Id: 'movie-1', Type: 'Movie', Name: 'One' },
+            { Id: 'somebody-else', Type: 'Movie', Name: 'Unrelated' },
+          ],
+        },
+      });
+
+      await expect(service.getMetadataBatch(['movie-1'])).resolves.toEqual([
+        expect.objectContaining({ id: 'movie-1' }),
+      ]);
+    });
+
+    it('serves cached ids without asking for them again', async () => {
+      embyCacheMocks.data.get.mockImplementation((key: string) =>
+        key === 'emby:metadata:movie-1' ? { id: 'movie-1' } : undefined,
+      );
+      http.get.mockResolvedValue({
+        data: { Items: [{ Id: 'movie-2', Type: 'Movie', Name: 'Two' }] },
+      });
+
+      const items = await service.getMetadataBatch(['movie-1', 'movie-2']);
+
+      expect(http.get).toHaveBeenCalledWith(
+        '/Items',
+        expect.objectContaining({
+          params: expect.objectContaining({ Ids: 'movie-2' }),
+        }),
+      );
+      expect(items.map((item) => item.id).sort()).toEqual([
+        'movie-1',
+        'movie-2',
+      ]);
+    });
+
+    // Emby answers 500 for a malformed id, so a bad id costs its batch. Same
+    // contract as getMetadata: those ids are absent, not reported missing.
+    it('leaves out the ids of a failed read', async () => {
+      embyCacheMocks.data.get.mockReturnValue(undefined);
+      http.get.mockRejectedValue(new Error('boom'));
+
+      await expect(service.getMetadataBatch(['movie-1'])).resolves.toEqual([]);
+    });
+  });
+
+  // Emby answers fewer fields on `/Items` than on `/Users/{id}/Items/{id}`, and a
+  // batch result is cached under the key getMetadata reads, so the two reads have
+  // to ask for exactly the same set.
+  describe('metadata read parity', () => {
+    const fieldsOf = (call: unknown[]) =>
+      (call[1] as { params: { Fields: string } }).params.Fields;
+
+    it('asks for the same fields in the batch read as in the single read', async () => {
+      http.get.mockResolvedValue({
+        data: { Id: 'movie-1', Type: 'Movie', Name: 'One' },
+      });
+      await service.getMetadata('movie-1');
+      const singleFields = fieldsOf(http.get.mock.calls[0]);
+
+      http.get.mockClear();
+      embyCacheMocks.data.get.mockReturnValue(undefined);
+      http.get.mockResolvedValue({
+        data: { Items: [{ Id: 'movie-1', Type: 'Movie', Name: 'One' }] },
+      });
+      await service.getMetadataBatch(['movie-1']);
+
+      expect(fieldsOf(http.get.mock.calls[0])).toBe(singleFields);
+    });
+
+    // Verified on Emby 4.9.5: a list read omits each of these unless it is named,
+    // and the mapper reads all of them.
+    it.each([
+      ['ParentId', 'parentId'],
+      ['ChildCount', 'childCount'],
+      ['PremiereDate', 'originallyAvailableAt'],
+      ['CommunityRating', 'ratings'],
+      ['OfficialRating', 'contentRating'],
+    ])('names %s, which the mapper needs for %s', (field) => {
+      expect(EMBY_METADATA_FIELDS.split(',')).toContain(field);
+    });
+
+    it('maps a batch item to the same shape as a single item', async () => {
+      const payload = {
+        Id: 'movie-1',
+        Type: 'Movie',
+        Name: 'One',
+        ParentId: '6',
+        ChildCount: 1,
+        PremiereDate: '2008-05-20T00:00:00.0000000Z',
+        CommunityRating: 7.5,
+        OfficialRating: 'PG',
+        ProviderIds: { Tmdb: '10378' },
+      };
+
+      http.get.mockResolvedValue({ data: payload });
+      const single = await service.getMetadata('movie-1');
+
+      embyCacheMocks.data.get.mockReturnValue(undefined);
+      http.get.mockResolvedValue({ data: { Items: [payload] } });
+      const [batched] = await service.getMetadataBatch(['movie-1']);
+
+      expect(batched).toEqual(single);
+      expect(batched.parentId).toBe('6');
+      expect(batched.originallyAvailableAt).toBeInstanceOf(Date);
+      expect(batched.ratings).not.toEqual([]);
+      expect(batched.contentRating).toBe('PG');
     });
   });
 
@@ -1129,10 +1286,7 @@ describe('EmbyAdapterService', () => {
           id: '42',
         });
         expect(http.get).toHaveBeenCalledWith('/Users/admin-9/Items/42', {
-          params: {
-            Fields:
-              'ProviderIds,DateCreated,Overview,Tags,MediaSources,Genres,People,Studios',
-          },
+          params: { Fields: EMBY_METADATA_FIELDS },
         });
       });
     });

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -36,6 +36,7 @@ import {
   EMBY_CLIENT_INFO,
   EMBY_DEVICE_INFO,
 } from './emby.constants';
+import { readMetadataInBatches } from '../metadata-batch.util';
 import { EmbyMapper } from './emby.mapper';
 import type {
   EmbyAuthenticationResult,
@@ -60,6 +61,19 @@ import type {
  * Methods marked with TODO(emby-server-test) have not been verified against a
  * live Emby server and require validation before production use.
  */
+// The fields a metadata read needs, shared by the single-item and bulk reads so
+// the two can never drift into answering differently shaped items.
+//
+// The trailing five are only returned by `/Users/{userId}/Items/{itemId}` unless
+// they are named: verified on Emby 4.9.5 that a `/Items` list read omits
+// ParentId and ChildCount entirely, and PremiereDate, CommunityRating and
+// OfficialRating for movies. The mapper reads all five - the last three are the
+// airDate and rating sort keys and the content rating - and a batch result is
+// cached under the key getMetadata reads, so a short list read would then be
+// served to callers that never asked for one.
+export const EMBY_METADATA_FIELDS =
+  'ProviderIds,DateCreated,Overview,Tags,MediaSources,Genres,People,Studios,ParentId,ChildCount,PremiereDate,CommunityRating,OfficialRating';
+
 @Injectable()
 export class EmbyAdapterService implements IMediaServerService {
   private http: AxiosInstance | undefined;
@@ -450,15 +464,57 @@ export class EmbyAdapterService implements IMediaServerService {
     return pending;
   }
 
+  async getMetadataBatch(itemIds: string[]): Promise<MediaItem[]> {
+    if (!this.http) return [];
+
+    return readMetadataInBatches({
+      itemIds,
+      // Ids are comma separated in one `Ids` parameter.
+      perIdCost: 1,
+      cache: {
+        get: (itemId) =>
+          this.cache.data.get<MediaItem>(
+            `${EMBY_CACHE_KEYS.METADATA}:${itemId}`,
+          ),
+        set: (item) =>
+          this.cache.data.set(
+            `${EMBY_CACHE_KEYS.METADATA}:${item.id}`,
+            item,
+            EMBY_CACHE_TTL.METADATA,
+          ),
+      },
+      readBatch: async (idBatch) => {
+        // User-scoped, like every other Emby read: the unscoped path 404s for
+        // items that exist.
+        const userId = await this.resolveUserId();
+        const { data } = await this.http.get<EmbyItemsQueryResponse>('/Items', {
+          params: {
+            ...(userId ? { UserId: userId } : {}),
+            Ids: idBatch.join(','),
+            Fields: EMBY_METADATA_FIELDS,
+          },
+        });
+
+        return (data.Items ?? []).map(EmbyMapper.toMediaItem);
+      },
+      // Emby answers 500 for a malformed id, so one bad id costs its batch.
+      onBatchError: (idBatch, error) => {
+        this.logger.warn(
+          `Failed to get metadata for ${idBatch.length} Emby item(s)`,
+        );
+        this.logger.debug(
+          formatConnectionFailureMessage(error, 'Connection failed'),
+        );
+      },
+    });
+  }
+
   private async fetchMetadata(
     itemId: string,
     cacheKey: string,
   ): Promise<MediaItem | undefined> {
     try {
-      const data = await this.fetchItem(
-        itemId,
-        'ProviderIds,DateCreated,Overview,Tags,MediaSources,Genres,People,Studios',
-      );
+      const data = await this.fetchItem(itemId, EMBY_METADATA_FIELDS);
 
       if (!data) {
         return undefined;

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -13,6 +13,7 @@ import {
   JELLYFIN_WATCH_SNAPSHOT_MAX_RECORDS,
   jellyfinWatchSnapshotCacheKey,
 } from './jellyfin.constants';
+import { batchIdsByRequestCost } from '../metadata-batch.util';
 import { JellyfinAdapterService } from './jellyfin-adapter.service';
 import { JELLYFIN_BATCH_SIZE, JELLYFIN_CACHE_TTL } from './jellyfin.constants';
 
@@ -1039,6 +1040,102 @@ describe('JellyfinAdapterService', () => {
       expect(jellyfinCacheMocks.data.del).not.toHaveBeenCalledWith(
         'jellyfin:users',
       );
+    });
+  });
+
+  describe('getMetadataBatch', () => {
+    beforeEach(async () => {
+      settingsDataService.getSettings.mockResolvedValue(
+        mockSettings as unknown as Awaited<
+          ReturnType<SettingsDataService['getSettings']>
+        >,
+      );
+      await service.initialize();
+    });
+
+    it('reads a whole id list in one request and caches each item', async () => {
+      jellyfinApiMocks.getItems.mockResolvedValue({
+        data: {
+          Items: [
+            { Id: 'movie-1', Type: 'Movie', Name: 'One' },
+            { Id: 'movie-2', Type: 'Movie', Name: 'Two' },
+          ],
+        },
+      });
+
+      const items = await service.getMetadataBatch(['movie-1', 'movie-2']);
+
+      expect(jellyfinApiMocks.getItems).toHaveBeenCalledTimes(1);
+      expect(jellyfinApiMocks.getItems).toHaveBeenCalledWith(
+        expect.objectContaining({ ids: ['movie-1', 'movie-2'] }),
+      );
+      expect(items.map((item) => item.id)).toEqual(['movie-1', 'movie-2']);
+      expect(jellyfinCacheMocks.data.set).toHaveBeenCalledWith(
+        'jellyfin:metadata:movie-1',
+        expect.objectContaining({ id: 'movie-1' }),
+        JELLYFIN_CACHE_TTL.METADATA,
+      );
+    });
+
+    // The ids go in the query string and Jellyfin answers 414 past roughly an
+    // 8KB request line, so a long list cannot be one request.
+    it('splits a long id list', async () => {
+      jellyfinApiMocks.getItems.mockResolvedValue({ data: { Items: [] } });
+      const itemIds = Array.from({ length: 400 }, (unused, index) =>
+        `${index}`.padStart(32, 'i'),
+      );
+
+      await service.getMetadataBatch(itemIds);
+
+      // The shared helper decides the split from the ids themselves.
+      expect(jellyfinApiMocks.getItems).toHaveBeenCalledTimes(
+        batchIdsByRequestCost(itemIds, 5).length,
+      );
+      expect(jellyfinApiMocks.getItems.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    // Jellyfin answers an unfiltered listing when it cannot parse the filter.
+    it('keeps only the ids it was asked for', async () => {
+      jellyfinApiMocks.getItems.mockResolvedValue({
+        data: {
+          Items: [
+            { Id: 'movie-1', Type: 'Movie', Name: 'One' },
+            { Id: 'somebody-else', Type: 'Movie', Name: 'Unrelated' },
+          ],
+        },
+      });
+
+      const items = await service.getMetadataBatch(['movie-1']);
+
+      expect(items.map((item) => item.id)).toEqual(['movie-1']);
+    });
+
+    it('serves cached ids without asking for them again', async () => {
+      jellyfinCacheMocks.data.get.mockImplementation((key: string) =>
+        key === 'jellyfin:metadata:movie-1' ? { id: 'movie-1' } : undefined,
+      );
+      jellyfinApiMocks.getItems.mockResolvedValue({
+        data: { Items: [{ Id: 'movie-2', Type: 'Movie', Name: 'Two' }] },
+      });
+
+      const items = await service.getMetadataBatch(['movie-1', 'movie-2']);
+
+      expect(jellyfinApiMocks.getItems).toHaveBeenCalledWith(
+        expect.objectContaining({ ids: ['movie-2'] }),
+      );
+      expect(items.map((item) => item.id).sort()).toEqual([
+        'movie-1',
+        'movie-2',
+      ]);
+    });
+
+    // Same contract as getMetadata: a failed read leaves its ids out rather
+    // than reporting them as missing items.
+    it('leaves out the ids of a failed read', async () => {
+      jellyfinCacheMocks.data.get.mockReturnValue(undefined);
+      jellyfinApiMocks.getItems.mockRejectedValue(new Error('boom'));
+
+      await expect(service.getMetadataBatch(['movie-1'])).resolves.toEqual([]);
     });
   });
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -81,6 +81,7 @@ import {
   JELLYFIN_RETRYABLE_LIBRARY_ERROR_CODES,
   JELLYFIN_RETRYABLE_LIBRARY_STATUS_CODES,
 } from './jellyfin.constants';
+import { readMetadataInBatches } from '../metadata-batch.util';
 import { JellyfinMapper } from './jellyfin.mapper';
 import type { JellyfinWatchSnapshot } from './jellyfin.types';
 
@@ -122,6 +123,20 @@ const JELLYFIN_LIBRARY_LIST_FIELDS = [
  * - No watchlist API
  * - Uses ticks for duration (1 tick = 100 nanoseconds)
  */
+// The fields a metadata read needs, shared by the single-item and bulk reads so
+// the two can never drift into answering differently shaped items.
+const JELLYFIN_METADATA_FIELDS = [
+  ItemFields.ProviderIds,
+  ItemFields.Path,
+  ItemFields.DateCreated,
+  ItemFields.MediaSources,
+  ItemFields.Genres,
+  ItemFields.Tags,
+  ItemFields.Overview,
+  ItemFields.People,
+  ItemFields.Studios,
+];
+
 @Injectable()
 export class JellyfinAdapterService implements IMediaServerService {
   private api: Api | undefined;
@@ -930,17 +945,7 @@ export class JellyfinAdapterService implements IMediaServerService {
       const response = await getItemsApi(this.api).getItems({
         userId,
         ids: [itemId],
-        fields: [
-          ItemFields.ProviderIds,
-          ItemFields.Path,
-          ItemFields.DateCreated,
-          ItemFields.MediaSources,
-          ItemFields.Genres,
-          ItemFields.Tags,
-          ItemFields.Overview,
-          ItemFields.People,
-          ItemFields.Studios,
-        ],
+        fields: JELLYFIN_METADATA_FIELDS,
         enableUserData: true,
       });
 
@@ -961,6 +966,45 @@ export class JellyfinAdapterService implements IMediaServerService {
       this.logger.debug(error);
       return undefined;
     }
+  }
+
+  async getMetadataBatch(itemIds: string[]): Promise<MediaItem[]> {
+    if (!this.api) return [];
+
+    return readMetadataInBatches({
+      itemIds,
+      // The SDK sends one `ids=` parameter per id.
+      perIdCost: 'ids='.length + 1,
+      cache: {
+        get: (itemId) =>
+          this.cache.data.get<MediaItem>(
+            `${JELLYFIN_CACHE_KEYS.METADATA}:${itemId}`,
+          ),
+        set: (item) =>
+          this.cache.data.set(
+            `${JELLYFIN_CACHE_KEYS.METADATA}:${item.id}`,
+            item,
+            JELLYFIN_CACHE_TTL.METADATA,
+          ),
+      },
+      readBatch: async (idBatch) => {
+        const userId = await this.getUserId();
+        const response = await getItemsApi(this.api).getItems({
+          userId,
+          ids: idBatch,
+          fields: JELLYFIN_METADATA_FIELDS,
+          enableUserData: true,
+        });
+
+        return (response.data.Items ?? []).map(JellyfinMapper.toMediaItem);
+      },
+      onBatchError: (idBatch, error) => {
+        this.logger.warn(
+          `Failed to get metadata for ${idBatch.length} Jellyfin item(s)`,
+        );
+        this.logger.debug(error);
+      },
+    });
   }
 
   /**

--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -141,6 +141,19 @@ export interface IMediaServerService {
   getMetadata(itemId: string): Promise<MediaItem | undefined>;
 
   /**
+   * Metadata for many items, in as few reads as the server allows.
+   *
+   * Only the items the server resolved come back, in no guaranteed order, so
+   * callers must match on `id` rather than position. An id the server does not
+   * hold is left out rather than answering an entry for it.
+   *
+   * Same read contract as `getMetadata`: an absent item and a failed read are
+   * indistinguishable, both being an id that simply is not in the result. Never
+   * use it to decide an item is gone - `itemExists` is the primitive for that.
+   */
+  getMetadataBatch(itemIds: string[]): Promise<MediaItem[]>;
+
+  /**
    * Confirm an item is still present on the media server.
    *
    * Returns `false` only when the server explicitly reports the item as

--- a/apps/server/src/modules/api/media-server/metadata-batch.util.spec.ts
+++ b/apps/server/src/modules/api/media-server/metadata-batch.util.spec.ts
@@ -1,0 +1,142 @@
+import { MediaItem } from '@maintainerr/contracts';
+import {
+  batchIdsByRequestCost,
+  readMetadataInBatches,
+} from './metadata-batch.util';
+
+const item = (id: string): MediaItem =>
+  ({
+    id,
+    title: id,
+    guid: `${id}-guid`,
+    type: 'movie',
+    addedAt: new Date(),
+    providerIds: {},
+    mediaSources: [],
+    library: { id: 'library-1', title: 'Movies' },
+  }) satisfies MediaItem;
+
+const ids = (count: number, length = 4) =>
+  Array.from({ length: count }, (unused, index) =>
+    `${index}`.padStart(length, 'i'),
+  );
+
+describe('batchIdsByRequestCost', () => {
+  it('fills a request up to its budget and no further', () => {
+    // 32-character ids costing 5 more each is Jellyfin's shape: 108 fit in 4000.
+    const batches = batchIdsByRequestCost(ids(109, 32), 5);
+
+    expect(batches.map((batch) => batch.length)).toEqual([108, 1]);
+  });
+
+  // Longer ids mean fewer per request without anyone choosing a number.
+  it('reads fewer per request when the ids are longer', () => {
+    const short = batchIdsByRequestCost(ids(500, 4), 1);
+    const long = batchIdsByRequestCost(ids(500, 40), 1);
+
+    expect(short[0].length).toBeGreaterThan(long[0].length);
+  });
+
+  it('still asks for an id that is over budget on its own', () => {
+    expect(batchIdsByRequestCost(['x'.repeat(9000)], 1)).toEqual([
+      ['x'.repeat(9000)],
+    ]);
+  });
+
+  it('has nothing to read for no ids', () => {
+    expect(batchIdsByRequestCost([], 1)).toEqual([]);
+  });
+});
+
+describe('readMetadataInBatches', () => {
+  it('reads a short list in one request', async () => {
+    const readBatch = jest.fn(async (batch: string[]) => batch.map(item));
+
+    const items = await readMetadataInBatches({
+      itemIds: ['a', 'b'],
+      perIdCost: 1,
+      readBatch,
+    });
+
+    expect(readBatch).toHaveBeenCalledTimes(1);
+    expect(readBatch).toHaveBeenCalledWith(['a', 'b']);
+    expect(items.map((entry) => entry.id)).toEqual(['a', 'b']);
+  });
+
+  it('asks for an id once even when a caller repeats it', async () => {
+    const readBatch = jest.fn(async (batch: string[]) => batch.map(item));
+
+    await readMetadataInBatches({
+      itemIds: ['a', 'a', 'b'],
+      perIdCost: 1,
+      readBatch,
+    });
+
+    expect(readBatch).toHaveBeenCalledWith(['a', 'b']);
+  });
+
+  // Jellyfin answers an unfiltered listing when it cannot parse the ids filter.
+  it('keeps only the ids it asked for', async () => {
+    const items = await readMetadataInBatches({
+      itemIds: ['a'],
+      perIdCost: 1,
+      readBatch: async () => [item('a'), item('somebody-else')],
+    });
+
+    expect(items.map((entry) => entry.id)).toEqual(['a']);
+  });
+
+  it('serves a cached id without reading it, and caches what it reads', async () => {
+    const cached = item('a');
+    const set = jest.fn();
+    const readBatch = jest.fn(async (batch: string[]) => batch.map(item));
+
+    const items = await readMetadataInBatches({
+      itemIds: ['a', 'b'],
+      perIdCost: 1,
+      readBatch,
+      cache: { get: (id) => (id === 'a' ? cached : undefined), set },
+    });
+
+    expect(readBatch).toHaveBeenCalledWith(['b']);
+    expect(items.map((entry) => entry.id).sort()).toEqual(['a', 'b']);
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({ id: 'b' }));
+    expect(set).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'a' }));
+  });
+
+  it('makes no request when every id is cached', async () => {
+    const readBatch = jest.fn();
+
+    await readMetadataInBatches({
+      itemIds: ['a'],
+      perIdCost: 1,
+      readBatch,
+      cache: { get: () => item('a'), set: jest.fn() },
+    });
+
+    expect(readBatch).not.toHaveBeenCalled();
+  });
+
+  // A failed read leaves its ids out rather than reporting them as missing, and
+  // must not abandon the batches after it.
+  it('reports a failed batch and keeps reading the rest', async () => {
+    const onBatchError = jest.fn();
+    const longIds = ids(200, 32);
+    const readBatch = jest.fn(async (batch: string[]) => {
+      if (batch.includes(longIds[0])) throw new Error('boom');
+      return batch.map(item);
+    });
+
+    const items = await readMetadataInBatches({
+      itemIds: longIds,
+      perIdCost: 5,
+      readBatch,
+      onBatchError,
+    });
+
+    expect(readBatch.mock.calls.length).toBeGreaterThan(1);
+    expect(onBatchError).toHaveBeenCalledTimes(1);
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.length).toBeLessThan(longIds.length);
+  });
+});

--- a/apps/server/src/modules/api/media-server/metadata-batch.util.ts
+++ b/apps/server/src/modules/api/media-server/metadata-batch.util.ts
@@ -1,0 +1,117 @@
+import { MediaItem } from '@maintainerr/contracts';
+
+/**
+ * Characters a batched id read may spend on its request line.
+ *
+ * Every server takes the ids in the request line, and the low ceiling belongs to
+ * whatever sits in front of it: nginx and Apache both stop at about 8KB by
+ * default, and Jellyfin itself answers HTTP 414 past roughly the same (measured
+ * on 10.11: 215 ids pass at 8025 characters, 230 fail at 8580). Half of that
+ * leaves room for a reverse proxy configured tighter than the default.
+ */
+const REQUEST_BUDGET_CHARS = 4000;
+
+interface MetadataBatchRead {
+  itemIds: string[];
+  /**
+   * Characters an id costs beyond its own length - the separator or parameter
+   * name the server's request shape puts in front of it. Batch sizes follow
+   * from this and the ids themselves, so a server with long ids reads fewer per
+   * request without anyone picking a number.
+   */
+  perIdCost: number;
+  /** One read for these ids, answering only the items it resolved. */
+  readBatch: (itemIds: string[]) => Promise<MediaItem[]>;
+  /** Per-item cache, so an id already held is not read again. */
+  cache?: {
+    get: (itemId: string) => MediaItem | undefined;
+    set: (item: MediaItem) => void;
+  };
+  /** A read that threw. Its ids are simply absent from the result. */
+  onBatchError?: (itemIds: string[], error: unknown) => void;
+}
+
+/**
+ * Split ids into as few reads as each request line allows.
+ *
+ * Always at least one id per batch: a single id over budget still has to be
+ * asked for, and the server is the one to reject it.
+ */
+export const batchIdsByRequestCost = (
+  itemIds: string[],
+  perIdCost: number,
+): string[][] => {
+  const batches: string[][] = [];
+  let batch: string[] = [];
+  let cost = 0;
+
+  for (const itemId of itemIds) {
+    const idCost = itemId.length + perIdCost;
+
+    if (batch.length > 0 && cost + idCost > REQUEST_BUDGET_CHARS) {
+      batches.push(batch);
+      batch = [];
+      cost = 0;
+    }
+
+    batch.push(itemId);
+    cost += idCost;
+  }
+
+  if (batch.length > 0) {
+    batches.push(batch);
+  }
+
+  return batches;
+};
+
+/**
+ * Read metadata for many ids, in as few requests as the server allows.
+ *
+ * Shared by every adapter's `getMetadataBatch`, so they contribute only their
+ * own request and mapping: the caching, the batching, keeping the answer to the
+ * ids that were asked for, and swallowing a failed read all behave the same
+ * whichever server is configured.
+ *
+ * Only resolved items come back. An id the server did not answer for is absent
+ * rather than reported, so this can never be read as evidence an item is gone.
+ */
+export const readMetadataInBatches = async ({
+  itemIds,
+  perIdCost,
+  readBatch,
+  cache,
+  onBatchError,
+}: MetadataBatchRead): Promise<MediaItem[]> => {
+  const items: MediaItem[] = [];
+  const toRead: string[] = [];
+
+  for (const itemId of new Set(itemIds)) {
+    const cached = cache?.get(itemId);
+
+    if (cached === undefined) {
+      toRead.push(itemId);
+    } else {
+      items.push(cached);
+    }
+  }
+
+  for (const batch of batchIdsByRequestCost(toRead, perIdCost)) {
+    // Jellyfin answers an unfiltered listing when it cannot parse the ids
+    // filter, so no server is trusted to answer only what it was asked for.
+    const requested = new Set(batch);
+
+    try {
+      for (const item of await readBatch(batch)) {
+        if (!requested.has(item.id)) continue;
+
+        cache?.set(item);
+        items.push(item);
+      }
+    } catch (error) {
+      onBatchError?.(batch, error);
+    }
+  }
+
+  return items;
+};

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -12,7 +12,7 @@ import { MaintainerrLogger } from '../../../logging/logs.service';
 import type { PlexStatusResponse } from '../../plex-api/interfaces/server.interface';
 import { PlexApiService } from '../../plex-api/plex-api.service';
 import { PlexAdapterService } from './plex-adapter.service';
-import { PLEX_BATCH_SIZE } from './plex.constants';
+import { batchIdsByRequestCost } from '../metadata-batch.util';
 
 describe('PlexAdapterService', () => {
   let service: PlexAdapterService;
@@ -639,6 +639,50 @@ describe('PlexAdapterService', () => {
     });
   });
 
+  describe('getMetadataBatch', () => {
+    it('reads a whole id list in one request', async () => {
+      plexApi.getMetadataBatch.mockResolvedValue([
+        createPlexMetadata({ ratingKey: 'movie-1', type: 'movie' }),
+        createPlexMetadata({ ratingKey: 'movie-2', type: 'movie' }),
+      ]);
+
+      const items = await service.getMetadataBatch(['movie-1', 'movie-2']);
+
+      expect(plexApi.getMetadataBatch).toHaveBeenCalledTimes(1);
+      expect(plexApi.getMetadataBatch).toHaveBeenCalledWith([
+        'movie-1',
+        'movie-2',
+      ]);
+      expect(items.map((item) => item.id)).toEqual(['movie-1', 'movie-2']);
+    });
+
+    it('splits a long id list so the request line stays bounded', async () => {
+      plexApi.getMetadataBatch.mockResolvedValue([]);
+      const itemIds = Array.from(
+        { length: 1500 },
+        (unused, index) => `movie-${index}`,
+      );
+
+      await service.getMetadataBatch(itemIds);
+
+      // The shared helper decides the split from the ids themselves.
+      expect(plexApi.getMetadataBatch).toHaveBeenCalledTimes(
+        batchIdsByRequestCost(itemIds, 1).length,
+      );
+      expect(plexApi.getMetadataBatch.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it('leaves out the ids Plex did not answer for', async () => {
+      plexApi.getMetadataBatch.mockResolvedValue([
+        createPlexMetadata({ ratingKey: 'movie-1', type: 'movie' }),
+      ]);
+
+      await expect(
+        service.getMetadataBatch(['movie-1', 'gone']),
+      ).resolves.toEqual([expect.objectContaining({ id: 'movie-1' })]);
+    });
+  });
+
   describe('getCollectionChildren', () => {
     it('reads no metadata at all when the listing carries provider ids', async () => {
       plexApi.getCollectionChildren.mockResolvedValue([
@@ -691,7 +735,7 @@ describe('PlexAdapterService', () => {
     });
 
     it('splits the lookup so the request line cannot grow without bound', async () => {
-      const childCount = PLEX_BATCH_SIZE.METADATA_LOOKUP * 2 + 3;
+      const childCount = 1500;
       plexApi.getCollectionChildren.mockResolvedValue(
         Array.from({ length: childCount }, (_, index) =>
           createPlexLibraryItem('movie', {
@@ -712,12 +756,7 @@ describe('PlexAdapterService', () => {
 
       const children = await service.getCollectionChildren('col123');
 
-      expect(plexApi.getMetadataBatch).toHaveBeenCalledTimes(3);
-      expect(
-        plexApi.getMetadataBatch.mock.calls.every(
-          ([keys]) => keys.length <= PLEX_BATCH_SIZE.METADATA_LOOKUP,
-        ),
-      ).toBe(true);
+      expect(plexApi.getMetadataBatch.mock.calls.length).toBeGreaterThan(1);
       expect(children.every((child) => child.providerIds.tmdb.length > 0)).toBe(
         true,
       );

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -18,7 +18,6 @@ import {
   WatchRecord,
 } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
-import { chunk } from 'lodash';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { EPlexDataType } from '../../plex-api/enums/plex-data-type-enum';
 import { PlexLibraryItem } from '../../plex-api/interfaces/library.interfaces';
@@ -30,6 +29,7 @@ import {
 } from '../media-server-id.utils';
 import { resolveContextActionIds } from '../context-action.util';
 import { supportsFeature } from '../media-server.constants';
+import { readMetadataInBatches } from '../metadata-batch.util';
 import {
   IMediaServerService,
   type MediaWatchState,
@@ -193,6 +193,19 @@ export class PlexAdapterService implements IMediaServerService {
     const metadata = await this.plexApi.getMetadata(itemId);
     if (!metadata) return undefined;
     return PlexMapper.metadataToMediaItem(metadata);
+  }
+
+  async getMetadataBatch(itemIds: string[]): Promise<MediaItem[]> {
+    return readMetadataInBatches({
+      itemIds,
+      // Ids are comma separated in the path.
+      perIdCost: 1,
+      // plexApi answers [] for a failed read, so there is nothing to report.
+      readBatch: async (idBatch) =>
+        (await this.plexApi.getMetadataBatch(idBatch)).map(
+          PlexMapper.metadataToMediaItem,
+        ),
+    });
   }
 
   async itemExists(itemId: string): Promise<boolean> {
@@ -521,19 +534,12 @@ export class PlexAdapterService implements IMediaServerService {
     // episodes and seasons, and for any library whose agent publishes none. In
     // id batches, never one request per child: that is what a Plex host answers
     // with 503s.
-    const resolvedById = new Map<string, MediaItem>();
-
-    for (const idBatch of chunk(
-      idsWithoutProviderIds,
-      PLEX_BATCH_SIZE.METADATA_LOOKUP,
-    )) {
-      for (const metadata of await this.plexApi.getMetadataBatch(idBatch)) {
-        resolvedById.set(
-          metadata.ratingKey,
-          PlexMapper.metadataToMediaItem(metadata),
-        );
-      }
-    }
+    const resolvedById = new Map(
+      (await this.getMetadataBatch(idsWithoutProviderIds)).map((item) => [
+        item.id,
+        item,
+      ]),
+    );
 
     const unresolved = idsWithoutProviderIds.filter(
       (id) => !this.hasUsableProviderIds(resolvedById.get(id)?.providerIds),

--- a/apps/server/src/modules/api/media-server/plex/plex.constants.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.constants.ts
@@ -5,9 +5,6 @@ import {
 
 export const PLEX_BATCH_SIZE = {
   COLLECTION_MUTATION: 4,
-  // PMS applies no container cap to /library/metadata (240 ids in one response
-  // on 1.43.3), so this bounds only the request line: ~800 characters.
-  METADATA_LOOKUP: 100,
 } as const;
 
 const PLEX_SORT_FIELDS: Partial<Record<MediaLibrarySortField, string>> = {

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -94,6 +94,7 @@ describe('CollectionsService', () => {
       getAllIdsForContextAction: jest.fn().mockResolvedValue([]),
       getLibraries: jest.fn().mockResolvedValue([{ id: 'library-1' }]),
       getMetadata: jest.fn().mockResolvedValue(undefined),
+      getMetadataBatch: jest.fn().mockResolvedValue([]),
       itemExists: jest.fn().mockResolvedValue(true),
       removeFromCollection: jest.fn().mockResolvedValue(undefined),
       deleteCollection: jest.fn().mockResolvedValue(undefined),
@@ -3100,9 +3101,9 @@ describe('CollectionsService', () => {
     );
     // getCollection confirms the collection is truly gone
     mediaServer.getCollection.mockResolvedValue(undefined);
-    mediaServer.getMetadata.mockResolvedValue(
+    mediaServer.getMetadataBatch.mockResolvedValue([
       createMediaItem({ id: 'movie-1', title: 'Fallback Movie' }),
-    );
+    ]);
 
     const result = await (service as any).hydrateCollectionMediaWithMetadata(
       items,
@@ -3116,8 +3117,8 @@ describe('CollectionsService', () => {
     expect(collectionRepo.save).toHaveBeenCalledWith(
       expect.objectContaining({ mediaServerId: null }),
     );
-    // Fallback per-item lookup still works
-    expect(mediaServer.getMetadata).toHaveBeenCalledWith('movie-1');
+    // The batched fallback read still answers for the row
+    expect(mediaServer.getMetadataBatch).toHaveBeenCalledWith(['movie-1']);
     expect(result).toHaveLength(1);
     expect(result[0].mediaData?.title).toBe('Fallback Movie');
   });
@@ -3143,9 +3144,9 @@ describe('CollectionsService', () => {
       childCount: 1,
       smart: false,
     });
-    mediaServer.getMetadata.mockResolvedValue(
+    mediaServer.getMetadataBatch.mockResolvedValue([
       createMediaItem({ id: 'movie-1', title: 'Fallback Movie' }),
-    );
+    ]);
 
     const result = await (service as any).hydrateCollectionMediaWithMetadata(
       items,
@@ -3179,9 +3180,9 @@ describe('CollectionsService', () => {
       new Error('Request failed with status code 400'),
     );
     mediaServer.getCollection.mockRejectedValue(new Error('status code 502'));
-    mediaServer.getMetadata.mockResolvedValue(
+    mediaServer.getMetadataBatch.mockResolvedValue([
       createMediaItem({ id: 'movie-1', title: 'Fallback Movie' }),
-    );
+    ]);
 
     const result = await (service as any).hydrateCollectionMediaWithMetadata(
       items,
@@ -3194,7 +3195,7 @@ describe('CollectionsService', () => {
     );
     expect(collectionRepo.save).not.toHaveBeenCalled();
     expect(collection.mediaServerId).toBe('verification-failure-collection');
-    expect(mediaServer.getMetadata).toHaveBeenCalledWith('movie-1');
+    expect(mediaServer.getMetadataBatch).toHaveBeenCalledWith(['movie-1']);
     expect(result).toHaveLength(1);
     expect(result[0].mediaData?.title).toBe('Fallback Movie');
   });
@@ -3286,13 +3287,15 @@ describe('CollectionsService', () => {
     // if the comparator falls through to MediaItem.addedAt (the bug) the
     // ordering becomes whatever Map iteration gives us; the assertion
     // below would fail.
-    mediaServer.getMetadata.mockImplementation(async (id: string) =>
-      createMediaItem({
-        id,
-        title: id,
-        type: 'movie',
-        addedAt: libraryAddDate,
-      }),
+    mediaServer.getMetadataBatch.mockImplementation(async (ids: string[]) =>
+      ids.map((id) =>
+        createMediaItem({
+          id,
+          title: id,
+          type: 'movie',
+          addedAt: libraryAddDate,
+        }),
+      ),
     );
 
     mediaServer.reorderCollectionItems = jest.fn().mockResolvedValue(undefined);
@@ -3303,6 +3306,66 @@ describe('CollectionsService', () => {
       'remote-99',
       ['leaves-soonest', 'leaves-middle', 'leaves-latest'],
     );
+  });
+
+  describe('getCollectionMediaMetadata per-item fallback', () => {
+    const collection = () =>
+      createCollection({
+        id: 21,
+        mediaServerId: 'remote-collection',
+        type: 'movie',
+      });
+
+    // Every row falls through to this read when the collection read above it
+    // failed, which is exactly when the server is least able to answer a
+    // request each.
+    it('reads the rows the collection did not answer for in one batch', async () => {
+      const col = collection();
+      const entities = Array.from({ length: 25 }, (unused, index) =>
+        createCollectionMedia(col, { mediaServerId: `movie-${index}` }),
+      );
+      collectionRepo.findOne.mockResolvedValue(col);
+      mediaServer.getCollectionChildren.mockRejectedValue(new Error('503'));
+      mediaServer.getCollection.mockResolvedValue({
+        id: 'remote-collection',
+      } as MediaCollection);
+      mediaServer.getMetadataBatch.mockImplementation(async (ids: string[]) =>
+        ids.map((id) => createMediaItem({ id })),
+      );
+
+      const metadata = await (service as any).getCollectionMediaMetadata(
+        entities,
+        mediaServer,
+      );
+
+      expect(mediaServer.getMetadataBatch).toHaveBeenCalledTimes(1);
+      expect(mediaServer.getMetadata).not.toHaveBeenCalled();
+      expect(metadata.size).toBe(25);
+    });
+
+    it('skips a row the server answered nothing for rather than dropping it', async () => {
+      const col = collection();
+      const entities = [
+        createCollectionMedia(col, { mediaServerId: 'movie-1' }),
+        createCollectionMedia(col, { mediaServerId: 'gone' }),
+      ];
+      collectionRepo.findOne.mockResolvedValue(col);
+      mediaServer.getCollectionChildren.mockResolvedValue([]);
+      mediaServer.getMetadataBatch.mockResolvedValue([
+        createMediaItem({ id: 'movie-1' }),
+      ]);
+
+      const metadata = await (service as any).getCollectionMediaMetadata(
+        entities,
+        mediaServer,
+      );
+
+      expect(metadata.has('movie-1')).toBe(true);
+      expect(metadata.has('gone')).toBe(false);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('No metadata for 1 of 2 collection media rows'),
+      );
+    });
   });
 
   describe('removeStaleCollectionMedia', () => {

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -1095,33 +1095,26 @@ export class CollectionsService {
       return metadataByMediaServerId;
     }
 
-    const missingMetadataResults = await Promise.allSettled(
-      missingMediaServerIds.map(async (mediaServerId) => ({
-        mediaServerId,
-        mediaItem: await mediaServer.getMetadata(mediaServerId),
-      })),
+    // One read per batch of ids rather than one per row. Every row lands here
+    // when the collection read above failed, which is exactly when the server is
+    // least able to answer a request each.
+    for (const mediaItem of await mediaServer.getMetadataBatch(
+      missingMediaServerIds,
+    )) {
+      metadataByMediaServerId.set(mediaItem.id, mediaItem);
+    }
+
+    const unresolvedIds = missingMediaServerIds.filter(
+      (mediaServerId) => !metadataByMediaServerId.has(mediaServerId),
     );
 
-    missingMetadataResults.forEach((result, index) => {
-      const mediaServerId = missingMediaServerIds[index];
-
-      if (result.status === 'fulfilled') {
-        if (result.value.mediaItem) {
-          metadataByMediaServerId.set(mediaServerId, result.value.mediaItem);
-          return;
-        }
-
-        this.logger.debug(
-          `Missing metadata for collection media with mediaServerId=${mediaServerId}; skipping item without deleting`,
-        );
-        return;
-      }
-
+    if (unresolvedIds.length > 0) {
+      // An id the server did not answer for is skipped, never deleted: this read
+      // cannot tell a missing item from a failed one.
       this.logger.debug(
-        `Failed to fetch metadata for collection media with mediaServerId=${mediaServerId}`,
+        `No metadata for ${unresolvedIds.length} of ${entities.length} collection media rows; skipping them without deleting: ${unresolvedIds.slice(0, 10).join(', ')}`,
       );
-      this.logger.debug(result.reason);
-    });
+    }
 
     return metadataByMediaServerId;
   }


### PR DESCRIPTION
Stacked on #3429, which introduced the Plex multi-id read this builds on. Base
retargets to `development` once that merges.

`CollectionsService.getCollectionMediaMetadata` falls back to one metadata
request per row for anything the collection read did not answer for, all at once.
Every row falls through when that read failed - exactly when the media server is
least able to answer a request each - so a large collection answered a failed
read by opening a request per row. Server-agnostic, so it affected all three.

All three servers can answer a list of ids in one read, so `getMetadataBatch`
joins `IMediaServerService` and the fallback uses it. Verified on live servers by
pointing a counting proxy at each, then forcing the collection link to a missing
remote id so every row falls through:

| server | rows | requests the fallback made |
|---|---|---|
| Plex 1.43.3 | 4 | 1 - `/library/metadata/1,2,4,3` |
| Jellyfin 10.11 | 5 | 1 - `/Items` with 5 `ids=` params |
| Emby 4.9 | 5 | 1 - `/Items?Ids=17,13,12,18,16` |

Every row hydrated with real metadata in all three cases.

The batching, caching, keeping the answer to the ids that were asked for, and
swallowing a failed read all live once in `metadata-batch.util`. An adapter
contributes only its own request and mapping, so the three cannot drift apart -
and the Jellyfin hazard of answering an unfiltered listing when it cannot parse
the ids filter is handled in one place rather than three.

Batch sizes are derived, not chosen. The helper spends a fixed request line
budget on ids, and each adapter states only what an id costs beyond its own
length in its request shape (a comma for Plex and Emby, an `ids=` parameter for
Jellyfin). A server with long ids therefore reads fewer per request without
anyone picking a number, and there is nothing to re-tune if id formats change.
The budget is half of the roughly 8KB that nginx, Apache and Jellyfin itself all
stop at, which leaves room for a reverse proxy configured tighter than default -
measured on Jellyfin 10.11, where 215 ids pass at 8025 characters and 230 fail at
8580.

What each server does with an id it cannot resolve had to be established too,
since the contract depends on it: Plex and Jellyfin omit it, Emby omits an
unknown numeric id but answers HTTP 500 for a malformed one, so a bad id costs
its batch rather than the whole call.

The read keeps `getMetadata`'s contract, documented on the interface: only the
items the server resolved come back, in no guaranteed order, so callers match on
`id`; an absent id is never evidence the item is gone (`itemExists` remains the
primitive for that). The collections fallback therefore skips an unanswered row
with a counted debug line instead of deleting it.

Two incidental tidies in the same code: Jellyfin and Emby serve ids already in
their metadata cache without re-reading them and populate it for the ones they
do read, so a following single read hits the same entry; and each server's
metadata field list is now declared once instead of per read site, so the single
and bulk reads cannot drift into answering differently shaped items.

The Emby read needed five more fields named than its single read appeared to
require. `/Items` omits `ParentId` and `ChildCount` entirely, and `PremiereDate`,
`CommunityRating` and `OfficialRating` for movies, where
`/Users/{userId}/Items/{itemId}` returns all five unasked. The mapper reads every
one - the last three being the `airDate` and `rating` sort keys and the content
rating - and a batch result is cached under the key `getMetadata` reads, so a
short read would then be served to callers that never asked for a list read. Both
Emby reads now name the same set; a test asserts they request identical fields
and map to an identical item, and on the live server the batched row and a direct
`getMetadata` agree field for field.
