### PR TITLE
fix(seerr): keep the other seasons' requests when one has none

### DIFF
--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.spec.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.spec.ts
@@ -247,6 +247,83 @@ describe('SeerrApiService', () => {
     results,
   });
 
+  describe('removeSeasonRequest', () => {
+    const tvRequest = (id: number, seasonNumbers: number[]) =>
+      ({
+        id,
+        type: 'tv',
+        status: SeerrRequestStatus.APPROVED,
+        createdAt: '2026-03-14T00:00:00.000Z',
+        updatedAt: '2026-03-14T00:00:00.000Z',
+        requestedBy: {} as never,
+        modifiedBy: {} as never,
+        is4k: false,
+        serverId: 1,
+        profileId: 1,
+        rootFolder: '/',
+        media: {} as never,
+        seasons: seasonNumbers.map((seasonNumber) => ({
+          id: seasonNumber,
+          name: `Season ${seasonNumber}`,
+          seasonNumber,
+          status: SeerrRequestStatus.APPROVED,
+        })),
+      }) as never;
+
+    const arrange = (requests: unknown[]) => {
+      jest.spyOn(service, 'getShow').mockResolvedValue({
+        id: 100,
+        mediaInfo: {
+          id: 7,
+          tmdbId: 100,
+          tvdbId: 200,
+          status: 1,
+          updatedAt: '2026-03-14T00:00:00.000Z',
+          mediaAddedAt: '2026-03-14T00:00:00.000Z',
+          externalServiceId: 1,
+          externalServiceId4k: 1,
+          mediaType: 'tv',
+          requests,
+        },
+      } as never);
+
+      const del = jest.fn().mockResolvedValue('');
+      service.api = { delete: del } as never;
+      return del;
+    };
+
+    it('deletes only the requests covering the season', async () => {
+      const del = arrange([tvRequest(10, [1]), tvRequest(11, [2])]);
+
+      await expect(service.removeSeasonRequest(100, 1)).resolves.toBe(true);
+
+      expect(del).toHaveBeenCalledTimes(1);
+      expect(del).toHaveBeenCalledWith('/request/10', undefined, {
+        rethrow: true,
+      });
+    });
+
+    // Deleting the media record cascades into every request it holds, so a
+    // season with none of its own must not take the other seasons with it.
+    it('keeps the media record when another season is still requested', async () => {
+      const del = arrange([tvRequest(11, [2])]);
+
+      await expect(service.removeSeasonRequest(100, 1)).resolves.toBe(false);
+
+      expect(del).not.toHaveBeenCalled();
+    });
+
+    it('clears the stale media record when nothing is requested at all', async () => {
+      const del = arrange([]);
+
+      await expect(service.removeSeasonRequest(100, 1)).resolves.toBe(true);
+
+      expect(del).toHaveBeenCalledWith('/media/7', undefined, {
+        rethrow: true,
+      });
+    });
+  });
+
   describe('getRequests', () => {
     it('paginates until page === pages and accumulates all results', async () => {
       const getWithoutCache = jest

--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
@@ -570,7 +570,8 @@ export class SeerrApiService {
         return false;
       }
 
-      const requests = (media.mediaInfo.requests ?? []).filter((el) =>
+      const allRequests = media.mediaInfo.requests ?? [];
+      const requests = allRequests.filter((el) =>
         el.seasons.find((s) => s.seasonNumber === season),
       );
       if (requests.length > 0) {
@@ -579,11 +580,15 @@ export class SeerrApiService {
             rethrow: true,
           });
         }
+      } else if (allRequests.length > 0) {
+        // Other seasons are still requested. Deleting the media record cascades
+        // into their requests, so leave it alone and report nothing removed.
+        return false;
       } else {
-        // No requests? Clear the media record and let Seerr refetch. Keyed on
-        // Seerr's own media id, not `media.id`, which is the TMDB id: Seerr
-        // answers 204 for an id it does not hold, so the wrong one was a no-op
-        // that reported success.
+        // Nothing requested at all? Clear the stale media record and let Seerr
+        // refetch. Keyed on Seerr's own media id, not `media.id`, which is the
+        // TMDB id: Seerr answers 204 for an id it does not hold, so the wrong
+        // one was a no-op that reported success.
         await this.api.delete(`/media/${media.mediaInfo.id}`, undefined, {
           rethrow: true,
         });


### PR DESCRIPTION
`removeSeasonRequest` filters the show's requests down to the season being removed, then reads an empty result as the show having no requests at all and clears the whole media record. Seerr cascades that delete into every request the record holds, so removing a season nothing had requested took the requests for the seasons that did.

It only became reachable when #3428 corrected the media id: the call used the TMDB id, which Seerr answers 204 for without deleting anything, so the branch had never done what it said.

Clear the record only when the show has no requests for any season. When the target season has none but others do, there is nothing to remove for it, which is what `false` already means to the caller.

Confirmed against a live Seerr. Seeded a show with a request for season 1 only, then removed season 2:

| | before | `removeSeasonRequest(tmdb, 2)` | after |
|---|---|---|---|
| on `development` | `#108[seasons 1]` | `true` | `(none)`, media record gone |
| with this change | `#108[seasons 1]` | `false` | `#108[seasons 1]` intact |

Removing season 1 still deletes its request and answers `true`, and a show with no requests at all still has its stale record cleared.

Reported by @whitestrake in #3427, including the cause and the shape of the fix.