### PR TITLE
test(emby): stop the metadata parity test racing the clock

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -279,10 +279,13 @@ describe('EmbyAdapterService', () => {
     });
 
     it('maps a batch item to the same shape as a single item', async () => {
+      // DateCreated is set because the mapper falls back to `new Date()`
+      // without it, which the two reads below stamp a few milliseconds apart.
       const payload = {
         Id: 'movie-1',
         Type: 'Movie',
         Name: 'One',
+        DateCreated: '2026-01-02T03:04:05.0000000Z',
         ParentId: '6',
         ChildCount: 1,
         PremiereDate: '2008-05-20T00:00:00.0000000Z',


### PR DESCRIPTION
`EmbyAdapterService › metadata read parity › maps a batch item to the same shape as a single item` is flaky. Its fixture carries no `DateCreated`, and the mapper falls back to `new Date()` without one, so the single read and the batch read stamp `addedAt` a few milliseconds apart:

```
-   "addedAt": 2026-08-07T00:18:41.637Z,
+   "addedAt": 2026-08-07T00:18:41.640Z,
```

It fails whenever the two calls straddle a millisecond: 3 runs in 8 locally, and it took out the CI run on #3433, which is a Seerr-only change.

Giving the fixture a `DateCreated` keeps the assertion comparing what it is meant to, the mapped shape, rather than when each read happened. It is also the realistic payload, since Emby always sends the field. 15 consecutive runs pass after the change.

Introduced by #3432.