### PR TITLE
fix(collections): read collection media parents in one request

### DIFF
--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -2565,13 +2565,9 @@ describe('CollectionsService', () => {
         grandparentTitle: undefined,
       }),
     ]);
-    mediaServer.getMetadata.mockImplementation(async (itemId: string) => {
-      if (itemId === 'show-1') {
-        return showMetadata;
-      }
-
-      return undefined;
-    });
+    mediaServer.getMetadataBatch.mockImplementation(async (ids: string[]) =>
+      ids.includes('show-1') ? [showMetadata] : [],
+    );
 
     const result = await (service as any).hydrateCollectionMediaWithMetadata(
       items,
@@ -2581,10 +2577,80 @@ describe('CollectionsService', () => {
     expect(mediaServer.getCollectionChildren).toHaveBeenCalledWith(
       'remote-collection',
     );
-    expect(mediaServer.getMetadata).toHaveBeenCalledTimes(1);
+    // Two episodes of one show: the shared parent is asked for once, in one read.
+    expect(mediaServer.getMetadataBatch).toHaveBeenCalledTimes(1);
+    expect(mediaServer.getMetadataBatch).toHaveBeenCalledWith(['show-1']);
+    expect(mediaServer.getMetadata).not.toHaveBeenCalled();
     expect(result).toHaveLength(2);
     expect(result[0].mediaData?.parentItem?.id).toBe('show-1');
     expect(result[0].mediaData?.grandparentTitle).toBe('Shared Show');
+  });
+
+  // Emby and Jellyfin put a movie under its library folder, so a collection
+  // stored one folder per film has about as many parents as it has rows.
+  it('reads many distinct parents in one request', async () => {
+    const collection = createCollection({
+      id: 31,
+      mediaServerId: 'remote-collection',
+      type: 'movie',
+    });
+    const entities = Array.from({ length: 25 }, (unused, index) =>
+      createCollectionMedia(collection, { mediaServerId: `movie-${index}` }),
+    );
+    collectionRepo.findOne.mockResolvedValue(collection);
+    mediaServer.getCollectionChildren.mockResolvedValue(
+      entities.map((entity, index) =>
+        createMediaItem({
+          id: entity.mediaServerId,
+          type: 'movie',
+          parentId: `folder-${index}`,
+        }),
+      ),
+    );
+    mediaServer.getMetadataBatch.mockImplementation(async (ids: string[]) =>
+      ids.map((id) => createMediaItem({ id, title: id })),
+    );
+
+    const result = await (service as any).hydrateCollectionMediaWithMetadata(
+      entities,
+      mediaServer,
+    );
+
+    expect(mediaServer.getMetadataBatch).toHaveBeenCalledTimes(1);
+    expect(mediaServer.getMetadataBatch.mock.calls[0][0]).toHaveLength(25);
+    expect(mediaServer.getMetadata).not.toHaveBeenCalled();
+    expect(result[0].mediaData?.parentItem?.id).toBe('folder-0');
+  });
+
+  it('keeps a row whose parent the server did not answer for', async () => {
+    const collection = createCollection({
+      id: 32,
+      mediaServerId: 'remote-collection',
+      type: 'episode',
+    });
+    const entity = createCollectionMedia(collection, {
+      mediaServerId: 'episode-1',
+    });
+    collectionRepo.findOne.mockResolvedValue(collection);
+    mediaServer.getCollectionChildren.mockResolvedValue([
+      createMediaItem({
+        id: 'episode-1',
+        type: 'episode',
+        grandparentId: 'show-gone',
+      }),
+    ]);
+    mediaServer.getMetadataBatch.mockResolvedValue([]);
+
+    const result = await (service as any).hydrateCollectionMediaWithMetadata(
+      [entity],
+      mediaServer,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].mediaData?.parentItem).toBeUndefined();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'No metadata for 1 of 1 collection media parents',
+    );
   });
 
   it('hydrates only the requested page after sorting collection media', async () => {

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -1177,29 +1177,22 @@ export class CollectionsService {
     ];
 
     if (parentIds.length > 0) {
-      const parentMetadataResults = await Promise.allSettled(
-        parentIds.map(async (parentId) => ({
-          parentId,
-          mediaItem: await mediaServer.getMetadata(parentId),
-        })),
-      );
+      // One read per batch of ids rather than one per parent. Emby and Jellyfin
+      // put a movie under its library folder, so a collection stored one folder
+      // per film has about as many parents as it has rows.
+      for (const parent of await mediaServer.getMetadataBatch(parentIds)) {
+        parentMetadataById.set(parent.id, parent);
+      }
 
-      parentMetadataResults.forEach((result, index) => {
-        const parentId = parentIds[index];
+      const unresolved = parentIds.length - parentMetadataById.size;
 
-        if (result.status === 'fulfilled') {
-          if (result.value.mediaItem) {
-            parentMetadataById.set(parentId, result.value.mediaItem);
-          }
-
-          return;
-        }
-
+      if (unresolved > 0) {
+        // Counted, not one line each. A parent that does not resolve only costs
+        // the item its parent title and artwork, so the row is still returned.
         this.logger.debug(
-          `Failed to fetch parent metadata for collection media parentId=${parentId}`,
+          `No metadata for ${unresolved} of ${parentIds.length} collection media parents`,
         );
-        this.logger.debug(result.reason);
-      });
+      }
     }
 
     return entities


### PR DESCRIPTION
The last per-item fan-out on the collection hydrate path.

`hydrateCollectionMediaWithMetadata` resolved each item's parent with its own
`getMetadata`, all at once, and that parent set is not small: Emby and Jellyfin
put a movie under its library folder, so a collection stored one folder per film
has about as many distinct parents as it has rows.

It now uses the batched read the adapters gained in #3432. Same contract - a
parent the server does not answer for simply has no entry, and its row is still
returned without a parent title or artwork rather than dropped - and the existing
dedupe by parent id is unchanged.

Measured against live servers, with the collection link forced to a missing id so
every row hydrates through this path:

| server | rows | parent reads before | after |
|---|---|---|---|
| Emby 4.9.5, 5 movies in 5 folders | 5 | 5 separate `/Users/{id}/Items/{id}` | **1** batched `/Items` |
| Plex 1.43.3, 5 episodes of one show | 5 | 1 (shared parent) | **1**, dedupe intact |

Every row kept its `parentItem`, and the Plex episodes kept their
`grandparentTitle`.

Two tests cover what the numbers show: many distinct parents resolve in a single
request, and a row whose parent the server did not answer for is still returned,
with the miss counted in one debug line rather than one per parent.
