### PR TITLE
fix: address release-review findings across rules, collections and integrations

### DIFF
--- a/.github/instructions/project-notes.instructions.md
+++ b/.github/instructions/project-notes.instructions.md
@@ -249,6 +249,11 @@ Non-obvious facts:
 - The getter returns `undefined` (transient skip) when membership is null;
   `false`/`[]` only when genuinely fetched. This prevents a failed lookup from
   flipping negative list comparisons and matching protected items.
+- Streamystats user ids ARE the Jellyfin user ids (verified live), while its
+  copy of the display name is nullable and can lag a rename. Rules store the
+  media-server username; the getter resolves that name against the Jellyfin
+  user list and then matches statistics rows **by id**, never by
+  Streamystats' name column.
 - Gating mirrors Tautulli: UI gate folded into the Jellyfin line in RuleInput
   `shouldFilterApplication`; server gate in `getRuleConstants()` removes the
   Application when `streamystats_url` / `jellyfin_api_key` are unset. Emby stays

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -44,3 +44,8 @@ jobs:
 
       - name: Run tests
         run: yarn turbo test
+
+      # Guards the rules regression matrix itself: it silently stopped
+      # starting once before because nothing ran it (#3426).
+      - name: Run rules regression matrix
+        run: yarn workspace @maintainerr/server test:e2e

--- a/apps/server/src/modules/actions/sonarr-action-handler.ts
+++ b/apps/server/src/modules/actions/sonarr-action-handler.ts
@@ -178,6 +178,7 @@ export class SonarrActionHandler {
           sonarrMedia,
           collection.type,
           mediaData,
+          seasonNumber,
         );
       }
     }
@@ -549,13 +550,15 @@ export class SonarrActionHandler {
     sonarrMedia: SonarrSeries,
     type: 'season' | 'episode',
     mediaData?: MediaItem,
+    // The handler's once-resolved, fail-closed season number (#3415) - not
+    // re-derived here so the guard cannot be bypassed by a future edit.
+    seasonNumber?: number,
   ): Promise<string[]> {
     try {
       // The deleted set comes from Sonarr's episode list (what the delete acts
       // on), not history, so it matches the files actually removed.
       let deletedEpisodes: SonarrEpisode[];
       if (type === 'season') {
-        const seasonNumber = mediaData?.index;
         if (seasonNumber === undefined || seasonNumber === null) {
           this.logger.debug(
             `[Sonarr] Skipping download cleanup for '${sonarrMedia.title}': season number could not be determined.`,

--- a/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.ts
+++ b/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.ts
@@ -139,6 +139,12 @@ export class QbittorrentApi
       .map((hash) => hash?.trim().toLowerCase())
       .filter((hash) => !!hash && hash !== 'all');
 
+    if (validHashes.length < hashes.length) {
+      this.logger.warn(
+        `Refused ${hashes.length - validHashes.length} download id(s) that do not name a single torrent`,
+      );
+    }
+
     if (validHashes.length === 0) {
       return;
     }

--- a/apps/server/src/modules/api/emby-api/emby-api.helper.ts
+++ b/apps/server/src/modules/api/emby-api/emby-api.helper.ts
@@ -1,3 +1,4 @@
+import { stripTrailingSlashes } from '@maintainerr/contracts';
 import axios, { type AxiosInstance } from 'axios';
 import { applyHttpRetry } from '../lib/httpRetry';
 
@@ -26,8 +27,9 @@ export class EmbyApi {
   readonly axios: AxiosInstance;
 
   constructor(options: EmbyApiOptions) {
-    let baseURL = options.url;
-    while (baseURL.endsWith('/')) baseURL = baseURL.slice(0, -1);
+    // Rows saved before the schema stripped trailing slashes (#3422) can
+    // still hold one, and Emby 404s routes reached through a double slash.
+    const baseURL = stripTrailingSlashes(options.url);
 
     const headers: Record<string, string> = {
       Accept: 'application/json',

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -3,6 +3,7 @@ import { batchIdsByRequestCost } from '../metadata-batch.util';
 import { EMBY_METADATA_FIELDS } from './emby-adapter.service';
 import { EMBY_CACHE_TTL } from './emby.constants';
 import { EmbyAdapterService } from './emby-adapter.service';
+import { EmbyMapper } from './emby.mapper';
 
 const embyCacheMocks = {
   flush: jest.fn(),
@@ -172,8 +173,10 @@ describe('EmbyAdapterService', () => {
         }),
       );
       expect(items.map((item) => item.id)).toEqual(['movie-1', 'movie-2']);
+      // Batched list-route rows stub UserData, so they live in their own
+      // namespace and are never served to getMetadata callers.
       expect(embyCacheMocks.data.set).toHaveBeenCalledWith(
-        'emby:metadata:movie-1',
+        'emby:metadata-batch:movie-1',
         expect.objectContaining({ id: 'movie-1' }),
         EMBY_CACHE_TTL.METADATA,
       );
@@ -212,7 +215,7 @@ describe('EmbyAdapterService', () => {
 
     it('serves cached ids without asking for them again', async () => {
       embyCacheMocks.data.get.mockImplementation((key: string) =>
-        key === 'emby:metadata:movie-1' ? { id: 'movie-1' } : undefined,
+        key === 'emby:metadata-batch:movie-1' ? { id: 'movie-1' } : undefined,
       );
       http.get.mockResolvedValue({
         data: { Items: [{ Id: 'movie-2', Type: 'Movie', Name: 'Two' }] },
@@ -239,6 +242,22 @@ describe('EmbyAdapterService', () => {
       http.get.mockRejectedValue(new Error('boom'));
 
       await expect(service.getMetadataBatch(['movie-1'])).resolves.toEqual([]);
+    });
+
+    // Unscoped, the list route answers rows with no UserData at all, so a
+    // missing user must leave the ids unresolved rather than read unscoped.
+    it('resolves nothing rather than reading unscoped when no user resolves', async () => {
+      setHttp('');
+      embyCacheMocks.data.get.mockReturnValue(undefined);
+      http.get.mockResolvedValue({ data: [] });
+
+      await expect(service.getMetadataBatch(['movie-1'])).resolves.toEqual([]);
+      expect(http.get).not.toHaveBeenCalledWith(
+        '/Items',
+        expect.objectContaining({
+          params: expect.objectContaining({ Ids: 'movie-1' }),
+        }),
+      );
     });
   });
 
@@ -274,8 +293,59 @@ describe('EmbyAdapterService', () => {
       ['PremiereDate', 'originallyAvailableAt'],
       ['CommunityRating', 'ratings'],
       ['OfficialRating', 'contentRating'],
+      ['ProductionYear', 'year'],
+      ['IndexNumberEnd', 'indexEnd'],
     ])('names %s, which the mapper needs for %s', (field) => {
       expect(EMBY_METADATA_FIELDS.split(',')).toContain(field);
+    });
+
+    // The keys the list route answers without being asked, verified on 4.9.5
+    // for a movie and an episode. Everything else the mapper consumes must be
+    // named in EMBY_METADATA_FIELDS or the batched row silently loses it.
+    const LIST_ROUTE_BASE_KEYS = [
+      'BackdropImageTags',
+      'Id',
+      'ImageTags',
+      'IndexNumber',
+      'IsFolder',
+      'MediaType',
+      'Name',
+      'ParentIndexNumber',
+      'RunTimeTicks',
+      'SeasonId',
+      'SeasonName',
+      'SeriesId',
+      'SeriesName',
+      'ServerId',
+      'Type',
+      // Answered as a stub (PlayCount 0, no LastPlayedDate), which is why the
+      // batch caches apart from getMetadata rather than asking for it.
+      'UserData',
+      // Read only to classify library folders, which no metadata batch holds.
+      'CollectionType',
+    ];
+
+    it('asks for every field the mapper actually reads', () => {
+      const accessed = new Set<string>();
+      const record = (payload: Record<string, unknown>) =>
+        new Proxy(payload, {
+          get(target, key) {
+            if (typeof key === 'string') accessed.add(key);
+            return target[key as keyof typeof payload];
+          },
+        });
+
+      for (const type of ['Movie', 'Series', 'Season', 'Episode']) {
+        EmbyMapper.toMediaItem(
+          record({ Id: 'item-1', Type: type, Name: 'One' }) as never,
+        );
+      }
+
+      const askedFor = new Set(EMBY_METADATA_FIELDS.split(','));
+      const unrequested = [...accessed].filter(
+        (key) => !askedFor.has(key) && !LIST_ROUTE_BASE_KEYS.includes(key),
+      );
+      expect(unrequested).toEqual([]);
     });
 
     it('maps a batch item to the same shape as a single item', async () => {

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -64,15 +64,18 @@ import type {
 // The fields a metadata read needs, shared by the single-item and bulk reads so
 // the two can never drift into answering differently shaped items.
 //
-// The trailing five are only returned by `/Users/{userId}/Items/{itemId}` unless
-// they are named: verified on Emby 4.9.5 that a `/Items` list read omits
-// ParentId and ChildCount entirely, and PremiereDate, CommunityRating and
-// OfficialRating for movies. The mapper reads all five - the last three are the
-// airDate and rating sort keys and the content rating - and a batch result is
-// cached under the key getMetadata reads, so a short list read would then be
-// served to callers that never asked for one.
+// Everything after Studios is only returned by `/Users/{userId}/Items/{itemId}`
+// unless it is named: verified on Emby 4.9.5 that a `/Items` list read omits
+// each one until asked, while the mapper reads them all (PremiereDate,
+// CommunityRating and ProductionYear are sort keys). The parity spec derives
+// this list from the mapper, so a newly consumed field fails a test instead of
+// silently losing its value on batched rows. Naming fields cannot close every
+// list-route gap, though: it stubs UserData (PlayCount 0, no LastPlayedDate,
+// EnableUserData or not) and answers a BoxSet id only with IncludeItemTypes -
+// which is why batch rows are cached apart from the direct-route rows
+// getMetadata serves.
 export const EMBY_METADATA_FIELDS =
-  'ProviderIds,DateCreated,Overview,Tags,MediaSources,Genres,People,Studios,ParentId,ChildCount,PremiereDate,CommunityRating,OfficialRating';
+  'ProviderIds,DateCreated,Overview,Tags,MediaSources,Genres,People,Studios,ParentId,ChildCount,PremiereDate,CommunityRating,OfficialRating,ProductionYear,IndexNumberEnd,CriticRating,DateLastSaved';
 
 @Injectable()
 export class EmbyAdapterService implements IMediaServerService {
@@ -474,22 +477,29 @@ export class EmbyAdapterService implements IMediaServerService {
       cache: {
         get: (itemId) =>
           this.cache.data.get<MediaItem>(
-            `${EMBY_CACHE_KEYS.METADATA}:${itemId}`,
+            `${EMBY_CACHE_KEYS.METADATA_BATCH}:${itemId}`,
           ),
         set: (item) =>
           this.cache.data.set(
-            `${EMBY_CACHE_KEYS.METADATA}:${item.id}`,
+            `${EMBY_CACHE_KEYS.METADATA_BATCH}:${item.id}`,
             item,
             EMBY_CACHE_TTL.METADATA,
           ),
       },
       readBatch: async (idBatch) => {
-        // User-scoped, like every other Emby read: the unscoped path 404s for
-        // items that exist.
+        // User-scoped, like every other Emby read. Unscoped, the list route
+        // answers rows with no UserData at all, so treat a missing user as
+        // inconclusive: the thrown batch comes back unresolved rather than
+        // trimmed (fetchItem draws the same line).
         const userId = await this.resolveUserId();
+        if (!userId) {
+          throw new Error(
+            'Cannot resolve an Emby user for the batched metadata read',
+          );
+        }
         const { data } = await this.http.get<EmbyItemsQueryResponse>('/Items', {
           params: {
-            ...(userId ? { UserId: userId } : {}),
+            UserId: userId,
             Ids: idBatch.join(','),
             Fields: EMBY_METADATA_FIELDS,
           },
@@ -1024,8 +1034,8 @@ export class EmbyAdapterService implements IMediaServerService {
    * though auth is a server-level admin key. Prefer the configured admin user;
    * otherwise resolve and cache the first admin so token-only setups still get
    * a user-scoped read instead of the unreliable plain /Items path. Returns
-   * undefined only when no admin can be resolved (callers then fall back to
-   * /Items).
+   * undefined only when no admin can be resolved - callers must treat that as
+   * inconclusive, never fall back to an unscoped read.
    */
   private async resolveUserId(): Promise<string | undefined> {
     if (this.embyUserId) return this.embyUserId;

--- a/apps/server/src/modules/api/media-server/emby/emby.constants.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby.constants.ts
@@ -22,6 +22,10 @@ export const EMBY_BATCH_SIZE = {
 
 export const EMBY_CACHE_KEYS = {
   METADATA: 'emby:metadata',
+  // Batched list-route rows carry a stubbed UserData (PlayCount 0, no
+  // LastPlayedDate - verified on 4.9.5, EnableUserData does not help), so
+  // they are cached apart from the full direct-route rows getMetadata serves.
+  METADATA_BATCH: 'emby:metadata-batch',
   CHILDREN: 'emby:children',
   USERS: 'emby:users',
   LIBRARIES: 'emby:libraries',

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -28,6 +28,7 @@ import {
 import {
   MediaServerFeature,
   MediaServerType,
+  stripTrailingSlashes,
   type CollectionVisibilitySettings,
   type CreateCollectionParams,
   type LibraryQueryOptions,
@@ -178,7 +179,9 @@ export class JellyfinAdapterService implements IMediaServerService {
       },
     });
 
-    const api = jellyfin.createApi(url, apiKey);
+    // Rows saved before the schema stripped trailing slashes (#3422) can
+    // still hold one, and Jellyfin 404s routes reached through a double slash.
+    const api = jellyfin.createApi(stripTrailingSlashes(url), apiKey);
 
     // Retry transient failures with exponential backoff, like every other
     // outbound client (e.g. so a momentary blip doesn't surface as a null

--- a/apps/server/src/modules/api/tautulli-api/tautulli-api.service.ts
+++ b/apps/server/src/modules/api/tautulli-api/tautulli-api.service.ts
@@ -190,6 +190,11 @@ export class TautulliApiService {
       };
 
       let data = await this.getPaginatedHistory(newOptions);
+      // A page that could not be read must not collapse into "no plays" -
+      // the caller cannot tell a confirmed-empty history from an outage.
+      if (!data) {
+        return null;
+      }
       const pageSize: number = MAX_PAGE_SIZE;
 
       const totalCount: number =
@@ -208,6 +213,10 @@ export class TautulliApiService {
         while (currentPage < pageCount) {
           newOptions.start = currentPage * pageSize;
           data = await this.getPaginatedHistory(newOptions);
+          // Same for a later page: partial results would undercount views.
+          if (!data) {
+            return null;
+          }
 
           currentPage++;
 

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -110,14 +110,19 @@ describe('TracearrApiService', () => {
     expect(service.getHistoryIndex()?.rowsByRatingKey.get('movie-2')).toEqual([
       second,
     ]);
+    // The fixture account carries no username, so the live media-server
+    // account list fills in.
     expect(service.getUsernamesByTracearrUserId()?.get(USER_ID)).toEqual([
       'alice',
     ]);
   });
 
   // A username that maps to no Tracearr user means "unknown user" to the
-  // per-user properties, so users without history must still be mapped.
-  it('maps every Tracearr user, under both the media server and Tracearr names', async () => {
+  // per-user properties, so users without history must still be mapped. One
+  // name per account: Tracearr re-reads the media server's username on every
+  // sync (plex.tv on Plex), so its copy is authoritative and emitting the
+  // local spelling too would count one viewer twice in the watcher lists.
+  it('maps every Tracearr user to the username Tracearr read off the media server', async () => {
     const OTHER_USER_ID = '55555555-5555-4555-8555-555555555555';
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
       if (endpoint === '/history') {
@@ -158,7 +163,6 @@ describe('TracearrApiService', () => {
     await service.prefetchHistory();
 
     expect(service.getUsernamesByTracearrUserId()?.get(USER_ID)).toEqual([
-      'alice',
       'alice.on.plex.tv',
     ]);
     expect(service.getUsernamesByTracearrUserId()?.get(OTHER_USER_ID)).toEqual([

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -504,8 +504,11 @@ export class TracearrApiService {
         // Mapped whether or not they appear in the swept history: absence has
         // to mean "Tracearr has no such user" so the per-user properties can
         // skip rather than read an unknown user as "watched nothing" (#3387
-        // fails closed). Both spellings are kept because the media server and
-        // Tracearr can name the same Plex account differently.
+        // fails closed). One name per account: Tracearr's `username` IS the
+        // media server's - it re-reads it on every user sync, from plex.tv on
+        // Plex (the spelling the rule editor offers) and from the server's
+        // user list on Jellyfin and Emby. The live account list only fills in
+        // when Tracearr answered no name at all.
         const usernames = [
           ...new Set(
             user.accounts
@@ -513,10 +516,11 @@ export class TracearrApiService {
                 (account) =>
                   account.server_id === serverId && !account.removed_at,
               )
-              .flatMap((account) => [
-                usernamesByAccountId.get(account.external_user_id),
-                account.username,
-              ])
+              .map(
+                (account) =>
+                  account.username ??
+                  usernamesByAccountId.get(account.external_user_id),
+              )
               .filter((username): username is string => Boolean(username)),
           ),
         ];

--- a/apps/server/src/modules/collections/collection-handler.ts
+++ b/apps/server/src/modules/collections/collection-handler.ts
@@ -182,7 +182,9 @@ export class CollectionHandler {
                 media.mediaServerId,
               );
 
-              if (mediaDataSeason?.index !== undefined) {
+              // != null: a null season index must not reach Seerr as a season
+              // number either
+              if (mediaDataSeason?.index != null) {
                 const removed = await this.seerrApi.removeSeasonRequest(
                   tmdbId,
                   mediaDataSeason.index,

--- a/apps/server/src/modules/collections/collections.controller.ts
+++ b/apps/server/src/modules/collections/collections.controller.ts
@@ -468,7 +468,7 @@ export class CollectionsController {
     return await this.collectionService.bulkMediaCollectionAction(
       request.mediaIds,
       request.collectionId,
-      request.action === 0 ? 'add' : 'remove',
+      request.action === ExclusionAction.ADD ? 'add' : 'remove',
       request.mediaType,
       request.context,
     );

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -126,6 +126,9 @@ export interface PostponeCollectionMediaResult {
 export interface CollectionAddResult {
   collection?: Collection;
   serverRejectedIds: string[];
+  /** Ids the server accepted but whose membership row failed to persist; the
+   * server add was rolled back, so nothing of the add survived. */
+  unpersistedIds?: string[];
 }
 
 export interface ContextActionResult extends CollectionAddResult {
@@ -1275,6 +1278,18 @@ export class CollectionsService {
       );
       return;
     }
+    // The status sorts compare Maintainerr-side state this hydrate never
+    // resolves, so every comparison would tie and the pushed order would be
+    // arbitrary. The rule group form withholds them; refuse one that arrives
+    // anyway.
+    if (
+      (mediaLibraryStatusSortFields as readonly string[]).includes(parsed.sort)
+    ) {
+      this.logger.warn(
+        `Ignoring collection sort '${sortKey}' on collection ${collection.id}: status sorts cannot be pushed to the media server`,
+      );
+      return;
+    }
     if (!collection.mediaServerId) {
       return;
     }
@@ -1340,35 +1355,50 @@ export class CollectionsService {
     entities: Exclusion[],
     mediaServer: IMediaServerService,
   ): Promise<Exclusion[]> {
-    const results = await Promise.allSettled(
-      entities.map(async (el) => {
-        const mediaItem = await mediaServer.getMetadata(
-          el.mediaServerId.toString(),
-        );
+    if (entities.length === 0) {
+      return [];
+    }
 
+    // One batched read for the rows and one for their deduped parents, not a
+    // request per row - the same shape as the collection media hydrate.
+    const metadataById = new Map<string, MediaItem>();
+    for (const mediaItem of await mediaServer.getMetadataBatch([
+      ...new Set(entities.map((el) => el.mediaServerId.toString())),
+    ])) {
+      metadataById.set(mediaItem.id, mediaItem);
+    }
+
+    const parentMetadataById = new Map<string, MediaItem>();
+    const parentIds = [
+      ...new Set(
+        [...metadataById.values()]
+          .map((mediaItem) => mediaItem.grandparentId ?? mediaItem.parentId)
+          .filter((parentId): parentId is string => Boolean(parentId)),
+      ),
+    ];
+    if (parentIds.length > 0) {
+      for (const parent of await mediaServer.getMetadataBatch(parentIds)) {
+        parentMetadataById.set(parent.id, parent);
+      }
+    }
+
+    return entities
+      .map((el) => {
+        const mediaItem = metadataById.get(el.mediaServerId.toString());
+
+        // A row the server did not answer for stays hidden, as before.
         if (!mediaItem) {
-          return { ...el, mediaData: undefined };
+          return undefined;
         }
 
         const parentId = mediaItem.grandparentId ?? mediaItem.parentId;
-        const parentItem = parentId
-          ? await mediaServer.getMetadata(parentId)
-          : undefined;
-
         el.mediaData = {
           ...mediaItem,
-          parentItem,
+          parentItem: parentId ? parentMetadataById.get(parentId) : undefined,
         };
         return el;
-      }),
-    );
-
-    return results
-      .filter(
-        (result): result is PromiseFulfilledResult<Exclusion> =>
-          result.status === 'fulfilled' && result.value.mediaData !== undefined,
-      )
-      .map((result) => result.value);
+      })
+      .filter((el): el is Exclusion => el !== undefined);
   }
 
   public async getCollectionMediaWithServerDataAndPaging(
@@ -2673,11 +2703,14 @@ export class CollectionsService {
             // The helper swallows its own failures so a rule run survives one
             // bad collection; an interactive caller has to be told.
             failAllResolved('Failed - the collection could not be updated');
-          } else if (result.serverRejectedIds.length > 0) {
+          } else {
             const rejected = new Set(result.serverRejectedIds);
+            const unpersisted = new Set(result.unpersistedIds ?? []);
             for (const [mediaId, ids] of resolvedByMediaId) {
               if (ids.some((id) => rejected.has(id))) {
                 fail(mediaId, 'Failed - refused by the media server');
+              } else if (ids.some((id) => unpersisted.has(id))) {
+                fail(mediaId, 'Failed - the collection could not be updated');
               }
             }
           }
@@ -2688,6 +2721,26 @@ export class CollectionsService {
           }
         } else if (!(await this.removeFromCollection(collectionId, media))) {
           failAllResolved('Failed - the collection could not be updated');
+        } else {
+          // The helper answers the collection even when the media server
+          // refused some children, but it only deletes the rows the server
+          // confirmed - so a row still present is a removal that did not
+          // happen.
+          const remaining = new Set(
+            (
+              (await this.CollectionMediaRepo.find({
+                where: {
+                  collectionId,
+                  mediaServerId: In(media.map((m) => m.mediaServerId)),
+                },
+              })) ?? []
+            ).map((row) => row.mediaServerId),
+          );
+          for (const [mediaId, ids] of resolvedByMediaId) {
+            if (ids.some((id) => remaining.has(id))) {
+              fail(mediaId, 'Failed - refused by the media server');
+            }
+          }
         }
       } catch (error) {
         this.logger.warn(`Bulk collection ${action} failed`);
@@ -2775,14 +2828,22 @@ export class CollectionsService {
         true,
       );
       return {
-        ...result,
         collection: orFail(result.collection),
+        // A rolled-back add left nothing behind either, so the caller reports
+        // it alongside the refusals.
+        serverRejectedIds: [
+          ...result.serverRejectedIds,
+          ...(result.unpersistedIds ?? []),
+        ],
         resolvedCount: handleMedia.length,
       };
     }
 
     if (!collectionDbId) {
-      await this.removeFromAllCollections(handleMedia);
+      const result = await this.removeFromAllCollections(handleMedia);
+      if (result && result.code !== 1) {
+        orFail(undefined);
+      }
       return { serverRejectedIds: [], resolvedCount: handleMedia.length };
     }
 
@@ -2882,6 +2943,7 @@ export class CollectionsService {
           !collectionMedia.find((el) => el.mediaServerId === m.mediaServerId),
       );
       let rejectedByServer: string[] = [];
+      let unpersistedIds: string[] = [];
 
       if (collection) {
         if (!skipAutomaticLinkCheck) {
@@ -3081,6 +3143,11 @@ export class CollectionsService {
               manualMembershipSource,
             );
           rejectedByServer = [...serverRejectedIds];
+          unpersistedIds = newMedia
+            .map((m) => m.mediaServerId)
+            .filter(
+              (id) => !serverRejectedIds.has(id) && !persistedIds.has(id),
+            );
 
           // Only notify for items whose membership was persisted - both
           // server-rejected items and locally-rolled-back items never
@@ -3140,7 +3207,11 @@ export class CollectionsService {
         // Update cached total size (non-blocking)
         this.updateCollectionTotalSize(collectionDbId).catch(() => {});
 
-        return { collection, serverRejectedIds: rejectedByServer };
+        return {
+          collection,
+          serverRejectedIds: rejectedByServer,
+          unpersistedIds,
+        };
       } else {
         this.logger.warn("Collection doesn't exist.");
       }

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -31,7 +31,10 @@ import { chunk } from 'lodash';
 import { Brackets, DataSource, In, LessThan, Not, Repository } from 'typeorm';
 import { CollectionLog } from '../../modules/collections/entities/collection_log.entities';
 import { getErrorMessage } from '../../utils/connection-error';
-import { MediaItemEnrichmentService } from '../api/media-server/media-item-enrichment.service';
+import {
+  ENRICHMENT_ID_CHUNK,
+  MediaItemEnrichmentService,
+} from '../api/media-server/media-item-enrichment.service';
 import { MediaServerFactory } from '../api/media-server/media-server.factory';
 import { IMediaServerService } from '../api/media-server/media-server.interface';
 import {
@@ -2725,17 +2728,19 @@ export class CollectionsService {
           // The helper answers the collection even when the media server
           // refused some children, but it only deletes the rows the server
           // confirmed - so a row still present is a removal that did not
-          // happen.
-          const remaining = new Set(
-            (
-              (await this.CollectionMediaRepo.find({
-                where: {
-                  collectionId,
-                  mediaServerId: In(media.map((m) => m.mediaServerId)),
-                },
-              })) ?? []
-            ).map((row) => row.mediaServerId),
-          );
+          // happen. Chunked because a show selection can resolve to enough
+          // episode ids to pass SQLite's parameter cap (#3431).
+          const remaining = new Set<string>();
+          for (const idBatch of chunk(
+            media.map((m) => m.mediaServerId),
+            ENRICHMENT_ID_CHUNK,
+          )) {
+            for (const row of (await this.CollectionMediaRepo.find({
+              where: { collectionId, mediaServerId: In(idBatch) },
+            })) ?? []) {
+              remaining.add(row.mediaServerId);
+            }
+          }
           for (const [mediaId, ids] of resolvedByMediaId) {
             if (ids.some((id) => remaining.has(id))) {
               fail(mediaId, 'Failed - refused by the media server');

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
@@ -249,6 +249,108 @@ describe('SonarrGetterService', () => {
       );
     });
 
+    // Season 0 used to short-circuit on truthiness to a definitive false;
+    // specials are a real season and compare like any other (#3421 review).
+    it('answers true for specials when only specials have aired', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2025-01-01'));
+
+      const collectionMedia = createCollectionMedia('season');
+      collectionMedia.collection.sonarrSettingsId = 1;
+
+      mockMediaServer.getMetadata.mockResolvedValue(
+        createMediaItem({ type: 'show' }),
+      );
+      const series = createSonarrSeries({
+        seasons: [
+          { seasonNumber: 0, monitored: false },
+          { seasonNumber: 1, monitored: true },
+        ],
+      });
+
+      const mockedSonarrApi = mockSonarrApi(series);
+      jest
+        .spyOn(mockedSonarrApi, 'getEpisodes')
+        .mockImplementation((seriesId, seasonNumber) =>
+          Promise.resolve([
+            createSonarrEpisode({
+              seriesId,
+              seasonNumber,
+              episodeNumber: 1,
+              // Only the specials have aired; season 1 is in the future.
+              airDateUtc:
+                seasonNumber === 0
+                  ? '2024-06-26T00:00:00Z'
+                  : '2025-04-01T00:00:00Z',
+            }),
+          ]),
+        );
+
+      const mediaItem = createMediaItem({ type: 'season', index: 0 });
+
+      const response = await sonarrGetterService.get(
+        13,
+        mediaItem,
+        'season',
+        createRuleGroupDto({
+          collection: collectionMedia.collection,
+          dataType: 'season',
+        }),
+      );
+
+      expect(response).toBe(true);
+    });
+
+    // A show-scoped rule used to fall through into the originalLanguage case
+    // and answer a language string for a boolean property (#3421 review).
+    it('answers null for a show, not the next case in the switch', async () => {
+      const collectionMedia = createCollectionMedia('show');
+      collectionMedia.collection.sonarrSettingsId = 1;
+
+      mockSonarrApi(
+        createSonarrSeries({
+          originalLanguage: { id: 1, name: 'English' },
+        } as Partial<SonarrSeries>),
+      );
+
+      const response = await sonarrGetterService.get(
+        13,
+        createMediaItem({ type: 'show' }),
+        'show',
+        createRuleGroupDto({
+          collection: collectionMedia.collection,
+          dataType: 'show',
+        }),
+      );
+
+      expect(response).toBeNull();
+    });
+
+    it('skips a season Sonarr does not list', async () => {
+      const collectionMedia = createCollectionMedia('season');
+      collectionMedia.collection.sonarrSettingsId = 1;
+
+      mockMediaServer.getMetadata.mockResolvedValue(
+        createMediaItem({ type: 'show' }),
+      );
+      mockSonarrApi(
+        createSonarrSeries({
+          seasons: [{ seasonNumber: 1, monitored: true }],
+        }),
+      );
+
+      const response = await sonarrGetterService.get(
+        13,
+        createMediaItem({ type: 'season', index: 5 }),
+        'season',
+        createRuleGroupDto({
+          collection: collectionMedia.collection,
+          dataType: 'season',
+        }),
+      );
+
+      expect(response).toBeUndefined();
+    });
+
     // #3153: in a full run the comparator resolves several of a show's seasons
     // concurrently, all sharing ONE memoized `showResponse.seasons` array via the
     // run-scoped ArrLookupCache. The latest-aired-season scan must not mutate that

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -515,6 +515,9 @@ export class SonarrGetterService {
           // returns true if a season with unaired episodes is found in monitored seasons
           const data: SonarrSeason[] = [];
           if (dataType === 'season') {
+            if (!season) {
+              return undefined;
+            }
             data.push(season);
           } else {
             data.push(...showResponse.seasons.filter((el) => el.monitored));
@@ -546,17 +549,24 @@ export class SonarrGetterService {
         case 'part_of_latest_season': {
           // returns the true when this is the latest season or the episode is part of the latest season
           if (dataType === 'season' || dataType === 'episode') {
-            return season.seasonNumber && showResponse.seasons
-              ? +season.seasonNumber ===
-                  (
-                    await this.getLastAiredOrCurrentlyAiringSeason(
-                      showResponse.seasons,
-                      showResponse.id,
-                      sonarrApiClient,
-                    )
-                  )?.seasonNumber
-              : false;
+            // A season Sonarr does not list cannot be judged - skip the item
+            // rather than answer. Season 0 is a real season: specials compare
+            // like any other, and are the latest when only specials aired.
+            if (!season) {
+              return undefined;
+            }
+            return (
+              +season.seasonNumber ===
+              (
+                await this.getLastAiredOrCurrentlyAiringSeason(
+                  showResponse.seasons,
+                  showResponse.id,
+                  sonarrApiClient,
+                )
+              )?.seasonNumber
+            );
           }
+          return null;
         }
         case 'originalLanguage': {
           return showResponse.originalLanguage?.name
@@ -579,7 +589,7 @@ export class SonarrGetterService {
           );
         }
         case 'seasonNumber': {
-          return season.seasonNumber;
+          return season?.seasonNumber ?? null;
         }
         case 'rating': {
           return showResponse.ratings?.value ?? null;

--- a/apps/server/src/modules/rules/getter/streamystats-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/streamystats-getter.service.spec.ts
@@ -15,8 +15,11 @@ const WATCH_TIME_BY_USER_PROP_ID = 5;
 const LAST_VIEWED_AT_BY_USER_PROP_ID = 6;
 
 const itemDetailsOf = (
+  // Streamystats reports the Jellyfin user id; its copy of the name can lag a
+  // rename or be null, which is why the getter matches on id.
   usersWatched: {
-    name: string;
+    id: string;
+    name: string | null;
     watchCount: number;
     totalWatchTime: number;
     lastWatched: string | null;
@@ -32,8 +35,8 @@ const itemDetailsOf = (
     watchHistory: [],
     watchCountByMonth: [],
     usersWatched: usersWatched.map(
-      ({ name, watchCount, totalWatchTime, lastWatched }) => ({
-        user: { id: `id-${name}`, name },
+      ({ id, name, watchCount, totalWatchTime, lastWatched }) => ({
+        user: { id, name },
         watchCount,
         totalWatchTime,
         completionRate: 0,
@@ -345,12 +348,14 @@ describe('StreamystatsGetterService', () => {
       streamystatsApi.getItemDetails.mockResolvedValue(
         itemDetailsOf([
           {
+            id: 'user-a',
             name: 'alice',
             watchCount: 3,
             totalWatchTime: 5400,
             lastWatched: '2026-05-01T10:00:00.000Z',
           },
           {
+            id: 'user-b',
             name: 'bob',
             watchCount: 9,
             totalWatchTime: 60,
@@ -369,6 +374,29 @@ describe('StreamystatsGetterService', () => {
       expect(
         await service.get(LAST_VIEWED_AT_BY_USER_PROP_ID, libItem, rule),
       ).toEqual(new Date('2026-05-01T10:00:00.000Z'));
+    });
+
+    // Streamystats' copy of the name lags a Jellyfin rename (and is nullable),
+    // so a name match would read this as "never watched" and let a delete rule
+    // sweep the item.
+    it('matches the statistics row by user id when the names disagree', async () => {
+      const { service, streamystatsApi } = createService([alice]);
+      const libItem = createMediaItem({ type: 'movie', id: 'item-1' });
+      streamystatsApi.getItemDetails.mockResolvedValue(
+        itemDetailsOf([
+          {
+            id: 'user-a',
+            name: null,
+            watchCount: 3,
+            totalWatchTime: 60,
+            lastWatched: null,
+          },
+        ]),
+      );
+
+      expect(await service.get(VIEW_COUNT_BY_USER_PROP_ID, libItem, rule)).toBe(
+        3,
+      );
     });
 
     it('answers zero and no date for a known user who never watched the item', async () => {
@@ -403,6 +431,7 @@ describe('StreamystatsGetterService', () => {
       streamystatsApi.getItemDetails.mockResolvedValue(
         itemDetailsOf([
           {
+            id: 'user-a',
             name: 'alice',
             watchCount: 3,
             totalWatchTime: 60,

--- a/apps/server/src/modules/rules/getter/streamystats-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/streamystats-getter.service.ts
@@ -130,7 +130,8 @@ export class StreamystatsGetterService {
     if (users.length === 0) {
       return undefined;
     }
-    if (!users.some((user) => user.name === username)) {
+    const mediaServerUser = users.find((user) => user.name === username);
+    if (!mediaServerUser) {
       this.logger.warn(
         `Streamystats-Getter - Skipping '${propName}': the media server has no user named '${username}'.`,
       );
@@ -144,8 +145,10 @@ export class StreamystatsGetterService {
       return undefined;
     }
 
+    // Streamystats user ids are the Jellyfin user ids (verified live), while
+    // its copy of the name is nullable and can lag a rename - so match on id.
     const userStats = details.usersWatched.find(
-      (entry) => entry.user.name === username,
+      (entry) => entry.user.id === mediaServerUser.id,
     );
 
     switch (propName) {

--- a/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/tautulli-getter.service.ts
@@ -124,6 +124,13 @@ export class TautulliGetterService {
               const viewers = await this.tautulliApi.getHistory({
                 rating_key: episode.rating_key,
               });
+              // An unreadable episode history would read as "nobody watched
+              // this episode" and empty the whole list.
+              if (!viewers) {
+                throw new Error(
+                  `Tautulli could not answer the watch history for episode ${episode.rating_key}`,
+                );
+              }
 
               const arrLength = allViewers.length - 1;
               allViewers
@@ -131,7 +138,7 @@ export class TautulliGetterService {
                 .reverse()
                 .forEach((el, idx) => {
                   if (
-                    !viewers?.find(
+                    !viewers.find(
                       (viewEl) =>
                         (tautulliWatchedPercentOverride != null
                           ? viewEl.percent_complete >=
@@ -312,6 +319,13 @@ export class TautulliGetterService {
     }
 
     const history = await this.tautulliApi.getHistory(options);
+    // null is a failed read, not an empty history - throw into the outer
+    // catch so the item pauses instead of reading as never watched.
+    if (!history) {
+      throw new Error(
+        `Tautulli could not answer the watch history for item ${metadata.rating_key}`,
+      );
+    }
     return history;
   }
 

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -560,10 +560,16 @@ export class RulesService {
         return managerState;
       }
       let state: ReturnStatus = this.createReturnStatus(true, 'Success');
-      const knownUsernames = [
-        ...(await this.getKnownUsernames(params.rules as RuleDto[])),
-        ...(await this.getSavedUsernames(params.id)),
-      ];
+      // Same gate getKnownUsernames applies internally: no rule names a user,
+      // so nothing consults the list and neither read is needed.
+      const knownUsernames = (params.rules as RuleDto[]).some((rule) =>
+        rule.username?.trim(),
+      )
+        ? [
+            ...(await this.getKnownUsernames(params.rules as RuleDto[])),
+            ...(await this.getSavedUsernames(params.id)),
+          ]
+        : [];
       for (const [index, rule] of (params.rules as RuleDto[]).entries()) {
         if (state.code === 1 && index > 0 && rule.operator == null) {
           state = this.createReturnStatus(

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -1551,11 +1551,27 @@ export class RulesService {
       }
       handleMedia = resolved;
     } else {
+      // Without a context the entry point removes its own rows, typed like
+      // setExclusion writes them (a bare global un-exclude, API-only today).
+      let entryPoint = data.context
+        ? { type: data.context.type, id: String(data.context.id) }
+        : undefined;
+      if (!entryPoint) {
+        const metaData = await mediaServer.getMetadata(String(data.mediaId));
+        if (!metaData?.type) {
+          this.logger.warn(
+            `No metadata found for media ${data.mediaId}, cannot remove exclusion`,
+          );
+          return this.createReturnStatus(false, 'Failed - no metadata');
+        }
+        topLevelType = metaData.type;
+        entryPoint = { type: metaData.type, id: String(data.mediaId) };
+      }
       // get media - traverse show -> seasons -> episodes if needed
       const resolved = await this.resolveContextActionIdsOrFail(
         mediaServer,
         undefined,
-        { type: data.context.type, id: String(data.context.id) },
+        entryPoint,
         String(data.mediaId),
       );
       if (!resolved) {

--- a/apps/ui/src/components/Collection/CollectionDetail/Exclusions/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/Exclusions/index.tsx
@@ -48,6 +48,7 @@ const CollectionExcludions = (props: ICollectionExclusions) => {
     toggleSelection,
     toggleSelectionMode,
     applyBulkOutcome,
+    resetSelection,
   } = useMediaSelection()
   const libraryType = props.collection.type === 'movie' ? 'movie' : 'show'
   const sortConfig = getCollectionSortConfig(
@@ -114,6 +115,9 @@ const CollectionExcludions = (props: ICollectionExclusions) => {
       return
     }
 
+    // A selection made against the previous item set must never survive into
+    // the next one - same contract as the Overview sync.
+    resetSelection()
     resetAndLoad({
       fetchPage: (page) => fetchExclusionsPage(page, nextSortState.sortParams),
     })

--- a/apps/ui/src/components/Common/MediaActionModal.spec.tsx
+++ b/apps/ui/src/components/Common/MediaActionModal.spec.tsx
@@ -93,12 +93,39 @@ describe('MediaActionModal', () => {
   it('offers only the collections the selection can be applied to', () => {
     renderModal({})
 
+    // The picker is scoped to the page's library - offering another library's
+    // collections only produces a rejected add (#3383's shape).
+    expect(useCollectionsMock).toHaveBeenCalledWith(
+      'library-1',
+      expect.objectContaining({ enabled: true }),
+    )
     expect(
       screen.getByRole('option', { name: 'Movie collection' }),
     ).toBeTruthy()
     expect(screen.queryByRole('option', { name: 'Show collection' })).toBeNull()
     // an add needs a real target, so it cannot mean "every collection"
     expect(screen.queryByRole('option', { name: 'All collections' })).toBeNull()
+  })
+
+  // A search spans libraries, so the page passes none - the picker-driven
+  // actions drop rather than offering every library's collections.
+  it('offers only library-agnostic actions when the page has no library', () => {
+    renderModal({ libraryId: undefined })
+
+    expect(useCollectionsMock).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ enabled: false }),
+    )
+    expect(
+      screen.queryByRole('option', { name: 'Add to collection' }),
+    ).toBeNull()
+    expect(
+      screen.queryByRole('option', { name: 'Remove from collection' }),
+    ).toBeNull()
+    expect(
+      screen.getByRole('option', { name: 'Remove from all collections' }),
+    ).toBeTruthy()
+    expect(screen.getByRole('option', { name: 'Add exclusion' })).toBeTruthy()
   })
 
   it('adds the selection to the chosen collection and reports per-item results', async () => {

--- a/apps/ui/src/components/Common/MediaActionModal.tsx
+++ b/apps/ui/src/components/Common/MediaActionModal.tsx
@@ -108,9 +108,10 @@ const MediaActionModal = ({
   })
   const episodesQuery = useMediaServerMetadataChildren(selectedSeasons)
   // A collection only accepts items from its own library, so offering the other
-  // libraries' collections only produces a rejected add.
+  // libraries' collections only produces a rejected add. No library (a search
+  // spanning them) means no list to offer, not every list.
   const collectionsQuery = useCollections(libraryId, {
-    enabled: !lockedCollection,
+    enabled: !lockedCollection && libraryId !== undefined,
   })
 
   const submittedType = useMemo((): MediaItemType | undefined => {
@@ -148,11 +149,15 @@ const MediaActionModal = ({
   }, [submittedType])
 
   const actionOptions = useMemo((): MediaAction[] => {
-    // A mixed selection has no single type, so no collection can take it.
+    // A mixed selection has no single type, so no collection can take it. The
+    // picker-driven actions also need a library (or a pinned collection) to
+    // scope the picker; without one only the library-agnostic actions remain.
+    const canPickCollection = lockedCollection || libraryId !== undefined
     const actions: MediaAction[] = mediaType
       ? [
-          'collection-add',
-          'collection-remove',
+          ...(canPickCollection
+            ? (['collection-add', 'collection-remove'] as const)
+            : []),
           'collection-remove-all',
           'exclusion-add',
           'exclusion-remove',
@@ -162,7 +167,7 @@ const MediaActionModal = ({
     return hiddenActions
       ? actions.filter((action) => !hiddenActions.includes(action))
       : actions
-  }, [mediaType, hiddenActions])
+  }, [mediaType, hiddenActions, lockedCollection, libraryId])
 
   // Derived, not synced: a page can hide actions, and a mixed selection drops
   // the collection ones, so fall back to the first one still offered.

--- a/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
+++ b/apps/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
@@ -400,8 +400,11 @@ const RuleInput = (props: IRuleInput) => {
     isPerUserProperty(selectedFirstValueProp?.name) ||
     isPerUserProperty(getPropFromValue(secondVal, constants)?.name)
 
-  const { data: ruleUsernames = [], isLoading: ruleUsernamesLoading } =
-    useRuleUsernames({ enabled: isSelectedPerUserRule })
+  const {
+    data: ruleUsernames = [],
+    isLoading: ruleUsernamesLoading,
+    isError: ruleUsernamesFailed,
+  } = useRuleUsernames({ enabled: isSelectedPerUserRule })
 
   // A typo would save a rule that then skips every item, so only a known user
   // counts - or the one already saved, which keeps a rule editable after the
@@ -891,8 +894,19 @@ const RuleInput = (props: IRuleInput) => {
               }
               onChange={updateUsername}
               value={username}
+              error={!!username && !isUsernameUsable}
             />
-            {!ruleUsernamesLoading && ruleUsernames.length === 0 ? (
+            {!!username && !isUsernameUsable ? (
+              // The same reason the save would be rejected with - without it
+              // the rule just never commits and nothing says why.
+              <p className="mt-1 text-xs text-error-500">
+                The media server has no user named &apos;{username}&apos;
+              </p>
+            ) : ruleUsernamesFailed ? (
+              <p className="mt-1 text-xs text-zinc-400">
+                The user list could not be loaded
+              </p>
+            ) : !ruleUsernamesLoading && ruleUsernames.length === 0 ? (
               <p className="mt-1 text-xs text-zinc-400">
                 No users reported by the media server
               </p>

--- a/apps/ui/src/components/Settings/Servarr/ServarrSettingsModal.tsx
+++ b/apps/ui/src/components/Settings/Servarr/ServarrSettingsModal.tsx
@@ -145,7 +145,12 @@ const buildServarrPayload = <TSetting extends ServarrSettingShape>(
 
   return {
     payload: {
-      url: `${url}${state.baseUrl ? `/${state.baseUrl}` : ''}`,
+      // The base URL slot can contribute its own trailing slash (#3416), so
+      // the composed URL is stripped as well - the host strip above still
+      // keeps a slash-ended hostname from doubling at the join.
+      url: stripTrailingSlashes(
+        `${url}${state.baseUrl ? `/${state.baseUrl}` : ''}`,
+      ),
       apiKey: state.apiKey,
       serverName: state.serverName,
       ...(settings?.id ? { id: settings.id } : {}),

--- a/apps/ui/src/pages/CollectionMediaPage.tsx
+++ b/apps/ui/src/pages/CollectionMediaPage.tsx
@@ -49,6 +49,7 @@ const CollectionMediaPage = () => {
     toggleSelection,
     toggleSelectionMode,
     applyBulkOutcome,
+    resetSelection,
   } = useMediaSelection()
   const fetchAmount = 30
   const mediaRef = useRef<ICollectionMedia[]>([])
@@ -130,6 +131,9 @@ const CollectionMediaPage = () => {
       return
     }
 
+    // A selection made against the previous item set must never survive into
+    // the next one - same contract as the Overview sync.
+    resetSelection()
     resetAndLoad({
       fetchPage: (page) =>
         fetchCollectionMediaPage(page, nextSortState.sortParams),

--- a/packages/contracts/src/bulk-media-action/index.ts
+++ b/packages/contracts/src/bulk-media-action/index.ts
@@ -9,7 +9,7 @@ import { MediaItemTypes, type MediaItemType } from '../media-server/enums'
 export const BULK_MEDIA_ACTION_MAX_ITEMS = 250
 
 /** 0 = add, 1 = remove, matching the singular endpoints' action field. */
-export const bulkMediaActionSchema = z.union([z.literal(0), z.literal(1)])
+const bulkMediaActionSchema = z.union([z.literal(0), z.literal(1)])
 
 const bulkMediaIdsSchema = z
   .array(z.string().trim().min(1))


### PR DESCRIPTION
Fixes for the findings of the #3421 release review, from high to nit. Every fix was traced against the PR history since v3.20.0 and proven against the real dev stack (fault-injecting proxy for the failure paths) before and after the change. All existing tests pass unchanged; new tests are additive.

## Fixed

| Finding | Fix |
| --- | --- |
| Streamystats matched the stats row by a name Streamystats itself treats as nullable and rename-lagging | Resolve the media-server user by the username written in the rule, then match statistics rows by user id. Live: alice on a movie answers 5 views / 4 min through the id match |
| Tracearr rules matched Tracearr-side identities | Match only the username Tracearr reads off the media server (re-read every sync); departed accounts (`removed_at`) are skipped |
| Emby batched metadata read fell back to an unscoped route and shared the per-item cache namespace | The batch read resolves a user or refuses to answer, caches under its own key, and asks for every field the mapper reads |
| Sonarr season properties broke on specials and fell through | Season 0 is a real season; `part_of_latest_season` answers null on shows instead of falling into `originalLanguage` (proven live); an unlisted season answers the transient signal; the handler passes its once-resolved season number |
| A failed Tautulli history page read as an empty page | `getHistory` answers null when any page fails and the getter pauses the item. Live: with only `cmd=get_history` 500ing, "Times viewed" answered a fabricated 0; now it holds and self-heals |
| Bulk remove reported success for children the media server refused | The remove branch verifies the post-condition: a membership row still present is a removal that did not happen. Live: a proxy-refused child now answers `Failed - refused by the media server` while DB and Plex agree |
| A rolled-back add and a failed remove-from-all reported success | `addToCollectionInternal` reports unpersisted ids; the context path folds them into the refusals; the global remove branch checks the result code |
| Exclusions tab read metadata one request per row plus one per parent | Hydrates rows and deduped parents through `getMetadataBatch`, the #3432/#3435 shape |
| A manual/excluded sort key would push an arbitrary order to the media server | `applyCollectionSort` refuses status sort keys (their comparators read Maintainerr-side state the push hydrate never resolves) |
| Jellyfin client 404s every route when a pre-#3422 row holds a trailing slash | `createApiClient` strips on read, like the Seerr client already does. Live: a slashed stored URL now answers libraries |
| A null season index reached Seerr as a season number | `!= null` guard in the handler |
| qBittorrent silently dropped refused download ids | One warn naming the refused count |
| Collection picker offered every library's collections when the page has none | Picker and collection actions gated on the page's library; a cross-library search offers only library-agnostic actions and fetches nothing |
| A selection survived into a different item set after a sort change | Selection resets on sort change on both collection tabs |
| Removing an exclusion without a context 500ed | The context resolves from metadata when the caller sends none (proven live: 500 before, 201 + row gone after) |
| An unknown rule username silently kept the rule uncommitted | The field shows the error state and the same reason the save rejects with; a failed user-list load says so |
| Both username reads ran on every rule-group update | Skipped when no rule names a user, matching the gate `getKnownUsernames` already had |
| Servarr modal stripped the host but not the composed URL | The composed URL is stripped as well, so the base-url slot cannot contribute a trailing slash |
| The rules regression matrix was not run anywhere | CI runs `test:e2e` (107 scenarios) so it cannot silently stop starting again (#3426) |
| Nits | `ExclusionAction.ADD` instead of a raw `0`; un-export the schema nothing imports; Emby helper uses the shared `stripTrailingSlashes`; project notes record the Streamystats id facts |

## Deliberately not changed

| Item | Why |
| --- | --- |
| Plex `resetMetadataCache` leaving `/children` entries | Recorded as left out on purpose in #3363 and pinned by a #3429 spec |
| `requestLogging.ts` local slash walk | Symmetric with its leading-slash walk in a self-contained log formatter; a cross-package import changes nothing |
| Spec-file-only findings | Existing tests stay untouched by policy for this PR |

## Verification

- Live before/after proofs on the real dev stack: Plex, Jellyfin, Emby, Sonarr, Radarr, Tautulli, Tracearr, Streamystats, Seerr, with a fault-injecting proxy for refused deletes and failed history pages
- Playwright over every UI change: modal gating on search, selection reset on both tabs, exclusions hydration, username error state, servarr URL compose
- `yarn turbo test lint check-types` green; rules regression matrix runs 107 scenarios clean
