### PR TITLE
fix(download-client): keep the qBittorrent session on 5.2+

### DIFF
--- a/apps/server/src/modules/api/download-client-api/download-client-api.service.ts
+++ b/apps/server/src/modules/api/download-client-api/download-client-api.service.ts
@@ -9,11 +9,11 @@ import {
 } from '../../../utils/connection-error';
 
 // qBittorrent rejects an authenticated request with 403 when its Web UI security
-// blocks the caller. Bad credentials are NOT this case (they return HTTP 200
-// "Fails." and are handled at login), so "Invalid API key" (the shared util's
-// 401/403 message) is misleading. The reliable fix is whitelisting Maintainerr's
-// IP - it and qBittorrent commonly run on different (Docker) IPs - so lead with
-// that and only mention proxy/host validation as a secondary cause.
+// blocks the caller. Bad credentials are NOT this case (they are rejected at
+// login instead), so "Invalid API key" (the shared util's 401/403 message) is
+// misleading. The reliable fix is whitelisting Maintainerr's IP - it and
+// qBittorrent commonly run on different (Docker) IPs - so lead with that and
+// only mention proxy/host validation as a secondary cause.
 const DOWNLOAD_CLIENT_FORBIDDEN_MESSAGE =
   'The download client accepted the login but returned 403 Forbidden - a ' +
   'qBittorrent Web UI security restriction, not a wrong username or password. ' +

--- a/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.spec.ts
+++ b/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.spec.ts
@@ -1,3 +1,4 @@
+import { AxiosError, AxiosHeaders, AxiosResponse } from 'axios';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { QbittorrentApi } from './qbittorrent.helper';
 
@@ -39,22 +40,60 @@ describe('QbittorrentApi auth', () => {
     expect(axiosMock.defaults.headers.common['Cookie']).toBeUndefined();
   });
 
-  it('captures the SID cookie when one is issued', async () => {
-    const { api, axiosMock } = buildApi();
-    axiosMock.post.mockResolvedValue({
+  it.each([
+    // qBittorrent 5.1 and older: HTTP 200 "Ok." plus a cookie named `SID`.
+    {
       data: 'Ok.',
-      headers: { 'set-cookie': ['SID=abc123; HttpOnly; path=/'] },
-    });
-    axiosMock.get.mockResolvedValue({ data: 'v5.0.0' });
+      setCookie: 'SID=abc123; HttpOnly; path=/',
+      expected: 'SID=abc123',
+    },
+    // 5.2+: HTTP 204 with no body, and the cookie is named after qBittorrent's
+    // OWN WebUI port - here 8090, deliberately not the configured URL's 8080,
+    // because a Docker port mapping or reverse proxy hides it (#3437).
+    {
+      data: '',
+      setCookie: 'QBT_SID_8090=Zk6xfR8Y+Vl6; HttpOnly; SameSite=Lax; path=/',
+      expected: 'QBT_SID_8090=Zk6xfR8Y+Vl6',
+    },
+  ])(
+    'captures the session cookie whatever qBittorrent names it ($expected)',
+    async ({ data, setCookie, expected }) => {
+      const { api, axiosMock } = buildApi();
+      axiosMock.post.mockResolvedValue({
+        data,
+        headers: { 'set-cookie': [setCookie] },
+      });
+      axiosMock.get.mockResolvedValue({ data: 'v5.0.0' });
 
-    await api.getVersion();
+      await api.getVersion();
 
-    expect(axiosMock.defaults.headers.common['Cookie']).toBe('SID=abc123');
-  });
+      expect(axiosMock.defaults.headers.common['Cookie']).toBe(expected);
+    },
+  );
 
-  it('rejects invalid credentials (HTTP 200 body "Fails.")', async () => {
+  it('rejects invalid credentials (HTTP 200 body "Fails." on 5.1 and older)', async () => {
     const { api, axiosMock } = buildApi();
     axiosMock.post.mockResolvedValue({ data: 'Fails.', headers: {} });
+
+    await expect(api.getVersion()).rejects.toThrow(
+      'Invalid username or password',
+    );
+    expect(axiosMock.get).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid credentials (HTTP 401 on 5.2+)', async () => {
+    const { api, axiosMock } = buildApi();
+    axiosMock.post.mockRejectedValue(
+      new AxiosError(
+        'Request failed with status code 401',
+        undefined,
+        {
+          headers: new AxiosHeaders(),
+        },
+        undefined,
+        { status: 401 } as AxiosResponse,
+      ),
+    );
 
     await expect(api.getVersion()).rejects.toThrow(
       'Invalid username or password',

--- a/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.ts
+++ b/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.ts
@@ -1,4 +1,4 @@
-import { AxiosError, RawAxiosRequestConfig } from 'axios';
+import { AxiosError, AxiosResponse, RawAxiosRequestConfig } from 'axios';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { ExternalApiService } from '../../external-api/external-api.service';
 import {
@@ -57,14 +57,17 @@ const toDownloadClientTorrent = (
 };
 
 /**
- * Thin client for the qBittorrent WebUI API (v2, qBittorrent 4.1+) - the
- * qBittorrent implementation of the backend-agnostic `DownloadClient` contract.
+ * Thin client for the qBittorrent WebUI API (v2) - the qBittorrent
+ * implementation of the backend-agnostic `DownloadClient` contract. The v2 API
+ * itself dates from 4.1, but the oldest usable version is 4.3.4: `content_path`
+ * (cross-seed detection) only arrived in 4.3.1 and `seeding_time` in 4.3.4.
  *
- * qBittorrent uses cookie/session auth: `POST /api/v2/auth/login` issues a `SID`
- * cookie that must accompany every subsequent request. `ExternalApiService` has
- * no cookie jar, so this helper manages the `SID` on its own axios instance and
- * re-logs in once on a 401/403. Calls go through `this.axios` directly (not the
- * cached `get`/`post` wrappers) so auth failures surface and reads stay fresh.
+ * qBittorrent uses cookie/session auth: `POST /api/v2/auth/login` issues a
+ * session cookie that must accompany every subsequent request.
+ * `ExternalApiService` has no cookie jar, so this helper keeps that cookie on
+ * its own axios instance and re-logs in once on a 401/403. Calls go through
+ * `this.axios` directly (not the cached `get`/`post` wrappers) so auth failures
+ * surface and reads stay fresh.
  */
 export class QbittorrentApi
   extends ExternalApiService
@@ -165,27 +168,35 @@ export class QbittorrentApi
     body.set('username', this.username ?? '');
     body.set('password', this.password ?? '');
 
-    const response = await this.axios.post<string>(
-      '/auth/login',
-      body.toString(),
-      { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
-    );
+    let response: AxiosResponse<string>;
+    try {
+      response = await this.axios.post<string>('/auth/login', body.toString(), {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      });
+    } catch (error) {
+      // qBittorrent 5.2+ rejects invalid credentials with HTTP 401 instead of
+      // the older HTTP 200 body "Fails." handled below.
+      if (error instanceof AxiosError && error.response?.status === 401) {
+        throw new Error('Invalid username or password');
+      }
+      throw error;
+    }
 
-    // qBittorrent answers HTTP 200 with body "Fails." on invalid credentials.
+    // qBittorrent 5.1 and older answer HTTP 200 with body "Fails." instead.
     const responseBody =
       typeof response.data === 'string' ? response.data.trim() : '';
     if (responseBody === 'Fails.') {
       throw new Error('Invalid username or password');
     }
 
-    // On a normal login qBittorrent issues an SID cookie to use on subsequent
-    // requests. When the WebUI bypasses authentication (e.g. "Bypass
-    // authentication for clients on localhost"/whitelisted subnets) it returns
-    // "Ok." with no cookie - that is still a valid, authenticated session, so
+    // On a normal login qBittorrent issues a session cookie to send back on
+    // every subsequent request. When the WebUI bypasses authentication (e.g.
+    // "Bypass authentication for clients on localhost"/whitelisted subnets) it
+    // can answer without one - that is still a valid, authenticated session, so
     // capture the cookie when present but never require it.
-    const sid = this.extractSid(response.headers['set-cookie']);
-    if (sid) {
-      this.axios.defaults.headers.common['Cookie'] = `SID=${sid}`;
+    const cookie = this.extractSessionCookie(response.headers['set-cookie']);
+    if (cookie) {
+      this.axios.defaults.headers.common['Cookie'] = cookie;
     }
     this.authenticated = true;
   }
@@ -215,25 +226,28 @@ export class QbittorrentApi
     }
   }
 
-  private extractSid(setCookie: string[] | undefined): string | undefined {
-    if (!setCookie) {
-      return undefined;
+  /**
+   * Echo back whatever cookie the login response set, name included. The name
+   * is deliberately not matched: qBittorrent 5.1 and older call it `SID` (and
+   * let the user rename it), while 5.2+ call it `QBT_SID_<WebUI port>` - and
+   * that is qBittorrent's own port, which a Docker port mapping or reverse
+   * proxy hides, so it cannot be derived from the configured URL either.
+   */
+  private extractSessionCookie(
+    setCookie: string[] | undefined,
+  ): string | undefined {
+    const cookies: string[] = [];
+
+    for (const cookie of setCookie ?? []) {
+      const end = cookie.indexOf(';');
+      const pair = (end === -1 ? cookie : cookie.slice(0, end)).trim();
+      // Keep only `name=value`; a cookie without a value is a deletion.
+      const separator = pair.indexOf('=');
+      if (separator > 0 && separator < pair.length - 1) {
+        cookies.push(pair);
+      }
     }
 
-    for (const cookie of setCookie) {
-      const trimmed = cookie.trimStart();
-      if (!trimmed.startsWith('SID=')) {
-        continue;
-      }
-
-      const afterEquals = trimmed.slice('SID='.length);
-      const end = afterEquals.indexOf(';');
-      const value = end === -1 ? afterEquals : afterEquals.slice(0, end);
-      if (value) {
-        return value;
-      }
-    }
-
-    return undefined;
+    return cookies.length > 0 ? cookies.join('; ') : undefined;
   }
 }


### PR DESCRIPTION
Fixes #3437.

qBittorrent 5.2.0 rewrote the `POST /api/v2/auth/login` contract. Maintainerr only recognised the pre-5.2 shape, so on 5.2+ it kept no session cookie: login looked fine, then every request 403'd and the connection test blamed a WebUI security restriction.

| Behaviour | 5.1 and older | 5.2.0+ | Handled before |
| --- | --- | --- | --- |
| Session cookie name | `SID` (user-renameable) | `QBT_SID_<WebUI port>` | no |
| Login success | 200, body `Ok.` | 204, empty body | yes |
| Invalid credentials | 200, body `Fails.` | 401 | no |

Source: [`webapplication.cpp`](https://github.com/qbittorrent/qBittorrent/blob/release-5.2.0/src/webui/webapplication.cpp#L75) (`SESSION_COOKIE_NAME_PREFIX` + WebUI port) and [`authcontroller.cpp`](https://github.com/qbittorrent/qBittorrent/blob/release-5.2.0/src/webui/api/authcontroller.cpp#L43).

## Changes

| Change | Why |
| --- | --- |
| Echo back whatever cookie the login response set, rather than matching a name | The 5.2+ name embeds qBittorrent's own WebUI port, which a Docker port mapping or reverse proxy hides, so it cannot be derived from the configured URL |
| Map a 401 at login to "Invalid username or password" | A typo'd password previously surfaced as "Invalid API key", for a client that has no API key |

The auth-bypass path (no cookie issued) is unchanged and still supported.

## Verification

Against a real qBittorrent 5.2.3, with WebUI auth bypass both off and on:

| Case | Before | After |
| --- | --- | --- |
| Test connection | 403 security-restriction message | `v5.2.3` |
| Cookie kept after login | none | `QBT_SID_8088=...` |
| List / lookup / delete a torrent | n/a | removal confirmed in qBittorrent's own log |
| Wrong password | "Invalid API key" | "Invalid username or password" |

qBittorrent's log also showed two logins per failed attempt before the fix (the 403 retry) and one after.
