### PR TITLE
fix(tracearr): bind to the Tracearr server that tracks the managed media server

### DIFF
--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.constants.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.constants.ts
@@ -12,6 +12,11 @@ export const TRACEARR_SERVER_PROBE_SIZE = 20;
 // in every library and Plex and Emby both number items from the same range.
 export const TRACEARR_SERVER_MATCH_THRESHOLD = 2;
 
+// How many items must be checked before "nothing matched" is treated as the
+// wrong server rather than as unknown. Guards against condemning a correct
+// server whose few recent items happen to have been deleted since.
+export const TRACEARR_SERVER_PROBE_MINIMUM = 5;
+
 // Tracearr can only filter history by server, not by Maintainerr library. Keep
 // the server-wide snapshot within the same 500k-record ceiling as the
 // library-scoped Plex and Jellyfin snapshots (#3284, #3368). The rule getter

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.constants.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.constants.ts
@@ -2,6 +2,16 @@ export const TRACEARR_CACHE_ID = 'tracearr';
 export const TRACEARR_HISTORY_CACHE_KEY = 'history-index';
 export const TRACEARR_PAGE_SIZE = 100;
 
+// How many of a candidate server's most recently added items to check before
+// deciding it is not the media server Maintainerr manages. Sized for items the
+// media server no longer has, since those are skipped rather than counted.
+export const TRACEARR_SERVER_PROBE_SIZE = 20;
+
+// How many of those items must agree before a server counts as the managed
+// one. More than one, because a single agreement is cheap: "Season 1" exists
+// in every library and Plex and Emby both number items from the same range.
+export const TRACEARR_SERVER_MATCH_THRESHOLD = 2;
+
 // Tracearr can only filter history by server, not by Maintainerr library. Keep
 // the server-wide snapshot within the same 500k-record ceiling as the
 // library-scoped Plex and Jellyfin snapshots (#3284, #3368). The rule getter

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -534,10 +534,19 @@ describe('TracearrApiService', () => {
       // else entirely.
       getMetadata: jest.fn(async (id: string) =>
         id === 'ours-1'
-          ? { title: 'Real Movie', year: 2020 }
+          ? {
+              title: 'Real Movie',
+              addedAt: new Date('2026-01-01T00:00:00.000Z'),
+            }
           : id === 'ours-2'
-            ? { title: 'Other Real Movie', year: 2021 }
-            : { title: 'Something Else', year: 1999 },
+            ? {
+                title: 'Other Real Movie',
+                addedAt: new Date('2026-01-01T00:00:00.000Z'),
+              }
+            : {
+                title: 'Something Else',
+                addedAt: new Date('1999-01-01T00:00:00.000Z'),
+              },
       ),
     } as never);
     apiMock.getRawWithoutCache.mockResolvedValue({
@@ -571,13 +580,25 @@ describe('TracearrApiService', () => {
         return config.params.server_id === SERVER_ID
           ? {
               data: [
-                { rating_key: 'ours-1', title: 'Real Movie', year: 2020 },
-                { rating_key: 'ours-2', title: 'Other Real Movie', year: 2021 },
+                {
+                  rating_key: 'ours-1',
+                  title: 'Real Movie',
+                  added_at: '2026-01-01T00:00:00.000Z',
+                },
+                {
+                  rating_key: 'ours-2',
+                  title: 'Other Real Movie',
+                  added_at: '2026-01-01T00:00:00.000Z',
+                },
               ],
             }
           : {
               data: [
-                { rating_key: 'theirs-1', title: 'Real Movie', year: 2020 },
+                {
+                  rating_key: 'theirs-1',
+                  title: 'Real Movie',
+                  added_at: '2026-01-01T00:00:00.000Z',
+                },
                 {
                   rating_key: 'theirs-2',
                   title: 'Other Real Movie',
@@ -607,9 +628,15 @@ describe('TracearrApiService', () => {
       getChildrenMetadata: jest.fn().mockResolvedValue([]),
       getMetadata: jest.fn(async (id: string) =>
         id.startsWith('ours-')
-          ? { title: `Real ${id}`, year: 2020 }
+          ? {
+              title: `Real ${id}`,
+              addedAt: new Date('2026-01-01T00:00:00.000Z'),
+            }
           : undefined,
       ),
+      // The foreign server's GUIDs are genuinely absent. getMetadata alone
+      // cannot tell that from a failed read, which is what itemExists answers.
+      itemExists: jest.fn(async (id: string) => id.startsWith('ours-')),
     } as never);
     apiMock.getWithoutCache.mockImplementation(
       async (endpoint: string, config: { params: { server_id: string } }) => {
@@ -626,7 +653,7 @@ describe('TracearrApiService', () => {
           data: Array.from({ length: 6 }, (_unused, i) => ({
             rating_key: own ? `ours-${i}` : `theirs-${i}`,
             title: own ? `Real ours-${i}` : `Foreign ${i}`,
-            year: 2020,
+            added_at: '2026-01-01T00:00:00.000Z',
           })),
         };
       },
@@ -638,6 +665,59 @@ describe('TracearrApiService', () => {
         foreignId,
       ),
     ).resolves.toBe(false);
+  });
+
+  // getMetadata cannot tell an absent item from a failed read, so a timeout
+  // must not be read as proof that the server is foreign.
+  it('does not condemn a server when the media server cannot be read', async () => {
+    const otherId = '99999999-9999-4999-8999-999999999999';
+    Object.assign(settings, { media_server_type: MediaServerType.JELLYFIN });
+    mediaServerFactory.getService.mockResolvedValue({
+      getUsers: jest.fn().mockResolvedValue([{ id: 'account-1', name: 'a' }]),
+      getChildrenMetadata: jest.fn().mockResolvedValue([]),
+      getMetadata: jest.fn().mockResolvedValue(undefined),
+      itemExists: jest.fn().mockRejectedValue(new Error('gateway timeout')),
+    } as never);
+    apiMock.getWithoutCache.mockResolvedValue({
+      data: Array.from({ length: 8 }, (_unused, i) => ({
+        rating_key: `key-${i}`,
+        title: `Title ${i}`,
+        added_at: '2026-01-01T00:00:00.000Z',
+      })),
+    });
+
+    await expect(
+      service.serverSharesLibrary(
+        { url: 'http://tracearr.local', apiKey: 'trr_pub_token' },
+        otherId,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  // Live recently-added rows are full of seasons and episodes with no year, so
+  // a title on its own must not confirm a server.
+  it('does not confirm a server from title-only agreement', async () => {
+    Object.assign(settings, { media_server_type: MediaServerType.PLEX });
+    mediaServerFactory.getService.mockResolvedValue({
+      getUsers: jest.fn().mockResolvedValue([{ id: 'account-1', name: 'a' }]),
+      getChildrenMetadata: jest.fn().mockResolvedValue([]),
+      getMetadata: jest.fn(async () => ({ title: 'Season 1', year: null })),
+      itemExists: jest.fn().mockResolvedValue(true),
+    } as never);
+    apiMock.getWithoutCache.mockResolvedValue({
+      data: Array.from({ length: 8 }, (_unused, i) => ({
+        rating_key: `${i}`,
+        title: 'Season 1',
+        added_at: '2026-01-01T00:00:00.000Z',
+      })),
+    });
+
+    await expect(
+      service.serverSharesLibrary(
+        { url: 'http://tracearr.local', apiKey: 'trr_pub_token' },
+        SERVER_ID,
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it('refuses history from a server that is not the configured media server', async () => {

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -667,6 +667,38 @@ describe('TracearrApiService', () => {
     ).resolves.toBe(false);
   });
 
+  // Plex and Emby number items from a shared range and generic titles like
+  // "Season 1" repeat everywhere, so a foreign server's keys can resolve to
+  // same-titled items. The added date is then the only thing separating them.
+  it('rejects a same-titled server whose items were added at other times', async () => {
+    const foreignId = '66666666-6666-4666-8666-666666666666';
+    Object.assign(settings, { media_server_type: MediaServerType.PLEX });
+    mediaServerFactory.getService.mockResolvedValue({
+      getUsers: jest.fn().mockResolvedValue([{ id: 'account-1', name: 'a' }]),
+      getChildrenMetadata: jest.fn().mockResolvedValue([]),
+      // Same key, same title, different copy: added months earlier.
+      getMetadata: jest.fn(async () => ({
+        title: 'Season 1',
+        addedAt: new Date('2025-03-04T10:00:00.000Z'),
+      })),
+      itemExists: jest.fn().mockResolvedValue(true),
+    } as never);
+    apiMock.getWithoutCache.mockResolvedValue({
+      data: Array.from({ length: 6 }, (_unused, i) => ({
+        rating_key: `${100 + i}`,
+        title: 'Season 1',
+        added_at: '2026-01-01T00:00:00.000Z',
+      })),
+    });
+
+    await expect(
+      service.serverSharesLibrary(
+        { url: 'http://tracearr.local', apiKey: 'trr_pub_token' },
+        foreignId,
+      ),
+    ).resolves.toBe(false);
+  });
+
   // getMetadata cannot tell an absent item from a failed read, so a timeout
   // must not be read as proof that the server is foreign.
   it('does not condemn a server when the media server cannot be read', async () => {

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -1,4 +1,4 @@
-import { TracearrHistoryItem } from '@maintainerr/contracts';
+import { MediaServerType, TracearrHistoryItem } from '@maintainerr/contracts';
 import { Mocked, TestBed } from '@suites/unit';
 import { MediaServerFactory } from '../media-server/media-server.factory';
 import { SettingsDataService } from '../../settings/settings-data.service';
@@ -77,6 +77,7 @@ describe('TracearrApiService', () => {
       getChildrenMetadata: jest.fn().mockResolvedValue([]),
     } as never);
     Object.assign(settings, {
+      media_server_type: MediaServerType.PLEX,
       tracearr_url: 'http://tracearr.local',
       tracearr_api_key: 'trr_pub_token',
       tracearr_server_id: SERVER_ID,
@@ -443,6 +444,173 @@ describe('TracearrApiService', () => {
         apiKey: 'trr_pub_token',
       }),
     ).resolves.toEqual([{ id: SERVER_ID, name: 'Dev Plex' }]);
+  });
+
+  it('offers only the Tracearr server matching the configured media server', async () => {
+    const jellyfinServerId = '66666666-6666-4666-8666-666666666666';
+    Object.assign(settings, { media_server_type: MediaServerType.PLEX });
+    apiMock.getRawWithoutCache.mockResolvedValue({
+      data: {
+        paths: {
+          '/api/v2/public/history': {
+            get: {
+              parameters: [
+                {
+                  name: 'server_id',
+                  in: 'query',
+                  schema: { enum: [SERVER_ID, jellyfinServerId] },
+                  description: `Available servers: **Dev Plex**: \`${SERVER_ID}\` **Dev Jellyfin**: \`${jellyfinServerId}\``,
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    apiMock.getWithoutCache.mockResolvedValue({
+      data: [
+        { server_id: SERVER_ID, server_type: 'plex' },
+        { server_id: jellyfinServerId, server_type: 'jellyfin' },
+      ],
+    });
+
+    await expect(
+      service.getServers({
+        url: 'http://tracearr.local',
+        apiKey: 'trr_pub_token',
+      }),
+    ).resolves.toEqual([{ id: SERVER_ID, name: 'Dev Plex' }]);
+  });
+
+  it('resolves the server itself when a media server switch cleared it', async () => {
+    Object.assign(settings, { tracearr_server_id: undefined });
+    service.init();
+    apiMock.getRawWithoutCache.mockResolvedValue({
+      data: {
+        paths: {
+          '/api/v2/public/history': {
+            get: {
+              parameters: [
+                {
+                  name: 'server_id',
+                  in: 'query',
+                  schema: { enum: [SERVER_ID] },
+                  description: `Available servers: **Dev Plex**: \`${SERVER_ID}\``,
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/libraries') {
+        return { data: [{ server_id: SERVER_ID, server_type: 'plex' }] };
+      }
+      if (endpoint === '/history') {
+        return {
+          data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
+          meta: { nextCursor: null, pageSize: 100 },
+        };
+      }
+      return usersPage;
+    });
+
+    await service.prefetchHistory();
+
+    expect(service.getHistoryIndex()?.rowsByRatingKey.has('movie-1')).toBe(
+      true,
+    );
+  });
+
+  it('picks the server whose library the media server actually has', async () => {
+    const otherPlexId = '77777777-7777-4777-8777-777777777777';
+    Object.assign(settings, { media_server_type: MediaServerType.PLEX });
+    mediaServerFactory.getService.mockResolvedValue({
+      getUsers: jest.fn().mockResolvedValue([{ id: 'account-1', name: 'a' }]),
+      getChildrenMetadata: jest.fn().mockResolvedValue([]),
+      // Both servers number items the same way, so only the titles separate
+      // them: 'ours' resolves, the other server's keys resolve to something
+      // else entirely.
+      getMetadata: jest.fn(async (id: string) =>
+        id === 'ours-1'
+          ? { title: 'Real Movie', year: 2020 }
+          : id === 'ours-2'
+            ? { title: 'Other Real Movie', year: 2021 }
+            : { title: 'Something Else', year: 1999 },
+      ),
+    } as never);
+    apiMock.getRawWithoutCache.mockResolvedValue({
+      data: {
+        paths: {
+          '/api/v2/public/history': {
+            get: {
+              parameters: [
+                {
+                  name: 'server_id',
+                  in: 'query',
+                  schema: { enum: [SERVER_ID, otherPlexId] },
+                  description: `Available servers: **Ours**: \`${SERVER_ID}\` **Theirs**: \`${otherPlexId}\``,
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    apiMock.getWithoutCache.mockImplementation(
+      async (endpoint: string, config: { params: { server_id: string } }) => {
+        if (endpoint === '/libraries') {
+          return {
+            data: [
+              { server_id: SERVER_ID, server_type: 'plex' },
+              { server_id: otherPlexId, server_type: 'plex' },
+            ],
+          };
+        }
+        return config.params.server_id === SERVER_ID
+          ? {
+              data: [
+                { rating_key: 'ours-1', title: 'Real Movie', year: 2020 },
+                { rating_key: 'ours-2', title: 'Other Real Movie', year: 2021 },
+              ],
+            }
+          : {
+              data: [
+                { rating_key: 'theirs-1', title: 'Real Movie', year: 2020 },
+                {
+                  rating_key: 'theirs-2',
+                  title: 'Other Real Movie',
+                  year: 2021,
+                },
+              ],
+            };
+      },
+    );
+
+    await expect(
+      service.resolveServerId({
+        url: 'http://tracearr.local',
+        apiKey: 'trr_pub_token',
+      }),
+    ).resolves.toBe(SERVER_ID);
+  });
+
+  it('refuses history from a server that is not the configured media server', async () => {
+    Object.assign(settings, { media_server_type: MediaServerType.JELLYFIN });
+    apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/history') {
+        return {
+          data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
+          meta: { nextCursor: null, pageSize: 100 },
+        };
+      }
+      return usersPage;
+    });
+
+    await service.prefetchHistory();
+
+    expect(service.getHistoryIndex()).toBeUndefined();
   });
 
   it('reports a failed Tracearr server discovery', async () => {

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -596,6 +596,50 @@ describe('TracearrApiService', () => {
     ).resolves.toBe(SERVER_ID);
   });
 
+  // Jellyfin ids are per-server GUIDs, so a foreign server's keys resolve to
+  // nothing rather than to the wrong title. Skipping unresolvable keys made
+  // such a server look merely unreadable, and it was accepted.
+  it('rejects a server whose items do not exist on the media server at all', async () => {
+    const foreignId = '88888888-8888-4888-8888-888888888888';
+    Object.assign(settings, { media_server_type: MediaServerType.JELLYFIN });
+    mediaServerFactory.getService.mockResolvedValue({
+      getUsers: jest.fn().mockResolvedValue([{ id: 'account-1', name: 'a' }]),
+      getChildrenMetadata: jest.fn().mockResolvedValue([]),
+      getMetadata: jest.fn(async (id: string) =>
+        id.startsWith('ours-')
+          ? { title: `Real ${id}`, year: 2020 }
+          : undefined,
+      ),
+    } as never);
+    apiMock.getWithoutCache.mockImplementation(
+      async (endpoint: string, config: { params: { server_id: string } }) => {
+        if (endpoint === '/libraries') {
+          return {
+            data: [
+              { server_id: SERVER_ID, server_type: 'jellyfin' },
+              { server_id: foreignId, server_type: 'jellyfin' },
+            ],
+          };
+        }
+        const own = config.params.server_id === SERVER_ID;
+        return {
+          data: Array.from({ length: 6 }, (_unused, i) => ({
+            rating_key: own ? `ours-${i}` : `theirs-${i}`,
+            title: own ? `Real ours-${i}` : `Foreign ${i}`,
+            year: 2020,
+          })),
+        };
+      },
+    );
+
+    await expect(
+      service.serverSharesLibrary(
+        { url: 'http://tracearr.local', apiKey: 'trr_pub_token' },
+        foreignId,
+      ),
+    ).resolves.toBe(false);
+  });
+
   it('refuses history from a server that is not the configured media server', async () => {
     Object.assign(settings, { media_server_type: MediaServerType.JELLYFIN });
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -29,6 +29,7 @@ import {
   TRACEARR_HISTORY_MAX_RECORDS,
   TRACEARR_PAGE_SIZE,
   TRACEARR_SERVER_MATCH_THRESHOLD,
+  TRACEARR_SERVER_PROBE_MINIMUM,
   TRACEARR_SERVER_PROBE_SIZE,
 } from './tracearr-api.constants';
 import { TracearrApi } from './helpers/tracearr-api.helper';
@@ -179,8 +180,9 @@ export class TracearrApiService {
    * server. A key alone proves nothing, since every Plex server numbers its
    * items from the same small range, so the title has to agree too.
    *
-   * Returns undefined when nothing could be checked (no readable items), which
-   * is deliberately not the same as "wrong server".
+   * Returns undefined only when too little could be checked to judge, which is
+   * deliberately not the same as "wrong server": an unreadable library must not
+   * lock anyone out, while a foreign one must not be accepted.
    */
   public async serverSharesLibrary(
     params: ConstructorParameters<typeof TracearrApi>[0],
@@ -196,22 +198,20 @@ export class TracearrApiService {
     }
 
     const mediaServer = await this.mediaServerFactory.getService();
-    let checked = 0;
+    let probed = 0;
     let matches = 0;
     for (const item of parsed.data.data) {
       if (!item.rating_key) {
         continue;
       }
 
+      probed += 1;
       const metadata = await mediaServer.getMetadata(item.rating_key);
-      if (metadata === undefined) {
-        continue;
-      }
-      checked += 1;
       // Titles like "Season 1" repeat across every library, and Plex and Emby
       // both number items from the same small range, so one agreement is not
       // evidence. Year has to agree too, and several items have to agree.
       if (
+        metadata !== undefined &&
         metadata.title === item.title &&
         (item.year == null || metadata.year === item.year)
       ) {
@@ -222,7 +222,16 @@ export class TracearrApiService {
       }
     }
 
-    return checked > 0 ? false : undefined;
+    // A key that resolves to nothing counts against the server rather than
+    // being skipped. Plex and Emby number items from a shared range so a wrong
+    // server resolves to the wrong title, but Jellyfin ids are per-server
+    // GUIDs, so a wrong server resolves to nothing at all. Skipping those made
+    // an entirely foreign server look merely unreadable.
+    if (matches === 0 && probed >= TRACEARR_SERVER_PROBE_MINIMUM) {
+      return false;
+    }
+
+    return undefined;
   }
 
   /**

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -5,6 +5,8 @@ import {
   TracearrServer,
   TracearrHistoryItem,
   tracearrHistoryPageSchema,
+  tracearrLibrariesPageSchema,
+  tracearrRecentlyAddedPageSchema,
   tracearrServerSchema,
   tracearrUsersPageSchema,
 } from '@maintainerr/contracts';
@@ -26,6 +28,8 @@ import {
   TRACEARR_HISTORY_CACHE_KEY,
   TRACEARR_HISTORY_MAX_RECORDS,
   TRACEARR_PAGE_SIZE,
+  TRACEARR_SERVER_MATCH_THRESHOLD,
+  TRACEARR_SERVER_PROBE_SIZE,
 } from './tracearr-api.constants';
 import { TracearrApi } from './helpers/tracearr-api.helper';
 import { isBelowMinimumVersion } from '../../../utils/required-version-helper';
@@ -69,6 +73,7 @@ export class TracearrApiService {
   private activeHistoryIndex: TracearrHistoryIndex | undefined;
   private activeUsernamesByTracearrUserId: Map<string, string[]> | undefined;
   private episodeIdsByItemId = new Map<string, Promise<string[] | undefined>>();
+  private resolvedServerId: string | undefined;
   private sweepPromise: Promise<void> | undefined;
 
   constructor(
@@ -110,6 +115,7 @@ export class TracearrApiService {
     this.activeHistoryIndex = undefined;
     this.activeUsernamesByTracearrUserId = undefined;
     this.episodeIdsByItemId.clear();
+    this.resolvedServerId = undefined;
     cacheManager
       .getCache(TRACEARR_CACHE_ID)
       ?.data.del(TRACEARR_HISTORY_CACHE_KEY);
@@ -156,7 +162,8 @@ export class TracearrApiService {
 
     try {
       const document = await this.getOpenApiDocument(api);
-      return this.getServersFromOpenApiDocument(document);
+      const servers = this.getServersFromOpenApiDocument(document);
+      return await this.keepServersMatchingMediaServer(api, servers);
     } catch (error) {
       this.logger.warn(
         'Could not load Tracearr servers from the public API document.',
@@ -164,6 +171,122 @@ export class TracearrApiService {
       this.logger.debug(error);
       return undefined;
     }
+  }
+
+  /**
+   * Confirms a Tracearr server is the one Maintainerr manages by taking its own
+   * recently added items and resolving their rating keys against the media
+   * server. A key alone proves nothing, since every Plex server numbers its
+   * items from the same small range, so the title has to agree too.
+   *
+   * Returns undefined when nothing could be checked (no readable items), which
+   * is deliberately not the same as "wrong server".
+   */
+  public async serverSharesLibrary(
+    params: ConstructorParameters<typeof TracearrApi>[0],
+    serverId: string,
+  ): Promise<boolean | undefined> {
+    const api = new TracearrApi(params, this.loggerFactory.createLogger());
+    const raw = await api.getWithoutCache<unknown>('/recently-added', {
+      params: { server_id: serverId, pageSize: TRACEARR_SERVER_PROBE_SIZE },
+    });
+    const parsed = tracearrRecentlyAddedPageSchema.safeParse(raw);
+    if (!parsed.success || parsed.data.data.length === 0) {
+      return undefined;
+    }
+
+    const mediaServer = await this.mediaServerFactory.getService();
+    let checked = 0;
+    let matches = 0;
+    for (const item of parsed.data.data) {
+      if (!item.rating_key) {
+        continue;
+      }
+
+      const metadata = await mediaServer.getMetadata(item.rating_key);
+      if (metadata === undefined) {
+        continue;
+      }
+      checked += 1;
+      // Titles like "Season 1" repeat across every library, and Plex and Emby
+      // both number items from the same small range, so one agreement is not
+      // evidence. Year has to agree too, and several items have to agree.
+      if (
+        metadata.title === item.title &&
+        (item.year == null || metadata.year === item.year)
+      ) {
+        matches += 1;
+        if (matches >= TRACEARR_SERVER_MATCH_THRESHOLD) {
+          return true;
+        }
+      }
+    }
+
+    return checked > 0 ? false : undefined;
+  }
+
+  /**
+   * Resolves the one Tracearr server whose media server Maintainerr manages.
+   * Undefined when Tracearr has no such server, or more than one, since either
+   * way there is nothing safe to bind to.
+   */
+  public async resolveServerId(
+    params: ConstructorParameters<typeof TracearrApi>[0],
+  ): Promise<string | undefined> {
+    const servers = await this.getServers(params);
+    if (!servers || servers.length === 0) {
+      return undefined;
+    }
+    if (servers.length === 1) {
+      return servers[0].id;
+    }
+
+    // Several servers of the configured type: nothing in the server list tells
+    // them apart, so ask their libraries which one Maintainerr is managing.
+    const confirmed: string[] = [];
+    for (const server of servers) {
+      if (await this.serverSharesLibrary(params, server.id)) {
+        confirmed.push(server.id);
+      }
+    }
+
+    return confirmed.length === 1 ? confirmed[0] : undefined;
+  }
+
+  /**
+   * The server list carries no type, so /libraries supplies it. Only the media
+   * server Maintainerr manages shares its rating keys, and offering the others
+   * yields rules that silently match nothing. A server absent from /libraries
+   * has no type to compare and is kept, so it stays selectable.
+   */
+  private async keepServersMatchingMediaServer(
+    api: TracearrApi,
+    servers: TracearrServer[],
+  ): Promise<TracearrServer[]> {
+    const mediaServerType = this.settings.media_server_type;
+    if (!mediaServerType) {
+      return servers;
+    }
+
+    const raw = await api.getWithoutCache<unknown>('/libraries');
+    const parsed = tracearrLibrariesPageSchema.safeParse(raw);
+    if (!parsed.success) {
+      this.logger.warn(
+        'Could not read Tracearr library types. Listing every Tracearr server.',
+      );
+      return servers;
+    }
+
+    const typeByServerId = new Map(
+      parsed.data.data.map((library) => [
+        library.server_id,
+        library.server_type,
+      ]),
+    );
+    return servers.filter((server) => {
+      const serverType = typeByServerId.get(server.id);
+      return serverType === undefined || serverType === mediaServerType;
+    });
   }
 
   public async testConnection(
@@ -214,14 +337,35 @@ export class TracearrApiService {
     }
   }
 
+  /**
+   * The stored server id is only a cache. A media server switch clears it, and
+   * an unchanged settings form cannot be re-saved, so the matching server is
+   * resolved here rather than making the user reconfigure.
+   */
+  private async resolveActiveServerId(): Promise<string | undefined> {
+    if (!this.api) {
+      return undefined;
+    }
+    if (this.settings.tracearr_server_id) {
+      this.resolvedServerId = this.settings.tracearr_server_id;
+    } else if (!this.resolvedServerId) {
+      this.resolvedServerId = await this.resolveServerId({
+        url: this.settings.tracearr_url,
+        apiKey: this.settings.tracearr_api_key,
+      });
+    }
+
+    return this.resolvedServerId;
+  }
+
   private async prefetchHistoryInternal(): Promise<void> {
     this.activeHistoryIndex = undefined;
     this.activeUsernamesByTracearrUserId = undefined;
     this.episodeIdsByItemId.clear();
 
-    if (!this.isHistoryConfigured()) {
+    if (!(await this.resolveActiveServerId())) {
       this.logger.warn(
-        'Tracearr history rules are unavailable until a server ID is configured.',
+        'Tracearr has no server matching the configured media server. Tracearr rule values are unavailable for this run.',
       );
       return;
     }
@@ -265,7 +409,8 @@ export class TracearrApiService {
     TracearrHistoryIndex | undefined
   > {
     const api = this.api;
-    const serverId = this.settings.tracearr_server_id;
+    const serverId = this.resolvedServerId;
+    const mediaServerType = this.settings.media_server_type;
     if (!api || !serverId) {
       return undefined;
     }
@@ -304,6 +449,15 @@ export class TracearrApiService {
         if (row.server_id !== serverId) {
           this.logger.warn(
             'Tracearr history response included a row for a different server.',
+          );
+          return undefined;
+        }
+
+        // Rating keys only exist within one media server, so a mismatched
+        // selection matches nothing at all rather than matching partially.
+        if (mediaServerType && row.server_type !== mediaServerType) {
+          this.logger.warn(
+            `The selected Tracearr server is ${row.server_type}, but Maintainerr is configured for ${mediaServerType}. Select the Tracearr server for the media server Maintainerr manages.`,
           );
           return undefined;
         }
@@ -464,7 +618,7 @@ export class TracearrApiService {
     Map<string, string[]> | undefined
   > {
     const api = this.api;
-    const serverId = this.settings.tracearr_server_id;
+    const serverId = this.resolvedServerId;
     if (!api || !serverId) {
       return undefined;
     }
@@ -540,10 +694,6 @@ export class TracearrApiService {
       cursors.add(nextCursor);
       cursor = nextCursor;
     }
-  }
-
-  private isHistoryConfigured(): boolean {
-    return Boolean(this.api && this.settings.tracearr_server_id);
   }
 
   private async fetchEpisodeIds(

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -60,6 +60,13 @@ interface TracearrOpenApiParameter {
   };
 }
 
+// Tracearr truncates the media server's added date to milliseconds, so the two
+// only agree to the second.
+const sameSecond = (left: Date | undefined, right: number): boolean =>
+  left != null &&
+  !Number.isNaN(right) &&
+  Math.floor(left.getTime() / 1000) === Math.floor(right / 1000);
+
 export interface TracearrHistoryIndex {
   rowsById: Map<string, TracearrHistoryItem>;
   rowsByRatingKey: Map<string, TracearrHistoryItem[]>;
@@ -199,36 +206,48 @@ export class TracearrApiService {
     }
 
     const mediaServer = await this.mediaServerFactory.getService();
-    let probed = 0;
     let matches = 0;
+    let contradictions = 0;
     for (const item of parsed.data.data) {
       if (!item.rating_key) {
         continue;
       }
 
-      probed += 1;
       const metadata = await mediaServer.getMetadata(item.rating_key);
-      // Titles like "Season 1" repeat across every library, and Plex and Emby
-      // both number items from the same small range, so one agreement is not
-      // evidence. Year has to agree too, and several items have to agree.
-      if (
-        metadata !== undefined &&
-        metadata.title === item.title &&
-        (item.year == null || metadata.year === item.year)
-      ) {
-        matches += 1;
-        if (matches >= TRACEARR_SERVER_MATCH_THRESHOLD) {
+      if (metadata !== undefined) {
+        // Titles like "Season 1" repeat across every library, and Plex and Emby
+        // both number items from the same small range, so a title alone proves
+        // nothing. The added date is the second signal: every server reports
+        // one for every item, unlike year, which is missing on most rows.
+        // Tracearr stores it at millisecond precision, so compare by second.
+        if (metadata.title !== item.title) {
+          contradictions += 1;
+        } else if (
+          sameSecond(metadata.addedAt, Date.parse(item.added_at)) &&
+          ++matches >= TRACEARR_SERVER_MATCH_THRESHOLD
+        ) {
           return true;
         }
+        continue;
+      }
+
+      // getMetadata cannot tell an absent item from a failed read, so it must
+      // not decide this on its own. itemExists answers false only when the
+      // server says the item is gone, and throws otherwise, which keeps a
+      // timeout or a 5xx from condemning the right server.
+      try {
+        if (!(await mediaServer.itemExists(item.rating_key))) {
+          contradictions += 1;
+        }
+      } catch {
+        return undefined;
       }
     }
 
-    // A key that resolves to nothing counts against the server rather than
-    // being skipped. Plex and Emby number items from a shared range so a wrong
-    // server resolves to the wrong title, but Jellyfin ids are per-server
-    // GUIDs, so a wrong server resolves to nothing at all. Skipping those made
-    // an entirely foreign server look merely unreadable.
-    if (matches === 0 && probed >= TRACEARR_SERVER_PROBE_MINIMUM) {
+    // Jellyfin ids are per-server GUIDs, so a foreign server's items are absent
+    // rather than merely different. Absence and disagreement both count against
+    // the server, but only once enough items agree on it.
+    if (matches === 0 && contradictions >= TRACEARR_SERVER_PROBE_MINIMUM) {
       return false;
     }
 

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -164,7 +164,8 @@ export class TracearrApiService {
     try {
       const document = await this.getOpenApiDocument(api);
       const servers = this.getServersFromOpenApiDocument(document);
-      return await this.keepServersMatchingMediaServer(api, servers);
+      const sameType = await this.keepServersMatchingMediaServer(api, servers);
+      return await this.keepServersSharingLibrary(params, sameType);
     } catch (error) {
       this.logger.warn(
         'Could not load Tracearr servers from the public API document.',
@@ -235,31 +236,39 @@ export class TracearrApiService {
   }
 
   /**
+   * Narrows several same-type candidates to those whose items resolve on the
+   * managed library, which is the only thing that separates two servers of one
+   * type. Falls back to the whole list when that confirms none, so an
+   * unreadable library leaves something to choose from rather than nothing.
+   */
+  private async keepServersSharingLibrary(
+    params: ConstructorParameters<typeof TracearrApi>[0],
+    servers: TracearrServer[],
+  ): Promise<TracearrServer[]> {
+    if (servers.length < 2) {
+      return servers;
+    }
+
+    const confirmed: TracearrServer[] = [];
+    for (const server of servers) {
+      if (await this.serverSharesLibrary(params, server.id)) {
+        confirmed.push(server);
+      }
+    }
+
+    return confirmed.length > 0 ? confirmed : servers;
+  }
+
+  /**
    * Resolves the one Tracearr server whose media server Maintainerr manages.
-   * Undefined when Tracearr has no such server, or more than one, since either
-   * way there is nothing safe to bind to.
+   * Undefined when Tracearr has no such server, or when more than one survives,
+   * since either way there is nothing safe to bind to on its own.
    */
   public async resolveServerId(
     params: ConstructorParameters<typeof TracearrApi>[0],
   ): Promise<string | undefined> {
     const servers = await this.getServers(params);
-    if (!servers || servers.length === 0) {
-      return undefined;
-    }
-    if (servers.length === 1) {
-      return servers[0].id;
-    }
-
-    // Several servers of the configured type: nothing in the server list tells
-    // them apart, so ask their libraries which one Maintainerr is managing.
-    const confirmed: string[] = [];
-    for (const server of servers) {
-      if (await this.serverSharesLibrary(params, server.id)) {
-        confirmed.push(server.id);
-      }
-    }
-
-    return confirmed.length === 1 ? confirmed[0] : undefined;
+    return servers?.length === 1 ? servers[0].id : undefined;
   }
 
   /**

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -220,13 +220,29 @@ export class TracearrApiService {
         // nothing. The added date is the second signal: every server reports
         // one for every item, unlike year, which is missing on most rows.
         // Tracearr stores it at millisecond precision, so compare by second.
+        const localAddedAt = metadata.addedAt?.getTime();
+        const remoteAddedAt = Date.parse(item.added_at);
+        const datesComparable =
+          localAddedAt !== undefined &&
+          !Number.isNaN(localAddedAt) &&
+          !Number.isNaN(remoteAddedAt);
+
         if (metadata.title !== item.title) {
           contradictions += 1;
-        } else if (
-          sameSecond(metadata.addedAt, Date.parse(item.added_at)) &&
-          ++matches >= TRACEARR_SERVER_MATCH_THRESHOLD
-        ) {
-          return true;
+        } else if (!datesComparable) {
+          // No date to compare on this item, so the title alone decides
+          // nothing either way rather than condemning a server whose media
+          // server reports no added date.
+          continue;
+        } else if (sameSecond(metadata.addedAt, remoteAddedAt)) {
+          matches += 1;
+          if (matches >= TRACEARR_SERVER_MATCH_THRESHOLD) {
+            return true;
+          }
+        } else {
+          // Same title, different moment: a different copy on a different
+          // server, which argues against this one rather than proving nothing.
+          contradictions += 1;
         }
         continue;
       }

--- a/apps/server/src/modules/settings/media-server-switch.service.spec.ts
+++ b/apps/server/src/modules/settings/media-server-switch.service.spec.ts
@@ -12,6 +12,7 @@ import { MaintainerrLogger } from '../logging/logs.service';
 import { Exclusion } from '../rules/entities/exclusion.entities';
 import { MediaServerSwitchService } from './media-server-switch.service';
 import { RuleMigrationService } from './rule-migration.service';
+import { TracearrApiService } from '../api/tracearr-api/tracearr-api.service';
 import { SettingsDataService } from './settings-data.service';
 
 const STORAGE_DIR = path.join(configDataDir, 'collection-posters');
@@ -19,6 +20,7 @@ const STORAGE_DIR = path.join(configDataDir, 'collection-posters');
 describe('MediaServerSwitchService', () => {
   let service: MediaServerSwitchService;
   let settingsDataService: Mocked<SettingsDataService>;
+  let tracearrApi: Mocked<TracearrApiService>;
   let ruleMigrationService: Mocked<RuleMigrationService>;
   let dataSource: Mocked<DataSource>;
   let collectionRepo: Mocked<Repository<Collection>>;
@@ -33,6 +35,7 @@ describe('MediaServerSwitchService', () => {
 
     service = unit;
     settingsDataService = unitRef.get(SettingsDataService);
+    tracearrApi = unitRef.get(TracearrApiService);
     ruleMigrationService = unitRef.get(RuleMigrationService);
     dataSource = unitRef.get(DataSource);
     collectionRepo = unitRef.get('CollectionRepository');
@@ -495,6 +498,35 @@ describe('MediaServerSwitchService', () => {
         );
       },
     );
+
+    // Clearing the stored binding is only half of it: the resolved server is
+    // also held in memory, and reusing it would point the next run at the
+    // server the switch just moved away from.
+    it('should invalidate the resolved Tracearr server on a switch', async () => {
+      const queryRunner = createQueryRunnerMock();
+      queryRunner.manager.findOne.mockResolvedValue({
+        id: 1,
+        media_server_type: MediaServerType.JELLYFIN,
+        tracearr_server_id: 'jellyfin-server-uuid',
+      });
+      dataSource.createQueryRunner.mockReturnValue(queryRunner as any);
+
+      settingsDataService.getMediaServerType.mockReturnValue(
+        MediaServerType.JELLYFIN,
+      );
+      settingsDataService.init.mockResolvedValue(undefined);
+      collectionRepo.count.mockResolvedValue(0);
+      collectionMediaRepo.count.mockResolvedValue(0);
+      collectionLogRepo.count.mockResolvedValue(0);
+      exclusionRepo.count.mockResolvedValue(0);
+
+      await service.executeSwitch({
+        targetServerType: MediaServerType.PLEX,
+        migrateRules: false,
+      });
+
+      expect(tracearrApi.invalidateHistory).toHaveBeenCalled();
+    });
 
     it('should clear the Tracearr server binding but keep its credentials', async () => {
       const queryRunner = createQueryRunnerMock();

--- a/apps/server/src/modules/settings/media-server-switch.service.spec.ts
+++ b/apps/server/src/modules/settings/media-server-switch.service.spec.ts
@@ -495,5 +495,40 @@ describe('MediaServerSwitchService', () => {
         );
       },
     );
+
+    it('should clear the Tracearr server binding but keep its credentials', async () => {
+      const queryRunner = createQueryRunnerMock();
+      queryRunner.manager.findOne.mockResolvedValue({
+        id: 1,
+        media_server_type: MediaServerType.JELLYFIN,
+        tracearr_url: 'http://tracearr.local:3000',
+        tracearr_api_key: 'trr_pub_key',
+        tracearr_server_id: 'jellyfin-server-uuid',
+      });
+      dataSource.createQueryRunner.mockReturnValue(queryRunner as any);
+
+      settingsDataService.getMediaServerType.mockReturnValue(
+        MediaServerType.JELLYFIN,
+      );
+      settingsDataService.init.mockResolvedValue(undefined);
+      collectionRepo.count.mockResolvedValue(0);
+      collectionMediaRepo.count.mockResolvedValue(0);
+      collectionLogRepo.count.mockResolvedValue(0);
+      exclusionRepo.count.mockResolvedValue(0);
+
+      await service.executeSwitch({
+        targetServerType: MediaServerType.PLEX,
+        migrateRules: false,
+      });
+
+      expect(queryRunner.manager.save).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          tracearr_url: 'http://tracearr.local:3000',
+          tracearr_api_key: 'trr_pub_key',
+          tracearr_server_id: null,
+        }),
+      );
+    });
   });
 });

--- a/apps/server/src/modules/settings/media-server-switch.service.ts
+++ b/apps/server/src/modules/settings/media-server-switch.service.ts
@@ -418,6 +418,11 @@ export class MediaServerSwitchService {
       updatedSettings.emby_server_name = null;
     }
 
+    // The Tracearr instance survives a switch, but its selected server does
+    // not: rating keys are per media server, so a stale binding silently
+    // matches nothing.
+    updatedSettings.tracearr_server_id = null;
+
     await queryRunner.manager.save(Settings, updatedSettings);
   }
 

--- a/apps/server/src/modules/settings/media-server-switch.service.ts
+++ b/apps/server/src/modules/settings/media-server-switch.service.ts
@@ -20,6 +20,7 @@ import { Exclusion } from '../rules/entities/exclusion.entities';
 import { RuleGroup } from '../rules/entities/rule-group.entities';
 import { Settings } from './entities/settings.entities';
 import { RuleMigrationService } from './rule-migration.service';
+import { TracearrApiService } from '../api/tracearr-api/tracearr-api.service';
 import { SettingsDataService } from './settings-data.service';
 
 interface MediaServerDataCounts {
@@ -55,6 +56,7 @@ export class MediaServerSwitchService {
     private readonly exclusionRepo: Repository<Exclusion>,
     private readonly connection: DataSource,
     private readonly ruleMigrationService: RuleMigrationService,
+    private readonly tracearrApi: TracearrApiService,
     private readonly logger: MaintainerrLogger,
   ) {
     logger.setContext(MediaServerSwitchService.name);
@@ -227,6 +229,11 @@ export class MediaServerSwitchService {
 
       // Refresh in-memory settings and uninitialize old server after commit
       await this.settingsDataService.init();
+
+      // Clearing the stored binding is not enough: the resolved server is also
+      // held in memory, and reusing it would point the next run at the server
+      // the switch just moved away from.
+      this.tracearrApi.invalidateHistory();
 
       // Uninitialize old media server adapter
       this.uninitializeOldServer(currentServerType);

--- a/apps/server/src/modules/settings/settings-operations.service.spec.ts
+++ b/apps/server/src/modules/settings/settings-operations.service.spec.ts
@@ -99,8 +99,10 @@ describe('SettingsOperationsService', () => {
     const setting: TracearrSetting = {
       url: 'http://tracearr.local',
       api_key: 'trr_pub_token',
-      server_id: '11111111-1111-4111-8111-111111111111',
     };
+    tracearr.resolveServerId.mockResolvedValue(
+      '11111111-1111-4111-8111-111111111111',
+    );
 
     await expect(service.updateTracearrSetting(setting)).resolves.toEqual({
       status: 'OK',
@@ -112,7 +114,7 @@ describe('SettingsOperationsService', () => {
       expect.objectContaining({
         tracearr_url: setting.url,
         tracearr_api_key: setting.api_key,
-        tracearr_server_id: setting.server_id,
+        tracearr_server_id: '11111111-1111-4111-8111-111111111111',
       }),
     );
     expect(tracearr.init).toHaveBeenCalledTimes(1);
@@ -129,31 +131,8 @@ describe('SettingsOperationsService', () => {
       service.testTracearr({
         url: 'http://tracearr.local',
         api_key: 'trr_pub_token',
-        server_id: '11111111-1111-4111-8111-111111111111',
       }),
     ).resolves.toEqual({ status: 'OK', code: 1, message: '2.0.0-beta.1' });
-  });
-
-  it('loads Tracearr servers with connection fields only', async () => {
-    const connection = {
-      url: 'http://tracearr.local',
-      api_key: 'trr_pub_token',
-    };
-    const servers = [
-      {
-        id: '11111111-1111-4111-8111-111111111111',
-        name: 'Sample Plex',
-      },
-    ];
-    tracearr.getServers.mockResolvedValue(servers);
-
-    await expect(service.getTracearrServers(connection)).resolves.toEqual(
-      servers,
-    );
-    expect(tracearr.getServers).toHaveBeenCalledWith({
-      url: connection.url,
-      apiKey: connection.api_key,
-    });
   });
 
   it('rejects Plex server setting changes when no Plex credentials are stored', async () => {

--- a/apps/server/src/modules/settings/settings-operations.service.ts
+++ b/apps/server/src/modules/settings/settings-operations.service.ts
@@ -9,8 +9,8 @@ import {
   StreamystatsSetting,
   TautulliSetting,
   TracearrConnection,
-  TracearrSetting,
   TracearrServer,
+  TracearrSetting,
 } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -371,11 +371,42 @@ export class SettingsOperationsService {
     try {
       const settingsDb = await this.settingsRepo.findOne({ where: {} });
 
+      // A chosen server wins: it is only ever offered when Tracearr has several
+      // of the configured type and nothing can pick between them.
+      const serverId =
+        settings.server_id ??
+        (await this.tracearr.resolveServerId({
+          url: settings.url,
+          apiKey: settings.api_key,
+        }));
+      if (!serverId) {
+        return {
+          status: 'NOK',
+          code: 0,
+          message: `Tracearr has no single ${this.settingsDataService.media_server_type ?? 'media'} server matching the one Maintainerr manages. Add it in Tracearr and let it sync a library first, or pick the server to use.`,
+        };
+      }
+
+      // A chosen server is checked rather than trusted: rating keys from the
+      // wrong server match nothing, and every rule would read as unwatched.
+      const sharesLibrary = await this.tracearr.serverSharesLibrary(
+        { url: settings.url, apiKey: settings.api_key },
+        serverId,
+      );
+      if (sharesLibrary === false) {
+        return {
+          status: 'NOK',
+          code: 0,
+          message:
+            'That Tracearr server tracks a different media server than the one Maintainerr manages. Pick the Tracearr server for this media server.',
+        };
+      }
+
       await this.settingsDataService.saveSettings({
         ...settingsDb,
         tracearr_url: settings.url,
         tracearr_api_key: settings.api_key,
-        tracearr_server_id: settings.server_id,
+        tracearr_server_id: serverId,
       });
 
       await this.settingsDataService.init();
@@ -389,17 +420,17 @@ export class SettingsOperationsService {
     }
   }
 
-  public testTracearr(settings: TracearrSetting): Promise<BasicResponseDto> {
-    return this.tracearr.testConnection({
+  public getTracearrServers(
+    settings: TracearrConnection,
+  ): Promise<TracearrServer[] | undefined> {
+    return this.tracearr.getServers({
       url: settings.url,
       apiKey: settings.api_key,
     });
   }
 
-  public getTracearrServers(
-    settings: TracearrConnection,
-  ): Promise<TracearrServer[] | undefined> {
-    return this.tracearr.getServers({
+  public testTracearr(settings: TracearrSetting): Promise<BasicResponseDto> {
+    return this.tracearr.testConnection({
       url: settings.url,
       apiKey: settings.api_key,
     });

--- a/apps/server/src/modules/settings/settings.controller.spec.ts
+++ b/apps/server/src/modules/settings/settings.controller.spec.ts
@@ -3,7 +3,7 @@ import {
   radarrSettingSchema,
   seerrSettingSchema,
 } from '@maintainerr/contracts';
-import { BadGatewayException, StreamableFile } from '@nestjs/common';
+import { StreamableFile } from '@nestjs/common';
 import { Response } from 'express';
 import { createReadStream } from 'fs';
 import { ZodValidationPipe } from 'nestjs-zod';
@@ -314,42 +314,6 @@ describe('SettingsController', () => {
 
     expect(settingsOperationsService.testPlexAuthToken).toHaveBeenCalledTimes(
       1,
-    );
-  });
-
-  it('delegates Tracearr server discovery with connection fields', async () => {
-    const connection = {
-      url: 'http://tracearr.local',
-      api_key: 'trr_pub_token',
-    };
-    const servers = [
-      {
-        id: '11111111-1111-4111-8111-111111111111',
-        name: 'Sample Plex',
-      },
-    ];
-    settingsOperationsService.getTracearrServers.mockResolvedValue(servers);
-
-    await expect(controller.getTracearrServers(connection)).resolves.toEqual(
-      servers,
-    );
-    expect(settingsOperationsService.getTracearrServers).toHaveBeenCalledWith(
-      connection,
-    );
-  });
-
-  it('rejects an unavailable Tracearr server list', async () => {
-    settingsOperationsService.getTracearrServers.mockResolvedValue(undefined);
-
-    await expect(
-      controller.getTracearrServers({
-        url: 'http://tracearr.local',
-        api_key: 'trr_pub_token',
-      }),
-    ).rejects.toEqual(
-      new BadGatewayException(
-        'Could not load Tracearr servers. Verify URL and API key.',
-      ),
     );
   });
 });

--- a/apps/server/src/modules/settings/settings.controller.ts
+++ b/apps/server/src/modules/settings/settings.controller.ts
@@ -31,8 +31,8 @@ import {
   streamystatsSettingSchema,
   TracearrConnection,
   TracearrSetting,
-  tracearrConnectionSchema,
   TracearrSettingForm,
+  tracearrConnectionSchema,
   tracearrSettingSchema,
   SwitchMediaServerRequest,
   SwitchMediaServerResponse,
@@ -48,9 +48,9 @@ import {
 } from '@maintainerr/contracts';
 import {
   Body,
-  BadGatewayException,
   Controller,
   Delete,
+  BadGatewayException,
   ForbiddenException,
   Get,
   Header,
@@ -354,14 +354,6 @@ export class SettingsController {
     return await this.settingsOperationsService.removeTracearrSetting();
   }
 
-  @Post('/test/tracearr')
-  testTracearr(
-    @Body(new ZodValidationPipe(tracearrSettingSchema))
-    payload: TracearrSetting,
-  ): Promise<BasicResponseDto> {
-    return this.settingsOperationsService.testTracearr(payload);
-  }
-
   @Post('/tracearr/servers')
   async getTracearrServers(
     @Body(new ZodValidationPipe(tracearrConnectionSchema))
@@ -369,6 +361,7 @@ export class SettingsController {
   ) {
     const servers =
       await this.settingsOperationsService.getTracearrServers(payload);
+
     if (!servers) {
       throw new BadGatewayException(
         'Could not load Tracearr servers. Verify URL and API key.',
@@ -376,6 +369,14 @@ export class SettingsController {
     }
 
     return servers;
+  }
+
+  @Post('/test/tracearr')
+  testTracearr(
+    @Body(new ZodValidationPipe(tracearrSettingSchema))
+    payload: TracearrSetting,
+  ): Promise<BasicResponseDto> {
+    return this.settingsOperationsService.testTracearr(payload);
   }
 
   @Get('/download-client')

--- a/apps/ui/src/components/Settings/ExternalServiceSettingsPage.spec.tsx
+++ b/apps/ui/src/components/Settings/ExternalServiceSettingsPage.spec.tsx
@@ -1,5 +1,11 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import ExternalServiceSettingsPage, {
   type ExternalServiceFieldConfig,
@@ -64,6 +70,7 @@ const tracearrFields: ExternalServiceFieldConfig[] = [
 
 describe('ExternalServiceSettingsPage', () => {
   beforeEach(() => {
+    cleanup()
     getApiHandler.mockReset()
     postApiHandler.mockReset()
     deleteApiHandler.mockReset()
@@ -71,6 +78,10 @@ describe('ExternalServiceSettingsPage', () => {
       url: 'http://seerr.local',
       api_key: 'saved-key',
     })
+  })
+
+  afterEach(() => {
+    cleanup()
   })
 
   it('keeps Save Changes enabled regardless of whether connection values have changed', async () => {
@@ -238,10 +249,15 @@ describe('ExternalServiceSettingsPage', () => {
   })
 
   it('loads select options after connection fields are available', async () => {
+    // The picker only renders when there is a real choice to make.
     postApiHandler.mockResolvedValue([
       {
         value: '11111111-1111-4111-8111-111111111111',
         label: 'Sample Plex',
+      },
+      {
+        value: '22222222-2222-4222-8222-222222222222',
+        label: 'Other Plex',
       },
     ])
 
@@ -360,7 +376,10 @@ describe('ExternalServiceSettingsPage', () => {
     await waitFor(() => {
       expect(postApiHandler).toHaveBeenCalledTimes(1)
     })
-    resolveOptions?.([])
+    resolveOptions?.([
+      { value: '11111111-1111-4111-8111-111111111111', label: 'Sample Plex' },
+      { value: '22222222-2222-4222-8222-222222222222', label: 'Other Plex' },
+    ])
     await waitFor(() => {
       expect((serverSelect as HTMLSelectElement).disabled).toBe(false)
     })
@@ -370,5 +389,43 @@ describe('ExternalServiceSettingsPage', () => {
     fireEvent.focus(serverSelect)
 
     expect(postApiHandler).toHaveBeenCalledTimes(2)
+  })
+
+  it('hides a select once it resolves to a single option', async () => {
+    postApiHandler.mockResolvedValue([
+      {
+        value: '11111111-1111-4111-8111-111111111111',
+        label: 'Sample Plex',
+      },
+    ])
+
+    render(
+      <ExternalServiceSettingsPage
+        scope="Tracearr settings"
+        pageTitle="Tracearr settings - Maintainerr"
+        heading="Tracearr Settings"
+        description="Tracearr configuration"
+        docsPage="Configuration/#tracearr"
+        settingsPath="/settings/tracearr"
+        testPath="/settings/test/tracearr"
+        schema={z.object({
+          url: z.string().min(1),
+          api_key: z.string().min(1),
+          server_id: z.string().uuid().optional(),
+        })}
+        fields={tracearrFields}
+        testSuccessTitle="Tracearr"
+        testFailureMessage="Failed to connect"
+      />,
+    )
+
+    await screen.findByLabelText('API key')
+    await waitFor(() => {
+      expect(postApiHandler).toHaveBeenCalledTimes(1)
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Tracearr server *')).toBeNull()
+    })
   })
 })

--- a/apps/ui/src/components/Settings/ExternalServiceSettingsPage.spec.tsx
+++ b/apps/ui/src/components/Settings/ExternalServiceSettingsPage.spec.tsx
@@ -372,14 +372,16 @@ describe('ExternalServiceSettingsPage', () => {
     )
 
     const apiKey = await screen.findByLabelText('API key')
-    const serverSelect = screen.getByLabelText('Tracearr server *')
     await waitFor(() => {
       expect(postApiHandler).toHaveBeenCalledTimes(1)
     })
+    // The field only renders once there is a choice to make, so it cannot be
+    // queried until the options resolve.
     resolveOptions?.([
       { value: '11111111-1111-4111-8111-111111111111', label: 'Sample Plex' },
       { value: '22222222-2222-4222-8222-222222222222', label: 'Other Plex' },
     ])
+    const serverSelect = await screen.findByLabelText('Tracearr server *')
     await waitFor(() => {
       expect((serverSelect as HTMLSelectElement).disabled).toBe(false)
     })

--- a/apps/ui/src/components/Settings/ExternalServiceSettingsPage.tsx
+++ b/apps/ui/src/components/Settings/ExternalServiceSettingsPage.tsx
@@ -40,7 +40,10 @@ export interface ExternalServiceFieldConfig {
   label: string
   type?: 'text' | 'password' | 'select'
   placeholder?: string
-  helpText?: JSX.Element | string
+  // A function receives the current form values, so a field can point at the
+  // service the user is configuring rather than at generic documentation.
+  helpText?:
+    JSX.Element | string | ((values: SettingsValues) => JSX.Element | string)
   normalize?: (value: string) => string
   required?: boolean
   options?: ExternalServiceSelectOption[]
@@ -362,6 +365,18 @@ const ExternalServiceSettingsPage = ({
                           ]
                         : options
 
+                    // One candidate is not a choice. The backend resolves that
+                    // case itself, so rendering the field would only ask the
+                    // user to confirm something that cannot vary. Only hide it
+                    // once options actually loaded: while pending or after a
+                    // failure the field has to stay, or its error has nowhere
+                    // to appear.
+                    const optionsLoaded =
+                      loadedOptionsByFieldName[fieldConfig.name] !== undefined
+                    if (optionsLoaded && selectOptions.length < 2) {
+                      return <></>
+                    }
+
                     return (
                       <SelectGroup
                         label={fieldConfig.label}
@@ -385,7 +400,11 @@ const ExternalServiceSettingsPage = ({
                         ref={field.ref}
                         name={field.name}
                         error={error}
-                        helpText={fieldConfig.helpText ?? undefined}
+                        helpText={
+                          typeof fieldConfig.helpText === 'function'
+                            ? fieldConfig.helpText(currentValues)
+                            : (fieldConfig.helpText ?? undefined)
+                        }
                         required={fieldConfig.required}
                         disabled={loadingOptionsByFieldName[fieldConfig.name]}
                       >
@@ -432,7 +451,11 @@ const ExternalServiceSettingsPage = ({
                       name={field.name}
                       type={fieldConfig.type ?? 'text'}
                       error={error}
-                      helpText={fieldConfig.helpText ?? undefined}
+                      helpText={
+                        typeof fieldConfig.helpText === 'function'
+                          ? fieldConfig.helpText(currentValues)
+                          : (fieldConfig.helpText ?? undefined)
+                      }
                       required={fieldConfig.required}
                     />
                   )

--- a/apps/ui/src/components/Settings/ExternalServiceSettingsPage.tsx
+++ b/apps/ui/src/components/Settings/ExternalServiceSettingsPage.tsx
@@ -365,15 +365,18 @@ const ExternalServiceSettingsPage = ({
                           ]
                         : options
 
-                    // One candidate is not a choice. The backend resolves that
-                    // case itself, so rendering the field would only ask the
-                    // user to confirm something that cannot vary. Only hide it
-                    // once options actually loaded: while pending or after a
-                    // failure the field has to stay, or its error has nowhere
-                    // to appear.
+                    // One candidate is not a choice: the backend resolves that
+                    // case itself, so the field would only ask the user to
+                    // confirm something that cannot vary. It stays hidden while
+                    // the options load as well, since appearing and then
+                    // vanishing reads as a glitch. An error is the exception,
+                    // because it would otherwise have nowhere to appear.
                     const optionsLoaded =
                       loadedOptionsByFieldName[fieldConfig.name] !== undefined
-                    if (optionsLoaded && selectOptions.length < 2) {
+                    if (
+                      !error &&
+                      (!optionsLoaded || selectOptions.length < 2)
+                    ) {
                       return <></>
                     }
 

--- a/apps/ui/src/components/Settings/ExternalServiceSettingsPage.tsx
+++ b/apps/ui/src/components/Settings/ExternalServiceSettingsPage.tsx
@@ -77,6 +77,26 @@ const allEmpty = (
   fields: ExternalServiceFieldConfig[],
 ) => fields.every((field) => (values[field.name] ?? '') === '')
 
+// An unchosen select is '' in the form but "not provided" to the API, and a
+// schema that accepts an optional id still rejects an empty string. The field
+// is hidden whenever the backend can resolve the value itself, so this is the
+// normal path rather than an edge case.
+const withoutEmptySelects = (
+  values: SettingsValues,
+  fields: ExternalServiceFieldConfig[],
+): SettingsValues => {
+  const emptySelects = new Set(
+    fields
+      .filter((field) => field.type === 'select')
+      .map((field) => field.name),
+  )
+  return Object.fromEntries(
+    Object.entries(values).filter(
+      ([name, value]) => !(emptySelects.has(name) && value === ''),
+    ),
+  )
+}
+
 const valuesEqual = (a: SettingsValues, b: SettingsValues): boolean =>
   Object.keys(a).length === Object.keys(b).length &&
   Object.keys(a).every((key) => a[key] === b[key])
@@ -216,7 +236,7 @@ const ExternalServiceSettingsPage = ({
       return true
     }
 
-    const result = schema.safeParse(values)
+    const result = schema.safeParse(withoutEmptySelects(values, fields))
 
     if (result.success) {
       clearErrors()
@@ -240,7 +260,7 @@ const ExternalServiceSettingsPage = ({
   }
 
   const onSubmit = async () => {
-    const data = getValues()
+    const data = withoutEmptySelects(getValues(), fields)
 
     clearError()
 
@@ -267,7 +287,7 @@ const ExternalServiceSettingsPage = ({
   }
 
   const performTest = async () => {
-    const values = getValues()
+    const values = withoutEmptySelects(getValues(), fields)
 
     if (testing || !validateValues(values)) {
       return

--- a/apps/ui/src/components/Settings/Tracearr/index.tsx
+++ b/apps/ui/src/components/Settings/Tracearr/index.tsx
@@ -21,12 +21,27 @@ const fields: ExternalServiceFieldConfig[] = [
     label: 'API key',
     type: 'password',
     required: true,
+    helpText: (values) =>
+      values.url ? (
+        <a
+          className="underline"
+          href={`${stripTrailingSlashes(values.url)}/settings`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Find it in Tracearr under Settings, General, API Key.
+        </a>
+      ) : (
+        'Find it in Tracearr under Settings, General, API Key.'
+      ),
   },
+  // Only rendered when Tracearr has more than one server of the configured
+  // media server's type, since that is the only case Maintainerr cannot
+  // resolve on its own.
   {
     name: 'server_id',
     label: 'Tracearr server',
     type: 'select',
-    required: true,
     loadOptions: async (values) => {
       if (!values.url || !values.api_key) {
         return []
@@ -34,10 +49,7 @@ const fields: ExternalServiceFieldConfig[] = [
 
       const servers = await PostApiHandler<TracearrServer[]>(
         '/settings/tracearr/servers',
-        {
-          url: values.url,
-          api_key: values.api_key,
-        },
+        { url: values.url, api_key: values.api_key },
       )
       return servers.map((server) => ({
         value: server.id,
@@ -53,14 +65,14 @@ const TracearrSettings = () => {
       scope="Tracearr settings"
       pageTitle="Tracearr settings - Maintainerr"
       heading="Tracearr Settings"
-      description="Tracearr configuration"
+      description="Maintainerr picks the Tracearr media server backend automatically: the one tracking the media server configured in Maintainerr."
       docsPage="Configuration/#tracearr"
       settingsPath="/settings/tracearr"
       testPath="/settings/test/tracearr"
       schema={tracearrSettingSchema}
       fields={fields}
       testSuccessTitle="Tracearr"
-      testFailureMessage="Failed to connect to Tracearr. Verify URL, API key, and server ID."
+      testFailureMessage="Failed to connect to Tracearr. Verify the URL and API key."
     />
   )
 }

--- a/packages/contracts/src/settings/tracearr/tracearrSetting.ts
+++ b/packages/contracts/src/settings/tracearr/tracearrSetting.ts
@@ -8,8 +8,11 @@ export const tracearrConnectionSchema = z.object({
 
 export type TracearrConnection = z.infer<typeof tracearrConnectionSchema>
 
+// server_id is optional: Maintainerr manages one media server, so the matching
+// Tracearr server is resolved on save. It is only supplied when Tracearr has
+// several servers of that type and nothing can tell them apart automatically.
 export const tracearrSettingSchema = tracearrConnectionSchema.extend({
-  server_id: z.uuid('Tracearr server ID must be a UUID'),
+  server_id: z.uuid('Tracearr server ID must be a UUID').optional(),
 })
 
 export type TracearrSetting = z.infer<typeof tracearrSettingSchema>
@@ -17,7 +20,7 @@ export type TracearrSetting = z.infer<typeof tracearrSettingSchema>
 export const tracearrSettingFormSchema = z.object({
   url: serviceUrlSchema,
   api_key: z.string(),
-  server_id: z.string(),
+  server_id: z.string().optional(),
 })
 
 export type TracearrSettingForm = z.infer<typeof tracearrSettingFormSchema>

--- a/packages/contracts/src/tracearr/servers.ts
+++ b/packages/contracts/src/tracearr/servers.ts
@@ -17,7 +17,9 @@ export const tracearrRecentlyAddedPageSchema = z.object({
     z.object({
       rating_key: z.string().min(1).nullable(),
       title: z.string().min(1),
-      year: z.number().int().nullable(),
+      // The media server's own added date, which every server reports for every
+      // item. Year is not usable for this: it is absent on most rows.
+      added_at: z.iso.datetime(),
     }),
   ),
 })

--- a/packages/contracts/src/tracearr/servers.ts
+++ b/packages/contracts/src/tracearr/servers.ts
@@ -6,3 +6,29 @@ export const tracearrServerSchema = z.object({
 })
 
 export type TracearrServer = z.infer<typeof tracearrServerSchema>
+
+// Rating keys only mean anything within one media server, so a candidate is
+// confirmed by reading its own library items: the same key resolving to the
+// same title on the media server Maintainerr manages means one id space.
+// /recently-added is used because it lists library items rather than plays,
+// so it works on a server nobody has watched anything on.
+export const tracearrRecentlyAddedPageSchema = z.object({
+  data: z.array(
+    z.object({
+      rating_key: z.string().min(1).nullable(),
+      title: z.string().min(1),
+      year: z.number().int().nullable(),
+    }),
+  ),
+})
+
+// The server list carries no type, so /libraries supplies it: it reports one
+// row per library with its server, and needs no watch history to do so.
+export const tracearrLibrariesPageSchema = z.object({
+  data: z.array(
+    z.object({
+      server_id: z.uuid(),
+      server_type: z.string().min(1),
+    }),
+  ),
+})


### PR DESCRIPTION
Rating keys only exist within one media server, so a Tracearr server tracking a
different one matches nothing and every rule reads as unwatched. Nothing checked
for that, and switching media server left the binding pointing at the old server.

Reported by a user whose Tracearr tracked both Plex and Jellyfin: rules worked
against one and silently returned nothing against the other.

| Change | Why |
|---|---|
| A media server switch clears `tracearr_server_id` | The Tracearr instance survives a switch, its selected server does not |
| Servers filtered to the configured media server type | `/libraries` reports each server type without needing watch history |
| A candidate is confirmed against the managed library | Several servers of one type are otherwise indistinguishable |
| A server whose items do not resolve is refused on save | A wrong choice used to be accepted silently |
| The picker appears only when more than one candidate survives | One candidate is not a choice |

The Tracearr server is no longer entered by hand.

Confirmation requires two matching items including the year, not one: Plex and
Emby both number items from the same small range and titles like "Season 1"
repeat across libraries, so a single match is not evidence. The check answers
confirmed, contradicted, or unknown, and only a contradiction blocks a save, so
an empty or unreadable library never locks anyone out.