### PR TITLE
fix(tracearr): keep watcher rules working and re-check a stale server binding

### DIFF
--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -950,6 +950,38 @@ describe('TracearrApiService', () => {
     expect(service.getUsernamesByTracearrUserId()).toBeUndefined();
   });
 
+  // A confirmation belongs to the configuration it was taken under. Keeping
+  // one from a superseded sweep would let the next sweep skip the probe and
+  // read the previous server's history as verified.
+  it('probes again when the snapshot is invalidated while the server is being confirmed', async () => {
+    let invalidated = false;
+    apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/recently-added') {
+        if (!invalidated) {
+          invalidated = true;
+          service.invalidateHistory();
+        }
+        return CONFIRMING_LIBRARY;
+      }
+      if (endpoint === '/history') {
+        return {
+          data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
+          meta: { nextCursor: null, pageSize: 100 },
+        };
+      }
+      return usersPage;
+    });
+
+    await service.prefetchHistory();
+    await service.prefetchHistory();
+
+    expect(
+      apiMock.getWithoutCache.mock.calls.filter(
+        (call) => call[0] === '/recently-added',
+      ),
+    ).toHaveLength(2);
+  });
+
   it('reports a failed Tracearr server discovery', async () => {
     apiMock.getRawWithoutCache.mockRejectedValue(new Error('Unauthorized'));
 

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -925,6 +925,31 @@ describe('TracearrApiService', () => {
     expect(service.getHistoryIndex()).toBeUndefined();
   });
 
+  // A media-server re-point discards the snapshot mid-sweep. The sweep is
+  // already past its own guards by then, so only the generation stops it
+  // writing the previous server's history back.
+  it('discards a sweep that finishes after the snapshot was invalidated', async () => {
+    apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/recently-added') {
+        return CONFIRMING_LIBRARY;
+      }
+      if (endpoint === '/history') {
+        // The re-point lands while the history pages are being read.
+        service.invalidateHistory();
+        return {
+          data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
+          meta: { nextCursor: null, pageSize: 100 },
+        };
+      }
+      return usersPage;
+    });
+
+    await service.prefetchHistory();
+
+    expect(service.getHistoryIndex()).toBeUndefined();
+    expect(service.getUsernamesByTracearrUserId()).toBeUndefined();
+  });
+
   it('reports a failed Tracearr server discovery', async () => {
     apiMock.getRawWithoutCache.mockRejectedValue(new Error('Unauthorized'));
 

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -38,6 +38,14 @@ const historyRow = (id: string, ratingKey: string): TracearrHistoryItem => ({
   user: { id: USER_ID },
 });
 
+const CONFIRMING_LIBRARY = {
+  data: Array.from({ length: 6 }, (_unused, i) => ({
+    rating_key: `confirm-${i}`,
+    title: 'Confirming Title',
+    added_at: '2026-01-01T00:00:00.000Z',
+  })),
+};
+
 const usersPage = {
   data: [
     {
@@ -75,6 +83,11 @@ describe('TracearrApiService', () => {
         .fn()
         .mockResolvedValue([{ id: 'account-1', name: 'alice' }]),
       getChildrenMetadata: jest.fn().mockResolvedValue([]),
+      getMetadata: jest.fn(async () => ({
+        title: 'Confirming Title',
+        addedAt: new Date('2026-01-01T00:00:00.000Z'),
+      })),
+      itemExists: jest.fn().mockResolvedValue(true),
     } as never);
     Object.assign(settings, {
       media_server_type: MediaServerType.PLEX,
@@ -92,6 +105,9 @@ describe('TracearrApiService', () => {
       'movie-2',
     );
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/recently-added') {
+        return CONFIRMING_LIBRARY;
+      }
       if (endpoint === '/history') {
         const calls = apiMock.getWithoutCache.mock.calls.filter(
           (call) => call[0] === '/history',
@@ -126,6 +142,9 @@ describe('TracearrApiService', () => {
   it('maps every Tracearr user to the username Tracearr read off the media server', async () => {
     const OTHER_USER_ID = '55555555-5555-4555-8555-555555555555';
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/recently-added') {
+        return CONFIRMING_LIBRARY;
+      }
       if (endpoint === '/history') {
         return {
           data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
@@ -176,6 +195,9 @@ describe('TracearrApiService', () => {
   // the server no longer has, instead of skipping the item.
   it('does not resolve an account Tracearr marks as removed', async () => {
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/recently-added') {
+        return CONFIRMING_LIBRARY;
+      }
       if (endpoint === '/history') {
         return {
           data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
@@ -209,6 +231,9 @@ describe('TracearrApiService', () => {
   it('keeps mapping real users when an account has no external user id', async () => {
     const UNKNOWN_USER_ID = '66666666-6666-4666-8666-666666666666';
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/recently-added') {
+        return CONFIRMING_LIBRARY;
+      }
       if (endpoint === '/history') {
         return {
           data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
@@ -256,6 +281,9 @@ describe('TracearrApiService', () => {
 
   it('invalidates a prefetched history snapshot', async () => {
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/recently-added') {
+        return CONFIRMING_LIBRARY;
+      }
       if (endpoint === '/history') {
         return {
           data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
@@ -281,7 +309,7 @@ describe('TracearrApiService', () => {
         return usersPage;
       }
       if (endpoint === '/recently-added') {
-        return undefined;
+        return CONFIRMING_LIBRARY;
       }
       sweep += 1;
       if (sweep === 1) {
@@ -322,7 +350,7 @@ describe('TracearrApiService', () => {
         return usersPage;
       }
       if (endpoint === '/recently-added') {
-        return undefined;
+        return CONFIRMING_LIBRARY;
       }
       sweep += 1;
       if (sweep === 1) {
@@ -366,7 +394,7 @@ describe('TracearrApiService', () => {
         return usersPage;
       }
       if (endpoint === '/recently-added') {
-        return undefined;
+        return CONFIRMING_LIBRARY;
       }
       sweep += 1;
       if (sweep === 1) {
@@ -412,6 +440,9 @@ describe('TracearrApiService', () => {
   it('does not expose an index after a later cursor page fails', async () => {
     const first = historyRow('33333333-3333-4333-8333-333333333333', 'movie-1');
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/recently-added') {
+        return CONFIRMING_LIBRARY;
+      }
       if (endpoint === '/history') {
         const calls = apiMock.getWithoutCache.mock.calls.filter(
           (call) => call[0] === '/history',
@@ -430,6 +461,9 @@ describe('TracearrApiService', () => {
 
   it('does not expose an empty history index', async () => {
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/recently-added') {
+        return CONFIRMING_LIBRARY;
+      }
       if (endpoint === '/history') {
         return { data: [], meta: { nextCursor: null, pageSize: 100 } };
       }
@@ -563,6 +597,9 @@ describe('TracearrApiService', () => {
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
       if (endpoint === '/libraries') {
         return { data: [{ server_id: SERVER_ID, server_type: 'plex' }] };
+      }
+      if (endpoint === '/recently-added') {
+        return CONFIRMING_LIBRARY;
       }
       if (endpoint === '/history') {
         return {
@@ -812,6 +849,9 @@ describe('TracearrApiService', () => {
   it('refuses history from a server that is not the configured media server', async () => {
     Object.assign(settings, { media_server_type: MediaServerType.JELLYFIN });
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/recently-added') {
+        return CONFIRMING_LIBRARY;
+      }
       if (endpoint === '/history') {
         return {
           data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
@@ -854,6 +894,28 @@ describe('TracearrApiService', () => {
             added_at: '2026-01-01T00:00:00.000Z',
           })),
         };
+      }
+      return usersPage;
+    });
+
+    await service.prefetchHistory();
+
+    expect(service.getHistoryIndex()).toBeUndefined();
+  });
+
+  // A re-point invalidates the snapshot, so the next run probes again. The
+  // probe cannot always decide, and history it cannot vouch for must not be
+  // read as "watched nothing".
+  it('refuses history from a server it cannot confirm', async () => {
+    apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/history') {
+        return {
+          data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
+          meta: { nextCursor: null, pageSize: 100 },
+        };
+      }
+      if (endpoint === '/recently-added') {
+        return { data: [] };
       }
       return usersPage;
     });

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -206,6 +206,54 @@ describe('TracearrApiService', () => {
     expect(service.getUsernamesByTracearrUserId()?.has(USER_ID)).toBe(false);
   });
 
+  it('keeps mapping real users when an account has no external user id', async () => {
+    const UNKNOWN_USER_ID = '66666666-6666-4666-8666-666666666666';
+    apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/history') {
+        return {
+          data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
+          meta: { nextCursor: null, pageSize: 100 },
+        };
+      }
+      return {
+        data: [
+          {
+            id: UNKNOWN_USER_ID,
+            accounts: [
+              {
+                server_id: SERVER_ID,
+                server_type: 'plex',
+                external_user_id: '',
+                username: 'Unknown',
+              },
+            ],
+          },
+          {
+            id: USER_ID,
+            accounts: [
+              {
+                server_id: SERVER_ID,
+                server_type: 'plex',
+                external_user_id: 'account-1',
+                username: 'alice',
+              },
+            ],
+          },
+        ],
+        meta: { nextCursor: null, pageSize: 100 },
+      };
+    });
+
+    await service.prefetchHistory();
+
+    expect(service.getUsernamesByTracearrUserId()?.get(USER_ID)).toEqual([
+      'alice',
+    ]);
+    expect(
+      service.getUsernamesByTracearrUserId()?.get(UNKNOWN_USER_ID),
+    ).toEqual(['Unknown']);
+  });
+
   it('invalidates a prefetched history snapshot', async () => {
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
       if (endpoint === '/history') {
@@ -231,6 +279,9 @@ describe('TracearrApiService', () => {
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
       if (endpoint === '/users') {
         return usersPage;
+      }
+      if (endpoint === '/recently-added') {
+        return undefined;
       }
       sweep += 1;
       if (sweep === 1) {
@@ -269,6 +320,9 @@ describe('TracearrApiService', () => {
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
       if (endpoint === '/users') {
         return usersPage;
+      }
+      if (endpoint === '/recently-added') {
+        return undefined;
       }
       sweep += 1;
       if (sweep === 1) {
@@ -310,6 +364,9 @@ describe('TracearrApiService', () => {
     apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
       if (endpoint === '/users') {
         return usersPage;
+      }
+      if (endpoint === '/recently-added') {
+        return undefined;
       }
       sweep += 1;
       if (sweep === 1) {
@@ -759,6 +816,43 @@ describe('TracearrApiService', () => {
         return {
           data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
           meta: { nextCursor: null, pageSize: 100 },
+        };
+      }
+      return usersPage;
+    });
+
+    await service.prefetchHistory();
+
+    expect(service.getHistoryIndex()).toBeUndefined();
+  });
+
+  // The wrong server's history is readable, so its rows answer "watched
+  // nothing" for every item it does not cover instead of failing.
+  it('refuses a populated history from a server that stopped matching', async () => {
+    Object.assign(settings, { media_server_type: MediaServerType.PLEX });
+    mediaServerFactory.getService.mockResolvedValue({
+      getUsers: jest.fn().mockResolvedValue([{ id: 'account-1', name: 'a' }]),
+      getChildrenMetadata: jest.fn().mockResolvedValue([]),
+      getMetadata: jest.fn(async () => ({
+        title: 'Season 1',
+        addedAt: new Date('2025-03-04T10:00:00.000Z'),
+      })),
+      itemExists: jest.fn().mockResolvedValue(true),
+    } as never);
+    apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/history') {
+        return {
+          data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
+          meta: { nextCursor: null, pageSize: 100 },
+        };
+      }
+      if (endpoint === '/recently-added') {
+        return {
+          data: Array.from({ length: 6 }, (_unused, i) => ({
+            rating_key: `${100 + i}`,
+            title: 'Season 1',
+            added_at: '2026-01-01T00:00:00.000Z',
+          })),
         };
       }
       return usersPage;

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -950,38 +950,6 @@ describe('TracearrApiService', () => {
     expect(service.getUsernamesByTracearrUserId()).toBeUndefined();
   });
 
-  // A confirmation belongs to the configuration it was taken under. Keeping
-  // one from a superseded sweep would let the next sweep skip the probe and
-  // read the previous server's history as verified.
-  it('probes again when the snapshot is invalidated while the server is being confirmed', async () => {
-    let invalidated = false;
-    apiMock.getWithoutCache.mockImplementation(async (endpoint: string) => {
-      if (endpoint === '/recently-added') {
-        if (!invalidated) {
-          invalidated = true;
-          service.invalidateHistory();
-        }
-        return CONFIRMING_LIBRARY;
-      }
-      if (endpoint === '/history') {
-        return {
-          data: [historyRow('33333333-3333-4333-8333-333333333333', 'movie-1')],
-          meta: { nextCursor: null, pageSize: 100 },
-        };
-      }
-      return usersPage;
-    });
-
-    await service.prefetchHistory();
-    await service.prefetchHistory();
-
-    expect(
-      apiMock.getWithoutCache.mock.calls.filter(
-        (call) => call[0] === '/recently-added',
-      ),
-    ).toHaveLength(2);
-  });
-
   it('reports a failed Tracearr server discovery', async () => {
     apiMock.getRawWithoutCache.mockRejectedValue(new Error('Unauthorized'));
 

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -83,7 +83,6 @@ export class TracearrApiService {
   private episodeIdsByItemId = new Map<string, Promise<string[] | undefined>>();
   private resolvedServerId: string | undefined;
   private historyGeneration = 0;
-  private verifiedServerId: string | undefined;
   private sweepPromise: Promise<void> | undefined;
 
   constructor(
@@ -126,7 +125,6 @@ export class TracearrApiService {
     this.activeUsernamesByTracearrUserId = undefined;
     this.episodeIdsByItemId.clear();
     this.resolvedServerId = undefined;
-    this.verifiedServerId = undefined;
     // A sweep already in flight resolves after this, so mark its results stale
     // rather than let them repopulate what was just discarded.
     this.historyGeneration += 1;
@@ -445,9 +443,6 @@ export class TracearrApiService {
     this.episodeIdsByItemId.clear();
 
     const serverId = await this.resolveActiveServerId();
-    if (generation !== this.historyGeneration) {
-      return;
-    }
     if (!serverId) {
       this.logger.warn(
         'Tracearr has no server matching the configured media server. Tracearr rule values are unavailable for this run.',
@@ -458,27 +453,21 @@ export class TracearrApiService {
     // A binding survives whatever the media server did since it was chosen, and
     // the wrong one's history reads as "watched nothing" for every item it does
     // not cover rather than as a failure. Unconfirmed is not good enough to
-    // read history by, so only a confirmed match is remembered and trusted.
-    if (this.verifiedServerId !== serverId) {
-      const sharesLibrary = await this.serverSharesLibrary(
-        {
-          url: this.settings.tracearr_url,
-          apiKey: this.settings.tracearr_api_key,
-        },
-        serverId,
+    // read history by.
+    const sharesLibrary = await this.serverSharesLibrary(
+      {
+        url: this.settings.tracearr_url,
+        apiKey: this.settings.tracearr_api_key,
+      },
+      serverId,
+    );
+    if (!sharesLibrary) {
+      this.logger.warn(
+        sharesLibrary === false
+          ? 'The selected Tracearr server tracks a different media server than the one Maintainerr manages. Pick the right server in Tracearr settings. Tracearr rule values are unavailable for this run.'
+          : 'The selected Tracearr server could not be confirmed to track the media server Maintainerr manages. Tracearr rule values are unavailable for this run.',
       );
-      if (generation !== this.historyGeneration) {
-        return;
-      }
-      if (!sharesLibrary) {
-        this.logger.warn(
-          sharesLibrary === false
-            ? 'The selected Tracearr server tracks a different media server than the one Maintainerr manages. Pick the right server in Tracearr settings. Tracearr rule values are unavailable for this run.'
-            : 'The selected Tracearr server could not be confirmed to track the media server Maintainerr manages. Tracearr rule values are unavailable for this run.',
-        );
-        return;
-      }
-      this.verifiedServerId = serverId;
+      return;
     }
 
     const historyIndex = await this.refreshHistoryIndex(generation);

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -419,13 +419,22 @@ export class TracearrApiService {
     }
     if (this.settings.tracearr_server_id) {
       this.resolvedServerId = this.settings.tracearr_server_id;
-    } else if (!this.resolvedServerId) {
-      this.resolvedServerId = await this.resolveServerId({
-        url: this.settings.tracearr_url,
-        apiKey: this.settings.tracearr_api_key,
-      });
+      return this.resolvedServerId;
+    }
+    if (this.resolvedServerId) {
+      return this.resolvedServerId;
     }
 
+    const generation = this.historyGeneration;
+    const resolved = await this.resolveServerId({
+      url: this.settings.tracearr_url,
+      apiKey: this.settings.tracearr_api_key,
+    });
+    if (generation !== this.historyGeneration) {
+      return undefined;
+    }
+
+    this.resolvedServerId = resolved;
     return this.resolvedServerId;
   }
 
@@ -436,6 +445,9 @@ export class TracearrApiService {
     this.episodeIdsByItemId.clear();
 
     const serverId = await this.resolveActiveServerId();
+    if (generation !== this.historyGeneration) {
+      return;
+    }
     if (!serverId) {
       this.logger.warn(
         'Tracearr has no server matching the configured media server. Tracearr rule values are unavailable for this run.',
@@ -455,6 +467,9 @@ export class TracearrApiService {
         },
         serverId,
       );
+      if (generation !== this.historyGeneration) {
+        return;
+      }
       if (!sharesLibrary) {
         this.logger.warn(
           sharesLibrary === false

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -440,8 +440,8 @@ export class TracearrApiService {
 
     // A binding survives whatever the media server did since it was chosen, and
     // the wrong one's history reads as "watched nothing" for every item it does
-    // not cover rather than as a failure. Only a confirmed match is remembered,
-    // so an undecided one is retried until it can be settled.
+    // not cover rather than as a failure. Unconfirmed is not good enough to
+    // read history by, so only a confirmed match is remembered and trusted.
     if (this.verifiedServerId !== serverId) {
       const sharesLibrary = await this.serverSharesLibrary(
         {
@@ -450,15 +450,15 @@ export class TracearrApiService {
         },
         serverId,
       );
-      if (sharesLibrary === false) {
+      if (!sharesLibrary) {
         this.logger.warn(
-          'The selected Tracearr server tracks a different media server than the one Maintainerr manages. Pick the right server in Tracearr settings. Tracearr rule values are unavailable for this run.',
+          sharesLibrary === false
+            ? 'The selected Tracearr server tracks a different media server than the one Maintainerr manages. Pick the right server in Tracearr settings. Tracearr rule values are unavailable for this run.'
+            : 'The selected Tracearr server could not be confirmed to track the media server Maintainerr manages. Tracearr rule values are unavailable for this run.',
         );
         return;
       }
-      if (sharesLibrary) {
-        this.verifiedServerId = serverId;
-      }
+      this.verifiedServerId = serverId;
     }
 
     const historyIndex = await this.refreshHistoryIndex();

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -82,6 +82,7 @@ export class TracearrApiService {
   private activeUsernamesByTracearrUserId: Map<string, string[]> | undefined;
   private episodeIdsByItemId = new Map<string, Promise<string[] | undefined>>();
   private resolvedServerId: string | undefined;
+  private verifiedServerId: string | undefined;
   private sweepPromise: Promise<void> | undefined;
 
   constructor(
@@ -124,6 +125,7 @@ export class TracearrApiService {
     this.activeUsernamesByTracearrUserId = undefined;
     this.episodeIdsByItemId.clear();
     this.resolvedServerId = undefined;
+    this.verifiedServerId = undefined;
     cacheManager
       .getCache(TRACEARR_CACHE_ID)
       ?.data.del(TRACEARR_HISTORY_CACHE_KEY);
@@ -180,6 +182,18 @@ export class TracearrApiService {
       this.logger.debug(error);
       return undefined;
     }
+  }
+
+  /** True when nothing is bound: there is no stale selection to catch. */
+  public async savedServerTracksMediaServer(): Promise<boolean | undefined> {
+    const url = this.settings.tracearr_url;
+    const apiKey = this.settings.tracearr_api_key;
+    const serverId = this.settings.tracearr_server_id;
+    if (!url || !apiKey || !serverId) {
+      return true;
+    }
+
+    return this.serverSharesLibrary({ url, apiKey }, serverId);
   }
 
   /**
@@ -416,11 +430,35 @@ export class TracearrApiService {
     this.activeUsernamesByTracearrUserId = undefined;
     this.episodeIdsByItemId.clear();
 
-    if (!(await this.resolveActiveServerId())) {
+    const serverId = await this.resolveActiveServerId();
+    if (!serverId) {
       this.logger.warn(
         'Tracearr has no server matching the configured media server. Tracearr rule values are unavailable for this run.',
       );
       return;
+    }
+
+    // A binding survives whatever the media server did since it was chosen, and
+    // the wrong one's history reads as "watched nothing" for every item it does
+    // not cover rather than as a failure. Only a confirmed match is remembered,
+    // so an undecided one is retried until it can be settled.
+    if (this.verifiedServerId !== serverId) {
+      const sharesLibrary = await this.serverSharesLibrary(
+        {
+          url: this.settings.tracearr_url,
+          apiKey: this.settings.tracearr_api_key,
+        },
+        serverId,
+      );
+      if (sharesLibrary === false) {
+        this.logger.warn(
+          'The selected Tracearr server tracks a different media server than the one Maintainerr manages. Pick the right server in Tracearr settings. Tracearr rule values are unavailable for this run.',
+        );
+        return;
+      }
+      if (sharesLibrary) {
+        this.verifiedServerId = serverId;
+      }
     }
 
     const historyIndex = await this.refreshHistoryIndex();

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -82,6 +82,7 @@ export class TracearrApiService {
   private activeUsernamesByTracearrUserId: Map<string, string[]> | undefined;
   private episodeIdsByItemId = new Map<string, Promise<string[] | undefined>>();
   private resolvedServerId: string | undefined;
+  private historyGeneration = 0;
   private verifiedServerId: string | undefined;
   private sweepPromise: Promise<void> | undefined;
 
@@ -126,6 +127,9 @@ export class TracearrApiService {
     this.episodeIdsByItemId.clear();
     this.resolvedServerId = undefined;
     this.verifiedServerId = undefined;
+    // A sweep already in flight resolves after this, so mark its results stale
+    // rather than let them repopulate what was just discarded.
+    this.historyGeneration += 1;
     cacheManager
       .getCache(TRACEARR_CACHE_ID)
       ?.data.del(TRACEARR_HISTORY_CACHE_KEY);
@@ -426,6 +430,7 @@ export class TracearrApiService {
   }
 
   private async prefetchHistoryInternal(): Promise<void> {
+    const generation = this.historyGeneration;
     this.activeHistoryIndex = undefined;
     this.activeUsernamesByTracearrUserId = undefined;
     this.episodeIdsByItemId.clear();
@@ -461,7 +466,7 @@ export class TracearrApiService {
       this.verifiedServerId = serverId;
     }
 
-    const historyIndex = await this.refreshHistoryIndex();
+    const historyIndex = await this.refreshHistoryIndex(generation);
     if (!historyIndex) {
       this.logger.warn(
         'Tracearr history sweep did not complete. Tracearr rule values are unavailable for this run.',
@@ -473,6 +478,10 @@ export class TracearrApiService {
       this.logger.warn(
         'Tracearr history contains no usable rating keys. Tracearr rule values are unavailable until history is recorded.',
       );
+      return;
+    }
+
+    if (generation !== this.historyGeneration) {
       return;
     }
 
@@ -488,6 +497,10 @@ export class TracearrApiService {
       return;
     }
 
+    if (generation !== this.historyGeneration) {
+      return;
+    }
+
     this.activeUsernamesByTracearrUserId = usernames;
   }
 
@@ -496,9 +509,9 @@ export class TracearrApiService {
    * for 2 minutes or more, so every Tracearr rule property counts sustained
    * plays only.
    */
-  private async refreshHistoryIndex(): Promise<
-    TracearrHistoryIndex | undefined
-  > {
+  private async refreshHistoryIndex(
+    generation: number,
+  ): Promise<TracearrHistoryIndex | undefined> {
     const api = this.api;
     const serverId = this.resolvedServerId;
     const mediaServerType = this.settings.media_server_type;
@@ -591,7 +604,9 @@ export class TracearrApiService {
     }
 
     const index = this.createHistoryIndex(rowsById);
-    cache?.set(TRACEARR_HISTORY_CACHE_KEY, index);
+    if (generation === this.historyGeneration) {
+      cache?.set(TRACEARR_HISTORY_CACHE_KEY, index);
+    }
     return index;
   }
 

--- a/apps/server/src/modules/settings/settings-operations.service.spec.ts
+++ b/apps/server/src/modules/settings/settings-operations.service.spec.ts
@@ -146,7 +146,10 @@ describe('SettingsOperationsService', () => {
     expect(tracearr.invalidateHistory).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps the Tracearr server selection when the match cannot be determined', async () => {
+  // The selection survives an inconclusive check, but the snapshot it was
+  // verified against does not: keeping it would let the next run read the
+  // previous media server's history without probing again.
+  it('keeps the Tracearr server selection but drops its snapshot when the match cannot be determined', async () => {
     tracearr.savedServerTracksMediaServer.mockResolvedValue(undefined);
 
     await service.updateSettings({ plex_hostname: 'other-plex.local' });
@@ -154,7 +157,7 @@ describe('SettingsOperationsService', () => {
     expect(settingsDataService.saveSettings).not.toHaveBeenCalledWith(
       expect.objectContaining({ tracearr_server_id: null }),
     );
-    expect(tracearr.invalidateHistory).not.toHaveBeenCalled();
+    expect(tracearr.invalidateHistory).toHaveBeenCalledTimes(1);
   });
 
   it('rejects Plex server setting changes when no Plex credentials are stored', async () => {

--- a/apps/server/src/modules/settings/settings-operations.service.spec.ts
+++ b/apps/server/src/modules/settings/settings-operations.service.spec.ts
@@ -135,6 +135,28 @@ describe('SettingsOperationsService', () => {
     ).resolves.toEqual({ status: 'OK', code: 1, message: '2.0.0-beta.1' });
   });
 
+  it('clears the Tracearr server selection when the reconfigured media server no longer matches', async () => {
+    tracearr.savedServerTracksMediaServer.mockResolvedValue(false);
+
+    await service.updateSettings({ plex_hostname: 'other-plex.local' });
+
+    expect(settingsDataService.saveSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ tracearr_server_id: null }),
+    );
+    expect(tracearr.invalidateHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the Tracearr server selection when the match cannot be determined', async () => {
+    tracearr.savedServerTracksMediaServer.mockResolvedValue(undefined);
+
+    await service.updateSettings({ plex_hostname: 'other-plex.local' });
+
+    expect(settingsDataService.saveSettings).not.toHaveBeenCalledWith(
+      expect.objectContaining({ tracearr_server_id: null }),
+    );
+    expect(tracearr.invalidateHistory).not.toHaveBeenCalled();
+  });
+
   it('rejects Plex server setting changes when no Plex credentials are stored', async () => {
     settingsRepo.findOne.mockResolvedValue(
       createSettings({ plex_auth_token: null }),

--- a/apps/server/src/modules/settings/settings-operations.service.ts
+++ b/apps/server/src/modules/settings/settings-operations.service.ts
@@ -427,6 +427,12 @@ export class SettingsOperationsService {
    */
   private async revalidateMediaServerDependentSettings(): Promise<void> {
     try {
+      // The swept history, the resolved server and its verification all
+      // describe the previous connection, so they go regardless of what the
+      // check below concludes. Keeping them would let the next run read the
+      // old server from memory without probing it again.
+      this.tracearr.invalidateHistory();
+
       if ((await this.tracearr.savedServerTracksMediaServer()) !== false) {
         return;
       }
@@ -437,8 +443,6 @@ export class SettingsOperationsService {
         tracearr_server_id: null,
       });
       await this.settingsDataService.init();
-      // The resolved server is cached in memory too.
-      this.tracearr.invalidateHistory();
 
       this.logger.log(
         'Cleared the selected Tracearr server: it tracks a different media server than the one now configured.',

--- a/apps/server/src/modules/settings/settings-operations.service.ts
+++ b/apps/server/src/modules/settings/settings-operations.service.ts
@@ -462,29 +462,11 @@ export class SettingsOperationsService {
     });
   }
 
-  public async testTracearr(
-    settings: TracearrSetting,
-  ): Promise<BasicResponseDto> {
-    const connection = await this.tracearr.testConnection({
+  public testTracearr(settings: TracearrSetting): Promise<BasicResponseDto> {
+    return this.tracearr.testConnection({
       url: settings.url,
       apiKey: settings.api_key,
     });
-    if (connection.code !== 1 || !settings.server_id) {
-      return connection;
-    }
-
-    const sharesLibrary = await this.tracearr.serverSharesLibrary(
-      { url: settings.url, apiKey: settings.api_key },
-      settings.server_id,
-    );
-    return sharesLibrary === false
-      ? {
-          status: 'NOK',
-          code: 0,
-          message:
-            'That Tracearr server tracks a different media server than the one Maintainerr manages. Pick the Tracearr server for this media server.',
-        }
-      : connection;
   }
 
   public async removeDownloadClientSetting() {

--- a/apps/server/src/modules/settings/settings-operations.service.ts
+++ b/apps/server/src/modules/settings/settings-operations.service.ts
@@ -420,6 +420,35 @@ export class SettingsOperationsService {
     }
   }
 
+  /**
+   * Settings resolved against the media server go stale when Maintainerr is
+   * re-pointed at another instance of the same type: the type is unchanged, so
+   * the switch path never runs.
+   */
+  private async revalidateMediaServerDependentSettings(): Promise<void> {
+    try {
+      if ((await this.tracearr.savedServerTracksMediaServer()) !== false) {
+        return;
+      }
+
+      const settingsDb = await this.settingsRepo.findOne({ where: {} });
+      await this.settingsDataService.saveSettings({
+        ...settingsDb,
+        tracearr_server_id: null,
+      });
+      await this.settingsDataService.init();
+      // The resolved server is cached in memory too.
+      this.tracearr.invalidateHistory();
+
+      this.logger.log(
+        'Cleared the selected Tracearr server: it tracks a different media server than the one now configured.',
+      );
+    } catch (error) {
+      // The settings are already saved; this check must not fail that.
+      this.logger.debug(error);
+    }
+  }
+
   public getTracearrServers(
     settings: TracearrConnection,
   ): Promise<TracearrServer[] | undefined> {
@@ -429,11 +458,29 @@ export class SettingsOperationsService {
     });
   }
 
-  public testTracearr(settings: TracearrSetting): Promise<BasicResponseDto> {
-    return this.tracearr.testConnection({
+  public async testTracearr(
+    settings: TracearrSetting,
+  ): Promise<BasicResponseDto> {
+    const connection = await this.tracearr.testConnection({
       url: settings.url,
       apiKey: settings.api_key,
     });
+    if (connection.code !== 1 || !settings.server_id) {
+      return connection;
+    }
+
+    const sharesLibrary = await this.tracearr.serverSharesLibrary(
+      { url: settings.url, apiKey: settings.api_key },
+      settings.server_id,
+    );
+    return sharesLibrary === false
+      ? {
+          status: 'NOK',
+          code: 0,
+          message:
+            'That Tracearr server tracks a different media server than the one Maintainerr manages. Pick the Tracearr server for this media server.',
+        }
+      : connection;
   }
 
   public async removeDownloadClientSetting() {
@@ -643,6 +690,8 @@ export class SettingsOperationsService {
       // Streamystats uses the Jellyfin API key + server identity. Re-init so
       // the cached client and resolved serverId track the new credentials.
       this.streamystats.init();
+
+      await this.revalidateMediaServerDependentSettings();
 
       this.logger.log('Jellyfin settings saved successfully');
       return { status: 'OK', code: 1, message: 'Success' };
@@ -880,6 +929,8 @@ export class SettingsOperationsService {
       this.mediaServerFactory.uninitializeServer(MediaServerType.EMBY);
 
       await this.settingsDataService.init();
+
+      await this.revalidateMediaServerDependentSettings();
 
       this.logger.log('Emby settings saved successfully');
       return { status: 'OK', code: 1, message: 'Success' };
@@ -1282,6 +1333,13 @@ export class SettingsOperationsService {
       merged.plex_hostname = normalizedPlexServerSettings.hostname;
       merged.plex_ssl = normalizedPlexServerSettings.ssl;
 
+      // Plex is the only media server configured through this endpoint; the
+      // others have their own save paths.
+      const mediaServerConnectionChanged = this.isPlexServerSettingsUpdate(
+        settingsDb,
+        merged,
+      );
+
       await this.settingsDataService.saveSettings(merged);
 
       await this.settingsDataService.init();
@@ -1291,6 +1349,10 @@ export class SettingsOperationsService {
       this.tautulli.init();
       this.downloadClient.init();
       this.internalApi.init();
+
+      if (mediaServerConnectionChanged) {
+        await this.revalidateMediaServerDependentSettings();
+      }
 
       // reload Collection handler job if changed
       if (

--- a/apps/ui/src/components/Settings/ExternalServiceSettingsPage.spec.tsx
+++ b/apps/ui/src/components/Settings/ExternalServiceSettingsPage.spec.tsx
@@ -431,6 +431,38 @@ describe('ExternalServiceSettingsPage', () => {
     })
   })
 
+  // Most services answer a bare "Failed", which says less than the scoped
+  // message the page shows by default.
+  it('keeps the scoped message when a save fails without a reason', async () => {
+    postApiHandler.mockResolvedValue({
+      status: 'NOK',
+      code: 0,
+      message: 'Failed',
+    })
+
+    render(
+      <ExternalServiceSettingsPage
+        scope="Seerr settings"
+        pageTitle="Seerr settings - Maintainerr"
+        heading="Seerr Settings"
+        description="Seerr configuration"
+        docsPage="Configuration/#seerr"
+        settingsPath="/settings/seerr"
+        testPath="/settings/test/seerr"
+        schema={urlApiKeySchema}
+        fields={urlApiKeyFields}
+        testSuccessTitle="Seerr"
+        testFailureMessage="Failed to connect"
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Save Changes' }))
+
+    expect(
+      await screen.findByText('Seerr settings could not be updated'),
+    ).toBeTruthy()
+  })
+
   it('surfaces the server message when a save is rejected', async () => {
     postApiHandler.mockResolvedValue({
       status: 'NOK',

--- a/apps/ui/src/components/Settings/ExternalServiceSettingsPage.spec.tsx
+++ b/apps/ui/src/components/Settings/ExternalServiceSettingsPage.spec.tsx
@@ -430,4 +430,90 @@ describe('ExternalServiceSettingsPage', () => {
       expect(screen.queryByLabelText('Tracearr server *')).toBeNull()
     })
   })
+
+  it('surfaces the server message when a save is rejected', async () => {
+    postApiHandler.mockResolvedValue({
+      status: 'NOK',
+      code: 0,
+      message: 'Pick the Tracearr server for this media server.',
+    })
+
+    render(
+      <ExternalServiceSettingsPage
+        scope="Seerr settings"
+        pageTitle="Seerr settings - Maintainerr"
+        heading="Seerr Settings"
+        description="Seerr configuration"
+        docsPage="Configuration/#seerr"
+        settingsPath="/settings/seerr"
+        testPath="/settings/test/seerr"
+        schema={urlApiKeySchema}
+        fields={urlApiKeyFields}
+        testSuccessTitle="Seerr"
+        testFailureMessage="Failed to connect"
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Save Changes' }))
+
+    expect(
+      await screen.findByText(
+        'Pick the Tracearr server for this media server.',
+      ),
+    ).toBeTruthy()
+    expect(screen.queryByText('Seerr settings could not be updated')).toBeNull()
+  })
+
+  it('clears an integration whose hidden select still holds a resolved value', async () => {
+    getApiHandler.mockResolvedValue({
+      url: 'http://tracearr.local',
+      api_key: 'saved-key',
+      server_id: '11111111-1111-4111-8111-111111111111',
+    })
+    postApiHandler.mockResolvedValue([
+      {
+        value: '11111111-1111-4111-8111-111111111111',
+        label: 'Sample Plex',
+      },
+    ])
+    deleteApiHandler.mockResolvedValue({
+      status: 'OK',
+      code: 1,
+      message: 'Deleted',
+    })
+
+    render(
+      <ExternalServiceSettingsPage
+        scope="Tracearr settings"
+        pageTitle="Tracearr settings - Maintainerr"
+        heading="Tracearr Settings"
+        description="Tracearr configuration"
+        docsPage="Configuration/#tracearr"
+        settingsPath="/settings/tracearr"
+        testPath="/settings/test/tracearr"
+        schema={z.object({
+          url: z.string().min(1),
+          api_key: z.string().min(1),
+          server_id: z.string().uuid().optional(),
+        })}
+        fields={tracearrFields}
+        testSuccessTitle="Tracearr"
+        testFailureMessage="Failed to connect"
+      />,
+    )
+
+    const saveButton = await screen.findByRole('button', {
+      name: 'Save Changes',
+    })
+
+    fireEvent.change(screen.getByLabelText(/URL/), { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: '' },
+    })
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(deleteApiHandler).toHaveBeenCalledWith('/settings/tracearr')
+    })
+  })
 })

--- a/apps/ui/src/components/Settings/ExternalServiceSettingsPage.tsx
+++ b/apps/ui/src/components/Settings/ExternalServiceSettingsPage.tsx
@@ -72,10 +72,15 @@ interface ExternalServiceSettingsPageProps {
   testFailureMessage: string
 }
 
+// Selects are resolved for the user and can be hidden, so one holding a value
+// must not stop a cleared form from counting as a removal.
 const allEmpty = (
   values: SettingsValues,
   fields: ExternalServiceFieldConfig[],
-) => fields.every((field) => (values[field.name] ?? '') === '')
+) =>
+  fields
+    .filter((field) => field.type !== 'select')
+    .every((field) => (values[field.name] ?? '') === '')
 
 // An unchosen select is '' in the form but "not provided" to the API, and a
 // schema that accepts an optional id still rejects an empty string. The field
@@ -126,7 +131,7 @@ const ExternalServiceSettingsPage = ({
   >({})
   const loadingOptionFieldNamesRef = useRef(new Set<string>())
   const selectOptionsVersionRef = useRef(0)
-  const { feedback, showUpdated, showUpdateError, clearError } =
+  const { feedback, showUpdated, showUpdateError, showError, clearError } =
     useSettingsFeedback(scope)
 
   const {
@@ -278,6 +283,8 @@ const ExternalServiceSettingsPage = ({
       if (response.code) {
         reset(data)
         showUpdated()
+      } else if (response.message) {
+        showError(response.message)
       } else {
         showUpdateError()
       }

--- a/apps/ui/src/components/Settings/ExternalServiceSettingsPage.tsx
+++ b/apps/ui/src/components/Settings/ExternalServiceSettingsPage.tsx
@@ -283,8 +283,14 @@ const ExternalServiceSettingsPage = ({
       if (response.code) {
         reset(data)
         showUpdated()
-      } else if (response.message) {
-        showError(response.message)
+        return
+      }
+
+      // Most services answer a bare "Failed", which says less than the scoped
+      // message; only a specific one is worth showing instead.
+      const reason = normalizeConnectionErrorMessage(response.message, '')
+      if (reason) {
+        showError(reason)
       } else {
         showUpdateError()
       }

--- a/apps/ui/src/utils/ApiError.ts
+++ b/apps/ui/src/utils/ApiError.ts
@@ -77,7 +77,11 @@ export const normalizeConnectionErrorMessage = (
     return fallback
   }
 
-  if (message === 'Failure' || message === 'Unknown error') {
+  if (
+    message === 'Failure' ||
+    message === 'Failed' ||
+    message === 'Unknown error'
+  ) {
     return fallback
   }
 

--- a/packages/contracts/src/tracearr/users.ts
+++ b/packages/contracts/src/tracearr/users.ts
@@ -8,7 +8,8 @@ export const tracearrUsersPageSchema = z.object({
         z.object({
           server_id: z.uuid(),
           server_type: z.string().min(1),
-          external_user_id: z.string().min(1),
+          // Empty on an account Tracearr could not attribute to a user.
+          external_user_id: z.string(),
           // Tracearr's own copy of the account name, which can differ from
           // the media server's for the same Plex account.
           username: z.string().min(1).nullish(),


### PR DESCRIPTION
Follow-ups to #3446, plus one bug from #3387. All reproduced on the dev stack against real Tracearr 2.0.0, Jellyfin and rule runs.

| Bug | Effect |
|---|---|
| `external_user_id` required a non-empty value (#3387) | one unattributable account rejected the whole `/users` page, so `seenBy`, `sw_watchers` and `sw_allEpisodesSeenBy` were unavailable on every run |
| Binding survives a same-type re-point (#3446) | the switch path never runs, so the old server stays bound |
| Unverified history is trusted (#3446) | a wrong same-type server answers `0 views` for items it does not cover, which a deletion rule acts on |
| A bound integration cannot be cleared (#3446) | the hidden `server_id` kept a cleared form from reaching the remove path |
| A rejected save explained nothing (#3446) | the server's reason was replaced by the page's generic message |

## Changes

- Accept an empty `external_user_id`; the account falls back to its `username`.
- Confirm the bound server against the managed media server before reading its history. Mismatched and unconfirmed both fail closed, with distinct warnings.
- Drop the swept history on any media-server re-point, and clear the stored selection only on a definitive mismatch. A sweep that outlives the snapshot it started under is discarded rather than written back.
- Shared settings page: a cleared form removes an integration whose hidden select still holds a value, and a specific reason replaces the scoped message. `Failed` counts as generic, so Tautulli, Streamystats and Seerr keep theirs.

## Behaviour changes

- Tracearr values now require a confirmed server. Where the probe cannot decide (library not synced, media server unreadable), values are unavailable and items are preserved, per the fail-closed contract in #3387.
- Those three watcher properties have been failing closed since 3.22, so rules using them have been inert. They now return real values and can act, including deleting. Worth a release note.

Proof, same items and same wrong binding: `Times viewed = 0` before, `could not be read` after.