### PR TITLE
fix(collections): size a collection in one read, not a request per item (#3449)

### DIFF
--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -142,6 +142,49 @@ describe('PlexApiService.getMetadata', () => {
     );
   });
 
+  // #3449: a collection still listing deleted media logged one
+  // "is the application running?" ERROR per item against a healthy Plex.
+  it('reports a 404 as a missing item, not as a communication failure', async () => {
+    (service as any).plexClient = {
+      query: jest.fn().mockRejectedValue(
+        new Error('GET /library/metadata/123 failed: not found', {
+          cause: { response: { status: 404 } } as any,
+        }),
+      ),
+    };
+
+    expect(await service.getMetadata('123')).toBeUndefined();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('still reports a non-404 metadata failure as a communication failure', async () => {
+    (service as any).plexClient = {
+      query: jest.fn().mockRejectedValue(
+        new Error('GET /library/metadata/123 failed: server error', {
+          cause: { response: { status: 503 } } as any,
+        }),
+      ),
+    };
+
+    expect(await service.getMetadata('123')).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Plex api communication failure.. Is the application running?',
+    );
+  });
+
+  it('reads an all-missing batch as an empty answer, not a failure', async () => {
+    (service as any).plexClient = {
+      query: jest.fn().mockRejectedValue(
+        new Error('GET /library/metadata/1,2 failed: not found', {
+          cause: { response: { status: 404 } } as any,
+        }),
+      ),
+    };
+
+    expect(await service.getMetadataBatch(['1', '2'])).toEqual([]);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
   it('preserves includeChildren queries while requesting external media enrichment', async () => {
     const query = jest.fn().mockResolvedValue({
       MediaContainer: { Metadata: [{ ratingKey: '123' }] },

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -661,6 +661,13 @@ export class PlexApiService {
         return undefined;
       }
     } catch (error) {
+      // 404 is Plex answering that the item is gone, not that it is
+      // unreachable. Blaming the connection logged one ERROR per gone item.
+      if (this.responseStatus(error) === 404) {
+        this.logger.debug(`Plex has no item with id ${key}`);
+        return undefined;
+      }
+
       this.logger.error(
         'Plex api communication failure.. Is the application running?',
       );
@@ -685,6 +692,15 @@ export class PlexApiService {
       );
       return response?.MediaContainer?.Metadata ?? [];
     } catch (error) {
+      // Plex 404s only when it holds none of the requested ids; a mixed batch
+      // is a 200 listing just the live ones (verified on PMS 1.43.3).
+      if (this.responseStatus(error) === 404) {
+        this.logger.debug(
+          `Plex has none of the ${keys.length} requested items`,
+        );
+        return [];
+      }
+
       this.logger.error(
         'Plex api communication failure.. Is the application running?',
       );

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -101,6 +101,7 @@ describe('CollectionsService', () => {
       getLibraries: jest.fn().mockResolvedValue([{ id: 'library-1' }]),
       getMetadata: jest.fn().mockResolvedValue(undefined),
       getMetadataBatch: jest.fn().mockResolvedValue([]),
+      getChildrenMetadata: jest.fn().mockResolvedValue([]),
       itemExists: jest.fn().mockResolvedValue(true),
       removeFromCollection: jest.fn().mockResolvedValue(undefined),
       deleteCollection: jest.fn().mockResolvedValue(undefined),
@@ -4027,6 +4028,106 @@ describe('CollectionsService', () => {
       expect(collectionRepo.findOne).not.toHaveBeenCalled();
       expect(collectionLogRepo.delete).toHaveBeenCalledWith({
         collection: { id: 99 },
+      });
+    });
+  });
+
+  describe('updateCollectionTotalSize', () => {
+    beforeEach(() => {
+      (
+        service.updateCollectionTotalSize as jest.MockedFunction<
+          typeof service.updateCollectionTotalSize
+        >
+      ).mockRestore();
+    });
+
+    const sizedItem = (id: string, sizeBytes: number) =>
+      createMediaItem({
+        id,
+        type: 'movie',
+        mediaSources: [{ id: `source-${id}`, duration: 0, sizeBytes }],
+      });
+
+    it('reads every row in one batch instead of a request per item', async () => {
+      const collection = createCollection({ id: 3, type: 'movie' });
+      collectionRepo.findOne.mockResolvedValue(collection);
+      collectionMediaRepo.find.mockResolvedValue([
+        createCollectionMedia(collection, { id: 1, mediaServerId: 'a' }),
+        createCollectionMedia(collection, { id: 2, mediaServerId: 'b' }),
+      ]);
+      mediaServer.getMetadataBatch.mockResolvedValue([
+        sizedItem('a', 100),
+        sizedItem('b', 250),
+      ]);
+
+      await service.updateCollectionTotalSize(3);
+
+      expect(mediaServer.getMetadataBatch).toHaveBeenCalledWith(['a', 'b']);
+      expect(mediaServer.getMetadata).not.toHaveBeenCalled();
+      expect(collectionRepo.update).toHaveBeenCalledWith(3, {
+        totalSizeBytes: 350,
+      });
+    });
+
+    it('keeps the cached size of a row the server did not answer for', async () => {
+      const collection = createCollection({ id: 4, type: 'movie' });
+      collectionRepo.findOne.mockResolvedValue(collection);
+      collectionMediaRepo.find.mockResolvedValue([
+        createCollectionMedia(collection, { id: 1, mediaServerId: 'live' }),
+        createCollectionMedia(collection, {
+          id: 2,
+          mediaServerId: 'gone',
+          sizeBytes: 999,
+        }),
+      ]);
+      mediaServer.getMetadataBatch.mockResolvedValue([sizedItem('live', 100)]);
+
+      await service.updateCollectionTotalSize(4);
+
+      expect(collectionMediaRepo.update).not.toHaveBeenCalledWith(
+        2,
+        expect.anything(),
+      );
+      expect(collectionRepo.update).toHaveBeenCalledWith(4, {
+        totalSizeBytes: 100,
+      });
+    });
+
+    it('keeps the last known total when the read answers for nothing', async () => {
+      // Emby 500s an entire batch over one unparseable id, and the shared
+      // helper answers []. Writing null there would erase a known total.
+      const collection = createCollection({ id: 6, type: 'movie' });
+      collectionRepo.findOne.mockResolvedValue(collection);
+      collectionMediaRepo.find.mockResolvedValue([
+        createCollectionMedia(collection, { id: 1, mediaServerId: 'a' }),
+        createCollectionMedia(collection, { id: 2, mediaServerId: 'bad' }),
+      ]);
+      mediaServer.getMetadataBatch.mockResolvedValue([]);
+
+      await service.updateCollectionTotalSize(6);
+
+      expect(collectionRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('still totals the readable rows when a show cannot be traversed', async () => {
+      const collection = createCollection({ id: 5, type: 'show' });
+      collectionRepo.findOne.mockResolvedValue(collection);
+      collectionMediaRepo.find.mockResolvedValue([
+        createCollectionMedia(collection, { id: 1, mediaServerId: 'show-1' }),
+        createCollectionMedia(collection, { id: 2, mediaServerId: 'movie-1' }),
+      ]);
+      mediaServer.getMetadataBatch.mockResolvedValue([
+        createMediaItem({ id: 'show-1', type: 'show', mediaSources: [] }),
+        sizedItem('movie-1', 400),
+      ]);
+      mediaServer.getChildrenMetadata.mockRejectedValue(
+        new Error('children unavailable'),
+      );
+
+      await service.updateCollectionTotalSize(5);
+
+      expect(collectionRepo.update).toHaveBeenCalledWith(5, {
+        totalSizeBytes: 400,
       });
     });
   });

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -4487,10 +4487,25 @@ export class CollectionsService {
       let totalBytes = 0;
       let hasAnySize = false;
 
+      // One read for the whole collection; per row it opened a request per
+      // item against the media server on every handling run (#3449).
+      const metadataById = new Map(
+        (
+          await mediaServer.getMetadataBatch(
+            collectionMedia.map((media) => media.mediaServerId),
+          )
+        ).map((item) => [item.id, item]),
+      );
+
       for (const media of collectionMedia) {
-        const itemSize = await this.resolveItemSize(
+        const metadata = metadataById.get(media.mediaServerId);
+
+        // Absent means gone or unreadable; either way keep the cached size.
+        if (!metadata) continue;
+
+        const itemSize = await this.resolveSizeFromMetadata(
           mediaServer,
-          media.mediaServerId,
+          metadata,
         );
 
         if (itemSize != null && itemSize > 0) {
@@ -4509,6 +4524,13 @@ export class CollectionsService {
           });
         }
       }
+
+      // A read that answered for nothing is a failed read, not an empty
+      // collection: Emby 500s a whole batch over one unparseable id. Writing
+      // null there would erase a known total, so keep the last one until a
+      // read succeeds - a permanently bad id keeps poisoning its batch, so
+      // that may not be the next run. Same principle as the per-row size above.
+      if (metadataById.size === 0) return;
 
       await this.collectionRepo.update(collectionId, {
         totalSizeBytes: hasAnySize ? totalBytes : null,
@@ -4530,9 +4552,31 @@ export class CollectionsService {
     mediaServer: IMediaServerService,
     mediaServerId: string,
   ): Promise<number | null> {
+    let metadata: MediaItem | undefined;
+
     try {
-      const metadata = await mediaServer.getMetadata(mediaServerId);
-      if (!metadata) return null;
+      metadata = await mediaServer.getMetadata(mediaServerId);
+    } catch (error) {
+      this.logger.debug(`Failed to get size for media ${mediaServerId}`);
+      this.logger.debug(error);
+      return null;
+    }
+
+    return metadata
+      ? this.resolveSizeFromMetadata(mediaServer, metadata)
+      : null;
+  }
+
+  /**
+   * Size of an already-read item: its own files, or its children's for a show
+   * or season that carries none. Null when nothing usable resolved, so one
+   * bad item cannot fail the collection's total.
+   */
+  private async resolveSizeFromMetadata(
+    mediaServer: IMediaServerService,
+    metadata: MediaItem,
+  ): Promise<number | null> {
+    try {
       const directSize = this.sumMediaSourceSizes(metadata);
       if (directSize > 0) return directSize;
       if (metadata.type === 'show' || metadata.type === 'season') {
@@ -4544,7 +4588,7 @@ export class CollectionsService {
       }
       return null;
     } catch (error) {
-      this.logger.debug(`Failed to get size for media ${mediaServerId}`);
+      this.logger.debug(`Failed to get size for media ${metadata.id}`);
       this.logger.debug(error);
       return null;
     }


### PR DESCRIPTION
Fixes #3449.

The collection size cache re-read every row's metadata one request at a time,
for every collection, at the end of every handling run. A row whose item is gone
answered 404, and `PlexApiService.getMetadata` reported that as
`Plex api communication failure.. Is the application running?` - one ERROR per
gone item, pointing users at a Plex that was fine.

Not a 3.22.0 regression: this loop has read one row per request since #2394.
What changed is that its siblings on the collection path were batched around it
(#3429, #3432, #3435), leaving this as the last per-item fan-out there.

It now uses the batched read the adapters gained in #3432, and a Plex 404 is
logged as a missing item at debug. Plex answers 404 only when it holds none of
the requested ids, so an all-gone batch is an empty answer rather than a failure.

Measured against live servers through a counting proxy, one collection of 25 rows
(5 present, 20 deleted from the server):

| server | requests before | after | total |
|---|---|---|---|
| Plex 1.43.3 | 25 | **1** | 546,293,048 both ways |
| Jellyfin 10.11.11 | 25 | **1** | identical |
| Emby 4.9.5 | 25 | **1** | identical |

Plex ERROR lines over that run: 20 -> 0. A show collection still totals from its
children, and 571 ids in a ~4KB request line answer 200 on PMS 1.43.3, so the
shared 4000-character batch budget holds.

A row the server does not answer for keeps its cached `sizeBytes` and costs no
request, which is what the per-item read already did for a failed lookup.

The daily maintenance sweeps (`removeStaleCollectionMedia`,
`removeLeftoverExclusions`) are still per item on purpose: they delete rows on
the strength of a confirmed 404, which `readMetadataInBatches` explicitly cannot
answer. Batching those safely is a separate change.
