### PR TITLE
perf(maintenance): clear the daily sweeps with one read, not one per row

### DIFF
--- a/apps/server/src/modules/api/media-server/item-presence.util.spec.ts
+++ b/apps/server/src/modules/api/media-server/item-presence.util.spec.ts
@@ -1,0 +1,76 @@
+import { MediaItem } from '@maintainerr/contracts';
+import { readItemPresence } from './item-presence.util';
+import { IMediaServerService } from './media-server.interface';
+
+const item = (id: string): MediaItem => ({ id, type: 'movie' }) as MediaItem;
+
+const createMediaServer = (overrides: Partial<IMediaServerService> = {}) =>
+  ({
+    getMetadataBatch: jest.fn().mockResolvedValue([]),
+    itemExists: jest.fn().mockResolvedValue(true),
+    ...overrides,
+  }) as unknown as IMediaServerService;
+
+describe('readItemPresence', () => {
+  it('confirms only the ids the batch did not answer for', async () => {
+    const mediaServer = createMediaServer({
+      getMetadataBatch: jest.fn().mockResolvedValue([item('a'), item('c')]),
+      itemExists: jest.fn().mockResolvedValue(false),
+    });
+
+    const { found, missing } = await readItemPresence(
+      mediaServer,
+      ['a', 'b', 'c'],
+      jest.fn(),
+    );
+
+    expect(mediaServer.getMetadataBatch).toHaveBeenCalledTimes(1);
+    expect(mediaServer.itemExists).toHaveBeenCalledTimes(1);
+    expect(mediaServer.itemExists).toHaveBeenCalledWith('b');
+    expect([...found.keys()]).toEqual(['a', 'c']);
+    expect([...missing]).toEqual(['b']);
+  });
+
+  it('leaves an id the server still holds out of missing', async () => {
+    const mediaServer = createMediaServer({
+      itemExists: jest.fn().mockResolvedValue(true),
+    });
+
+    const { missing } = await readItemPresence(mediaServer, ['a'], jest.fn());
+
+    expect(missing.size).toBe(0);
+  });
+
+  it('reports an inconclusive check without calling the id missing', async () => {
+    const onInconclusive = jest.fn();
+    const mediaServer = createMediaServer({
+      itemExists: jest.fn().mockRejectedValue(new Error('unreachable')),
+    });
+
+    const { found, missing } = await readItemPresence(
+      mediaServer,
+      ['a'],
+      onInconclusive,
+    );
+
+    expect(found.size).toBe(0);
+    expect(missing.size).toBe(0);
+    expect(onInconclusive).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a check per id when the batch itself fails', async () => {
+    const mediaServer = createMediaServer({
+      getMetadataBatch: jest.fn().mockRejectedValue(new Error('batch failed')),
+      itemExists: jest.fn().mockResolvedValue(false),
+    });
+
+    const { missing } = await readItemPresence(
+      mediaServer,
+      ['a', 'b'],
+      jest.fn(),
+    );
+
+    expect(mediaServer.itemExists).toHaveBeenCalledTimes(2);
+    expect([...missing]).toEqual(['a', 'b']);
+  });
+});

--- a/apps/server/src/modules/api/media-server/item-presence.util.ts
+++ b/apps/server/src/modules/api/media-server/item-presence.util.ts
@@ -1,0 +1,54 @@
+import { MediaItem } from '@maintainerr/contracts';
+import { IMediaServerService } from './media-server.interface';
+
+export interface ItemPresence {
+  /** Items the server answered with, by id. */
+  found: Map<string, MediaItem>;
+  /** Ids confirmed gone. An id in neither set could not be checked. */
+  missing: Set<string>;
+}
+
+/**
+ * Which of these ids a media server still holds, and which it confirms are gone.
+ *
+ * One batched read clears the ids still answered for; the rest are checked one
+ * at a time, because `itemExists` is the only read that separates "gone" from
+ * "could not ask" - an id absent from a batch means either. So a caller's
+ * removals stay gated by that confirmation, they just no longer cost a request
+ * per item that is plainly still there.
+ */
+export const readItemPresence = async (
+  mediaServer: IMediaServerService,
+  itemIds: string[],
+  onInconclusive: (error: unknown) => void,
+): Promise<ItemPresence> => {
+  const found = new Map<string, MediaItem>();
+  const missing = new Set<string>();
+
+  if (itemIds.length === 0) {
+    return { found, missing };
+  }
+
+  try {
+    for (const item of await mediaServer.getMetadataBatch(itemIds)) {
+      found.set(item.id, item);
+    }
+  } catch (error) {
+    // Leaves every id to the per-item check below, as before batching.
+    onInconclusive(error);
+  }
+
+  for (const itemId of new Set(itemIds)) {
+    if (found.has(itemId)) continue;
+
+    try {
+      if (!(await mediaServer.itemExists(itemId))) {
+        missing.add(itemId);
+      }
+    } catch (error) {
+      onInconclusive(error);
+    }
+  }
+
+  return { found, missing };
+};

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -3572,6 +3572,23 @@ describe('CollectionsService', () => {
 
       expect(collectionMediaRepo.delete).not.toHaveBeenCalled();
     });
+
+    it('does not check a row the batched read already answered for', async () => {
+      collectionMediaRepo.find.mockResolvedValue([
+        buildMedia(1, 'present'),
+        buildMedia(2, 'gone'),
+      ]);
+      mediaServer.getMetadataBatch.mockResolvedValue([
+        createMediaItem({ id: 'present' }),
+      ]);
+      mediaServer.itemExists.mockResolvedValue(false);
+
+      await service.removeStaleCollectionMedia();
+
+      expect(mediaServer.itemExists).toHaveBeenCalledTimes(1);
+      expect(mediaServer.itemExists).toHaveBeenCalledWith('gone');
+      expect(collectionMediaRepo.delete).toHaveBeenCalledWith(2);
+    });
   });
 
   // Both used to answer 201 with an empty body, which is the same silent

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -31,6 +31,7 @@ import { chunk } from 'lodash';
 import { Brackets, DataSource, In, LessThan, Not, Repository } from 'typeorm';
 import { CollectionLog } from '../../modules/collections/entities/collection_log.entities';
 import { getErrorMessage } from '../../utils/connection-error';
+import { readItemPresence } from '../api/media-server/item-presence.util';
 import {
   ENRICHMENT_ID_CHUNK,
   MediaItemEnrichmentService,
@@ -1535,20 +1536,16 @@ export class CollectionsService {
     const mediaServer = await this.getMediaServer();
     let removedCount = 0;
 
-    for (const entry of allMedia) {
-      // Only remove a row when the media server *confirms* the item is gone.
-      // `itemExists` returns false solely on a 404/empty result and throws on
-      // an inconclusive check (network / 5xx / auth), unlike `getMetadata`
-      // which returns undefined for both absent and failed reads - so a
-      // transient blip can no longer delete a still-present item's row.
-      let exists = true;
-      try {
-        exists = await mediaServer.itemExists(entry.mediaServerId);
-      } catch (error) {
-        this.logger.debug(error);
-      }
+    // `missing` is a confirmed absence only, so a transient failure never
+    // deletes a still-present item's row.
+    const { missing } = await readItemPresence(
+      mediaServer,
+      allMedia.map((entry) => entry.mediaServerId),
+      (error) => this.logger.debug(error),
+    );
 
-      if (!exists) {
+    for (const entry of allMedia) {
+      if (missing.has(entry.mediaServerId)) {
         await this.CollectionMediaRepo.delete(entry.id);
         removedCount++;
       }

--- a/apps/server/src/modules/rules/tasks/exclusion-corrector.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/exclusion-corrector.service.spec.ts
@@ -14,7 +14,7 @@ describe('ExclusionTypeCorrectorService', () => {
     collections?: any[];
     ruleGroups?: any[];
     isSetup?: boolean;
-    mediaServer?: { getMetadata?: jest.Mock; itemExists?: jest.Mock };
+    mediaServer?: { getMetadataBatch?: jest.Mock; itemExists?: jest.Mock };
   }) => {
     const {
       exclusions = [],
@@ -45,7 +45,7 @@ describe('ExclusionTypeCorrectorService', () => {
     };
 
     const mediaServer = {
-      getMetadata: jest.fn().mockResolvedValue(null),
+      getMetadataBatch: jest.fn().mockResolvedValue([]),
       itemExists: jest.fn().mockResolvedValue(true),
       ...options?.mediaServer,
     };
@@ -205,19 +205,24 @@ describe('ExclusionTypeCorrectorService', () => {
   describe('correctExclusionTypes - stale vs unreachable media (#3307 follow-up)', () => {
     it('backfills the type and saves only corrected rows', async () => {
       const exclusions = [{ id: 1, type: null, mediaServerId: '11' }];
-      const { service, exclusionRepo, rulesService } = createService({
-        exclusions,
-        isSetup: true,
-        mediaServer: {
-          getMetadata: jest.fn().mockResolvedValue({ id: '11', type: 'movie' }),
-        },
-      });
+      const { service, exclusionRepo, rulesService, mediaServer } =
+        createService({
+          exclusions,
+          isSetup: true,
+          mediaServer: {
+            getMetadataBatch: jest
+              .fn()
+              .mockResolvedValue([{ id: '11', type: 'movie' }]),
+          },
+        });
 
       await service.onModuleInit();
 
       expect(exclusions[0].type).toBe('movie');
       expect(rulesService.removeExclusion).not.toHaveBeenCalled();
       expect(exclusionRepo.save).toHaveBeenLastCalledWith([exclusions[0]]);
+      // An item the batch answered for needs no confirmation of its own.
+      expect(mediaServer.itemExists).not.toHaveBeenCalled();
     });
 
     it('removes an exclusion only on a confirmed 404 and does not re-save the removed row', async () => {
@@ -226,7 +231,6 @@ describe('ExclusionTypeCorrectorService', () => {
         exclusions,
         isSetup: true,
         mediaServer: {
-          getMetadata: jest.fn().mockResolvedValue(undefined),
           itemExists: jest.fn().mockResolvedValue(false),
         },
       });
@@ -244,7 +248,6 @@ describe('ExclusionTypeCorrectorService', () => {
         exclusions,
         isSetup: true,
         mediaServer: {
-          getMetadata: jest.fn().mockResolvedValue(undefined),
           itemExists: jest.fn().mockRejectedValue(new Error('unreachable')),
         },
       });

--- a/apps/server/src/modules/rules/tasks/exclusion-corrector.service.ts
+++ b/apps/server/src/modules/rules/tasks/exclusion-corrector.service.ts
@@ -2,6 +2,7 @@ import { MediaItemType } from '@maintainerr/contracts';
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { readItemPresence } from '../../api/media-server/item-presence.util';
 import { MediaServerFactory } from '../../api/media-server/media-server.factory';
 import { Collection } from '../../collections/entities/collection.entities';
 import { MaintainerrLogger } from '../../logging/logs.service';
@@ -143,27 +144,21 @@ export class ExclusionTypeCorrectorService implements OnModuleInit {
 
     const mediaServer = await this.mediaServerFactory.getService();
 
+    // Neither typed nor confirmed gone: the row stays untyped and the next
+    // startup retries it.
+    const { found, missing } = await readItemPresence(
+      mediaServer,
+      exclusionsWithoutType.map((el) => el.mediaServerId),
+      (error) => this.logger.debug(error),
+    );
+
     const corrected: typeof exclusionsWithoutType = [];
     for (const el of exclusionsWithoutType) {
-      const metaData = await mediaServer.getMetadata(el.mediaServerId);
+      const metaData = found.get(el.mediaServerId);
       if (metaData) {
         el.type = metaData.type;
         corrected.push(el);
-        continue;
-      }
-
-      // getMetadata is undefined for both a gone item and a failed read.
-      // Only remove on a confirmed 404 via itemExists; on an inconclusive
-      // check leave the row untyped so the next startup retries - a
-      // transient blip must not delete the protection an exclusion provides.
-      let exists = true;
-      try {
-        exists = await mediaServer.itemExists(el.mediaServerId);
-      } catch (error) {
-        this.logger.debug(error);
-      }
-
-      if (!exists) {
+      } else if (missing.has(el.mediaServerId)) {
         await this.rulesService.removeExclusion(el.id);
       }
     }

--- a/apps/server/src/modules/rules/tasks/rule-maintenance.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-maintenance.service.spec.ts
@@ -5,10 +5,13 @@ describe('RuleMaintenanceService - removeLeftoverExclusions', () => {
   const createService = (options?: {
     exclusions?: any[];
     itemExists?: jest.Mock;
+    getMetadataBatch?: jest.Mock;
   }) => {
     const { exclusions = [] } = options ?? {};
 
     const mediaServer = {
+      getMetadataBatch:
+        options?.getMetadataBatch ?? jest.fn().mockResolvedValue([]),
       itemExists: options?.itemExists ?? jest.fn().mockResolvedValue(true),
     };
 
@@ -65,5 +68,24 @@ describe('RuleMaintenanceService - removeLeftoverExclusions', () => {
     await (service as any).executeTask();
 
     expect(rulesService.removeExclusion).not.toHaveBeenCalled();
+  });
+
+  it('does not check an exclusion the batched read already answered for', async () => {
+    const itemExists = jest.fn().mockResolvedValue(false);
+    const { service, rulesService } = createService({
+      exclusions: [
+        { id: 1, mediaServerId: '11' },
+        { id: 2, mediaServerId: '22' },
+      ],
+      getMetadataBatch: jest.fn().mockResolvedValue([{ id: '11' }]),
+      itemExists,
+    });
+
+    await (service as any).executeTask();
+
+    expect(itemExists).toHaveBeenCalledTimes(1);
+    expect(itemExists).toHaveBeenCalledWith('22');
+    expect(rulesService.removeExclusion).toHaveBeenCalledTimes(1);
+    expect(rulesService.removeExclusion).toHaveBeenCalledWith(2);
   });
 });

--- a/apps/server/src/modules/rules/tasks/rule-maintenance.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-maintenance.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { readItemPresence } from '../../api/media-server/item-presence.util';
 import { MediaServerFactory } from '../../api/media-server/media-server.factory';
 import { CollectionsService } from '../../collections/collections.service';
 import { Collection } from '../../collections/entities/collection.entities';
@@ -62,20 +63,17 @@ export class RuleMaintenanceService extends TaskBase {
   private async removeLeftoverExclusions() {
     const exclusions = await this.rulesService.getAllExclusions();
     const mediaServer = await this.mediaServerFactory.getService();
-    for (const exclusion of exclusions) {
-      // Only drop an exclusion when the media server *confirms* the item is
-      // gone. `itemExists` returns false solely on a 404/empty result and
-      // throws on an inconclusive check, unlike `getMetadata` which returns
-      // undefined for both absent and failed reads - a transient blip must
-      // not delete the protection an exclusion provides.
-      let exists = true;
-      try {
-        exists = await mediaServer.itemExists(exclusion.mediaServerId);
-      } catch (error) {
-        this.logger.debug(error);
-      }
 
-      if (!exists) {
+    // `missing` is a confirmed absence only, so a transient failure never
+    // deletes the protection an exclusion provides.
+    const { missing } = await readItemPresence(
+      mediaServer,
+      exclusions.map((exclusion) => exclusion.mediaServerId),
+      (error) => this.logger.debug(error),
+    );
+
+    for (const exclusion of exclusions) {
+      if (missing.has(exclusion.mediaServerId)) {
         await this.rulesService.removeExclusion(exclusion.id);
       }
     }


### PR DESCRIPTION
Follow-up to #3451, which left these three deliberately alone.

`removeStaleCollectionMedia`, `removeLeftoverExclusions` and the exclusion type
backfill each asked the media server about one row at a time. A batched read now
answers for every row still there, and only what is left costs an `itemExists`
call.

That per-item check stays because it is the only read that separates "gone" from
"could not ask" - an id absent from a batch means either, since a failed batch
answers nothing, and `readMetadataInBatches` documents exactly that. So every
removal is gated by the same confirmation it always was; it just no longer runs
for an item that is plainly still there. The existing #3307 tests, which pin
"a transient failure must never read as gone", pass unchanged.

Measured against a live Jellyfin 10.11.11 through a counting proxy, one
maintenance run over 5 exclusions and 24 collection media rows:

| | requests |
|---|---|
| before | 29 - one per row |
| after | 2 - one batch per sweep |

With 10 stale exclusions and 10 stale media rows added, the same run makes 22
requests: one batch per sweep, plus the one confirmation each stale row still has
to earn. It removed exactly those 20 rows and kept every live one. A failed batch
falls back to a check per id, which is what this did before.

Also verified against the nastiest input the batch has: an id Jellyfin cannot
parse as a GUID makes it drop the whole `ids` filter and answer an unfiltered
listing. `readMetadataInBatches` already keeps only the ids it asked for, so
those rows simply fall through to the per-item check - the run removed the
unparseable rows and kept all five live exclusions.

The shared `readItemPresence` lives beside `metadata-batch.util` and touches only
`IMediaServerService`, so it stays server-agnostic.
