### PR TITLE
fix: add search results to a collection, and exclude globally from a collection page

### DIFF
--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.spec.ts
@@ -11,6 +11,7 @@ import {
   PlexSeenBy,
   PlexUserAccount,
 } from '../../plex-api/interfaces/library.interfaces';
+import { PlexMetadata } from '../../plex-api/interfaces/media.interface';
 import { PlexMapper } from './plex.mapper';
 
 describe('PlexMapper', () => {
@@ -347,6 +348,28 @@ describe('PlexMapper', () => {
         type: 'audience',
       });
       expect(result.userRating).toBe(10);
+    });
+  });
+
+  describe('metadataToMediaItem', () => {
+    const baseMetadata = {
+      ratingKey: '1',
+      guid: 'plex://movie/abc',
+      type: 'movie',
+      title: 'Test Movie',
+      addedAt: 1600000000,
+      Guid: [],
+    } as unknown as PlexMetadata;
+
+    it('carries the library section the item reports', () => {
+      const result = PlexMapper.metadataToMediaItem({
+        ...baseMetadata,
+        librarySectionID: 1,
+        librarySectionTitle: 'Movies',
+      });
+
+      expect(result.library.id).toBe('1');
+      expect(result.library.title).toBe('Movies');
     });
   });
 

--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
@@ -263,8 +263,8 @@ export class PlexMapper {
       providerIds: PlexMapper.extractProviderIds(plex.Guid, plex.guid),
       mediaSources: PlexMapper.toMediaSources(plex.Media || plex.media),
       library: {
-        id: '', // Not available on PlexMetadata
-        title: '',
+        id: plex.librarySectionID?.toString() ?? '',
+        title: plex.librarySectionTitle ?? '',
       },
       summary: plex.summary,
       viewCount: plex.viewCount,

--- a/apps/server/src/modules/api/plex-api/interfaces/media.interface.ts
+++ b/apps/server/src/modules/api/plex-api/interfaces/media.interface.ts
@@ -40,6 +40,9 @@ export interface PlexMetadata {
   grandparentTitle?: string;
   Rating?: PlexRating[];
   contentRating?: string;
+  // /library/metadata/{id} and /search carry these; a child listing does not.
+  librarySectionID?: number;
+  librarySectionTitle?: string;
 }
 
 export interface PlexMediaPart {

--- a/apps/server/src/modules/collections/collection-worker.server.spec.ts
+++ b/apps/server/src/modules/collections/collection-worker.server.spec.ts
@@ -15,6 +15,8 @@ import { ExecutionLockService } from '../tasks/execution-lock.service';
 import { TasksService } from '../tasks/tasks.service';
 import { CollectionHandler } from './collection-handler';
 import { CollectionWorkerService } from './collection-worker.service';
+import { Exclusion } from '../rules/entities/exclusion.entities';
+import { RuleGroup } from '../rules/entities/rule-group.entities';
 import { Collection } from './entities/collection.entities';
 import {
   CollectionMedia,
@@ -30,12 +32,15 @@ describe('CollectionWorkerService', () => {
   let settings: Mocked<SettingsDataService>;
   let collectionRepository: Mocked<Repository<Collection>>;
   let collectionMediaRepository: Mocked<Repository<CollectionMedia>>;
+  let exclusionRepository: Mocked<Repository<Exclusion>>;
+  let ruleGroupRepository: Mocked<Repository<RuleGroup>>;
   let seerrApi: Mocked<SeerrApiService>;
   let collectionHandler: Mocked<CollectionHandler>;
   let executionLock: Mocked<ExecutionLockService>;
   let eventEmitter: Mocked<EventEmitter2>;
   let logger: Mocked<MaintainerrLogger>;
   let mediaServerFactory: Mocked<MediaServerFactory>;
+  let getMetadataBatch: jest.Mock;
 
   beforeEach(async () => {
     const { unit, unitRef } = await TestBed.solitary(
@@ -51,6 +56,8 @@ describe('CollectionWorkerService', () => {
     collectionMediaRepository = unitRef.get(
       getRepositoryToken(CollectionMedia) as string,
     );
+    exclusionRepository = unitRef.get(getRepositoryToken(Exclusion) as string);
+    ruleGroupRepository = unitRef.get(getRepositoryToken(RuleGroup) as string);
     seerrApi = unitRef.get(SeerrApiService);
     collectionHandler = unitRef.get(CollectionHandler);
     executionLock = unitRef.get(ExecutionLockService);
@@ -60,9 +67,13 @@ describe('CollectionWorkerService', () => {
 
     executionLock.acquire.mockResolvedValue(jest.fn());
     eventEmitter.emit.mockImplementation();
+    exclusionRepository.find.mockResolvedValue([]);
+    ruleGroupRepository.find.mockResolvedValue([]);
+    getMetadataBatch = jest.fn().mockResolvedValue([]);
     mediaServerFactory.verifyConnection.mockResolvedValue({
       supportsFeature: jest.fn().mockReturnValue(false),
       getActiveSessions: jest.fn().mockResolvedValue(new Set<string>()),
+      getMetadataBatch,
     } as any);
   });
 
@@ -134,6 +145,118 @@ describe('CollectionWorkerService', () => {
     });
     expect(collectionHandler.handleMedia).toHaveBeenCalled();
     expect(seerrApi.api.post).toHaveBeenCalled();
+  });
+
+  describe('exclusions protect a due member from the delete action', () => {
+    const arrangeDueMember = (
+      exclusions: Partial<Exclusion>[],
+      {
+        mediaServerId = 'episode-1',
+        ruleGroups = [] as Partial<RuleGroup>[],
+      } = {},
+    ) => {
+      const collection = createCollection({
+        arrAction: ServarrAction.DELETE,
+        type: 'movie',
+      });
+
+      collectionRepository.find.mockResolvedValue([collection]);
+      collectionMediaRepository.find.mockResolvedValue([
+        createCollectionMedia(collection, { mediaServerId }),
+      ]);
+      exclusionRepository.find.mockResolvedValue(exclusions as Exclusion[]);
+      ruleGroupRepository.find.mockResolvedValue(ruleGroups as RuleGroup[]);
+      collectionHandler.handleMedia.mockResolvedValue('handled');
+
+      return collection;
+    };
+
+    it('skips a globally excluded member', async () => {
+      arrangeDueMember([{ mediaServerId: 'episode-1', ruleGroupId: null }]);
+
+      await collectionWorkerService.execute();
+
+      expect(collectionHandler.handleMedia).not.toHaveBeenCalled();
+    });
+
+    it('skips a member excluded from this collection', async () => {
+      const collection = arrangeDueMember([
+        { mediaServerId: 'episode-1', ruleGroupId: 4 },
+      ]);
+      ruleGroupRepository.find.mockResolvedValue([
+        { id: 4, collectionId: collection.id } as RuleGroup,
+      ]);
+
+      await collectionWorkerService.execute();
+
+      expect(collectionHandler.handleMedia).not.toHaveBeenCalled();
+    });
+
+    it('still handles a member excluded from a different collection', async () => {
+      const collection = arrangeDueMember([
+        { mediaServerId: 'episode-1', ruleGroupId: 4 },
+      ]);
+      ruleGroupRepository.find.mockResolvedValue([
+        { id: 4, collectionId: collection.id + 1 } as RuleGroup,
+      ]);
+
+      await collectionWorkerService.execute();
+
+      expect(collectionHandler.handleMedia).toHaveBeenCalled();
+    });
+
+    it.each<[string, Partial<Exclusion>]>([
+      ['a show', { mediaServerId: 'show-1', ruleGroupId: null, type: 'show' }],
+      [
+        'a season',
+        { mediaServerId: 'season-1', ruleGroupId: null, type: 'season' },
+      ],
+      [
+        'a legacy untyped row',
+        { mediaServerId: 'other-1', ruleGroupId: null, parent: 'season-1' },
+      ],
+    ])('skips a member %s exclusion cascades to', async (_label, exclusion) => {
+      arrangeDueMember([exclusion]);
+      getMetadataBatch.mockResolvedValue([
+        { id: 'episode-1', parentId: 'season-1', grandparentId: 'show-1' },
+      ]);
+
+      await collectionWorkerService.execute();
+
+      expect(getMetadataBatch).toHaveBeenCalledWith(['episode-1']);
+      expect(collectionHandler.handleMedia).not.toHaveBeenCalled();
+    });
+
+    it('does not read the hierarchy when no exclusion reaches past its own id', async () => {
+      arrangeDueMember([{ mediaServerId: 'other-1', ruleGroupId: null }]);
+
+      await collectionWorkerService.execute();
+
+      expect(getMetadataBatch).not.toHaveBeenCalled();
+      expect(collectionHandler.handleMedia).toHaveBeenCalled();
+    });
+
+    // A batch read omits what it could not resolve, so an unread hierarchy
+    // cannot show the member sits outside the cascade.
+    it.each([
+      ['fails', () => getMetadataBatch.mockRejectedValue(new Error('boom'))],
+      [
+        'answers for other ids only',
+        () => getMetadataBatch.mockResolvedValue([{ id: 'episode-2' }]),
+      ],
+    ])(
+      'leaves a member to the next run when the batch %s',
+      async (_l, fault) => {
+        arrangeDueMember([
+          { mediaServerId: 'show-9', ruleGroupId: null, type: 'show' },
+        ]);
+        fault();
+
+        await collectionWorkerService.execute();
+
+        expect(collectionHandler.handleMedia).not.toHaveBeenCalled();
+      },
+    );
   });
 
   it('captures the media title before handling and carries it on the handled event (#3249)', async () => {

--- a/apps/server/src/modules/collections/collection-worker.service.ts
+++ b/apps/server/src/modules/collections/collection-worker.service.ts
@@ -19,6 +19,12 @@ import {
   NotificationMediaItem,
 } from '../events/events.dto';
 import { MaintainerrLogger } from '../logging/logs.service';
+import { Exclusion } from '../rules/entities/exclusion.entities';
+import { RuleGroup } from '../rules/entities/rule-group.entities';
+import {
+  buildExclusionCascadeSets,
+  isMediaItemExcluded,
+} from '../rules/helpers/exclusion-cascade.helper';
 import { SettingsDataService } from '../settings/settings-data.service';
 import {
   ExecutionLockService,
@@ -48,6 +54,10 @@ export class CollectionWorkerService extends TaskBase {
     private readonly collectionRepo: Repository<Collection>,
     @InjectRepository(CollectionMedia)
     private readonly collectionMediaRepo: Repository<CollectionMedia>,
+    @InjectRepository(Exclusion)
+    private readonly exclusionRepo: Repository<Exclusion>,
+    @InjectRepository(RuleGroup)
+    private readonly ruleGroupRepo: Repository<RuleGroup>,
     private readonly seerrApi: SeerrApiService,
     protected readonly taskService: TasksService,
     private readonly settings: SettingsDataService,
@@ -64,6 +74,75 @@ export class CollectionWorkerService extends TaskBase {
 
   protected onBootstrapHook(): void {
     this.cronSchedule = this.settings.collection_handler_job_cron;
+  }
+
+  /** Every global exclusion, plus the ones scoped to a collection's own group. */
+  private async readExclusionsPerCollection(): Promise<
+    (collectionId: number) => Exclusion[]
+  > {
+    const [exclusions, ruleGroups] = await Promise.all([
+      this.exclusionRepo.find(),
+      this.ruleGroupRepo.find(),
+    ]);
+
+    const ruleGroupIdByCollectionId = new Map(
+      ruleGroups.map((ruleGroup) => [ruleGroup.collectionId, ruleGroup.id]),
+    );
+
+    return (collectionId) => {
+      const ruleGroupId = ruleGroupIdByCollectionId.get(collectionId);
+      return exclusions.filter(
+        (exclusion) =>
+          exclusion.ruleGroupId == null ||
+          exclusion.ruleGroupId === ruleGroupId,
+      );
+    };
+  }
+
+  /** The cascade a rule run applies, so a show or legacy row reaches its own
+   * descendants (#2858). The hierarchy costs a request, so it is only read when
+   * an exclusion can reach past its own id. */
+  private async dropExcludedMedia(
+    mediaServer: IMediaServerService,
+    exclusions: Exclusion[],
+    dueMedia: CollectionMedia[],
+  ): Promise<CollectionMedia[]> {
+    if (exclusions.length === 0 || dueMedia.length === 0) {
+      return dueMedia;
+    }
+
+    const cascade = buildExclusionCascadeSets(exclusions);
+    const cascades =
+      cascade.excludedShowIds.size > 0 ||
+      cascade.excludedSeasonIds.size > 0 ||
+      cascade.legacyParentIds.size > 0;
+
+    if (!cascades) {
+      return dueMedia.filter(
+        (media) => !isMediaItemExcluded(cascade, { id: media.mediaServerId }),
+      );
+    }
+
+    const hierarchyById = new Map<string, MediaItem>();
+    try {
+      for (const item of await mediaServer.getMetadataBatch(
+        dueMedia.map((media) => media.mediaServerId),
+      )) {
+        hierarchyById.set(item.id, item);
+      }
+    } catch (error) {
+      this.logger.debug(error);
+    }
+
+    return dueMedia.filter((media) => {
+      const item = hierarchyById.get(media.mediaServerId);
+
+      // A batch read omits what it could not resolve, so no hierarchy means
+      // unread, not unrelated. This is the only path that deletes.
+      if (!item) return false;
+
+      return !isMediaItemExcluded(cascade, item);
+    });
   }
 
   protected async executeTask() {
@@ -135,10 +214,14 @@ export class CollectionWorkerService extends TaskBase {
         mediaToHandle: CollectionMedia[];
       }[] = [];
 
+      // Nothing else protects an excluded member: membership is reconciled only
+      // by a rule run, and never for a manually added one.
+      const exclusionsFor = await this.readExclusionsPerCollection();
+
       for (const collection of collectionsToHandle) {
         const dangerDate = getCollectionDangerDate(collection.deleteAfterDays);
 
-        const eligibleMedia = (
+        const dueMedia = (
           await this.collectionMediaRepo.find({
             where: {
               collectionId: collection.id,
@@ -149,6 +232,12 @@ export class CollectionWorkerService extends TaskBase {
           (media) =>
             !media.ruleEvaluationFailed ||
             hasCollectionMediaManualMembership(media),
+        );
+
+        const eligibleMedia = await this.dropExcludedMedia(
+          mediaServer,
+          exclusionsFor(collection.id),
+          dueMedia,
         );
 
         // Defer any eligible media that is currently being streamed; it stays

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -3752,6 +3752,82 @@ describe('CollectionsService', () => {
       expect(addInternal).not.toHaveBeenCalled();
     });
 
+    describe('a collection bound to one library', () => {
+      const addAllowed = () =>
+        jest
+          .spyOn(service as any, 'addToCollectionInternal')
+          .mockResolvedValue({
+            collection: createCollection(),
+            serverRejectedIds: [],
+          });
+
+      beforeEach(() => {
+        collectionRepo.findOne.mockResolvedValue({
+          id: 7,
+          type: 'movie',
+          libraryId: 'library-1',
+        } as any);
+        mediaServer.supportsFeature.mockReturnValue(false);
+      });
+
+      it('refuses an item from another library', async () => {
+        const addInternal = addAllowed();
+        mediaServer.getMetadata.mockResolvedValue({
+          library: { id: 'library-2' },
+        } as any);
+
+        await expect(
+          service.bulkMediaCollectionAction(['movie-1'], 7, 'add', 'movie'),
+        ).resolves.toEqual({
+          results: [
+            {
+              mediaId: 'movie-1',
+              code: 0,
+              message: "Failed - not in this collection's library",
+            },
+          ],
+        });
+        expect(addInternal).not.toHaveBeenCalled();
+      });
+
+      // An unreadable library is not evidence against the item; existence is
+      // already settled by itemExists, which throws when it cannot ask.
+      it.each([
+        ['its own library', { library: { id: 'library-1' } }],
+        ['no readable library at all', undefined],
+      ])('adds an item with %s', async (_label, metadata) => {
+        const addInternal = addAllowed();
+        mediaServer.getMetadata.mockResolvedValue(metadata as any);
+
+        await expect(
+          service.bulkMediaCollectionAction(['movie-1'], 7, 'add', 'movie'),
+        ).resolves.toEqual({ results: [{ mediaId: 'movie-1', code: 1 }] });
+        expect(addInternal).toHaveBeenCalled();
+      });
+    });
+
+    it('does not read metadata to check the library where collections span them', async () => {
+      collectionRepo.findOne.mockResolvedValue({
+        id: 7,
+        type: 'movie',
+        libraryId: 'library-1',
+      } as any);
+      mediaServer.supportsFeature.mockImplementation(
+        (feature) => feature === MediaServerFeature.CROSS_LIBRARY_COLLECTIONS,
+      );
+      mediaServer.getMetadata.mockReset();
+      jest.spyOn(service as any, 'addToCollectionInternal').mockResolvedValue({
+        collection: createCollection(),
+        serverRejectedIds: [],
+      });
+
+      await expect(
+        service.bulkMediaCollectionAction(['movie-1'], 7, 'add', 'movie'),
+      ).resolves.toEqual({ results: [{ mediaId: 'movie-1', code: 1 }] });
+      expect(mediaServer.itemExists).toHaveBeenCalledWith('movie-1');
+      expect(mediaServer.getMetadata).not.toHaveBeenCalled();
+    });
+
     it('adds anyway when the existence lookup is inconclusive', async () => {
       const addInternal = jest
         .spyOn(service as any, 'addToCollectionInternal')

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -2602,6 +2602,51 @@ export class CollectionsService {
   }
 
   /**
+   * Why this collection cannot take the item, or undefined when it can. An
+   * inconclusive lookup answers undefined: a blip must never block a real add.
+   */
+  private async explainRejectedAdd(
+    mediaServer: IMediaServerService,
+    mediaId: string,
+    collection: Collection | undefined,
+  ): Promise<string | undefined> {
+    // itemExists is the only read that separates "gone" from "could not ask":
+    // it throws on the second, which is what keeps a blip from blocking an add.
+    try {
+      if (!(await mediaServer.itemExists(mediaId))) {
+        return 'Failed - not found on the media server';
+      }
+    } catch (error) {
+      this.logger.debug(error);
+      return undefined;
+    }
+
+    // A collection bound to one library refuses a foreign id on its own, but
+    // silently drops it from a mixed batch, leaving a row for an add that
+    // never happened.
+    const libraryId = collection?.libraryId;
+    if (
+      !libraryId ||
+      mediaServer.supportsFeature(MediaServerFeature.CROSS_LIBRARY_COLLECTIONS)
+    ) {
+      return undefined;
+    }
+
+    let item: MediaItem | undefined;
+    try {
+      item = await mediaServer.getMetadata(mediaId);
+    } catch (error) {
+      this.logger.debug(error);
+      return undefined;
+    }
+
+    // An unread library cannot disprove membership, and existence is settled.
+    return item?.library?.id && item.library.id !== libraryId
+      ? "Failed - not in this collection's library"
+      : undefined;
+  }
+
+  /**
    * Resolution is bounded-parallel, but the write is a **single** batched call.
    * The write path find-or-creates the media server collection, which is not
    * safe to run concurrently against the same collection: parallel first adds
@@ -2637,20 +2682,15 @@ export class CollectionsService {
       await Promise.all(
         batch.map(async (mediaId) => {
           try {
-            // An add into a movie or show collection has nothing to resolve,
-            // so an id the library does not hold would become a membership row
-            // for media that does not exist. An inconclusive lookup throws and
-            // is taken as present, so a blip never blocks a real add.
             if (action === 'add') {
-              let exists = true;
-              try {
-                exists = await mediaServer.itemExists(mediaId);
-              } catch (error) {
-                this.logger.debug(error);
-              }
+              const rejection = await this.explainRejectedAdd(
+                mediaServer,
+                mediaId,
+                collection,
+              );
 
-              if (!exists) {
-                fail(mediaId, 'Failed - not found on the media server');
+              if (rejection) {
+                fail(mediaId, rejection);
                 return;
               }
             }

--- a/apps/server/src/modules/rules/rules.controller.spec.ts
+++ b/apps/server/src/modules/rules/rules.controller.spec.ts
@@ -1,5 +1,6 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import { MaintainerrLogger } from '../logging/logs.service';
+import { ExecutionLockService } from '../tasks/execution-lock.service';
 import { RuleUsersService } from './rule-users.service';
 import { RulesController } from './rules.controller';
 import { RulesService } from './rules.service';
@@ -14,6 +15,8 @@ describe('RulesController', () => {
     updateRules: jest.fn(),
     setBulkExclusions: jest.fn(),
     removeBulkExclusions: jest.fn(),
+    setExclusion: jest.fn(),
+    removeExclusionWitData: jest.fn(),
   } as unknown as jest.Mocked<RulesService>;
 
   const ruleExecutorSchedulerService =
@@ -21,6 +24,10 @@ describe('RulesController', () => {
   const ruleExecutorJobManagerService =
     {} as jest.Mocked<RuleExecutorJobManagerService>;
   const ruleUsersService = {} as jest.Mocked<RuleUsersService>;
+
+  const executionLock = {
+    acquireWithin: jest.fn(),
+  } as unknown as jest.Mocked<ExecutionLockService>;
 
   const logger = {
     setContext: jest.fn(),
@@ -35,8 +42,10 @@ describe('RulesController', () => {
       ruleExecutorSchedulerService,
       ruleExecutorJobManagerService,
       ruleUsersService,
+      executionLock,
       logger,
     );
+    executionLock.acquireWithin.mockResolvedValue(jest.fn());
   });
 
   // A rejected rule group answered 201 with the reason in the body, so a
@@ -147,5 +156,56 @@ describe('RulesController', () => {
       undefined,
       { id: 'season-1', type: 'season' },
     );
+  });
+
+  // A handler run picks its media up front, so an exclusion that lands mid-run
+  // would answer success while that run still deletes the item.
+  it.each([
+    ['in bulk', () => controller.setBulkExclusions({ mediaIds: ['m'] })],
+    ['one at a time', () => controller.setExclusion({ mediaId: 'm' } as never)],
+  ])(
+    'takes the execution lock to exclude %s, and releases it',
+    async (_label, call) => {
+      const release = jest.fn();
+      executionLock.acquireWithin.mockResolvedValue(release);
+      rulesService.setBulkExclusions.mockResolvedValue({ results: [] });
+      rulesService.setExclusion.mockResolvedValue({
+        code: 1,
+        message: 'Success',
+      });
+
+      await call();
+
+      expect(executionLock.acquireWithin).toHaveBeenCalled();
+      expect(release).toHaveBeenCalled();
+    },
+  );
+
+  it('releases the lock when excluding throws', async () => {
+    const release = jest.fn();
+    executionLock.acquireWithin.mockResolvedValue(release);
+    rulesService.setBulkExclusions.mockRejectedValue(new Error('boom'));
+
+    await expect(
+      controller.setBulkExclusions({ mediaIds: ['movie-1'], action: 0 }),
+    ).rejects.toThrow('boom');
+    expect(release).toHaveBeenCalled();
+  });
+
+  it('refuses to exclude rather than queue behind a long run', async () => {
+    executionLock.acquireWithin.mockResolvedValue(null);
+
+    await expect(
+      controller.setBulkExclusions({ mediaIds: ['movie-1'], action: 0 }),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(rulesService.setBulkExclusions).not.toHaveBeenCalled();
+  });
+
+  it('does not take the lock to un-exclude, which frees media rather than acting on it', async () => {
+    rulesService.removeBulkExclusions.mockResolvedValue({ results: [] });
+
+    await controller.setBulkExclusions({ mediaIds: ['movie-1'], action: 1 });
+
+    expect(executionLock.acquireWithin).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/modules/rules/rules.controller.ts
+++ b/apps/server/src/modules/rules/rules.controller.ts
@@ -28,6 +28,10 @@ import { Response } from 'express';
 import { omit } from 'lodash';
 import { ZodValidationPipe } from 'nestjs-zod';
 import { MaintainerrLogger } from '../logging/logs.service';
+import {
+  ExecutionLockService,
+  RULES_COLLECTIONS_EXECUTION_LOCK_KEY,
+} from '../tasks/execution-lock.service';
 import { CommunityRule } from './dtos/communityRule.dto';
 import { ExclusionAction, ExclusionContextDto } from './dtos/exclusion.dto';
 import { RuleGroupDto } from './dtos/ruleGroup.dto';
@@ -36,6 +40,9 @@ import { ReturnStatus, RulesService } from './rules.service';
 import { RuleExecutorJobManagerService } from './tasks/rule-executor-job-manager.service';
 import { RuleExecutorSchedulerService } from './tasks/rule-executor-scheduler.service';
 
+/** Matches the postpone endpoint: wait out a short run rather than 409 at once. */
+const EXCLUSION_LOCK_WAIT_MS = 30000;
+
 @Controller('api/rules')
 export class RulesController {
   constructor(
@@ -43,6 +50,7 @@ export class RulesController {
     private readonly ruleExecutorSchedulerService: RuleExecutorSchedulerService,
     private readonly ruleExecutorJobManagerService: RuleExecutorJobManagerService,
     private readonly ruleUsersService: RuleUsersService,
+    private readonly executionLock: ExecutionLockService,
     private readonly logger: MaintainerrLogger,
   ) {
     this.logger.setContext(RulesController.name);
@@ -281,12 +289,43 @@ export class RulesController {
     return this.orFail(await this.rulesService.setRules(body));
   }
 
+  /**
+   * Excluding shares the execution lock, as postpone does: a run picks its media
+   * up front, so an exclusion landing mid-run would answer success while that
+   * run still acts on the item. Un-excluding frees media, so it stays lock-free.
+   */
+  private async whileNotHandling<T>(run: () => Promise<T>): Promise<T> {
+    const release = await this.executionLock.acquireWithin(
+      RULES_COLLECTIONS_EXECUTION_LOCK_KEY,
+      EXCLUSION_LOCK_WAIT_MS,
+    );
+
+    if (!release) {
+      throw new ConflictException(
+        'Collection handling is already running. Try again when the current collection or rule execution finishes.',
+      );
+    }
+
+    try {
+      return await run();
+    } finally {
+      release();
+    }
+  }
+
   @Post('/exclusion')
+  @ApiResponse({
+    status: 409,
+    description:
+      'A collection or rule run held the execution lock for too long.',
+  })
   async setExclusion(@Body() body: ExclusionContextDto): Promise<ReturnStatus> {
     if (body.action === undefined || body.action === ExclusionAction.ADD) {
       // handledIds serves the bulk path's collection pairing; it is not part of
       // this endpoint's response.
-      return omit(await this.rulesService.setExclusion(body), 'handledIds');
+      return await this.whileNotHandling(async () =>
+        omit(await this.rulesService.setExclusion(body), 'handledIds'),
+      );
     } else {
       return await this.rulesService.removeExclusionWitData(body);
     }
@@ -301,6 +340,11 @@ export class RulesController {
     status: 400,
     description: `Rejected without processing: empty, or more than ${BULK_MEDIA_ACTION_MAX_ITEMS} media ids.`,
   })
+  @ApiResponse({
+    status: 409,
+    description:
+      'A collection or rule run held the execution lock for too long.',
+  })
   async setBulkExclusions(
     @Body(new ZodValidationPipe(bulkExclusionRequestSchema))
     body: BulkExclusionRequest,
@@ -313,10 +357,12 @@ export class RulesController {
       );
     }
 
-    return await this.rulesService.setBulkExclusions(
-      body.mediaIds,
-      body.collectionId,
-      body.context,
+    return await this.whileNotHandling(() =>
+      this.rulesService.setBulkExclusions(
+        body.mediaIds,
+        body.collectionId,
+        body.context,
+      ),
     );
   }
 

--- a/apps/server/src/modules/rules/rules.service.exclusions.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.exclusions.spec.ts
@@ -716,6 +716,7 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
 
   const createScopedBulkService = (
     removeFromCollection = jest.fn().mockResolvedValue({ id: 3 }),
+    removeFromAllCollections = jest.fn().mockResolvedValue({ code: 1 }),
   ) => {
     const mediaServer = {
       getMetadata: jest.fn().mockResolvedValue({ type: 'movie' }),
@@ -723,6 +724,7 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
     const collectionService = {
       CollectionLogRecordForChild: jest.fn().mockResolvedValue(undefined),
       removeFromCollection,
+      removeFromAllCollections,
     };
     const { service } = createService({
       collectionService,
@@ -731,7 +733,13 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
       },
     });
 
-    return { service, collectionService, mediaServer, removeFromCollection };
+    return {
+      service,
+      collectionService,
+      mediaServer,
+      removeFromCollection,
+      removeFromAllCollections,
+    };
   };
 
   it('setBulkExclusions scopes to the collection and drops the excluded items from it', async () => {
@@ -801,6 +809,47 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
       { mediaServerId: 'season-1' },
       { mediaServerId: 'season-2' },
     ]);
+  });
+
+  it('setBulkExclusions with no collection drops the items from every collection', async () => {
+    const { service, removeFromAllCollections, removeFromCollection } =
+      createScopedBulkService();
+    jest.spyOn(service, 'setExclusion').mockResolvedValue({
+      code: 1,
+      message: 'Success',
+      handledIds: ['season-1', 'season-2'],
+    });
+
+    await expect(service.setBulkExclusions(['show-1'])).resolves.toEqual({
+      results: [{ mediaId: 'show-1', code: 1, message: 'Success' }],
+    });
+    expect(removeFromAllCollections).toHaveBeenCalledWith([
+      { mediaServerId: 'season-1' },
+      { mediaServerId: 'season-2' },
+    ]);
+    expect(removeFromCollection).not.toHaveBeenCalled();
+  });
+
+  it('setBulkExclusions reports a failed removal from every collection', async () => {
+    const { service } = createScopedBulkService(
+      undefined,
+      jest.fn().mockResolvedValue({ code: 0 }),
+    );
+    jest.spyOn(service, 'setExclusion').mockResolvedValue({
+      code: 1,
+      message: 'Success',
+      handledIds: ['movie-1'],
+    });
+
+    await expect(service.setBulkExclusions(['movie-1'])).resolves.toEqual({
+      results: [
+        {
+          mediaId: 'movie-1',
+          code: 0,
+          message: 'Excluded, but not removed from every collection',
+        },
+      ],
+    });
   });
 
   it('setBulkExclusions leaves the collection alone when nothing was excluded', async () => {

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -1265,32 +1265,41 @@ export class RulesService {
       );
     }
 
-    // Excluding from a collection page also drops the items from it, the
+    // Excluding also drops the items from the collections it covers, the
     // pairing the per-item action performs. After the exclusions, so a failed
     // one never silently removes its item. The drop names the ids the exclusion
     // resolved to, which is what the collection holds.
-    if (collectionId !== undefined) {
-      const excludedIds = rootIds.filter(
-        (mediaId) => resultById.get(mediaId)?.code === 1,
-      );
-      const members = [
-        ...new Set(
-          excludedIds.flatMap((mediaId) => handledByRoot.get(mediaId) ?? []),
-        ),
-      ].map((mediaServerId) => ({ mediaServerId }));
+    const excludedIds = rootIds.filter(
+      (mediaId) => resultById.get(mediaId)?.code === 1,
+    );
+    const members = [
+      ...new Set(
+        excludedIds.flatMap((mediaId) => handledByRoot.get(mediaId) ?? []),
+      ),
+    ].map((mediaServerId) => ({ mediaServerId }));
 
-      if (
-        members.length > 0 &&
-        !(await this.collectionService.removeFromCollection(
-          collectionId,
-          members,
-        ))
-      ) {
+    if (members.length > 0) {
+      // A global exclusion says the items belong in no collection at all.
+      const removed =
+        collectionId === undefined
+          ? (await this.collectionService.removeFromAllCollections(members))
+              .code === 1
+          : Boolean(
+              await this.collectionService.removeFromCollection(
+                collectionId,
+                members,
+              ),
+            );
+
+      if (!removed) {
         for (const mediaId of excludedIds) {
           resultById.set(mediaId, {
             mediaId,
             code: 0,
-            message: 'Excluded, but not removed from the collection',
+            message:
+              collectionId === undefined
+                ? 'Excluded, but not removed from every collection'
+                : 'Excluded, but not removed from the collection',
           });
         }
       }

--- a/apps/server/test/rules-test-matrix.e2e.ts
+++ b/apps/server/test/rules-test-matrix.e2e.ts
@@ -40,6 +40,7 @@ import { ValueGetterService } from '../src/modules/rules/getter/getter.service';
 import { RuleComparatorServiceFactory } from '../src/modules/rules/helpers/rule.comparator.service';
 import { RuleYamlService } from '../src/modules/rules/helpers/yaml.service';
 import { RulesController } from '../src/modules/rules/rules.controller';
+import { ExecutionLockService } from '../src/modules/tasks/execution-lock.service';
 import { RulesService } from '../src/modules/rules/rules.service';
 import { RuleExecutorJobManagerService } from '../src/modules/rules/tasks/rule-executor-job-manager.service';
 import { RuleExecutorSchedulerService } from '../src/modules/rules/tasks/rule-executor-scheduler.service';
@@ -775,6 +776,7 @@ async function bootstrapApp(): Promise<INestApplication> {
       RulesService,
       RuleComparatorServiceFactory,
       RuleConstanstService,
+      ExecutionLockService,
       {
         provide: ValueGetterService,
         useValue: valueGetter,

--- a/apps/ui/src/components/Collection/CollectionDetail/Exclusions/index.spec.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/Exclusions/index.spec.tsx
@@ -162,6 +162,23 @@ describe('CollectionExclusions bulk removal', () => {
     expect(screen.getByRole('button', { name: 'Select items' })).toBeTruthy()
   })
 
+  it('keeps the cards an un-exclude aimed at another collection left alone', async () => {
+    submittedOutcome = {
+      action: 'exclusion-remove',
+      collectionId: 7,
+      succeededIds: ['movie-1'],
+      failedIds: [],
+    }
+
+    await renderAndSelect(['movie-1'])
+    fireEvent.click(screen.getByTestId('media-action-submit'))
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith('1 item un-excluded.'),
+    )
+    expect(screen.getByText('Item movie-1')).toBeTruthy()
+  })
+
   it('keeps the cards an action left excluded', async () => {
     submittedOutcome = {
       action: 'collection-add',

--- a/apps/ui/src/components/Collection/CollectionDetail/Exclusions/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/Exclusions/index.tsx
@@ -13,6 +13,7 @@ import {
   bulkOutcomeVerb,
   reportBulkOutcome,
 } from '../../../../utils/bulkOutcome'
+import { invalidateMaintainerrStatusDetails } from '../../../Common/MediaCard/maintainerrStatus'
 import MediaSelectionActions from '../../../Common/MediaSelectionActions'
 import type { MediaActionOutcome } from '../../../Common/MediaActionModal'
 import {
@@ -123,13 +124,24 @@ const CollectionExcludions = (props: ICollectionExclusions) => {
 
   const handleBulkOutcome = ({
     action,
+    collectionId,
     succeededIds,
     failedIds,
+    failureReasons,
   }: MediaActionOutcome) => {
     applyBulkOutcome(new Set(failedIds))
 
-    // This list is the collection's exclusions, so only an un-exclude empties it.
-    if (action === 'exclusion-remove') {
+    for (const mediaServerId of succeededIds) {
+      invalidateMaintainerrStatusDetails(mediaServerId)
+    }
+
+    // This list is the collection's exclusions, so only an un-exclude empties
+    // it, and only when it reached this collection: an undefined id means every
+    // exclusion the items carry, which includes these.
+    if (
+      action === 'exclusion-remove' &&
+      (collectionId === undefined || collectionId === props.collection.id)
+    ) {
       const removedIds = new Set(succeededIds)
       updateData((currentData) =>
         currentData.filter((item) => !removedIds.has(item.id)),
@@ -139,7 +151,8 @@ const CollectionExcludions = (props: ICollectionExclusions) => {
     reportBulkOutcome(
       succeededIds.length,
       failedIds.length,
-      bulkOutcomeVerb(action),
+      bulkOutcomeVerb({ action, collectionId }),
+      failureReasons,
     )
   }
 
@@ -157,13 +170,7 @@ const CollectionExcludions = (props: ICollectionExclusions) => {
             selectedIds={selectedIds}
             items={data}
             libraryId={props.collection.libraryId}
-            lockedCollection={{
-              id: props.collection.id,
-              title: props.collection.title,
-              type: props.collection.type,
-            }}
-            // Everything here is already excluded from this collection.
-            hiddenActions={['exclusion-add']}
+            defaultCollectionId={props.collection.id}
             onSubmitted={handleBulkOutcome}
           />
         }

--- a/apps/ui/src/components/Common/MediaActionModal.spec.tsx
+++ b/apps/ui/src/components/Common/MediaActionModal.spec.tsx
@@ -1,3 +1,4 @@
+import { MediaServerType } from '@maintainerr/contracts'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
@@ -6,8 +7,12 @@ import {
 } from '../../api/bulkMediaAction'
 import { useCollections } from '../../api/collections'
 import { useMediaServerMetadataChildren } from '../../api/media-server'
+import { useMediaServerType } from '../../hooks/useMediaServerType'
 import type { ICollection } from '../Collection'
-import { buildQuerySuccessResult } from '../../test-utils/queryResults'
+import {
+  buildQueryErrorResult,
+  buildQuerySuccessResult,
+} from '../../test-utils/queryResults'
 import MediaActionModal from './MediaActionModal'
 
 vi.mock('../../api/bulkMediaAction', () => ({
@@ -22,6 +27,10 @@ vi.mock('../../api/collections', () => ({
 
 vi.mock('../../api/media-server', () => ({
   useMediaServerMetadataChildren: vi.fn(),
+}))
+
+vi.mock('../../hooks/useMediaServerType', () => ({
+  useMediaServerType: vi.fn(),
 }))
 
 vi.mock('@tanstack/react-query', () => ({
@@ -59,10 +68,18 @@ const selectAction = (value: string) =>
 describe('MediaActionModal', () => {
   const useCollectionsMock = vi.mocked(useCollections)
   const useChildrenMock = vi.mocked(useMediaServerMetadataChildren)
+  const useMediaServerTypeMock = vi.mocked(useMediaServerType)
   const postExclusionsMock = vi.mocked(postBulkExclusions)
   const postCollectionMock = vi.mocked(postBulkCollectionMedia)
 
+  const setMediaServerType = (mediaServerType: MediaServerType) =>
+    useMediaServerTypeMock.mockReturnValue({
+      mediaServerType,
+    } as unknown as ReturnType<typeof useMediaServerType>)
+
   beforeEach(() => {
+    // Bound to one library by default, which is what the picker assertions test.
+    setMediaServerType(MediaServerType.PLEX)
     onSubmitted.mockReset()
     onCancel.mockReset()
     postExclusionsMock.mockReset()
@@ -107,9 +124,7 @@ describe('MediaActionModal', () => {
     expect(screen.queryByRole('option', { name: 'All collections' })).toBeNull()
   })
 
-  // A search spans libraries, so the page passes none - the picker-driven
-  // actions drop rather than offering every library's collections.
-  it('offers only library-agnostic actions when the page has no library', () => {
+  it('offers only library-agnostic actions when no library is known', () => {
     renderModal({ libraryId: undefined })
 
     expect(useCollectionsMock).toHaveBeenCalledWith(
@@ -122,10 +137,25 @@ describe('MediaActionModal', () => {
     expect(
       screen.queryByRole('option', { name: 'Remove from collection' }),
     ).toBeNull()
-    expect(
-      screen.getByRole('option', { name: 'Remove from all collections' }),
-    ).toBeTruthy()
     expect(screen.getByRole('option', { name: 'Add exclusion' })).toBeTruthy()
+    expect(screen.getByText(/spans more than one library/)).toBeTruthy()
+  })
+
+  // A search selection keeps them where any collection can take the item (#3448).
+  it('keeps the collection actions without a library where collections span them', () => {
+    setMediaServerType(MediaServerType.JELLYFIN)
+    renderModal({ libraryId: undefined })
+
+    expect(useCollectionsMock).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ enabled: true }),
+    )
+    expect(
+      screen.getByRole('option', { name: 'Add to collection' }),
+    ).toBeTruthy()
+    expect(
+      screen.getByRole('option', { name: 'Movie collection' }),
+    ).toBeTruthy()
   })
 
   it('adds the selection to the chosen collection and reports per-item results', async () => {
@@ -147,6 +177,7 @@ describe('MediaActionModal', () => {
       collectionTitle: 'Movie collection',
       succeededIds: ['movie-1'],
       failedIds: [],
+      failureReasons: [],
     })
   })
 
@@ -159,7 +190,10 @@ describe('MediaActionModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
 
-    expect(screen.getByText('Confirmation Required')).toBeTruthy()
+    expect(screen.getByText('Confirm Global Exclusion')).toBeTruthy()
+    expect(
+      screen.getByText(/removed from every collection they are currently in/),
+    ).toBeTruthy()
     expect(postExclusionsMock).not.toHaveBeenCalled()
 
     fireEvent.click(screen.getByRole('button', { name: 'Proceed' }))
@@ -178,43 +212,43 @@ describe('MediaActionModal', () => {
       collectionTitle: undefined,
       succeededIds: ['movie-1'],
       failedIds: ['movie-2'],
+      failureReasons: ['Failed'],
     })
   })
 
-  it('pins the collection a collection page acts on', async () => {
-    renderModal({
-      lockedCollection: { id: 42, title: 'This collection' },
-    })
+  it('preselects the calling page collection while still offering every scope', async () => {
+    renderModal({ defaultCollectionId: 7 })
     selectAction('exclusion-add')
 
     const collectionField = screen.getByLabelText(
       'Collection',
     ) as HTMLSelectElement
-    expect(collectionField.disabled).toBe(true)
-    expect(collectionField.options).toHaveLength(1)
-    // no "every collection" scope the page could not show the result of
-    expect(screen.queryByRole('option', { name: 'All collections' })).toBeNull()
+    expect(collectionField.disabled).toBe(false)
+    expect(collectionField.value).toBe('7')
+    expect(screen.getByRole('option', { name: 'All collections' })).toBeTruthy()
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() =>
       expect(postExclusionsMock).toHaveBeenCalledWith({
         mediaIds: ['movie-1', 'movie-2'],
-        collectionId: 42,
+        collectionId: 7,
         action: 0,
       }),
     )
   })
 
-  it('removes from every collection without asking for one', async () => {
+  it('removes from every collection through the all-collections scope', async () => {
     renderModal({})
-    selectAction('collection-remove-all')
-
-    // nothing to pick: the action names every collection itself
-    expect(screen.queryByLabelText('Collection')).toBeNull()
+    selectAction('collection-remove')
+    fireEvent.change(screen.getByLabelText('Collection'), {
+      target: { value: '-1' },
+    })
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
-    expect(screen.getByText('Confirmation Required')).toBeTruthy()
+    expect(
+      screen.getByText('Confirm Removal From Every Collection'),
+    ).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Proceed' }))
 
     await waitFor(() =>
@@ -224,21 +258,6 @@ describe('MediaActionModal', () => {
         action: 1,
         mediaType: 'movie',
       }),
-    )
-  })
-
-  it('hides the actions the calling page says cannot do anything', () => {
-    renderModal({
-      lockedCollection: { id: 42, title: 'This collection' },
-      hiddenActions: ['collection-add'],
-    })
-
-    expect(
-      screen.queryByRole('option', { name: 'Add to collection' }),
-    ).toBeNull()
-    // and the first action still offered is what the form falls back to
-    expect((screen.getByLabelText('Action') as HTMLSelectElement).value).toBe(
-      'collection-remove',
     )
   })
 
@@ -293,18 +312,6 @@ describe('MediaActionModal', () => {
     expect(screen.queryByLabelText('Seasons')).toBeNull()
   })
 
-  // A show collection acts on the show itself, so a narrowed season resolves
-  // straight back to it. The picker promised a reach the action never had.
-  it('does not offer season narrowing on a pinned show collection', () => {
-    renderModal({
-      mediaIds: ['show-1'],
-      mediaType: 'show',
-      lockedCollection: { id: 42, title: 'This collection', type: 'show' },
-    })
-
-    expect(screen.queryByLabelText('Seasons')).toBeNull()
-  })
-
   it('keeps the modal open and shows why when the request fails', async () => {
     postCollectionMock.mockRejectedValue(new Error('boom'))
 
@@ -314,5 +321,61 @@ describe('MediaActionModal', () => {
     await waitFor(() => expect(screen.getByText('boom')).toBeTruthy())
     expect(onSubmitted).not.toHaveBeenCalled()
     expect(screen.getByRole('button', { name: 'Submit' })).toBeTruthy()
+  })
+
+  it('reports the reasons the server refused items', async () => {
+    postCollectionMock.mockResolvedValue({
+      results: [
+        { mediaId: 'movie-1', code: 1 },
+        {
+          mediaId: 'movie-2',
+          code: 0,
+          message: "Failed - not in this collection's library",
+        },
+      ],
+    })
+
+    renderModal({})
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+    await waitFor(() =>
+      expect(onSubmitted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          failedIds: ['movie-2'],
+          failureReasons: ["Failed - not in this collection's library"],
+        }),
+      ),
+    )
+  })
+
+  it('says why the collections could not be loaded', () => {
+    useCollectionsMock.mockReturnValue(
+      buildQueryErrorResult(
+        new Error('Plex unreachable'),
+      ) as unknown as ReturnType<typeof useCollections>,
+    )
+
+    renderModal({})
+
+    // The reason the server gave beats the generic fallback.
+    expect(screen.getByText('Plex unreachable')).toBeTruthy()
+  })
+
+  it('says so, and refuses to submit, when no collection can take the selection', () => {
+    useCollectionsMock.mockReturnValue(
+      buildQuerySuccessResult([]) as unknown as ReturnType<
+        typeof useCollections
+      >,
+    )
+
+    renderModal({})
+
+    expect(
+      screen.getByText(/No collection can take this selection/),
+    ).toBeTruthy()
+    expect(
+      (screen.getByRole('button', { name: 'Submit' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true)
   })
 })

--- a/apps/ui/src/components/Common/MediaActionModal.tsx
+++ b/apps/ui/src/components/Common/MediaActionModal.tsx
@@ -1,4 +1,5 @@
 import type { MediaItemType } from '@maintainerr/contracts'
+import { MediaServerFeature, supportsFeature } from '@maintainerr/contracts'
 import { useQueryClient } from '@tanstack/react-query'
 import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -11,6 +12,7 @@ import {
   useCollections,
 } from '../../api/collections'
 import { useMediaServerMetadataChildren } from '../../api/media-server'
+import { useMediaServerType } from '../../hooks/useMediaServerType'
 import { getApiErrorMessage } from '../../utils/ApiError'
 import GetApiHandler from '../../utils/ApiHandler'
 import Alert from './Alert'
@@ -27,22 +29,14 @@ import { Select } from '../Forms/Select'
 const ALL_COLLECTIONS = -1
 
 export type MediaAction =
-  | 'collection-add'
-  | 'collection-remove'
-  | 'collection-remove-all'
-  | 'exclusion-add'
-  | 'exclusion-remove'
+  'collection-add' | 'collection-remove' | 'exclusion-add' | 'exclusion-remove'
 
 const actionLabels: Record<MediaAction, string> = {
   'collection-add': 'Add to collection',
   'collection-remove': 'Remove from collection',
-  'collection-remove-all': 'Remove from all collections',
   'exclusion-add': 'Add exclusion',
   'exclusion-remove': 'Remove exclusion',
 }
-
-const targetsEveryCollection = (action: MediaAction) =>
-  action === 'collection-remove-all'
 
 export interface MediaActionOutcome {
   action: MediaAction
@@ -51,6 +45,8 @@ export interface MediaActionOutcome {
   collectionTitle?: string
   succeededIds: string[]
   failedIds: string[]
+  /** Distinct reasons the server gave, so a refusal can say why. */
+  failureReasons?: string[]
 }
 
 export interface MediaActionModalProps {
@@ -58,10 +54,8 @@ export interface MediaActionModalProps {
   /** Undefined for a mixed selection, which no single collection can take. */
   mediaType?: MediaItemType
   libraryId?: string
-  /** Pins the picker, so a page cannot act outside the scope it can show. */
-  lockedCollection?: { id: number; title: string; type?: MediaItemType }
-  /** Actions that cannot do anything on the calling page. */
-  hiddenActions?: MediaAction[]
+  /** Preselects the picker with the collection the calling page is showing. */
+  defaultCollectionId?: number
   onCancel: () => void
   onSubmitted: (outcome: MediaActionOutcome) => void
 }
@@ -75,13 +69,18 @@ const MediaActionModal = ({
   mediaIds,
   mediaType,
   libraryId,
-  lockedCollection,
-  hiddenActions,
+  defaultCollectionId,
   onCancel,
   onSubmitted,
 }: MediaActionModalProps) => {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+  const { mediaServerType } = useMediaServerType()
+  // Where a collection can hold any library's items, it needs no library scope.
+  const collectionsSpanLibraries = supportsFeature(
+    mediaServerType,
+    MediaServerFeature.CROSS_LIBRARY_COLLECTIONS,
+  )
   const [pickedAction, setPickedAction] = useState<MediaAction>()
   const [selectedCollection, setSelectedCollection] = useState<number>()
   const [selectedSeasons, setSelectedSeasons] = useState<string>()
@@ -94,24 +93,19 @@ const MediaActionModal = ({
   >([])
 
   const singleMediaId = mediaIds.length === 1 ? mediaIds[0] : undefined
-  // A pinned show collection acts on the item itself, so a narrowed season
-  // resolves straight back to the show. Offering the choice there promises a
-  // reach the action does not have. An unpinned picker needs no such guard: a
-  // narrowed selection already drops show collections from collectionTypes.
-  const canNarrow =
-    singleMediaId !== undefined &&
-    mediaType === 'show' &&
-    lockedCollection?.type !== 'show'
+  // A narrowed selection drops show collections from collectionTypes, so the
+  // picker can never promise a reach the narrowed action does not have.
+  const canNarrow = singleMediaId !== undefined && mediaType === 'show'
 
   const seasonsQuery = useMediaServerMetadataChildren(singleMediaId, {
     enabled: canNarrow,
   })
   const episodesQuery = useMediaServerMetadataChildren(selectedSeasons)
-  // A collection only accepts items from its own library, so offering the other
-  // libraries' collections only produces a rejected add. No library (a search
-  // spanning them) means no list to offer, not every list.
+  // A collection bound to one library only accepts items from it, so offering
+  // the other libraries' collections there only produces a rejected add.
+  const canPickCollection = libraryId !== undefined || collectionsSpanLibraries
   const collectionsQuery = useCollections(libraryId, {
-    enabled: !lockedCollection && libraryId !== undefined,
+    enabled: canPickCollection,
   })
 
   const submittedType = useMemo((): MediaItemType | undefined => {
@@ -148,39 +142,32 @@ const MediaActionModal = ({
     }
   }, [submittedType])
 
-  const actionOptions = useMemo((): MediaAction[] => {
-    // A mixed selection has no single type, so no collection can take it. The
-    // picker-driven actions also need a library (or a pinned collection) to
-    // scope the picker; without one only the library-agnostic actions remain.
-    const canPickCollection = lockedCollection || libraryId !== undefined
-    const actions: MediaAction[] = mediaType
-      ? [
-          ...(canPickCollection
-            ? (['collection-add', 'collection-remove'] as const)
-            : []),
-          'collection-remove-all',
-          'exclusion-add',
-          'exclusion-remove',
-        ]
-      : ['exclusion-add', 'exclusion-remove']
+  const actionOptions = useMemo(
+    (): MediaAction[] =>
+      // A mixed selection has no single type, so no collection can take it, and
+      // without a scope for the picker only the library-agnostic actions remain.
+      mediaType && canPickCollection
+        ? [
+            'collection-add',
+            'collection-remove',
+            'exclusion-add',
+            'exclusion-remove',
+          ]
+        : ['exclusion-add', 'exclusion-remove'],
+    [mediaType, canPickCollection],
+  )
 
-    return hiddenActions
-      ? actions.filter((action) => !hiddenActions.includes(action))
-      : actions
-  }, [mediaType, hiddenActions, lockedCollection, libraryId])
-
-  // Derived, not synced: a page can hide actions, and a mixed selection drops
-  // the collection ones, so fall back to the first one still offered.
+  // Derived, not synced: a mixed selection drops the collection actions, so a
+  // choice made before that falls back to the first one still offered.
   const selectedAction =
     pickedAction && actionOptions.includes(pickedAction)
       ? pickedAction
       : actionOptions[0]
 
   const isCollectionAction = selectedAction.startsWith('collection-')
-  const isEveryCollection = targetsEveryCollection(selectedAction)
-  // Only an exclusion can be scoped to every collection at once; the collection
-  // actions say so through their own entry instead.
-  const allowsAllCollections = !lockedCollection && !isCollectionAction
+  // Only an add needs one specific target; every other action can mean the
+  // whole set, which is what makes an exclusion global.
+  const allowsAllCollections = selectedAction !== 'collection-add'
 
   const seasonOptions = useMemo(
     () => [
@@ -204,12 +191,8 @@ const MediaActionModal = ({
     [episodesQuery.data],
   )
 
-  const collectionOptions = useMemo((): { id: number; title: string }[] => {
-    if (lockedCollection) {
-      return [lockedCollection]
-    }
-
-    return [
+  const collectionOptions = useMemo(
+    (): { id: number; title: string }[] => [
       ...(allowsAllCollections
         ? [{ id: ALL_COLLECTIONS, title: 'All collections' }]
         : []),
@@ -218,26 +201,22 @@ const MediaActionModal = ({
           ? [{ id: collection.id, title: collection.title }]
           : [],
       ),
-    ]
-  }, [
-    lockedCollection,
-    allowsAllCollections,
-    collectionsQuery.data,
-    collectionTypes,
-  ])
+    ],
+    [allowsAllCollections, collectionsQuery.data, collectionTypes],
+  )
 
   // Derived, not synced: narrowing or switching action drops options, so a
-  // selection made before that is no longer offered and falls back to the first
-  // one. Keeping the state lets it come back if the user widens again.
+  // selection made before that falls back to the calling page's collection.
+  // Keeping the state lets it come back if the user widens again.
   const currentCollectionId = collectionOptions.some(
     (option) => option.id === selectedCollection,
   )
     ? selectedCollection
-    : collectionOptions[0]?.id
+    : (collectionOptions.find((option) => option.id === defaultCollectionId)
+        ?.id ?? collectionOptions[0]?.id)
   const isAllCollections = currentCollectionId === ALL_COLLECTIONS
-  // Everything but the every-collection action needs a target to act on.
-  const noCollectionSelectable =
-    !isEveryCollection && currentCollectionId === undefined
+  // Every action needs a target, even if that target is every collection.
+  const noCollectionSelectable = currentCollectionId === undefined
   const noCollectionsAvailable =
     noCollectionSelectable && collectionsQuery.isSuccess
 
@@ -274,8 +253,7 @@ const MediaActionModal = ({
     setConfirmAllCollections(false)
     setErrorMessage(undefined)
 
-    const collectionId =
-      isEveryCollection || isAllCollections ? undefined : currentCollectionId
+    const collectionId = isAllCollections ? undefined : currentCollectionId
 
     try {
       const response = isCollectionAction
@@ -297,15 +275,18 @@ const MediaActionModal = ({
       const succeededIds = response.results
         .filter((result) => result.code === 1)
         .map((result) => result.mediaId)
-      const failedIds = response.results
-        .filter((result) => result.code !== 1)
-        .map((result) => result.mediaId)
+      const failed = response.results.filter((result) => result.code !== 1)
+      const failedIds = failed.map((result) => result.mediaId)
+      // The server says why per item; without it a refusal reads as a bare
+      // count, which is the shape #3383 set out to stop.
+      const failureReasons = [
+        ...new Set(failed.flatMap((result) => result.message ?? [])),
+      ]
 
-      // A scoped exclusion also drops the items from the collection, so it
+      // Excluding drops the items from whatever it was scoped to, so it
       // invalidates the same caches a collection action does.
       const changedMembership =
-        isCollectionAction ||
-        (selectedAction === 'exclusion-add' && collectionId !== undefined)
+        isCollectionAction || selectedAction === 'exclusion-add'
 
       if (changedMembership && succeededIds.length > 0) {
         await invalidateCollectionQueries(queryClient)
@@ -319,6 +300,7 @@ const MediaActionModal = ({
         )?.title,
         succeededIds,
         failedIds,
+        failureReasons,
       })
     } catch (error) {
       setSubmitting(false)
@@ -363,7 +345,7 @@ const MediaActionModal = ({
       }
     }
 
-    if (isEveryCollection || isAllCollections) {
+    if (isAllCollections) {
       setAffectedExclusions([])
       setConfirmAllCollections(true)
       return
@@ -373,6 +355,12 @@ const MediaActionModal = ({
   }
 
   const itemLabel = `${mediaIds.length} item${mediaIds.length === 1 ? '' : 's'}`
+  const everyCollectionTitle =
+    selectedAction === 'exclusion-add'
+      ? 'Confirm Global Exclusion'
+      : selectedAction === 'exclusion-remove'
+        ? 'Confirm Removing Every Exclusion'
+        : 'Confirm Removal From Every Collection'
 
   return (
     <Modal
@@ -399,7 +387,7 @@ const MediaActionModal = ({
         <Modal
           backgroundClickable={false}
           onCancel={() => setConfirmAllCollections(false)}
-          title="Confirmation Required"
+          title={everyCollectionTitle}
           footerActions={
             <PendingButton
               buttonType="danger"
@@ -414,11 +402,22 @@ const MediaActionModal = ({
             />
           }
         >
+          <p>
+            {actionLabels[selectedAction]} applies to {itemLabel} across every
+            collection. For shows and seasons this covers everything they
+            contain.
+            {selectedAction === 'exclusion-add'
+              ? ' They are removed from every collection they are currently in as well.'
+              : ''}
+          </p>
+
           {affectedExclusions.length > 0 ? (
             <>
-              Making this a global exclusion removes the following rule-group
-              exclusions, and they will not return if you later remove the
-              global exclusion:
+              <p className="mt-2">
+                Making this a global exclusion removes the following rule-group
+                exclusions, and they will not return if you later remove the
+                global exclusion:
+              </p>
               <ul className="mt-2 list-disc pl-5">
                 {affectedExclusions.map((exclusion) => (
                   <li key={exclusion.targetPath}>
@@ -442,19 +441,13 @@ const MediaActionModal = ({
                 ))}
               </ul>
             </>
-          ) : (
-            <p>
-              {actionLabels[selectedAction]} applies to {itemLabel} across every
-              collection. For shows and seasons this covers everything they
-              contain.
-            </p>
-          )}
+          ) : null}
         </Modal>
       ) : null}
 
       {noCollectionsAvailable ? (
         <Alert
-          title="No collection in this library can take this selection. Create one from a rule first."
+          title="No collection can take this selection. Create one from a rule first."
           type="warning"
         />
       ) : null}
@@ -521,31 +514,30 @@ const MediaActionModal = ({
           </FormItem>
         ) : null}
 
-        {isEveryCollection ? null : (
-          <FormItem label="Collection">
-            <Select
-              name="Collection-field"
-              id="Collection-field"
-              value={currentCollectionId ?? ''}
-              disabled={Boolean(lockedCollection)}
-              onChange={(e: { target: { value: string } }) => {
-                setSelectedCollection(+e.target.value)
-              }}
-            >
-              {collectionOptions.map((collection) => (
-                <option key={collection.id} value={collection.id}>
-                  {collection.title}
-                </option>
-              ))}
-            </Select>
-          </FormItem>
-        )}
+        <FormItem label="Collection">
+          <Select
+            name="Collection-field"
+            id="Collection-field"
+            value={currentCollectionId ?? ''}
+            onChange={(e: { target: { value: string } }) => {
+              setSelectedCollection(+e.target.value)
+            }}
+          >
+            {collectionOptions.map((collection) => (
+              <option key={collection.id} value={collection.id}>
+                {collection.title}
+              </option>
+            ))}
+          </Select>
+        </FormItem>
 
         <p className="mt-4 text-sm text-zinc-400">
           Applies to {itemLabel}.
           {!mediaType
-            ? ' The selection mixes media types or libraries, so only exclusions can be applied to it.'
-            : ''}
+            ? ' The selection mixes media types, so only exclusions can be applied to it.'
+            : !canPickCollection
+              ? ' The selection spans more than one library, so only exclusions can be applied to it.'
+              : ''}
           {/* An item is global or scoped, never both, so removing "its"
               exclusion here removes a global one if that is what it has. */}
           {selectedAction === 'exclusion-remove' && !isAllCollections

--- a/apps/ui/src/components/Common/MediaSelectionActions.tsx
+++ b/apps/ui/src/components/Common/MediaSelectionActions.tsx
@@ -1,10 +1,7 @@
 import { CheckCircleIcon, PencilAltIcon } from '@heroicons/react/solid'
-import type { MediaItem, MediaItemType } from '@maintainerr/contracts'
+import type { MediaItem } from '@maintainerr/contracts'
 import { useState } from 'react'
-import MediaActionModal, {
-  type MediaAction,
-  type MediaActionOutcome,
-} from './MediaActionModal'
+import MediaActionModal, { type MediaActionOutcome } from './MediaActionModal'
 import Button from './Button'
 
 interface MediaSelectionActionsProps {
@@ -14,13 +11,12 @@ interface MediaSelectionActionsProps {
   /** The grid the selection was made in, to read the picked items from. */
   items: MediaItem[]
   /**
-   * The library the grid is showing, or undefined when it spans several. No
-   * media server fills a media item's own library, so only the page knows.
+   * The library the grid is showing, or undefined when it spans several (a
+   * search), in which case the picked items are asked instead.
    */
   libraryId?: string
-  /** Id is optional only to match ICollection; a saved collection always has one. */
-  lockedCollection?: { id?: number; title: string; type?: MediaItemType }
-  hiddenActions?: MediaAction[]
+  /** The collection the calling page shows, if it is showing one. */
+  defaultCollectionId?: number
   onSubmitted: (outcome: MediaActionOutcome) => void
 }
 
@@ -43,8 +39,7 @@ const MediaSelectionActions = ({
   selectedIds,
   items,
   libraryId,
-  lockedCollection,
-  hiddenActions,
+  defaultCollectionId,
   onSubmitted,
 }: MediaSelectionActionsProps) => {
   const [modalOpen, setModalOpen] = useState(false)
@@ -55,6 +50,15 @@ const MediaSelectionActions = ({
   const selected = items.filter((item) => selectedIds.has(item.id))
   const selectedTypes = new Set(selected.map((item) => item.type))
   const mediaType = selectedTypes.size === 1 ? [...selectedTypes][0] : undefined
+  // The page's library wins; a search has none, so fall back to the one the
+  // picked items agree on. An empty id is an unfilled read, not every library.
+  const selectedLibraryIds = selected.map((item) => item.library?.id)
+  const resolvedLibraryId =
+    libraryId ??
+    (selectedLibraryIds.length > 0 &&
+    selectedLibraryIds.every((id) => id && id === selectedLibraryIds[0])
+      ? selectedLibraryIds[0]
+      : undefined)
 
   return (
     <>
@@ -97,17 +101,8 @@ const MediaSelectionActions = ({
         <MediaActionModal
           mediaIds={[...selectedIds]}
           mediaType={mediaType}
-          libraryId={libraryId}
-          lockedCollection={
-            lockedCollection?.id !== undefined
-              ? {
-                  id: lockedCollection.id,
-                  title: lockedCollection.title,
-                  type: lockedCollection.type,
-                }
-              : undefined
-          }
-          hiddenActions={hiddenActions}
+          libraryId={resolvedLibraryId}
+          defaultCollectionId={defaultCollectionId}
           onCancel={() => setModalOpen(false)}
           onSubmitted={(outcome) => {
             setModalOpen(false)

--- a/apps/ui/src/components/Overview/index.spec.tsx
+++ b/apps/ui/src/components/Overview/index.spec.tsx
@@ -275,7 +275,7 @@ describe('Overview', () => {
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
-        '1 item excluded. 1 item could not be excluded; the failed items stay selected.',
+        '1 item excluded everywhere. 1 item could not be excluded everywhere; the failed items stay selected.',
       )
     })
     expect(

--- a/apps/ui/src/components/Overview/index.tsx
+++ b/apps/ui/src/components/Overview/index.tsx
@@ -413,6 +413,7 @@ const Overview = () => {
     collectionTitle,
     succeededIds: succeeded,
     failedIds: failed,
+    failureReasons,
   }: MediaActionOutcome) => {
     const succeededIds = new Set(succeeded)
     applyBulkOutcome(new Set(failed))
@@ -428,8 +429,12 @@ const Overview = () => {
           succeededIds.has(item.grandparentId))
 
       const isCollectionAction = action.startsWith('collection-')
+      // Excluding everywhere also drops the items from every collection.
+      const clearsEveryCollection =
+        collectionId === undefined &&
+        (action === 'collection-remove' || action === 'exclusion-add')
       const nextCollections = (current: string[]) => {
-        if (action === 'collection-remove-all') return []
+        if (clearsEveryCollection) return []
         if (!collectionTitle) return current
         return action === 'collection-add'
           ? [...new Set([...current, collectionTitle])].sort((left, right) =>
@@ -448,18 +453,21 @@ const Overview = () => {
             : null
 
       // A collection action moves membership, which the card names in its own
-      // badge; only a global exclusion changes the exclusion marker.
-      const patchCard = (item: MediaItem) => {
-        if (nextExclusionType !== null) {
-          return { ...item, maintainerrExclusionType: nextExclusionType }
-        }
-        return {
-          ...item,
-          maintainerrCollections: nextCollections(
-            item.maintainerrCollections ?? [],
-          ),
-        }
-      }
+      // badge; only a global exclusion changes the exclusion marker, and it
+      // does both.
+      const patchCard = (item: MediaItem) => ({
+        ...item,
+        ...(nextExclusionType !== null
+          ? { maintainerrExclusionType: nextExclusionType }
+          : {}),
+        ...(isCollectionAction || clearsEveryCollection
+          ? {
+              maintainerrCollections: nextCollections(
+                item.maintainerrCollections ?? [],
+              ),
+            }
+          : {}),
+      })
 
       if (nextExclusionType !== null || isCollectionAction) {
         const nextItems = dataRef.current.map((item) =>
@@ -483,7 +491,12 @@ const Overview = () => {
       setStatusChangedIds((current) => new Set([...current, ...invalidated]))
     }
 
-    reportBulkOutcome(succeededIds.size, failed.length, bulkOutcomeVerb(action))
+    reportBulkOutcome(
+      succeededIds.size,
+      failed.length,
+      bulkOutcomeVerb({ action, collectionId }),
+      failureReasons,
+    )
   }
 
   useEffect(() => {

--- a/apps/ui/src/pages/CollectionMediaPage.spec.tsx
+++ b/apps/ui/src/pages/CollectionMediaPage.spec.tsx
@@ -197,6 +197,7 @@ describe('CollectionMediaPage', () => {
     it('drops the cards an exclusion took out of the collection', async () => {
       submittedOutcome = {
         action: 'exclusion-add',
+        collectionId: 42,
         succeededIds: ['movie-1'],
         failedIds: [],
       }
@@ -211,9 +212,9 @@ describe('CollectionMediaPage', () => {
 
     // The item leaves this collection, and the grid holds its own state, so
     // nothing refetches it away.
-    it('drops the cards a remove-from-all-collections took out', async () => {
+    it('drops the cards a removal from every collection took out', async () => {
       submittedOutcome = {
-        action: 'collection-remove-all',
+        action: 'collection-remove',
         succeededIds: ['movie-1'],
         failedIds: [],
       }
@@ -222,6 +223,25 @@ describe('CollectionMediaPage', () => {
 
       await waitFor(() => expect(screen.queryByText('Item movie-1')).toBeNull())
       expect(screen.getByText('Item movie-2')).toBeTruthy()
+      expect(toast.success).toHaveBeenCalledWith(
+        '1 item removed from every collection.',
+      )
+    })
+
+    it('keeps the cards an action aimed at another collection left alone', async () => {
+      submittedOutcome = {
+        action: 'exclusion-add',
+        collectionId: 7,
+        succeededIds: ['movie-1'],
+        failedIds: [],
+      }
+
+      await selectAndSubmit(['movie-1'])
+
+      await waitFor(() =>
+        expect(toast.success).toHaveBeenCalledWith('1 item excluded.'),
+      )
+      expect(screen.getByText('Item movie-1')).toBeTruthy()
     })
 
     it('keeps the cards an action left in the collection', async () => {
@@ -242,8 +262,10 @@ describe('CollectionMediaPage', () => {
     it('keeps a failed item on screen and selected', async () => {
       submittedOutcome = {
         action: 'exclusion-add',
+        collectionId: 42,
         succeededIds: ['movie-1'],
         failedIds: ['movie-2'],
+        failureReasons: ["Failed - not in this collection's library"],
       }
 
       await selectAndSubmit(['movie-1', 'movie-2'])
@@ -256,8 +278,9 @@ describe('CollectionMediaPage', () => {
       expect(
         screen.getByRole('button', { name: 'Done selecting' }),
       ).toBeTruthy()
+      // The server says why per item; a bare count leaves the user guessing.
       expect(toast.error).toHaveBeenCalledWith(
-        '1 item excluded. 1 item could not be excluded; the failed items stay selected.',
+        "1 item excluded. 1 item could not be excluded (not in this collection's library); the failed items stay selected.",
       )
     })
   })

--- a/apps/ui/src/pages/CollectionMediaPage.tsx
+++ b/apps/ui/src/pages/CollectionMediaPage.tsx
@@ -6,6 +6,7 @@ import {
 import { useCallback, useRef, useState } from 'react'
 import { useOutletContext, useParams } from 'react-router-dom'
 import type { ICollectionMedia } from '../components/Collection'
+import { invalidateMaintainerrStatusDetails } from '../components/Common/MediaCard/maintainerrStatus'
 import MediaSelectionActions from '../components/Common/MediaSelectionActions'
 import type { MediaActionOutcome } from '../components/Common/MediaActionModal'
 import {
@@ -150,17 +151,25 @@ const CollectionMediaPage = () => {
 
   const handleBulkOutcome = ({
     action,
+    collectionId,
     succeededIds,
     failedIds,
+    failureReasons,
   }: MediaActionOutcome) => {
     applyBulkOutcome(new Set(failedIds))
 
-    // Only these drop the item from this collection.
-    if (
-      action === 'exclusion-add' ||
-      action === 'collection-remove' ||
-      action === 'collection-remove-all'
-    ) {
+    for (const mediaServerId of succeededIds) {
+      invalidateMaintainerrStatusDetails(mediaServerId)
+    }
+
+    // Removing and excluding both drop membership, but only from the collection
+    // they were aimed at: an undefined id means every collection, so it reaches
+    // this one too. Aimed elsewhere, this grid is unchanged.
+    const leavesThisCollection =
+      (action === 'exclusion-add' || action === 'collection-remove') &&
+      (collectionId === undefined || collectionId === collection.id)
+
+    if (leavesThisCollection) {
       for (const mediaServerId of succeededIds) {
         removeMediaItem(mediaServerId)
       }
@@ -169,7 +178,8 @@ const CollectionMediaPage = () => {
     reportBulkOutcome(
       succeededIds.length,
       failedIds.length,
-      bulkOutcomeVerb(action),
+      bulkOutcomeVerb({ action, collectionId }),
+      failureReasons,
     )
   }
 
@@ -187,13 +197,7 @@ const CollectionMediaPage = () => {
             selectedIds={selectedIds}
             items={data}
             libraryId={collection.libraryId}
-            lockedCollection={{
-              id: collection.id,
-              title: collection.title,
-              type: collection.type,
-            }}
-            // Everything here is already in this collection.
-            hiddenActions={['collection-add']}
+            defaultCollectionId={collection.id}
             onSubmitted={handleBulkOutcome}
           />
         }

--- a/apps/ui/src/utils/bulkOutcome.ts
+++ b/apps/ui/src/utils/bulkOutcome.ts
@@ -1,17 +1,29 @@
 import { toast } from 'react-toastify'
-import type { MediaAction } from '../components/Common/MediaActionModal'
+import type { MediaActionOutcome } from '../components/Common/MediaActionModal'
 
 export const formatItemCount = (count: number): string =>
   `${count} item${count === 1 ? '' : 's'}`
 
-export const bulkOutcomeVerb = (action: MediaAction): string =>
-  ({
+/** No collection id means the action covered every collection, so say which. */
+export const bulkOutcomeVerb = ({
+  action,
+  collectionId,
+}: Pick<MediaActionOutcome, 'action' | 'collectionId'>): string => {
+  const everyCollection = collectionId === undefined
+
+  return {
     'collection-add': 'added',
-    'collection-remove': 'removed',
-    'collection-remove-all': 'removed from every collection',
-    'exclusion-add': 'excluded',
+    'collection-remove': everyCollection
+      ? 'removed from every collection'
+      : 'removed',
+    'exclusion-add': everyCollection ? 'excluded everywhere' : 'excluded',
     'exclusion-remove': 'un-excluded',
-  })[action]
+  }[action]
+}
+
+/** The server prefixes its per-item messages; the count already says it failed. */
+const withoutFailedPrefix = (reason: string) =>
+  reason.startsWith('Failed - ') ? reason.slice('Failed - '.length) : reason
 
 /**
  * `verb` is the past participle of what was attempted, so every bulk action
@@ -21,10 +33,15 @@ export const reportBulkOutcome = (
   succeeded: number,
   failed: number,
   verb: string,
+  failureReasons: string[] = [],
 ): void => {
   if (failed > 0) {
+    const why = failureReasons.length
+      ? ` (${failureReasons.map(withoutFailedPrefix).join('; ')})`
+      : ''
+
     toast.error(
-      `${formatItemCount(succeeded)} ${verb}. ${formatItemCount(failed)} could not be ${verb}; the failed items stay selected.`,
+      `${formatItemCount(succeeded)} ${verb}. ${formatItemCount(failed)} could not be ${verb}${why}; the failed items stay selected.`,
     )
     return
   }


### PR DESCRIPTION
Closes #3448. Also covers the "add global exclusions from the collections page" request (features.maintainerr.info/posts/222).

Selecting a search result offered no way to add it to a collection, and a collection page could only ever scope an exclusion to itself. Both come down to the same modal being locked down in two different ways.

## What changed

| Area | Before | After |
| --- | --- | --- |
| Search selection | Collection actions dropped whenever the page had no library | Offered wherever a collection can take the item |
| Collection page | Picker pinned to that collection, one disabled option | Preselects that collection, still offers every collection and "All collections" |
| Action list | Differed per page via `hiddenActions` | Same four actions everywhere |
| Remove from all collections | Its own action | The "All collections" scope on "Remove from collection", which the other actions already had |
| Global exclusion | Wrote exclusion rows, changed no membership | Also drops the items from every collection, behind a confirmation that says so |
| Collection add | No library check; Plex answers 200 to a batch holding foreign ids and silently drops them, leaving a membership row for an add that never happened | Refused per item with `Failed - not in this collection's library` |
| Collection handler | Consulted no exclusion at all | Skips members an exclusion covers |
| Media status cache | Only the overview dropped the acted-on items | All three grids do |

## Scoping the picker without a page library

A search spans libraries, so the page passes none. What the picker does then depends on whether a collection is bound to one library:

- Jellyfin and Emby BoxSets are server-global, so every collection is a valid target and no library is needed. Their search payloads could not supply one anyway: Jellyfin returns no `ParentId`, and Emby's is the per-title folder rather than the library, so the real one costs an `/Items/{id}/Ancestors` call per item.
- A Plex collection lives in one library section. Plex already sends `librarySectionID` on both `/search` and `/library/metadata/{id}`; the mapper was dropping it. Reading it lets the picker offer exactly the collections the item can go into, at no extra request.

## Why the global exclusion now clears membership

A rule run only reconciles membership for rule-owned members: `rule-executor.service.ts` re-adds every manually added member to the desired set *after* the exclusion filter, so a manual member was never removed by any run. The handler never read the exclusion table, and on defaults it fires at 00:00/12:00 against rule runs at 00:00/08:00/16:00. A user could exclude a title to protect it and have it deleted at the next handler run.

## Notes

- No schema change and no migration. `CollectionWorkerService` gained two repositories, both already registered in `collections.module.ts`.
- Existence still decides through `itemExists`, the only read that separates "gone" from "could not ask". The library check is a second read that cannot refuse on its own, so a Plex blip never blocks a valid add.

## Verified

Real Plex, Jellyfin and Emby dev servers, with Plex and Emby driven from an isolated second instance so the primary stack was untouched.

- Jellyfin: search hit added to a cross-library collection, confirmed in the database and in the real BoxSet. Global exclusion on a manual member cleared its row. Handler run with the exclusion queued 0 items, without it queued 1 and ran.
- Plex: search hits now carry their library. Same-library add succeeds, cross-library is refused, and a mixed batch reports each foreign id instead of creating phantom rows; the database and the real Plex collection agree.
- Emby: cross-library add allowed and present in the real BoxSet; global exclusion cascaded and cleared membership.
- Fault-injected Plex (metadata reads 500): the add still succeeds, and the same request against the pre-fix build returned `Failed - not found on the media server`.
