### PR TITLE
feat(notifications): include type, title and provider ids in webhook media items

### DIFF
--- a/apps/server/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/server/src/modules/notifications/notifications.service.spec.ts
@@ -233,6 +233,47 @@ describe('NotificationService', () => {
     });
   });
 
+  describe('media identity on the wire', () => {
+    it('puts type, title and provider ids on the wire when the snapshot resolved', async () => {
+      const { service } = createService();
+      const sendNotification = jest
+        .spyOn(service, 'sendNotification')
+        .mockResolvedValue(undefined);
+
+      await service.handleNotification(
+        NotificationType.MEDIA_ABOUT_TO_BE_HANDLED,
+        [
+          {
+            mediaServerId: '1',
+            metadata: {
+              title: 'A Sample Movie',
+              type: 'movie',
+              providerIds: { imdb: ['tt0111161'], tmdb: ['278'], tvdb: [] },
+            } as any,
+          },
+          { mediaServerId: '2' },
+        ],
+        undefined,
+        3,
+      );
+
+      const payload = sendNotification.mock.calls[0][1];
+      const mediaItems = JSON.parse(
+        payload.extra!.find((e) => e.name === 'mediaItems')!.value,
+      );
+
+      expect(mediaItems).toEqual([
+        {
+          mediaServerId: '1',
+          type: 'movie',
+          title: 'A Sample Movie',
+          providerIds: { imdb: ['tt0111161'], tmdb: ['278'], tvdb: [] },
+        },
+        { mediaServerId: '2' },
+      ]);
+    });
+  });
+
   describe('media handled title snapshot (#3249)', () => {
     it('renders the pre-resolved title without a live lookup when the item is gone', async () => {
       // A delete action removes the item from the media server, so a live

--- a/apps/server/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/server/src/modules/notifications/notifications.service.spec.ts
@@ -1,6 +1,6 @@
 import { MaintainerrEvent } from '@maintainerr/contracts';
 import { ServiceUnavailableException } from '@nestjs/common';
-import { createMockLogger } from '../../../test/utils/data';
+import { createMediaItem, createMockLogger } from '../../../test/utils/data';
 import {
   CollectionMediaAddedDto,
   CollectionMediaRemovedDto,
@@ -204,37 +204,10 @@ describe('NotificationService', () => {
       expect(content).toContain('(requested by alice)');
       expect(content).not.toContain('{requested_by}');
     });
-
-    it('puts the requester on the wire for external approval workflows', async () => {
-      const { service } = createService();
-      const sendNotification = jest
-        .spyOn(service, 'sendNotification')
-        .mockResolvedValue(undefined);
-
-      await service.handleNotification(
-        NotificationType.MEDIA_ABOUT_TO_BE_HANDLED,
-        [
-          { mediaServerId: '1', requestedBy: ['alice'] },
-          { mediaServerId: '2' },
-        ],
-        undefined,
-        3,
-      );
-
-      const payload = sendNotification.mock.calls[0][1];
-      const mediaItems = JSON.parse(
-        payload.extra!.find((e) => e.name === 'mediaItems')!.value,
-      );
-
-      expect(mediaItems).toEqual([
-        { mediaServerId: '1', requestedBy: ['alice'] },
-        { mediaServerId: '2' },
-      ]);
-    });
   });
 
-  describe('media identity on the wire', () => {
-    it('puts type, title and provider ids on the wire when the snapshot resolved', async () => {
+  describe('media items on the wire', () => {
+    it('carries the identity an external workflow needs, and nothing else', async () => {
       const { service } = createService();
       const sendNotification = jest
         .spyOn(service, 'sendNotification')
@@ -245,11 +218,12 @@ describe('NotificationService', () => {
         [
           {
             mediaServerId: '1',
-            metadata: {
+            metadata: createMediaItem({
               title: 'A Sample Movie',
               type: 'movie',
               providerIds: { imdb: ['tt0111161'], tmdb: ['278'], tvdb: [] },
-            } as any,
+            }),
+            requestedBy: ['alice'],
           },
           { mediaServerId: '2' },
         ],
@@ -268,9 +242,80 @@ describe('NotificationService', () => {
           type: 'movie',
           title: 'A Sample Movie',
           providerIds: { imdb: ['tt0111161'], tmdb: ['278'], tvdb: [] },
+          requestedBy: ['alice'],
         },
         { mediaServerId: '2' },
       ]);
+    });
+
+    it('titles an item on the wire exactly as the message does', async () => {
+      const { service } = createService();
+      const sendNotification = jest
+        .spyOn(service, 'sendNotification')
+        .mockResolvedValue(undefined);
+
+      await service.handleNotification(
+        NotificationType.MEDIA_HANDLED,
+        [
+          {
+            mediaServerId: '1',
+            metadata: createMediaItem({
+              type: 'season',
+              parentTitle: 'Sample Series',
+              title: 'Season 1',
+              index: 1,
+            }),
+          },
+          // Jellyfin files an unnumbered season under "Season Unknown"; naming
+          // it beats rendering "season undefined".
+          {
+            mediaServerId: '2',
+            metadata: createMediaItem({
+              type: 'season',
+              parentTitle: 'Sample Series',
+              title: 'Season Unknown',
+              index: undefined,
+            }),
+          },
+          {
+            mediaServerId: '3',
+            metadata: createMediaItem({
+              type: 'episode',
+              grandparentTitle: 'Sample Series',
+              title: 'A Sample Episode',
+              index: undefined,
+              parentIndex: undefined,
+            }),
+          },
+          // A sports library names the episode after the show already.
+          {
+            mediaServerId: '4',
+            metadata: createMediaItem({
+              type: 'episode',
+              grandparentTitle: 'Sample Series',
+              title: 'Sample Series - S2026E01 - A Sample Event',
+              index: undefined,
+              parentIndex: undefined,
+            }),
+          },
+        ],
+        'A Sample Collection',
+      );
+
+      const payload = sendNotification.mock.calls[0][1];
+      const mediaItems: { title: string }[] = JSON.parse(
+        payload.extra!.find((e) => e.name === 'mediaItems')!.value,
+      );
+
+      expect(mediaItems.map((item) => item.title)).toEqual([
+        'Sample Series - season 1',
+        'Sample Series - Season Unknown',
+        'Sample Series - A Sample Episode',
+        'Sample Series - S2026E01 - A Sample Event',
+      ]);
+      for (const { title } of mediaItems) {
+        expect(payload.message).toContain(`* ${title}`);
+      }
     });
   });
 

--- a/apps/server/src/modules/notifications/notifications.service.ts
+++ b/apps/server/src/modules/notifications/notifications.service.ts
@@ -744,17 +744,21 @@ export class NotificationService implements OnModuleInit {
     payload.extra.push({ name: 'dayAmount', value: dayAmount?.toString() });
     payload.extra.push({
       name: 'mediaItems',
-      // Keep the wire shape lean; the metadata snapshot stays internal except
-      // what an external workflow needs: `requestedBy` to know who to ask
-      // before deletion, and `type`/`title`/`providerIds` to still identify
-      // the item after deletion invalidates its media server id.
+      // The identity an external workflow needs, and nothing else from the
+      // snapshot: `requestedBy` to know who to ask before deletion, and
+      // `type`/`title`/`providerIds` to still identify the item once deletion
+      // has invalidated its media server id. `title` is the message's own
+      // rendering, so both name the item the same way. `providerIds` are the
+      // item's own: a season or episode carries season/episode-scoped ids (a
+      // TVDB season id, not the series one), so a consumer keying a show-level
+      // list off them has to resolve the series itself.
       value: JSON.stringify(
         mediaItems?.map((item) => ({
           mediaServerId: item.mediaServerId,
           ...(item.metadata
             ? {
                 type: item.metadata.type,
-                title: item.metadata.title,
+                title: this.getTitle(item.metadata),
                 providerIds: item.metadata.providerIds,
               }
             : {}),
@@ -1070,12 +1074,26 @@ export class NotificationService implements OnModuleInit {
     // "undefined - season undefined".
     switch (item.type) {
       case 'episode':
-        return `${item.grandparentTitle} - season ${item.parentIndex} - episode ${item.index}`;
+        return item.parentIndex != null && item.index != null
+          ? `${item.grandparentTitle} - season ${item.parentIndex} - episode ${item.index}`
+          : this.underShow(item.grandparentTitle, item.title);
       case 'season':
-        return `${item.parentTitle} - season ${item.index}`;
+        return item.index != null
+          ? `${item.parentTitle} - season ${item.index}`
+          : this.underShow(item.parentTitle, item.title);
       default:
         return item.title;
     }
+  }
+
+  /**
+   * A library can leave the season/episode number unset - Jellyfin files those
+   * under a "Season Unknown" container - so name the item itself rather than
+   * render "season undefined". A sports or PVR library tends to name the
+   * episode after the show already, so don't repeat the show in that case.
+   */
+  private underShow(show: string | undefined, title: string): string {
+    return show && !title.startsWith(show) ? `${show} - ${title}` : title;
   }
 
   // OnEvent handlers

--- a/apps/server/src/modules/notifications/notifications.service.ts
+++ b/apps/server/src/modules/notifications/notifications.service.ts
@@ -744,12 +744,20 @@ export class NotificationService implements OnModuleInit {
     payload.extra.push({ name: 'dayAmount', value: dayAmount?.toString() });
     payload.extra.push({
       name: 'mediaItems',
-      // Keep the wire shape lean; the metadata snapshot is only for internal
-      // title rendering. `requestedBy` is the exception: an external workflow
-      // needs it to know who to ask before the item is deleted.
+      // Keep the wire shape lean; the metadata snapshot stays internal except
+      // what an external workflow needs: `requestedBy` to know who to ask
+      // before deletion, and `type`/`title`/`providerIds` to still identify
+      // the item after deletion invalidates its media server id.
       value: JSON.stringify(
         mediaItems?.map((item) => ({
           mediaServerId: item.mediaServerId,
+          ...(item.metadata
+            ? {
+                type: item.metadata.type,
+                title: item.metadata.title,
+                providerIds: item.metadata.providerIds,
+              }
+            : {}),
           ...(item.requestedBy?.length
             ? { requestedBy: item.requestedBy }
             : {}),


### PR DESCRIPTION
### Description & Design

The webhook's `mediaItems` carries only the `mediaServerId`. For *Media Handled* events that id points at something that was removed and thus downstream external tools have no way to reliably validate what was just actioned. 

**EDIT** - for context: I maintain Pulsarr and having it play nicely with Maintainerr is a frequently requested feature. The current problem is that if users never prune their watchlists, and then a Maintainerr rule actions those items, without them being added to Pulsarr's exclusions list, they would be re-added. If the webhook payload contained `providerIds` and `type`, they could be matched and added to the exclusions list automatically. 

It would be helpful if some of the metadata snapshot was also included in the payload, since it's already fully available at the call site:

`type` - needed for provider id collisions between types
`title` - currently exists only inside the `message` but would be helpful
`providerIds` - `{ imdb: string[], tmdb: string[], tvdb: string[] }` which are already existing, normalized from the mappers

The snapshot is best-effort, so the new fields appear only when it resolved. Failed lookup falls back to the current bare shape, and events that never carry metadata (added/removed/failed/overlay) are unchanged. 

An edge case: unmatched/personal media resolves with empty provider id arrays, so consumers need to handle `{ imdb: [], tmdb: [], tvdb: [] }`.

If this PR is accepted, I will submit a follow-up to add the updated payload to the docs. 

### Related issue

NA

### AI-Assisted Development

I used Claude to investigate, sanity check, write the test, and ensure everything matched the codebase conventions exactly. I reviewed and tested everything myself, including capturing the real payload from a live setup to confirm the shape. 

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I understand the code I am submitting and can explain how it works
- [x] I have performed a self-review of my code
- [x] I have linted and formatted my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

### How to test

1. `cd apps/server && yarn test` - suite is green, including the new spec case
2. Live: subscribed a webhook agent to Media Handled and let a rule group handle a single movie. The received `mediaItems` carry `type`, `title` and `providerIds`; Media Added/Removed payloads are unchanged.

### Additional context

Captured from a live run (Plex + Radarr, unmonitor action):

```json
{
  "notification_type": "MEDIA_HANDLED",
  "collectionName": "test-collection",
  "mediaItems": "[{\"mediaServerId\":\"116021\",\"type\":\"movie\",\"title\":\"The Rain People\",\"providerIds\":{\"imdb\":[\"tt0064873\"],\"tmdb\":[\"59231\"],\"tvdb\":[\"69565\"]}}]"
}
```