### PR TITLE
fix(calendar): name the season that is scheduled to leave

### DIFF
--- a/apps/ui/src/api/calendar.ts
+++ b/apps/ui/src/api/calendar.ts
@@ -233,6 +233,16 @@ const getMediaTitle = (media: ICollectionMedia) => {
     return media.mediaServerId
   }
 
+  if (mediaData.type === 'season') {
+    const showTitle = mediaData.grandparentTitle || mediaData.parentTitle || ''
+    // A library can leave the number unset - Jellyfin files those under a
+    // "Season Unknown" container - so name the season itself instead.
+    const season =
+      mediaData.index != null ? `S${pad2(mediaData.index)}` : mediaData.title
+
+    return [showTitle, season].filter(Boolean).join(' - ')
+  }
+
   if (mediaData.type === 'episode') {
     const showTitle = mediaData.grandparentTitle || mediaData.parentTitle || ''
     const seasonEpisode =


### PR DESCRIPTION
Fixes #3470

The calendar's scheduled-items modal special-cased episodes only. A season fell through to the generic branch, which prefers `grandparentTitle` / `parentTitle` (the show), so every season row read as its show name and several seasons of one show were indistinguishable.

Seasons are now named under their show the same way episode rows are.

| Item | Before | After |
| --- | --- | --- |
| Season 2 of a show | `Sample Series` | `Sample Series - S02` |
| Unnumbered season (Jellyfin/Emby "Season Unknown") | `Sample Series` | `Sample Series - Season Unknown` |

Movies, shows and episodes are untouched.

Verified against real Plex, Jellyfin and Emby servers.
