### PR TITLE
refactor(tracearr): read a show's episodes through the shared descendant walk

### DIFF
--- a/apps/server/src/modules/api/media-server/context-action.util.spec.ts
+++ b/apps/server/src/modules/api/media-server/context-action.util.spec.ts
@@ -1,5 +1,45 @@
 import { MediaItem, MediaItemType } from '@maintainerr/contracts';
-import { resolveContextActionIds } from './context-action.util';
+import {
+  resolveContextActionIds,
+  resolveDescendants,
+  SEASON_READ_CONCURRENCY,
+} from './context-action.util';
+
+describe('resolveDescendants', () => {
+  // More seasons than one batch holds, so the order across batches and the
+  // in-flight cap are both exercised.
+  const seasonCount = SEASON_READ_CONCURRENCY + 2;
+
+  it('keeps depth-first order while capping the season reads in flight', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const getChildren = async (parentId: string, type: MediaItemType) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setImmediate(resolve));
+      inFlight--;
+      return type === 'season'
+        ? Array.from(
+            { length: seasonCount },
+            (_, index) => ({ id: `s${index}` }) as MediaItem,
+          )
+        : [{ id: `${parentId}e` } as MediaItem];
+    };
+
+    const descendants = await resolveDescendants(
+      { type: 'show', id: 'series' },
+      getChildren,
+    );
+
+    expect(descendants.map((item) => item.id)).toEqual(
+      Array.from({ length: seasonCount }, (_, index) => [
+        `s${index}`,
+        `s${index}e`,
+      ]).flat(),
+    );
+    expect(maxInFlight).toBe(SEASON_READ_CONCURRENCY);
+  });
+});
 
 describe('resolveContextActionIds', () => {
   // show 'series' -> season 's1' -> episodes 'e1','e2'

--- a/apps/server/src/modules/api/media-server/context-action.util.ts
+++ b/apps/server/src/modules/api/media-server/context-action.util.ts
@@ -1,4 +1,10 @@
 import { MediaItem, MediaItemType } from '@maintainerr/contracts';
+import { chunk } from 'lodash';
+
+// Seasons are read a few at a time. One read per season would cost a
+// long-running show a round trip per season on the rule-evaluation path, while
+// an unbounded fan-out multiplies with the evaluator's own concurrency.
+export const SEASON_READ_CONCURRENCY = 5;
 
 /**
  * Every descendant of an item, depth first: a show's seasons and their
@@ -11,9 +17,15 @@ export const resolveDescendants = async (
   if (item.type === 'season') return getChildren(item.id, 'episode');
   if (item.type !== 'show') return [];
 
+  const seasons = await getChildren(item.id, 'season');
   const descendants: MediaItem[] = [];
-  for (const season of await getChildren(item.id, 'season')) {
-    descendants.push(season, ...(await getChildren(season.id, 'episode')));
+  for (const batch of chunk(seasons, SEASON_READ_CONCURRENCY)) {
+    const episodes = await Promise.all(
+      batch.map((season) => getChildren(season.id, 'episode')),
+    );
+    batch.forEach((season, index) =>
+      descendants.push(season, ...episodes[index]),
+    );
   }
   return descendants;
 };

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.spec.ts
@@ -425,8 +425,8 @@ describe('TracearrApiService', () => {
         .mockResolvedValue([{ id: 'account-1', name: 'alice' }]),
       getChildrenMetadata: jest
         .fn()
-        .mockResolvedValueOnce([{ id: 'season-1' }])
-        .mockResolvedValueOnce([{ id: 'episode-1' }]),
+        .mockResolvedValueOnce([{ id: 'season-1', type: 'season' }])
+        .mockResolvedValueOnce([{ id: 'episode-1', type: 'episode' }]),
     };
     mediaServerFactory.getService.mockResolvedValue(mediaServer as never);
     const show = { id: 'show-1', type: 'show' } as never;

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -12,6 +12,7 @@ import {
 } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import { SettingsDataService } from '../../settings/settings-data.service';
+import { resolveDescendants } from '../media-server/context-action.util';
 import { MediaServerFactory } from '../media-server/media-server.factory';
 import {
   CONNECTION_TEST_TIMEOUT_MS,
@@ -80,7 +81,7 @@ export class TracearrApiService {
   api: TracearrApi | undefined;
   private activeHistoryIndex: TracearrHistoryIndex | undefined;
   private activeUsernamesByTracearrUserId: Map<string, string[]> | undefined;
-  private episodeIdsByItemId = new Map<string, Promise<string[] | undefined>>();
+  private episodeIdsByItemId = new Map<string, Promise<string[]>>();
   private resolvedServerId: string | undefined;
   private historyGeneration = 0;
   private sweepPromise: Promise<void> | undefined;
@@ -807,33 +808,14 @@ export class TracearrApiService {
     }
   }
 
-  private async fetchEpisodeIds(
-    libItem: MediaItem,
-  ): Promise<string[] | undefined> {
+  /** Every episode under a show or season; callers guarantee the type. */
+  private async fetchEpisodeIds(libItem: MediaItem): Promise<string[]> {
     const mediaServer = await this.mediaServerFactory.getService();
-
-    if (libItem.type === 'season') {
-      const episodes = await mediaServer.getChildrenMetadata(
-        libItem.id,
-        'episode',
-        true,
-      );
-      return episodes.map((item) => item.id);
-    }
-    if (libItem.type !== 'show') {
-      return undefined;
-    }
-
-    const seasons = await mediaServer.getChildrenMetadata(
-      libItem.id,
-      'season',
-      true,
+    const descendants = await resolveDescendants(libItem, (parentId, type) =>
+      mediaServer.getChildrenMetadata(parentId, type, true),
     );
-    const episodeLists = await Promise.all(
-      seasons.map((season) =>
-        mediaServer.getChildrenMetadata(season.id, 'episode', true),
-      ),
-    );
-    return episodeLists.flatMap((episodes) => episodes.map((item) => item.id));
+    return descendants
+      .filter((item) => item.type === 'episode')
+      .map((item) => item.id);
   }
 }


### PR DESCRIPTION
Stacked on #3471, which is where `resolveDescendants` lives. Follow-up 1 of the notes taken while building that PR: Tracearr held a third copy of the show -> season -> episode walk.

`TracearrApiService.fetchEpisodeIds` now calls `resolveDescendants` and keeps only the episodes. It is the only caller that needs ids rather than items, and the only one on a per-item rule-evaluation path.

`resolveDescendants` reads a show's seasons in bounded batches instead of one at a time, so the shared walk can carry that path without giving up the parallelism Tracearr had.

| 20 seasons, 100 ms per read | wall clock | peak reads in flight |
|---|---|---|
| unbounded (Tracearr before) | 232 ms | 20 |
| one season at a time | 2135 ms | 1 |
| batches of 5 (this PR) | 513 ms | 5 |

At three seasons all three are within noise.

Peak concurrent child reads per caller, since the bound cuts both ways:

| caller | before | after |
|---|---|---|
| Tracearr, during a rule run (8 items wide) | 8 x seasons, unbounded | 40 |
| bulk exclusion (5 items wide) | 5 | 25 |
| global exclusion, overlay inheritance | 1 | 5 |

The one that was unbounded is the one that ran over a whole library; the two that go up are bounded user actions.

| | |
|---|---|
| Episode ids returned | Unchanged on Plex, Jellyfin and Emby, for every show and every season in the dev libraries |
| Order | Depth first, unchanged |
| Non show/season | `getEpisodeIds` still answers `undefined`; `fetchEpisodeIds` no longer has to |