### PR TITLE
refactor(overlays): derive the template mode from one shared helper

### DIFF
--- a/apps/server/src/modules/overlays/overlay-processor.service.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.ts
@@ -4,6 +4,7 @@ import {
   MediaItemType,
   OverlayProcessorRunResult,
   OverlayResult,
+  overlayModeForType,
   OverlayTemplate,
   OverlayTemplateMode,
   ServarrAction,
@@ -115,14 +116,10 @@ export class OverlayProcessorService {
     return Math.max(0, Math.ceil(diff / (1000 * 60 * 60 * 24)));
   }
 
-  private overlayMode(type: MediaItemType): OverlayTemplateMode {
-    return type === 'episode' ? 'titlecard' : 'poster';
-  }
-
   private getMemberTargets(
     collection: Collection & { collectionMedia: CollectionMedia[] },
   ): OverlayTarget[] {
-    const mode = this.overlayMode(collection.type);
+    const mode = overlayModeForType(collection.type);
     const targets: OverlayTarget[] = [];
     for (const media of collection.collectionMedia) {
       const deleteDate = this.getDeleteDate(
@@ -257,7 +254,7 @@ export class OverlayProcessorService {
       targets.set(item.id, {
         itemId: item.id,
         deleteDate,
-        mode: this.overlayMode(item.type),
+        mode: overlayModeForType(item.type),
       });
     };
 
@@ -553,8 +550,7 @@ export class OverlayProcessorService {
       return result;
     }
 
-    // Auto-detect title card vs poster based on collection type
-    const mode = this.overlayMode(collection.type);
+    const mode = overlayModeForType(collection.type);
 
     // Resolve the template: collection override → default for mode → null
     const template = await this.templateService.resolveForCollection(

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -15,6 +15,7 @@ import {
   MediaItemType,
   MediaLibrary,
   MediaServerFeature,
+  overlayModeForType,
   OverlayTemplate,
   parseCollectionSortKey,
   ServarrAction,
@@ -642,8 +643,11 @@ const AddModal = (props: AddModal) => {
   const [pendingDisableSubmit, setPendingDisableSubmit] =
     useState<RuleGroupFormOutput | null>(null)
 
-  const overlayTemplateMode =
-    selectedType === 'episode' ? 'titlecard' : 'poster'
+  const overlayTemplateMode = isValidMediaItemType(selectedType)
+    ? overlayModeForType(selectedType)
+    : 'poster'
+  const overlayTemplateModeLabel =
+    overlayTemplateMode === 'titlecard' ? 'title card' : 'poster'
   const availableOverlayTemplates = overlayTemplates.filter(
     (template) => template.mode === overlayTemplateMode,
   )
@@ -1539,10 +1543,7 @@ const AddModal = (props: AddModal) => {
                           Overlay template
                           <p className="text-xs font-normal">
                             Leave unset to use the default{' '}
-                            {overlayTemplateMode === 'titlecard'
-                              ? 'title card'
-                              : 'poster'}{' '}
-                            template
+                            {overlayTemplateModeLabel} template
                           </p>
                         </label>
                         <div className="form-input">
@@ -1562,7 +1563,7 @@ const AddModal = (props: AddModal) => {
                                   }}
                                 >
                                   <option value="">
-                                    Default {overlayTemplateMode} template
+                                    Default {overlayTemplateModeLabel} template
                                   </option>
                                   {availableOverlayTemplates.map((template) => (
                                     <option

--- a/packages/contracts/src/overlays/overlay-template.ts
+++ b/packages/contracts/src/overlays/overlay-template.ts
@@ -1,10 +1,19 @@
 import z from 'zod'
+import type { MediaItemType } from '../media-server/enums'
 import { overlayElementSchema, type OverlayElement } from './overlay-element'
 
 // ── Template mode ─────────────────────────────────────────────────────────
 
 export const overlayTemplateModeValues = ['poster', 'titlecard'] as const
 export type OverlayTemplateMode = (typeof overlayTemplateModeValues)[number]
+
+/**
+ * Which artwork an overlay is drawn on. An episode has a title card, every
+ * other kind of item has a poster. Shared so the rule form cannot offer a
+ * template the overlay run would not use.
+ */
+export const overlayModeForType = (type: MediaItemType): OverlayTemplateMode =>
+  type === 'episode' ? 'titlecard' : 'poster'
 
 // ── Canvas dimension defaults ─────────────────────────────────────────────
 


### PR DESCRIPTION
Stacked on #3471. Follow-up 2 of the notes taken while building that PR.

"episode -> title card, everything else -> poster" was written out twice, in two packages:

| where | decided |
|---|---|
| `OverlayProcessorService` | which template the run actually draws |
| rule form `AddModal` | which templates the picker offers |

They agreed, but nothing kept them agreeing, and a drift means the form offers a template the run will not use - the shape of the confusion behind #3455.

`overlayModeForType` now lives in `@maintainerr/contracts` beside `OverlayTemplateMode`, and both sides call it. On this branch that also absorbs the private `overlayMode` helper and its inherited-item call site.

The picker's placeholder printed the raw mode - "Default titlecard template", one line under help text saying "title card". Both now read from one label.

The `otherMode` flip a few lines below is left alone: it maps mode to mode, not type to mode, and is exhaustive over a two-value union.

| | |
|---|---|
| Rule form | episode offers title card templates, movie / show / season offer poster templates |
| Overlay run | episode collection drew with "Title Card Pill" (titlecard), movie collection with "Classic Pill" (poster) |