### PR TITLE
fix(overlays): say which media each template mode is drawn on

### DIFF
--- a/apps/ui/src/pages/OverlayTemplateEditorPage.tsx
+++ b/apps/ui/src/pages/OverlayTemplateEditorPage.tsx
@@ -464,21 +464,22 @@ const OverlayTemplateEditor = ({ routeId }: { routeId: string }) => {
                   placeholder="Template Name"
                 />
               </div>
-              {isNew && (
-                <div className="w-36">
-                  <Select
-                    name="template-mode"
-                    value={mode}
-                    disabled={isLoading}
-                    onChange={(e) =>
-                      setMode(e.target.value as OverlayTemplateMode)
-                    }
-                  >
-                    <option value="poster">Poster</option>
-                    <option value="titlecard">Title Card</option>
-                  </Select>
-                </div>
-              )}
+              {/* Fixed once created, but still shown: two templates can share
+                  a name across modes, and nothing else on this page says
+                  which artwork is being designed. */}
+              <div className="w-36">
+                <Select
+                  name="template-mode"
+                  value={mode}
+                  disabled={isLoading || !isNew}
+                  onChange={(e) =>
+                    setMode(e.target.value as OverlayTemplateMode)
+                  }
+                >
+                  <option value="poster">Poster</option>
+                  <option value="titlecard">Title Card</option>
+                </Select>
+              </div>
               <div className="flex w-56 items-center gap-2">
                 <Select
                   name="background-section"

--- a/apps/ui/src/pages/OverlayTemplateListPage.spec.tsx
+++ b/apps/ui/src/pages/OverlayTemplateListPage.spec.tsx
@@ -1,3 +1,4 @@
+import type { OverlayTemplate } from '@maintainerr/contracts'
 import { render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import OverlayTemplateListPage from './OverlayTemplateListPage'
@@ -39,5 +40,38 @@ describe('OverlayTemplateListPage', () => {
       screen.getByRole('heading', { name: 'Overlay Templates' }),
     ).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Import' })).toBeTruthy()
+  })
+
+  // Two templates can share a name across modes, and a title card default is
+  // inert until something draws on an episode. Both sections say who they are
+  // for, next to the star that sets their default (#3455, #2770).
+  it('says which media each mode is drawn on', async () => {
+    const template = (
+      id: number,
+      mode: OverlayTemplate['mode'],
+    ): OverlayTemplate => ({
+      id,
+      name: 'Leave Soon',
+      description: '',
+      mode,
+      canvasWidth: 1000,
+      canvasHeight: 1500,
+      elements: [],
+      isDefault: false,
+      isPreset: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    getOverlayTemplates.mockResolvedValue([
+      template(1, 'poster'),
+      template(2, 'titlecard'),
+    ])
+
+    render(<OverlayTemplateListPage />)
+
+    expect(
+      await screen.findByText('Drawn on movies, shows and seasons.'),
+    ).toBeTruthy()
+    expect(screen.getByText('Drawn on episodes.')).toBeTruthy()
   })
 })

--- a/apps/ui/src/pages/OverlayTemplateListPage.tsx
+++ b/apps/ui/src/pages/OverlayTemplateListPage.tsx
@@ -299,17 +299,17 @@ function TemplateCard({
 }) {
   return (
     <div className="rounded-lg border border-zinc-700 bg-zinc-800 p-4 transition hover:border-zinc-500">
-      <div className="mb-2 flex items-start justify-between">
+      <div className="mb-2 flex items-start justify-between gap-2">
         <div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <span className="font-medium text-zinc-100">{t.name}</span>
             {t.isDefault && (
-              <span className="rounded-sm bg-amber-600 px-1.5 py-0.5 text-xs text-white">
+              <span className="rounded-sm bg-amber-600 px-1.5 py-0.5 text-xs whitespace-nowrap text-white">
                 Default
               </span>
             )}
             {t.isPreset && (
-              <span className="rounded-sm bg-zinc-600/50 px-1.5 py-0.5 text-xs text-zinc-400">
+              <span className="rounded-sm bg-zinc-600/50 px-1.5 py-0.5 text-xs whitespace-nowrap text-zinc-400">
                 Preset
               </span>
             )}
@@ -318,7 +318,7 @@ function TemplateCard({
             <p className="mt-0.5 text-xs text-zinc-400">{t.description}</p>
           )}
         </div>
-        <span className="rounded-sm bg-zinc-700 px-1.5 py-0.5 text-xs text-zinc-300">
+        <span className="shrink-0 rounded-sm bg-zinc-700 px-1.5 py-0.5 text-xs whitespace-nowrap text-zinc-300">
           {t.elements.length} element{t.elements.length !== 1 ? 's' : ''}
         </span>
       </div>

--- a/apps/ui/src/pages/OverlayTemplateListPage.tsx
+++ b/apps/ui/src/pages/OverlayTemplateListPage.tsx
@@ -95,7 +95,11 @@ const OverlayTemplateListPage = () => {
   const handleSetDefault = async (id: number) => {
     const result = await setDefaultOverlayTemplate(id)
     if (result) {
-      showSuccess(`"${result.name}" set as default for ${result.mode}`)
+      showSuccess(
+        `"${result.name}" set as the default ${
+          result.mode === 'titlecard' ? 'title card' : 'poster'
+        } template`,
+      )
       void fetchTemplates()
     } else {
       showError('Failed to set default template')
@@ -146,7 +150,8 @@ const OverlayTemplateListPage = () => {
         <div className="section h-full w-full">
           <h3 className="heading">Overlay Templates</h3>
           <p className="description">
-            Manage the templates used by overlay-enabled collections.
+            Manage the templates used by overlay-enabled collections. Each mode
+            keeps its own default.
           </p>
         </div>
 
@@ -181,6 +186,7 @@ const OverlayTemplateListPage = () => {
             {/* Poster templates */}
             <TemplateSection
               title="Poster Templates"
+              description="Drawn on movies, shows and seasons."
               templates={posterTemplates}
               onEdit={handleEdit}
               onDuplicate={handleDuplicate}
@@ -192,6 +198,7 @@ const OverlayTemplateListPage = () => {
             {/* Title card templates */}
             <TemplateSection
               title="Title Card Templates"
+              description="Drawn on episodes."
               templates={titleCardTemplates}
               onEdit={handleEdit}
               onDuplicate={handleDuplicate}
@@ -233,6 +240,7 @@ const OverlayTemplateListPage = () => {
 
 function TemplateSection({
   title,
+  description,
   templates,
   onEdit,
   onDuplicate,
@@ -241,6 +249,7 @@ function TemplateSection({
   onExport,
 }: {
   title: string
+  description: string
   templates: OverlayTemplate[]
   onEdit: (id: number) => void
   onDuplicate: (id: number) => void
@@ -252,9 +261,10 @@ function TemplateSection({
 
   return (
     <div className="mb-8">
-      <h3 className="mb-3 text-sm font-medium tracking-wider text-zinc-400 uppercase">
+      <h3 className="text-sm font-medium tracking-wider text-zinc-400 uppercase">
         {title}
       </h3>
+      <p className="mb-3 text-xs text-zinc-500">{description}</p>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {templates.map((t) => (
           <TemplateCard


### PR DESCRIPTION
From the #3455 triage. Overlay templates come in two modes and nothing in the UI said what either is for, so a title card default could be set and then quietly never consulted. #2770 is the same gap filed as a bug: two "Default" badges, one per mode, read as duplicates.

| where | before | after |
|---|---|---|
| Template list sections | "Poster Templates" / "Title Card Templates" | plus "Drawn on movies, shows and seasons." / "Drawn on episodes.", right above the star that sets that mode's default |
| Template list page | "Manage the templates used by overlay-enabled collections." | plus "Each mode keeps its own default." |
| Template editor | mode shown only while creating, so two templates sharing a name across modes opened to identical pages | mode always shown, disabled once created |
| Set-default message | `"X" set as default for titlecard` | `"X" set as the default title card template` |

Wording holds if #3471 lands: it says what a mode is drawn on, not which collection types reach it.

No behaviour change. The editor never sent `mode` on update, so showing it disabled cannot alter a save; a preset fork still keeps the preset's mode.

The matching wording fix in the rule form's template picker rides with #3474, which already rewrites that expression.