### PR TITLE
perf(docker): keep the production dependency prune off the build path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:26.3.0-alpine3.22@sha256:c7932b9e5e337b0e733d6e16abc1b0e104759e8b05e59ed56586cce967d26dfe AS base
 LABEL Description="Contains the Maintainerr Docker image"
 
-FROM base AS builder
+# Dependency install. Only the manifests reach this stage, so the layer holds
+# for as long as the lockfile does.
+FROM base AS deps
 
 WORKDIR /app
 
@@ -29,6 +31,22 @@ COPY packages/contracts/package.json ./packages/contracts/package.json
 
 RUN yarn install --network-timeout 99999999
 
+# The tree the runtime image ships. Pruning the dev dependencies changes the
+# dependency tree, which makes yarn rebuild better-sqlite3 and node-canvas, so
+# this keeps its own branch off `deps`: it is now keyed on the lockfile rather
+# than redone on every commit, which is what happened while it sat after the
+# `COPY . .` below.
+FROM deps AS proddeps
+
+# Only install production dependencies to reduce image size
+RUN yarn workspaces focus --all --production
+
+# When all packages are hoisted, there is no node_modules folder. Ensure these folders always have a node_modules folder to COPY later on.
+RUN mkdir -p ./packages/contracts/node_modules
+RUN mkdir -p ./apps/server/node_modules
+
+FROM deps AS builder
+
 # Copy the rest of the repository after deps are installed
 COPY . .
 
@@ -37,13 +55,6 @@ VITE_BASE_PATH=/__PATH_PREFIX__
 EOF
 
 RUN yarn turbo build
-
-# Only install production dependencies to reduce image size
-RUN yarn workspaces focus --all --production
-
-# When all packages are hoisted, there is no node_modules folder. Ensure these folders always have a node_modules folder to COPY later on.
-RUN mkdir -p ./packages/contracts/node_modules
-RUN mkdir -p ./apps/server/node_modules
 
 FROM base AS runner
 
@@ -54,12 +65,12 @@ WORKDIR /opt/app
 # keeping it unwritable.
 
 # copy root node_modules
-COPY --from=builder --chmod=755 --chown=node:node /app/node_modules ./node_modules
+COPY --from=proddeps --chmod=755 --chown=node:node /app/node_modules ./node_modules
 
 # Copy standalone server
 COPY --from=builder --chmod=755 --chown=node:node /app/apps/server/dist ./apps/server/dist
 COPY --from=builder --chmod=755 --chown=node:node /app/apps/server/package.json ./apps/server/package.json
-COPY --from=builder --chmod=755 --chown=node:node /app/apps/server/node_modules ./apps/server/node_modules
+COPY --from=proddeps --chmod=755 --chown=node:node /app/apps/server/node_modules ./apps/server/node_modules
 
 # copy UI output to API to be served statically. Read-only like the rest:
 # start.sh stages a copy under the data directory and resolves the BASE_PATH
@@ -72,7 +83,7 @@ COPY --from=builder --chmod=755 --chown=node:node /app/apps/server/assets ./apps
 # Copy packages/contracts
 COPY --from=builder --chmod=755 --chown=node:node /app/packages/contracts/dist ./packages/contracts/dist
 COPY --from=builder --chmod=755 --chown=node:node /app/packages/contracts/package.json ./packages/contracts/package.json
-COPY --from=builder --chmod=755 --chown=node:node /app/packages/contracts/node_modules ./packages/contracts/node_modules
+COPY --from=proddeps --chmod=755 --chown=node:node /app/packages/contracts/node_modules ./packages/contracts/node_modules
 
 # 755 keeps these executable by whichever uid the docker user directive selects.
 COPY --chmod=755 --chown=node:node docker/start.sh /opt/app/start.sh


### PR DESCRIPTION
`yarn workspaces focus --all --production` sat after `COPY . .`, so no layer cache could reach it and it re-ran on every commit. Pruning the dev dependencies changes the dependency tree, which makes yarn rebuild the native modules that `yarn install` compiled ~90 seconds earlier in the same build:

```
#21 [builder 14/16] RUN yarn workspaces focus --all --production
#21 9.140  better-sqlite3@npm:13.0.3 must be rebuilt because its dependency tree changed
#21 9.142  canvas@npm:3.2.3 must be rebuilt because its dependency tree changed
#21 DONE 44.3s
```

## What changed

The install is now its own `deps` stage, with `proddeps` and `builder` branching off it in parallel instead of running in sequence:

| stage | from | does |
|---|---|---|
| `deps` | `base` | apk build deps, corepack, manifests, `yarn install` |
| `proddeps` | `deps` | `yarn workspaces focus --all --production`, the two `mkdir -p` |
| `builder` | `deps` | `COPY . .`, `yarn turbo build` |

The runtime image takes its three `node_modules` trees from `proddeps`; `dist`, `assets` and the manifests still come from `builder`. `proddeps` sees only the manifests, so it caches on the lockfile.

Pairs with #3480, which adds the buildx layer cache this relies on. Correct without it, just not yet faster.

## Verified by building and running both images

Warm cache, source-only change (one line appended to `apps/server/src/main.ts`):

| | before | after |
|---|---|---|
| `yarn turbo build` | 18.3s | 16.8s |
| `yarn workspaces focus --all --production` | 44.5s | **CACHED** |
| runner `COPY /app/node_modules` | 4.9s | **CACHED** |
| **wall clock** | **1m33s** | **0m25s** |

**~68s saved, 73%** - more than the 44s this PR originally claimed. The extra win: in the old layout `focus` mutated the builder's `node_modules`, so the runner's 700 MB root-`node_modules` copy was invalidated on every commit too. Sourcing it from `proddeps` makes that a cache hit as well.

The runtime image is unchanged against its parent (`15e9ee8c`):

| check | result |
|---|---|
| Filesystem manifest (paths, modes, sizes, symlink targets) | 36,476 entries, zero diff |
| Content hash of every regular file | 28,899 hashed, 2 differ |
| Compiled `.node` binaries (canvas, better-sqlite3, sharp) | all 13 match |
| Image size | 140,284,706 vs 140,284,685 bytes |

The two differing files are `node_modules/{canvas,better-sqlite3}/build/Makefile`, one line each: node-gyp emits prerequisite order nondeterministically. Same set, same paths, build byproduct, never loaded at runtime.

Runtime: container healthy on Docker's own HEALTHCHECK, `/api/health/ready` 200 `{"status":"ok","database":"ok"}`, `/api/app/status` 200, UI root 200, no `MODULE_NOT_FOUND`. Driving the compiled `OverlayRenderService` out of `apps/server/dist` in both images produced the same 19,135-byte JPEG with an identical sha256, 600x900, text in Roboto rather than the fallback - so `registerFont` finds the bundled assets from the pruned tree.

## Two notes for anyone re-measuring

`.dockerignore` lists `Dockerfile`, so two worktrees produce a byte-identical build context and BuildKit will hand the second build the first one's `turbo build` layer. A PR-vs-base comparison can come back at 6.4s that way. Use separate builders or a distinguishable context.

The latent risk here was the yarn plugin: `focus` used to run after `COPY . .` and now only ever sees `.yarn/releases`. Had `workspace-tools` lived in `.yarn/plugins` this would have broken. `git ls-files .yarn` returns only the release, so it is Yarn 4's bundled copy.

Not measured: a true cold-vs-cold build with no cache at all. `proddeps` and `builder` can now overlap, but treat "not slower cold" as unverified.