### PR TITLE
fix(rules): stop Test Media re-reading the whole Tracearr history

### DIFF
--- a/apps/server/src/modules/rules/getter/tracearr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/tracearr-getter.service.spec.ts
@@ -297,7 +297,7 @@ describe('TracearrGetterService', () => {
     ).resolves.toEqual(new Date('2026-01-02T01:00:00.000Z'));
   });
 
-  it('prefetches and reads a fresh index after Test Media invalidates history', async () => {
+  it('prefetches and reads a fresh index when no snapshot is held', async () => {
     const { service, tracearrApi } = createService([]);
     const freshIndex = createHistoryIndex([
       historyItem('33333333-3333-4333-8333-333333333333', {

--- a/apps/server/src/modules/rules/rules.service.testMedia.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.testMedia.spec.ts
@@ -10,6 +10,7 @@ import { RulesService } from './rules.service';
 describe('RulesService Test Media Tracearr freshness', () => {
   const createService = (firstValue: [number, number]) => {
     const tracearrApi = {
+      prefetchHistory: jest.fn().mockResolvedValue(undefined),
       invalidateHistory: jest.fn(),
     } as unknown as jest.Mocked<TracearrApiService>;
     const mediaServer = {
@@ -78,15 +79,17 @@ describe('RulesService Test Media Tracearr freshness', () => {
       result: [],
     });
 
-    expect(tracearrApi.invalidateHistory).toHaveBeenCalledTimes(1);
+    expect(tracearrApi.prefetchHistory).toHaveBeenCalledTimes(1);
+    // #3465: invalidating drops the snapshot the sweep resumes from.
+    expect(tracearrApi.invalidateHistory).not.toHaveBeenCalled();
     expect(comparator.executeRulesWithData).toHaveBeenCalledTimes(1);
   });
 
-  it('does not invalidate Tracearr history for other Test Media rules', async () => {
+  it('does not refresh Tracearr history for other Test Media rules', async () => {
     const { service, tracearrApi } = createService([Application.PLEX, 5]);
 
     await service.testRuleGroupWithData(1, 'movie-1');
 
-    expect(tracearrApi.invalidateHistory).not.toHaveBeenCalled();
+    expect(tracearrApi.prefetchHistory).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -2417,11 +2417,14 @@ export class RulesService {
 
     if (mediaResp) {
       group.rules = await this.getRules(group.id);
-      if (group.rules && this.usesTracearr(group.rules)) {
-        this.tracearrApi.invalidateHistory();
-      }
       const ruleComparator = this.ruleComparatorServiceFactory.create();
       try {
+        if (group.rules && this.usesTracearr(group.rules)) {
+          // The same refresh a rule run does, which resumes at the newest known
+          // play. Discarding the snapshot instead re-read the whole history on
+          // every test (#3465).
+          await this.tracearrApi.prefetchHistory();
+        }
         const result = await ruleComparator.executeRulesWithData(
           group as RuleGroupDto,
           [mediaResp],

--- a/apps/server/test/rules-test-matrix.e2e.ts
+++ b/apps/server/test/rules-test-matrix.e2e.ts
@@ -853,7 +853,7 @@ async function bootstrapApp(): Promise<INestApplication> {
       },
       {
         provide: TracearrApiService,
-        useValue: { invalidateHistory: () => undefined },
+        useValue: { prefetchHistory: async () => undefined },
       },
       {
         provide: RuleUsersService,

--- a/apps/ui/src/components/Collection/CollectionDetail/TestMediaItem/index.spec.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/TestMediaItem/index.spec.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useRuleGroupForCollection } from '../../../../api/rules'
+import type { IRuleGroup } from '../../../Rules/RuleGroup'
+import { createDeferred } from '../../../../test-utils/createDeferred'
+import { buildQuerySuccessResult } from '../../../../test-utils/queryResults'
+import { PostApiHandler } from '../../../../utils/ApiHandler'
+import TestMediaItem from './index'
+
+vi.mock('../../../../api/rules', () => ({
+  useRuleGroupForCollection: vi.fn(),
+}))
+
+vi.mock('../../../../utils/ApiHandler', () => ({
+  default: vi.fn(),
+  PostApiHandler: vi.fn(),
+}))
+
+vi.mock('../../../Common/LazyMonacoEditor', () => ({
+  default: () => <div data-testid="output-editor" />,
+}))
+
+vi.mock('../../../Common/SearchMediaITem', () => ({
+  default: ({ onChange }: { onChange: (item: unknown) => void }) => (
+    <button onClick={() => onChange({ id: 'movie-1' })}>pick media</button>
+  ),
+}))
+
+const ruleGroup = {
+  id: 1,
+  dataType: 'movie',
+  libraryId: 'library-1',
+} as IRuleGroup
+
+describe('TestMediaItem', () => {
+  beforeEach(() => {
+    vi.mocked(useRuleGroupForCollection).mockReturnValue(
+      buildQuerySuccessResult(ruleGroup),
+    )
+    vi.mocked(PostApiHandler).mockReset()
+  })
+
+  it('locks the test button until the result arrives', async () => {
+    const deferred = createDeferred<unknown>()
+    vi.mocked(PostApiHandler).mockReturnValue(deferred.promise)
+
+    render(
+      <TestMediaItem collectionId={42} onCancel={vi.fn()} onSubmit={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByText('pick media'))
+    fireEvent.click(screen.getByRole('button', { name: 'Test' }))
+
+    const pending = await screen.findByRole('button', { name: 'Testing...' })
+    expect((pending as HTMLButtonElement).disabled).toBe(true)
+
+    fireEvent.click(pending)
+    expect(PostApiHandler).toHaveBeenCalledTimes(1)
+
+    deferred.resolve({ code: 1, result: [] })
+
+    await waitFor(() => {
+      expect(
+        (screen.getByRole('button', { name: 'Test' }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(false)
+    })
+  })
+
+  it('unlocks the test button when the request fails', async () => {
+    vi.mocked(PostApiHandler).mockRejectedValue(new Error('boom'))
+
+    render(
+      <TestMediaItem collectionId={42} onCancel={vi.fn()} onSubmit={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByText('pick media'))
+    fireEvent.click(screen.getByRole('button', { name: 'Test' }))
+
+    await waitFor(() => {
+      expect(
+        (screen.getByRole('button', { name: 'Test' }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(false)
+    })
+  })
+})

--- a/apps/ui/src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
@@ -1,14 +1,14 @@
-import { ClipboardCopyIcon } from '@heroicons/react/solid'
+import { BeakerIcon, ClipboardCopyIcon } from '@heroicons/react/solid'
 import { useMemo, useRef, useState } from 'react'
 import { toast } from 'react-toastify'
 import YAML from 'yaml'
 import { useRuleGroupForCollection } from '../../../../api/rules'
 import GetApiHandler, { PostApiHandler } from '../../../../utils/ApiHandler'
 import Alert from '../../../Common/Alert'
-import Button from '../../../Common/Button'
 import FormItem from '../../../Common/FormItem'
 import LazyMonacoEditor from '../../../Common/LazyMonacoEditor'
 import Modal from '../../../Common/Modal'
+import PendingButton from '../../../Common/PendingButton'
 import SearchMediaItem, { IMediaOptions } from '../../../Common/SearchMediaITem'
 import { Select } from '../../../Forms/Select'
 
@@ -42,6 +42,7 @@ const TestMediaItem = (props: ITestMediaItem) => {
     emptyOption,
   ])
   const [comparisonResult, setComparisonResult] = useState<IComparisonResult>()
+  const [testing, setTesting] = useState(false)
   const editorRef = useRef(undefined)
 
   const ruleGroupQuery = useRuleGroupForCollection(props.collectionId)
@@ -150,12 +151,19 @@ const TestMediaItem = (props: ITestMediaItem) => {
 
     if (!ruleGroup) return
 
-    const result = await PostApiHandler(`/rules/test`, {
-      rulegroupId: ruleGroup.id,
-      mediaId: selectedMediaId,
-    })
+    setTesting(true)
+    try {
+      const result = await PostApiHandler(`/rules/test`, {
+        rulegroupId: ruleGroup.id,
+        mediaId: selectedMediaId,
+      })
 
-    setComparisonResult(result)
+      setComparisonResult(result)
+    } catch {
+      toast.error('Failed to test media')
+    } finally {
+      setTesting(false)
+    }
   }
 
   if (ruleGroupQuery.isLoading || !ruleGroup) {
@@ -201,14 +209,17 @@ const TestMediaItem = (props: ITestMediaItem) => {
         title={'Test Media'}
         iconSvg={''}
         footerActions={
-          <Button
+          <PendingButton
             buttonType="primary"
             className="ml-3"
-            disabled={!testable}
+            type="button"
+            disabled={!testable || testing}
+            isPending={testing}
+            idleLabel="Test"
+            pendingLabel="Testing..."
+            idleIcon={<BeakerIcon />}
             onClick={() => void onSubmit()}
-          >
-            Test
-          </Button>
+          />
         }
       >
         <div className="h-[80vh] overflow-hidden">


### PR DESCRIPTION
Closes #3465.

Test Media discarded the Tracearr history snapshot before every test, so each click paged the entire history again instead of resuming at the newest known play. It now runs the same refresh a rule run does.

| | before | after |
|---|---|---|
| Test Media click, 232-row dev-tracearr history | 3 `/history` pages, every click | 3 pages once, then 1 |
| Test Media click, 100k plays at 100 ms/page | 103 s, every click | 103 s once, then 0.19 s |
| Scheduled rule run | 1 page | 1 page |

A second click while the first was still running used to poison both answers with "could not be read": discarding the snapshot bumped the sweep generation, which threw away the in-flight result. Both clicks now return the value.

Freshness is unchanged. The sweep still re-reads the newest page in full, re-resolves unfinished chains, and rebuilds the username map and episode-id memo on every click - verified against the real stack by driving a play on Jellyfin and watching the rule value go 1 -> 2 on the next click, with nothing restarted. A cold snapshot (restart, settings save, or the cache's 1 hour TTL) still reads the history once.

The modal also gave no feedback during the wait, which is what made an impatient second click likely. The Test button now uses the shared `PendingButton`: spinner, "Testing...", disabled while the request is out, and a reserved width so nothing shifts.