### PR TITLE
feat(i18n): translate the strings from the declined i18n PR

### DIFF
--- a/apps/ui/src/components/Collection/CollectionOverview/index.spec.tsx
+++ b/apps/ui/src/components/Collection/CollectionOverview/index.spec.tsx
@@ -1,5 +1,5 @@
 import type { MediaLibrary } from '@maintainerr/contracts'
-import { render, screen } from '@testing-library/react'
+import { render, screen } from '../../../test-utils/render'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useMediaServerLibraries } from '../../../api/media-server'
 import { useTaskStatusContext } from '../../../contexts/taskstatus-context'

--- a/apps/ui/src/components/Collection/CollectionOverview/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionOverview/index.tsx
@@ -8,6 +8,7 @@ import LoadingSpinner, {
 } from '../../Common/LoadingSpinner'
 import PageControlRow from '../../Common/PageControlRow'
 import CollectionItem from '../CollectionItem'
+import { Trans, useLingui } from '@lingui/react/macro'
 
 interface ICollectionOverview {
   collections: ICollection[] | undefined
@@ -19,6 +20,7 @@ interface ICollectionOverview {
 }
 
 const CollectionOverview = (props: ICollectionOverview) => {
+  const { t } = useLingui()
   const { collectionHandlerRunning } = useTaskStatusContext()
   const {
     data: libraries,
@@ -39,10 +41,10 @@ const CollectionOverview = (props: ICollectionOverview) => {
           <ExecuteButton
             className="mx-0"
             onClick={props.doActions}
-            text="Handle Collections"
+            text={t`Handle Collections`}
             executing={collectionHandlerRunning}
             disabled={collectionHandlerRunning}
-            title="Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+            title={t`Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections.`}
           />
         }
         controls={
@@ -61,7 +63,7 @@ const CollectionOverview = (props: ICollectionOverview) => {
       <div className="w-full">
         <div className="m-auto mb-3 flex items-center justify-between gap-3">
           <h1 className="m-auto text-lg font-bold text-zinc-200 sm:m-0 xl:m-0">
-            {'Automatic collections'}
+            {t`Automatic collections`}
           </h1>
           <div className="flex min-h-6 min-w-6 items-center justify-end">
             {showRefreshing ? (
@@ -92,7 +94,7 @@ const CollectionOverview = (props: ICollectionOverview) => {
           </ul>
         ) : (
           <div className="flex min-h-80 items-center justify-center rounded-xl border border-dashed border-zinc-700 bg-zinc-900/30 p-6 text-sm text-zinc-400">
-            No collections found for this library.
+            <Trans>No collections found for this library.</Trans>
           </div>
         )}
       </div>

--- a/apps/ui/src/components/Layout/Layout.spec.tsx
+++ b/apps/ui/src/components/Layout/Layout.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '../../test-utils/render'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import SearchContext, {
   SearchContextProvider,

--- a/apps/ui/src/components/Layout/NavBar/index.tsx
+++ b/apps/ui/src/components/Layout/NavBar/index.tsx
@@ -156,7 +156,7 @@ const NavBar: React.FC<NavBarProps> = ({ open, setClosed }) => {
         <img
           className="block h-full w-full object-contain object-left"
           src={`${basePath}/logo.svg`}
-          alt="Maintainerr logo"
+          alt={t`Maintainerr logo`}
           width={340}
           height={100}
           decoding="sync"
@@ -179,7 +179,7 @@ const NavBar: React.FC<NavBarProps> = ({ open, setClosed }) => {
                 <div className="sidebar-close-button absolute top-0 right-0 -mr-14 p-1">
                   <button
                     className="flex h-12 w-12 items-center justify-center rounded-full text-white focus:bg-zinc-600 focus:outline-hidden"
-                    aria-label="Close sidebar"
+                    aria-label={t`Close sidebar`}
                     onClick={() => setClosed()}
                   >
                     <XIcon className="h-6 w-6 text-white" />

--- a/apps/ui/src/components/Layout/index.tsx
+++ b/apps/ui/src/components/Layout/index.tsx
@@ -1,4 +1,7 @@
 import { ArrowLeftIcon, MenuAlt2Icon } from '@heroicons/react/solid'
+import type { MessageDescriptor } from '@lingui/core'
+import { msg } from '@lingui/core/macro'
+import { Trans, useLingui } from '@lingui/react/macro'
 import { debounce } from 'lodash-es'
 import { ReactNode, use, useEffect, useRef, useState } from 'react'
 import {
@@ -22,6 +25,7 @@ type LayoutShellProps = {
 const LayoutShell: React.FC<LayoutShellProps> = ({ children }) => {
   const [navBarOpen, setNavBarOpen] = useState(false)
   const SearchCtx = use(SearchContext)
+  const { t } = useLingui()
   const navigate = useNavigate()
   const navigation = useNavigation()
   const basePath = import.meta.env.VITE_BASE_PATH ?? ''
@@ -85,7 +89,7 @@ const LayoutShell: React.FC<LayoutShellProps> = ({ children }) => {
           <div className="transparent-glass-bg flex flex-1 items-center justify-between pr-4 shadow-none md:pr-4 md:pl-4">
             <button
               className={`px-4 text-white opacity-70 transition duration-300 focus:outline-hidden lg:hidden`}
-              aria-label="Open sidebar"
+              aria-label={t`Open sidebar`}
               onClick={() => setNavBarOpen(true)}
             >
               <MenuAlt2Icon className="h-6 w-6" />
@@ -140,13 +144,18 @@ const Layout: React.FC = () => {
   )
 }
 
+// Runs outside a component, so the fixed messages are lazy descriptors that
+// the boundary resolves at render. Text coming off the wire stays a string.
 const describeRouteError = (
   error: unknown,
-): { title: string; message: string } => {
+): {
+  title: string | MessageDescriptor
+  message: string | MessageDescriptor
+} => {
   if (!error) {
     return {
-      title: 'Unknown error',
-      message: 'An unexpected error occurred.',
+      title: msg`Unknown error`,
+      message: msg`An unexpected error occurred.`,
     }
   }
 
@@ -158,7 +167,7 @@ const describeRouteError = (
 
     return {
       title: `${error.status} ${error.statusText}`.trim(),
-      message: dataMessage ?? 'The server returned an unexpected response.',
+      message: dataMessage ?? msg`The server returned an unexpected response.`,
     }
   }
 
@@ -170,7 +179,7 @@ const describeRouteError = (
   }
 
   return {
-    title: 'Unexpected error',
+    title: msg`Unexpected error`,
     message: String(error),
   }
 }
@@ -178,7 +187,10 @@ const describeRouteError = (
 export const LayoutErrorBoundary: React.FC = () => {
   const error = useRouteError()
   const navigate = useNavigate()
+  const { i18n } = useLingui()
   const { title, message } = describeRouteError(error)
+  const render = (value: string | MessageDescriptor) =>
+    typeof value === 'string' ? value : i18n._(value)
 
   return (
     <LayoutShell>
@@ -186,24 +198,28 @@ export const LayoutErrorBoundary: React.FC = () => {
         role="alert"
         className="rounded-sm border border-error-500/60 bg-error-500/10 p-6 text-error-100 shadow-lg"
       >
-        <h2 className="text-lg font-semibold text-error-200">{title}</h2>
-        <p className="mt-2 text-sm text-error-100">{message}</p>
+        <h2 className="text-lg font-semibold text-error-200">
+          {render(title)}
+        </h2>
+        <p className="mt-2 text-sm text-error-100">{render(message)}</p>
         <p className="mt-4 text-xs text-error-200/80">
-          You can try going back or reloading the page. If the problem persists,
-          please check the browser console for more details.
+          <Trans>
+            You can try going back or reloading the page. If the problem
+            persists, please check the browser console for more details.
+          </Trans>
         </p>
         <div className="mt-4 flex flex-wrap gap-3">
           <button
             className="rounded-sm bg-error-500/30 px-4 py-2 text-sm font-medium text-error-50 transition hover:bg-error-500/40 focus:ring-2 focus:ring-error-300/60 focus:outline-hidden"
             onClick={() => navigate(-1)}
           >
-            Go Back
+            <Trans>Go Back</Trans>
           </button>
           <button
             className="rounded-sm bg-zinc-800 px-4 py-2 text-sm font-medium text-zinc-100 transition hover:bg-zinc-700 focus:ring-2 focus:ring-zinc-500/60 focus:outline-hidden"
             onClick={() => navigate('/overview')}
           >
-            Go To Overview
+            <Trans>Go To Overview</Trans>
           </button>
         </div>
       </div>

--- a/apps/ui/src/components/Settings/Settings.spec.tsx
+++ b/apps/ui/src/components/Settings/Settings.spec.tsx
@@ -1,5 +1,5 @@
 import { MediaServerType } from '@maintainerr/contracts'
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '../../test-utils/render'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { INTERACTION_DEBOUNCE_MS } from '../../utils/uiBehavior'
 import SettingsWrapper from './index'

--- a/apps/ui/src/components/Settings/Tabs/index.tsx
+++ b/apps/ui/src/components/Settings/Tabs/index.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { prefetchRoute } from '../../../router'
 import { Select } from '../../Forms/Select'
 import { showMediaServerSetupRequiredToast } from '../../Layout/MediaServerSetupGuard'
+import { Trans, useLingui } from '@lingui/react/macro'
 
 export interface SettingsRoute {
   text: string
@@ -98,6 +99,7 @@ const SettingsTabs: React.FC<{
   isRouteDisabled,
   onBlockedNavigate = showMediaServerSetupRequiredToast,
 }) => {
+  const { t } = useLingui()
   const location = useLocation()
   const navigate = useNavigate()
 
@@ -114,7 +116,7 @@ const SettingsTabs: React.FC<{
     <>
       <div className="sm:hidden">
         <label htmlFor="tabs" className="sr-only">
-          Select a Tab
+          <Trans>Select a Tab</Trans>
         </label>
         <Select
           value={currentRoute}
@@ -146,7 +148,7 @@ const SettingsTabs: React.FC<{
               navigate(e.target.value)
             }
           }}
-          aria-label="Selected Tab"
+          aria-label={t`Selected Tab`}
         >
           {settingsRoutes.map((route, index) => (
             <SettingsLink

--- a/apps/ui/src/components/Settings/index.tsx
+++ b/apps/ui/src/components/Settings/index.tsx
@@ -26,6 +26,7 @@ import {
   showMediaServerSetupRequiredToast,
 } from '../Layout/MediaServerSetupGuard'
 import SettingsTabs, { SettingsRoute } from './Tabs'
+import { Trans, useLingui } from '@lingui/react/macro'
 
 const mediaServerTabContent = (label?: string) => {
   if (label) {
@@ -117,6 +118,7 @@ export const useSettingsOutletContext = () =>
   useOutletContext<SettingsOutletContext>()
 
 const SettingsWrapper = () => {
+  const { t } = useLingui()
   const location = useLocation()
   const { data: settings, isLoading, error } = useSettings()
   const [hasDismissedSetupWelcome, setHasDismissedSetupWelcome] =
@@ -274,7 +276,10 @@ const SettingsWrapper = () => {
           <SettingsTabs settingsRoutes={settingsRoutes} allEnabled={false} />
         </div>
         <div className="mt-10 flex">
-          <Alert type="error" title="There was a problem loading settings." />
+          <Alert
+            type="error"
+            title={t`There was a problem loading settings.`}
+          />
         </div>
       </>
     )
@@ -308,7 +313,7 @@ const SettingsWrapper = () => {
       <>
         {shouldShowSetupWelcome ? (
           <Modal
-            title="Welcome to Maintainerr!"
+            title={t`Welcome to Maintainerr!`}
             backgroundClickable={false}
             size="md"
             footerActions={
@@ -324,16 +329,20 @@ const SettingsWrapper = () => {
             <div className="space-y-4 text-zinc-100">
               <div className="rounded-md border border-info-500/40 bg-info-900/30 p-4 backdrop-blur-sm">
                 <p className="text-base font-medium text-info-100">
-                  Connect your media server to finish setup.
+                  <Trans>Connect your media server to finish setup.</Trans>
                 </p>
                 <p className="mt-2 leading-6 text-info-200">
-                  Choose your media server, confirm the connection, and then you
-                  can continue configuring the rest of Maintainerr.
+                  <Trans>
+                    Choose your media server, confirm the connection, and then
+                    you can continue configuring the rest of Maintainerr.
+                  </Trans>
                 </p>
               </div>
               <p className="text-sm leading-6 text-zinc-400">
-                The Logs page stays available during setup if you need to
-                troubleshoot your connection.
+                <Trans>
+                  The Logs page stays available during setup if you need to
+                  troubleshoot your connection.
+                </Trans>
               </p>
             </div>
           </Modal>

--- a/apps/ui/src/locales/cs.po
+++ b/apps/ui/src/locales/cs.po
@@ -13,16 +13,76 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr ""
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr ""
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
@@ -33,18 +93,70 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
 msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr ""
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr ""
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
 msgstr ""

--- a/apps/ui/src/locales/da.po
+++ b/apps/ui/src/locales/da.po
@@ -13,16 +13,76 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr ""
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr ""
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
@@ -33,18 +93,70 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
 msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr ""
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr ""
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
 msgstr ""

--- a/apps/ui/src/locales/de.po
+++ b/apps/ui/src/locales/de.po
@@ -13,16 +13,76 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr ""
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr ""
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
@@ -33,18 +93,70 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
 msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr ""
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr ""
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
 msgstr ""

--- a/apps/ui/src/locales/en.po
+++ b/apps/ui/src/locales/en.po
@@ -13,17 +13,77 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr "An unexpected error occurred."
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr "Automatic collections"
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
 msgstr "Calendar"
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
+msgstr "Close sidebar"
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr "Collections"
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr "Connect your media server to finish setup."
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
 msgstr "Display language"
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr "Failed to initiate rule execution."
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr "Failed to request stop of all rule executions."
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr "Go Back"
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr "Go To Overview"
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr "Handle Collections"
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr "Maintainerr logo"
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr "New Rule"
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr "No collections found for this library."
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
+msgstr "Open sidebar"
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Overlays"
@@ -33,18 +93,70 @@ msgstr "Overlays"
 msgid "Overview"
 msgstr "Overview"
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr "Requested to stop all rule executions."
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr "Rule execution started."
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
 msgstr "Rules"
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
+msgstr "Run Rules"
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr "Saved in this browser. Untranslated text falls back to English."
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr "Select a Tab"
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr "Selected Tab"
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr "Settings"
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr "Stop Rules"
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
 msgstr "Storage"
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr "The Logs page stays available during setup if you need to troubleshoot your connection."
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr "The server returned an unexpected response."
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr "There was a problem loading settings."
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr "Unexpected error"
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr "Unknown error"
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr "Welcome to Maintainerr!"
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
+msgstr "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."

--- a/apps/ui/src/locales/es.po
+++ b/apps/ui/src/locales/es.po
@@ -13,16 +13,76 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr ""
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr ""
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
@@ -33,18 +93,70 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
 msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr ""
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr ""
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
 msgstr ""

--- a/apps/ui/src/locales/fi.po
+++ b/apps/ui/src/locales/fi.po
@@ -13,16 +13,76 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr ""
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr ""
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
@@ -33,18 +93,70 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
 msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr ""
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr ""
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
 msgstr ""

--- a/apps/ui/src/locales/fr.po
+++ b/apps/ui/src/locales/fr.po
@@ -13,16 +13,76 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr ""
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr ""
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
@@ -33,18 +93,70 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
 msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr ""
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr ""
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
 msgstr ""

--- a/apps/ui/src/locales/it.po
+++ b/apps/ui/src/locales/it.po
@@ -13,16 +13,76 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr ""
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr ""
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
@@ -33,18 +93,70 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
 msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr ""
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr ""
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
 msgstr ""

--- a/apps/ui/src/locales/nb.po
+++ b/apps/ui/src/locales/nb.po
@@ -13,16 +13,76 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr ""
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr ""
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
@@ -33,18 +93,70 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
 msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr ""
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr ""
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
 msgstr ""

--- a/apps/ui/src/locales/nl.po
+++ b/apps/ui/src/locales/nl.po
@@ -13,16 +13,76 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr ""
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr ""
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
@@ -33,18 +93,70 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
 msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr ""
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr ""
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
 msgstr ""

--- a/apps/ui/src/locales/pl.po
+++ b/apps/ui/src/locales/pl.po
@@ -13,16 +13,76 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr ""
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr ""
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
@@ -33,18 +93,70 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
 msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr ""
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr ""
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
 msgstr ""

--- a/apps/ui/src/locales/pt.po
+++ b/apps/ui/src/locales/pt.po
@@ -13,16 +13,76 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr ""
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr ""
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
@@ -33,18 +93,70 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
 msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr ""
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr ""
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
 msgstr ""

--- a/apps/ui/src/locales/sv.po
+++ b/apps/ui/src/locales/sv.po
@@ -13,16 +13,76 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Layout/index.tsx
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Automatic collections"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Close sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
 msgstr ""
 
+#: src/components/Settings/index.tsx
+msgid "Connect your media server to finish setup."
+msgstr ""
+
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to initiate rule execution."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Failed to request stop of all rule executions."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go Back"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Go To Overview"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "Handle Collections"
+msgstr ""
+
+#: src/components/Layout/NavBar/index.tsx
+msgid "Maintainerr logo"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "New Rule"
+msgstr ""
+
+#: src/components/Collection/CollectionOverview/index.tsx
+msgid "No collections found for this library."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Open sidebar"
 msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
@@ -33,18 +93,70 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Requested to stop all rule executions."
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Rule execution started."
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
+msgstr ""
+
+#: src/pages/RulesListPage.tsx
+msgid "Run Rules"
 msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
 msgstr ""
 
+#: src/components/Settings/Tabs/index.tsx
+msgid "Select a Tab"
+msgstr ""
+
+#: src/components/Settings/Tabs/index.tsx
+msgid "Selected Tab"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
 msgstr ""
 
+#: src/pages/RulesListPage.tsx
+msgid "Stop Rules"
+msgstr ""
+
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "The Logs page stays available during setup if you need to troubleshoot your connection."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "The server returned an unexpected response."
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "There was a problem loading settings."
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unexpected error"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "Unknown error"
+msgstr ""
+
+#: src/components/Settings/index.tsx
+msgid "Welcome to Maintainerr!"
+msgstr ""
+
+#: src/components/Layout/index.tsx
+msgid "You can try going back or reloading the page. If the problem persists, please check the browser console for more details."
 msgstr ""

--- a/apps/ui/src/pages/RulesListPage.tsx
+++ b/apps/ui/src/pages/RulesListPage.tsx
@@ -12,8 +12,10 @@ import PageControlRow from '../components/Common/PageControlRow'
 import RuleGroup, { IRuleGroup } from '../components/Rules/RuleGroup'
 import { useTaskStatusContext } from '../contexts/taskstatus-context'
 import { PostApiHandler } from '../utils/ApiHandler'
+import { useLingui } from '@lingui/react/macro'
 
 const RulesListPage = () => {
+  const { t } = useLingui()
   const navigate = useNavigate()
   const [selectedLibrary, setSelectedLibrary] = useState<string>('all')
   const {
@@ -24,10 +26,10 @@ const RulesListPage = () => {
   const { ruleHandlerRunning } = useTaskStatusContext()
   const { mutate: stopAllExecution } = useStopAllRuleExecution({
     onSuccess() {
-      toast.success('Requested to stop all rule executions.')
+      toast.success(t`Requested to stop all rule executions.`)
     },
     onError() {
-      toast.error('Failed to request stop of all rule executions.')
+      toast.error(t`Failed to request stop of all rule executions.`)
     },
   })
   const { data = [], isLoading, refetch } = useRuleGroups(selectedLibrary)
@@ -47,13 +49,13 @@ const RulesListPage = () => {
   const sync = async () => {
     try {
       await PostApiHandler(`/rules/execute`, {})
-      toast.success('Rule execution started.')
+      toast.success(t`Rule execution started.`)
     } catch (error) {
       if (error instanceof AxiosError && error.response?.data?.message) {
         toast.error(error.response.data.message)
         return
       }
-      toast.error('Failed to initiate rule execution.')
+      toast.error(t`Failed to initiate rule execution.`)
     }
   }
 
@@ -66,7 +68,7 @@ const RulesListPage = () => {
             <>
               <AddButton
                 onClick={() => navigate('/rules/new')}
-                text="New Rule"
+                text={t`New Rule`}
               />
               <ExecuteButton
                 onClick={() => {
@@ -76,7 +78,7 @@ const RulesListPage = () => {
                     sync()
                   }
                 }}
-                text={ruleHandlerRunning ? 'Stop Rules' : 'Run Rules'}
+                text={ruleHandlerRunning ? t`Stop Rules` : t`Run Rules`}
                 executing={ruleHandlerRunning}
               />
             </>


### PR DESCRIPTION
Picks up the string set @slx612 identified in #3191 and runs it through the Lingui pipeline instead. Same screens, generated catalogs rather than hand-keyed JSON.

Catalog goes from 9 strings to **37**.

## Screens covered

| Area | Strings |
|---|---|
| Layout + route error boundary | Go Back, Go To Overview, Open/Close sidebar, error titles and help text |
| Nav | Maintainerr logo alt text |
| Settings | tab selector, loading error, first-setup modal |
| Collections | Handle Collections, Automatic collections, empty state, action tooltip |
| Rules | New Rule, Run/Stop Rules, the four execution toasts |

## One thing worth a look

`describeRouteError` runs **outside** a component, so it cannot use the `t` macro. Its fixed messages are now lazy `msg` descriptors that the boundary resolves at render, while text coming off the wire stays a plain string:

```ts
const describeRouteError = (
  error: unknown,
): { title: string | MessageDescriptor; message: string | MessageDescriptor } => {
```

That is the pattern to copy for any other translatable string defined outside a component.

Three specs moved onto `test-utils/render` so they get the i18n context.

## Not included: the Spanish

That PR also carried a full `es.json`. I checked the raw diff and it contains **zero non-ASCII bytes** - the Spanish is written without accents throughout (`menu`, `pagina`, `accion`, `esta`, `conexion`). In Spanish that is a spelling error rather than a style choice, and several change meaning.

Committing it would also mark `es` as translated in Weblate, so nobody would ever go back and fix it. Better submitted through Weblate, where @slx612 can correct the accents and a native speaker can review before it lands.
