### PR TITLE
ci(i18n): post the translation review as the bot

### DIFF
--- a/.github/workflows/weblate_review.yml
+++ b/.github/workflows/weblate_review.yml
@@ -22,6 +22,15 @@ jobs:
     name: Back-translation review
     runs-on: ubuntu-latest
     steps:
+      # Labels and the review comment come from the bot rather than
+      # github-actions, matching the rest of the repo's automation.
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.MERGE_APP_ID }}
+          private-key: ${{ secrets.MERGE_APP_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v7
         with:
@@ -37,6 +46,7 @@ jobs:
       - name: Label the pull request
         uses: actions/github-script@v9
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -62,6 +72,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: '<!-- maintainerr-i18n-back-translation -->'
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Upsert review comment
         uses: peter-evans/create-or-update-comment@v5
@@ -70,3 +81,4 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: .i18n-review.md
           edit-mode: replace
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
The translation review comment was posted by `github-actions[bot]`. It now uses the automation App token that the rest of the repo already uses, so it appears as the bot alongside the release and dependabot automation.

| Step | Token |
|---|---|
| Label the pull request | App token |
| Find + upsert review comment | App token |
| Back-translate changed strings | `GITHUB_TOKEN` |

The model call keeps the workflow token deliberately: `models: read` is granted on that one, and an App installation token does not carry it.

Uses `MERGE_APP_ID` / `MERGE_APP_KEY`, matching `docs_drift.yml`, `dependabot_merge.yml` and the release workflows.