### PR TITLE
fix(i18n): rescue the Swedish translation and fix the catalog check

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "i18n:extract": "lingui extract --clean",
-    "i18n:check": "lingui extract --clean && git diff --exit-code -- src/locales",
+    "i18n:check": "node ../../tools/i18n/check-catalog.mjs",
     "test": "vitest run --shard=1/2 && vitest run --shard=2/2",
     "check-types": "tsc --noEmit",
     "preview": "vite preview",

--- a/apps/ui/src/locales/sv.po
+++ b/apps/ui/src/locales/sv.po
@@ -4,14 +4,15 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
+"X-Generator: Weblate 2026.9.dev0\n"
 "Language: sv\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
+"PO-Revision-Date: 2026-08-13 18:23+0000\n"
+"Last-Translator: Maintainerr <get@maintainerr.info>\n"
+"Language-Team: Swedish <https://hosted.weblate.org/projects/maintainerr/ui/"
+"sv/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #: src/components/Layout/index.tsx
 msgid "An unexpected error occurred."
@@ -23,7 +24,7 @@ msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Calendar"
-msgstr ""
+msgstr "Kalender"
 
 #: src/components/Settings/index.tsx
 msgid "Choose your media server, confirm the connection, and then you can continue configuring the rest of Maintainerr."
@@ -43,7 +44,7 @@ msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Display language"
-msgstr ""
+msgstr "Språk"
 
 #: src/components/Collection/CollectionOverview/index.tsx
 msgid "Executes each collection's configured action (Delete / Unmonitor / Do Nothing). Does not remove items from collections."
@@ -91,7 +92,7 @@ msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Overview"
-msgstr ""
+msgstr "Översikt"
 
 #: src/pages/RulesListPage.tsx
 msgid "Requested to stop all rule executions."
@@ -103,7 +104,7 @@ msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Rules"
-msgstr ""
+msgstr "Regler"
 
 #: src/pages/RulesListPage.tsx
 msgid "Run Rules"
@@ -111,7 +112,7 @@ msgstr ""
 
 #: src/components/Settings/Main/LanguageSelector.tsx
 msgid "Saved in this browser. Untranslated text falls back to English."
-msgstr ""
+msgstr "Sparas i den här webbläsaren. Text som inte är översatt visas på Engelska."
 
 #: src/components/Settings/Tabs/index.tsx
 msgid "Select a Tab"
@@ -123,7 +124,7 @@ msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Settings"
-msgstr ""
+msgstr "Inställningar"
 
 #: src/pages/RulesListPage.tsx
 msgid "Stop Rules"
@@ -131,7 +132,7 @@ msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Storage"
-msgstr ""
+msgstr "Lagring"
 
 #: src/components/Settings/index.tsx
 msgid "The Logs page stays available during setup if you need to troubleshoot your connection."

--- a/tools/i18n/check-catalog.mjs
+++ b/tools/i18n/check-catalog.mjs
@@ -1,0 +1,83 @@
+/**
+ * Fails when a translatable string was added without re-running extraction.
+ *
+ * Compares the SET OF MESSAGES rather than the bytes of the file. Weblate
+ * writes these catalogs too, and it folds long header lines where Lingui does
+ * not, so a byte-exact diff fails on every translation pull request while
+ * saying nothing about whether the catalog is actually current.
+ *
+ * Leaves the working tree exactly as it found it.
+ *
+ * Usage: node tools/i18n/check-catalog.mjs [catalogDir]
+ */
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readPo } from './po.mjs';
+
+// Resolved from this file, so the script behaves the same whether it is run
+// from the repo root or from inside the workspace.
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const uiDir = path.join(repoRoot, 'apps/ui');
+const catalogDir = process.argv[2]
+  ? path.resolve(process.argv[2])
+  : path.join(uiDir, 'src/locales');
+
+const messageIds = (dir, file) =>
+  new Set(readPo(path.join(dir, file)).map((entry) => entry.msgid));
+
+const listCatalogs = (dir) =>
+  readdirSync(dir)
+    .filter((name) => name.endsWith('.po'))
+    .sort();
+
+const snapshot = mkdtempSync(path.join(tmpdir(), 'lingui-catalogs-'));
+cpSync(catalogDir, snapshot, { recursive: true });
+
+let failed = false;
+try {
+  execFileSync('yarn', ['lingui', 'extract', '--clean'], {
+    cwd: uiDir,
+    stdio: ['ignore', 'ignore', 'inherit'],
+  });
+
+  const committed = listCatalogs(snapshot);
+  const extracted = listCatalogs(catalogDir);
+
+  const onlyExtracted = extracted.filter((f) => !committed.includes(f));
+  const onlyCommitted = committed.filter((f) => !extracted.includes(f));
+  if (onlyExtracted.length > 0 || onlyCommitted.length > 0) {
+    failed = true;
+    console.error('Catalog files differ from extraction:');
+    for (const f of onlyExtracted) console.error(`  extraction produced ${f}`);
+    for (const f of onlyCommitted) console.error(`  committed but not produced: ${f}`);
+  }
+
+  for (const file of extracted.filter((f) => committed.includes(f))) {
+    const before = messageIds(snapshot, file);
+    const after = messageIds(catalogDir, file);
+
+    const missing = [...after].filter((id) => !before.has(id));
+    const obsolete = [...before].filter((id) => !after.has(id));
+    if (missing.length === 0 && obsolete.length === 0) continue;
+
+    failed = true;
+    console.error(`\n${path.join(catalogDir, file)}`);
+    for (const id of missing) console.error(`  + not in the catalog: ${id}`);
+    for (const id of obsolete) console.error(`  - no longer in source: ${id}`);
+  }
+} finally {
+  // Restore, so a passing check never leaves formatting churn behind.
+  rmSync(catalogDir, { recursive: true, force: true });
+  cpSync(snapshot, catalogDir, { recursive: true });
+  rmSync(snapshot, { recursive: true, force: true });
+}
+
+if (failed) {
+  console.error('\nRun `yarn workspace @maintainerr/ui i18n:extract` and commit the result.');
+  process.exit(1);
+}
+
+console.log('Translation catalog is current with the source strings.');


### PR DESCRIPTION
Two things, and the second one matters more than the first.

## 1. Rescues 7 Swedish strings that only existed inside Weblate

Weblate had committed them locally but could not push, because the component sits on the plain `github` VCS backend which authenticates from a settings dict rather than the GitHub App. Deleting the component to rebuild it on `github-app` would have destroyed this.

| Source | Swedish |
|---|---|
| Calendar | Kalender |
| Display language | Språk |
| Overview | Översikt |
| Rules | Regler |
| Settings | Inställningar |
| Storage | Lagring |
| Saved in this browser. Untranslated text falls back to English. | Sparas i den här webbläsaren. Text som inte är översatt visas på Engelska. |

Weblate's PO header is preserved verbatim, so its next sync sees no conflict.

## 2. Fixes a CI guard that would have blocked every translation PR

Rescuing that file exposed the real bug. **Weblate folds long PO header lines at the gettext width; Lingui writes them unfolded:**

```
 "X-Generator: Weblate 2026.9.dev0\n"
-"Language-Team: Swedish <https://hosted.weblate.org/projects/maintainerr/ui/"
-"sv/>\n"
+"Language-Team: Swedish <https://hosted.weblate.org/projects/maintainerr/ui/sv/>\n"
```

`i18n:check` compared **bytes** (`lingui extract --clean && git diff --exit-code`), so it failed on a catalog Weblate had written - while saying nothing about whether the catalog was actually current. Every Weblate PR would have been red.

The check now compares the **set of messages** per catalog and restores the working tree afterwards, so a passing run leaves no formatting churn.

Verified both directions:

| Scenario | Old check | New check |
|---|---|---|
| Weblate-formatted `sv.po` | ❌ fails | ✅ passes |
| String added without re-extracting | ✅ fails | ✅ fails |

Lingui's `foldLength` option is not the answer - it folds message strings as well as headers, which diverges further (tested at 76/77/78/79, all worse).
