### PR TITLE
l10n(sv): complete Swedish, and stop the review comment hiding failures

### DIFF
--- a/apps/ui/src/locales/sv.po
+++ b/apps/ui/src/locales/sv.po
@@ -36,7 +36,7 @@ msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Collections"
-msgstr ""
+msgstr "Samlingar"
 
 #: src/components/Settings/index.tsx
 msgid "Connect your media server to finish setup."
@@ -88,7 +88,7 @@ msgstr ""
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Overlays"
-msgstr ""
+msgstr "Overlays"
 
 #: src/components/Layout/NavBar/index.tsx
 msgid "Overview"

--- a/tools/i18n/back-translate.mjs
+++ b/tools/i18n/back-translate.mjs
@@ -166,6 +166,7 @@ const files = readdirSync(catalogDir)
 
 const rows = [];
 const problems = [];
+let pendingTotal = 0;
 
 for (const file of files) {
   const locale = path.basename(file, '.po');
@@ -178,6 +179,7 @@ for (const file of files) {
     return true;
   });
   if (pending.length === 0) continue;
+  pendingTotal += pending.length;
 
   log(`${locale}: reviewing ${pending.length} strings`);
 
@@ -217,7 +219,15 @@ lines.push('<!-- maintainerr-i18n-back-translation -->');
 lines.push('## Translation review');
 lines.push('');
 
-if (rows.length === 0) {
+if (rows.length === 0 && pendingTotal > 0) {
+  // Never report "nothing changed" when there was something to review and the
+  // provider refused: a silent pass here reads as a clean bill of health.
+  lines.push(
+    `:warning: **Could not review ${pendingTotal} changed translation` +
+      `${pendingTotal === 1 ? '' : 's'}.** The back-translation provider did not ` +
+      'respond, so these strings have NOT been checked. See the details below.',
+  );
+} else if (rows.length === 0) {
   lines.push('No new or changed translations in this pull request.');
 } else {
   const flagged = rows.filter((row) => row.flagged);


### PR DESCRIPTION
## Two more Swedish strings

Translated in Weblate after #3490 was cut, so they missed that merge. Swedish is now complete for every string the old component knew about.

| Source | Swedish |
|---|---|
| Collections | Samlingar |
| Overlays | Overlays |

`Overlays` is deliberately identical to its source (product term). The catalog validator reports that as a note, not an error.

## The review comment was hiding failures

On #3490 the comment said *"No new or changed translations in this pull request."* That was false. The log shows it found them:

```
sv: reviewing 7 strings
```

Then the model call failed and the empty-rows path printed a clean bill of health. It now says plainly that the strings were **not** checked.

## Why it failed, and what else it breaks

```
GitHub Models 410: github_models_retirement_brownout
```

**GitHub Models was fully retired on 2026-07-30.** Three other tools call the same dead endpoint and have been failing silently since:

| Tool | Workflow |
|---|---|
| `tools/generate-release-notes.mjs` | `release_5_publish.yml` |
| `tools/fider-triage.mjs` | `fider-triage.yml`, `fider-re-evaluate.yml`, `fider-pre-existing-scan.yml` |
| `tools/docs-drift-ai.mjs` | `docs_drift.yml` |

Choosing a replacement provider is a separate decision across all four; this PR only stops the translation one from lying about it.