### PR TITLE
fix(ci): unbreak the translation review job and pin Weblate PRs to a merge commit

### DIFF
--- a/.github/workflows/weblate_review.yml
+++ b/.github/workflows/weblate_review.yml
@@ -47,12 +47,55 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
+            const pr = context.payload.pull_request
+            const fromWeblate =
+              pr.user.login.startsWith('hosted-weblate') ||
+              pr.head.ref.startsWith('weblate-')
+            const labels = fromWeblate ? ['i18n', 'do-not-squash'] : ['i18n']
+            for (const name of labels) {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name,
+              }).catch(() => {})
+            }
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: ['i18n'],
+              issue_number: pr.number,
+              labels,
             })
+
+      # Squash and rebase both rewrite commit SHAs, after which Weblate no
+      # longer recognises its own commits upstream and every later sync
+      # conflicts. Auto-merge pins the method so nobody has to remember.
+      - name: Pin Weblate pull requests to a merge commit
+        if: >-
+          startsWith(github.event.pull_request.user.login, 'hosted-weblate') ||
+          startsWith(github.event.pull_request.head.ref, 'weblate-')
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            try {
+              await github.graphql(
+                `mutation($id: ID!) {
+                   enablePullRequestAutoMerge(
+                     input: { pullRequestId: $id, mergeMethod: MERGE }
+                   ) { clientMutationId }
+                 }`,
+                { id: context.payload.pull_request.node_id },
+              )
+              core.info('Auto-merge enabled with a merge commit.')
+            } catch (error) {
+              core.warning(
+                'Could not pin auto-merge to a merge commit: ' +
+                  error.message +
+                  '. Merge commits must be enabled on the repository ' +
+                  '(Settings -> General -> Allow merge commits). ' +
+                  'Until then, do NOT squash this pull request.',
+              )
+            }
 
       - name: Back-translate changed strings
         env:

--- a/tools/i18n/back-translate.mjs
+++ b/tools/i18n/back-translate.mjs
@@ -41,8 +41,27 @@ const SIMILARITY_FLOOR = 0.3;
 
 const log = (message) => console.log(message);
 
+// The workflow always consumes the --out file, so the skip path has to write
+// one too. Exiting early without it fails the step on a missing file.
+const emit = (body) => {
+  if (outFile) {
+    writeFileSync(outFile, body);
+    log(`Wrote review table to ${outFile}`);
+  } else {
+    console.log(body);
+  }
+};
+
+const SKIP_NOTE =
+  '<!-- maintainerr-i18n-back-translation -->\n' +
+  '## Translation review\n\n' +
+  'Back-translation is not configured, so these translations have not been ' +
+  'machine-reviewed. Set the `AI_MODEL_API_KEY` repository secret to enable it.\n\n' +
+  'The catalog and placeholder checks are unaffected and still gate this pull request.\n';
+
 if (!hasModelAccess()) {
   log('AI_MODEL_API_KEY not set; skipping back-translation review.');
+  emit(SKIP_NOTE);
   process.exit(0);
 }
 
@@ -261,10 +280,4 @@ lines.push(
   '_Back-translated by machine for review. Read it as a hint, not a verdict._',
 );
 
-const output = lines.join('\n') + '\n';
-if (outFile) {
-  writeFileSync(outFile, output);
-  log(`Wrote review table to ${outFile}`);
-} else {
-  console.log(output);
-}
+emit(lines.join('\n') + '\n');


### PR DESCRIPTION
## 1. The failing check on #3493

```
cat: .i18n-review.md: No such file or directory
```

My bug. When `AI_MODEL_API_KEY` is unset the script skipped and exited 0 **without writing its `--out` file**, so the next step died on the missing file. The skip path now writes a short note instead:

> Back-translation is not configured, so these translations have not been machine-reviewed. Set the `AI_MODEL_API_KEY` repository secret to enable it.
>
> The catalog and placeholder checks are unaffected and still gate this pull request.

More honest than silence, and the job stops failing for a reason that isn't the translations' fault.

## 2. Pinning the merge method

Weblate PRs now get the `do-not-squash` label and auto-merge enabled with `mergeMethod: MERGE`, so the method is chosen by automation rather than whoever clicks the button.

Squash **and rebase** both rewrite commit SHAs. Once that happens Weblate no longer recognises its own commits upstream and every later sync conflicts - the recurring-conflict problem the Weblate docs warn about.

Only applies to PRs authored by the Weblate app or from a `weblate-*` branch, so ordinary catalog PRs are untouched.

### This needs one repository setting

```
allow_merge_commit: false   <- currently
allow_squash_merge: true
allow_rebase_merge: true
```

**Merge commits are disabled**, so right now neither a human nor the automation can merge a Weblate PR safely. Enable them under Settings → General → Allow merge commits, or:

```bash
gh api -X PATCH repos/maintainerr/Maintainerr -f allow_merge_commit=true
```

Until then the step logs a warning rather than failing, and the `do-not-squash` label carries the message.