### PR TITLE
fix(ci): gate the Weblate merge pin behind an approval, and label l10n

### DIFF
--- a/.github/workflows/weblate_merge.yml
+++ b/.github/workflows/weblate_merge.yml
@@ -1,0 +1,61 @@
+name: Weblate merge
+
+# Pins Weblate's own pull requests to a merge commit, but only once a human has
+# approved one. Squash and rebase both rewrite commit SHAs, after which Weblate
+# stops recognising its own commits upstream and every later sync conflicts.
+#
+# Deliberately triggered on review rather than on the pull request: development
+# requires zero approvals, so enabling auto-merge any earlier would merge
+# translations the moment CI went green, with nobody having read them.
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: weblate-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  pin-merge-method:
+    name: Pin to a merge commit
+    if: >-
+      github.event.review.state == 'approved' &&
+      github.event.pull_request.base.ref == 'development' &&
+      (startsWith(github.event.pull_request.user.login, 'hosted-weblate') ||
+       startsWith(github.event.pull_request.head.ref, 'weblate-'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.MERGE_APP_ID }}
+          private-key: ${{ secrets.MERGE_APP_KEY }}
+
+      - name: Enable auto-merge with a merge commit
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            try {
+              await github.graphql(
+                `mutation($id: ID!) {
+                   enablePullRequestAutoMerge(
+                     input: { pullRequestId: $id, mergeMethod: MERGE }
+                   ) { clientMutationId }
+                 }`,
+                { id: context.payload.pull_request.node_id },
+              )
+              core.info('Auto-merge enabled with a merge commit.')
+            } catch (error) {
+              core.warning(
+                'Could not pin auto-merge to a merge commit: ' +
+                  error.message +
+                  '. Check that merge commits are allowed on the repository. ' +
+                  'Until then, merge this by hand and do NOT squash it.',
+              )
+            }

--- a/.github/workflows/weblate_review.yml
+++ b/.github/workflows/weblate_review.yml
@@ -51,7 +51,7 @@ jobs:
             const fromWeblate =
               pr.user.login.startsWith('hosted-weblate') ||
               pr.head.ref.startsWith('weblate-')
-            const labels = fromWeblate ? ['i18n', 'do-not-squash'] : ['i18n']
+            const labels = fromWeblate ? ['l10n', 'do-not-squash'] : ['l10n']
             for (const name of labels) {
               await github.rest.issues.createLabel({
                 owner: context.repo.owner,
@@ -65,37 +65,6 @@ jobs:
               issue_number: pr.number,
               labels,
             })
-
-      # Squash and rebase both rewrite commit SHAs, after which Weblate no
-      # longer recognises its own commits upstream and every later sync
-      # conflicts. Auto-merge pins the method so nobody has to remember.
-      - name: Pin Weblate pull requests to a merge commit
-        if: >-
-          startsWith(github.event.pull_request.user.login, 'hosted-weblate') ||
-          startsWith(github.event.pull_request.head.ref, 'weblate-')
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            try {
-              await github.graphql(
-                `mutation($id: ID!) {
-                   enablePullRequestAutoMerge(
-                     input: { pullRequestId: $id, mergeMethod: MERGE }
-                   ) { clientMutationId }
-                 }`,
-                { id: context.payload.pull_request.node_id },
-              )
-              core.info('Auto-merge enabled with a merge commit.')
-            } catch (error) {
-              core.warning(
-                'Could not pin auto-merge to a merge commit: ' +
-                  error.message +
-                  '. Merge commits must be enabled on the repository ' +
-                  '(Settings -> General -> Allow merge commits). ' +
-                  'Until then, do NOT squash this pull request.',
-              )
-            }
 
       - name: Back-translate changed strings
         env:


### PR DESCRIPTION
## The auto-merge pin was firing too early

```
required_approving_review_count: 0
```

`development` requires **zero** approvals, so enabling auto-merge on the pull request itself merges translations the moment CI goes green - with nobody having read them. That is the opposite of reviewing them on GitHub, and it is live on `development` right now.

It moves to `weblate_merge.yml`, triggered on `pull_request_review` and gated on `state == 'approved'`. The approval still happens; only the choice of merge method is taken out of human hands.

Squash and rebase both rewrite commit SHAs, after which Weblate stops recognising its own commits upstream and every later sync conflicts - which is why the method needs pinning at all.

## Label is now l10n

The work in the repo is internationalisation; what arrives in these pull requests is localisation. `do-not-squash` is unchanged.