### PR TITLE
fix(ci): use a current Gemini model, and make the AI_MODEL override reachable

### DIFF
--- a/.github/workflows/docs_drift.yml
+++ b/.github/workflows/docs_drift.yml
@@ -131,6 +131,7 @@ jobs:
           BASE_REF: ${{ steps.base.outputs.ref }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
+          AI_MODEL: ${{ vars.AI_MODEL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           OUTPUT_PATH: ${{ github.workspace }}/.drift-report.md
         run: node tools/docs-drift-ai.mjs

--- a/.github/workflows/fider-pre-existing-scan.yml
+++ b/.github/workflows/fider-pre-existing-scan.yml
@@ -56,6 +56,7 @@ jobs:
           FIDER_API_KEY: ${{ secrets.FIDER_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
+          AI_MODEL: ${{ vars.AI_MODEL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           DRY_RUN: ${{ inputs.dry_run }}
           FORCE_REEVAL: ${{ inputs.force_reeval }}

--- a/.github/workflows/fider-re-evaluate.yml
+++ b/.github/workflows/fider-re-evaluate.yml
@@ -46,6 +46,7 @@ jobs:
           FIDER_API_KEY: ${{ secrets.FIDER_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
+          AI_MODEL: ${{ vars.AI_MODEL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
           FORCE_REEVAL: 'true'

--- a/.github/workflows/fider-triage.yml
+++ b/.github/workflows/fider-triage.yml
@@ -39,6 +39,7 @@ jobs:
           FIDER_API_KEY: ${{ secrets.FIDER_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
+          AI_MODEL: ${{ vars.AI_MODEL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
           FIDER_TRIAGE_MODEL: openai/gpt-4.1-mini

--- a/.github/workflows/release_5_publish.yml
+++ b/.github/workflows/release_5_publish.yml
@@ -91,6 +91,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
+          AI_MODEL: ${{ vars.AI_MODEL }}
           DRY_RUN: ${{ github.event.inputs.dry-run-semantic-release }}
         run: |
           if [ "$DRY_RUN" == "true" ]; then

--- a/.github/workflows/weblate_review.yml
+++ b/.github/workflows/weblate_review.yml
@@ -70,6 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
+          AI_MODEL: ${{ vars.AI_MODEL }}
         run: |
           node tools/i18n/back-translate.mjs \
             --base "origin/${{ github.event.pull_request.base.ref }}" \

--- a/tools/ai/model-client.mjs
+++ b/tools/ai/model-client.mjs
@@ -18,7 +18,7 @@ export const MODEL_ENDPOINT =
   process.env.AI_MODEL_ENDPOINT ||
   'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions';
 
-export const DEFAULT_MODEL = process.env.AI_MODEL || 'gemini-2.0-flash';
+export const DEFAULT_MODEL = process.env.AI_MODEL || 'gemini-3.1-flash-lite';
 
 export const modelToken = () => process.env.AI_MODEL_API_KEY || '';
 
@@ -44,7 +44,13 @@ export const callModel = async (
     body: JSON.stringify({ model, messages, temperature }),
   });
   if (!res.ok) {
-    throw new Error(`Model endpoint ${res.status}: ${await res.text()}`);
+    const body = await res.text();
+    // Model names get retired; make the fix obvious rather than cryptic.
+    const hint =
+      res.status === 404
+        ? ' (set the AI_MODEL repository variable to a current model)'
+        : '';
+    throw new Error(`Model endpoint ${res.status}${hint}: ${body}`);
   }
   const data = await res.json();
   return (data.choices?.[0]?.message?.content || '').trim();

--- a/tools/docs-drift-ai.mjs
+++ b/tools/docs-drift-ai.mjs
@@ -9,7 +9,7 @@ import {
 import path from "node:path";
 
 import { MODEL_ENDPOINT, modelHeaders, modelToken } from "./ai/model-client.mjs";
-const MODEL = process.env.DOCS_DRIFT_MODEL || process.env.AI_MODEL || "gemini-2.0-flash";
+const MODEL = process.env.DOCS_DRIFT_MODEL || process.env.AI_MODEL || "gemini-3.1-flash-lite";
 const MAX_PROMPT_CHARS = 24000;
 const MAX_DOC_CHARS = 4000;
 const MAX_ISSUE_BODY_CHARS = 2000;

--- a/tools/fider-triage.mjs
+++ b/tools/fider-triage.mjs
@@ -14,7 +14,7 @@ const {
   FIDER_API_KEY,
   GITHUB_TOKEN,
   GITHUB_REPOSITORY: repo,
-  FIDER_TRIAGE_MODEL = process.env.AI_MODEL || 'gemini-2.0-flash',
+  FIDER_TRIAGE_MODEL = process.env.AI_MODEL || 'gemini-3.1-flash-lite',
   DRY_RUN = 'false',
   FORCE_REEVAL = 'false',
   CHECK_PRE_EXISTING = 'false',

--- a/tools/generate-release-notes.mjs
+++ b/tools/generate-release-notes.mjs
@@ -31,7 +31,7 @@ const {
   GITHUB_REPOSITORY: repo = "",
   GITHUB_TOKEN,
   GH_TOKEN,
-  RELEASE_NOTES_MODEL = process.env.AI_MODEL || "gemini-2.0-flash",
+  RELEASE_NOTES_MODEL = process.env.AI_MODEL || "gemini-3.1-flash-lite",
 } = process.env;
 
 const modelToken = GITHUB_TOKEN || GH_TOKEN || "";

--- a/tools/i18n/back-translate.mjs
+++ b/tools/i18n/back-translate.mjs
@@ -31,7 +31,7 @@ const baseRef = flagValue('--base');
 const outFile = flagValue('--out');
 
 const I18N_REVIEW_MODEL =
-  process.env.I18N_REVIEW_MODEL || process.env.AI_MODEL || 'gemini-2.0-flash';
+  process.env.I18N_REVIEW_MODEL || process.env.AI_MODEL || 'gemini-3.1-flash-lite';
 
 const SOURCE_LOCALE = 'en';
 const BATCH_SIZE = 40;


### PR DESCRIPTION
## The key works; the model name did not

First real call after the secret was added:

```
404: This model models/gemini-2.0-flash is no longer available.
```

`gemini-2.0-flash` was **shut down on 2026-06-01**. Default is now `gemini-3.1-flash-lite`, which Google's own retirement notice recommends.

Worth noting the failure behaved correctly: the review comment said *"Could not review 21 changed translations… these strings have NOT been checked"* rather than claiming a clean bill of health. That is the fix from #3495 doing its job.

## The override was never wired up

I said model changes would be a repository-variable edit rather than a code change. That was wrong: `AI_MODEL` was passed to **no workflow**, so nothing could ever read it.

It is now plumbed into all six as `${{ vars.AI_MODEL }}`, so the next retirement really is a variable change.

## Better failure message

A 404 from the endpoint now appends *"(set the AI_MODEL repository variable to a current model)"*, because model names clearly churn faster than this repo releases.