### PR TITLE
chore(fider): re-check post status before writing to it

### DIFF
--- a/tools/fider-stale.mjs
+++ b/tools/fider-stale.mjs
@@ -102,6 +102,14 @@ const declinePost = async (post, warnComment) => {
 };
 
 const sweepPost = async (post) => {
+  // Same reason as the triage bot: the queue is read once and worked through
+  // over minutes, so a post can be completed or declined mid-run while the
+  // object in hand still says "open".
+  const current = await fider(`/api/v1/posts/${post.number}`);
+  if (current && !SWEEPABLE_STATUSES.has(current.status)) {
+    return { skipped: `now-${current.status}` };
+  }
+
   if (isExempt(post)) return { skipped: 'exempt-tag' };
   if (ageInDays(post.createdAt) < STALE_AGE_DAYS) return { skipped: 'too-young' };
   if ((post.votesCount || 0) >= MAX_VOTES_FOR_STALE) return { skipped: 'enough-votes' };

--- a/tools/fider-triage.mjs
+++ b/tools/fider-triage.mjs
@@ -148,6 +148,16 @@ const findBotCommentOfType = async (post, marker) => {
 // body has changed. Lets re-evaluation update stale evidence (e.g. pointing
 // at a newer/better PR) instead of leaving the original verdict frozen.
 const upsertBotComment = async (post, marker, content, label) => {
+  // The queue is read once, then worked through one post at a time. A
+  // maintainer can complete or decline a post while the run is still going,
+  // and the post object in hand would still say "open". Re-read the status
+  // immediately before writing so the bot never comments on a closed request.
+  const current = await fider(`/api/v1/posts/${post.number}`);
+  if (current && !OPEN_STATUSES.has(current.status)) {
+    log(`#${post.number}: now ${current.status}, skipping ${label}`);
+    return;
+  }
+
   const existing = await findBotCommentOfType(post, marker);
   if (!existing) {
     if (dryRun) {


### PR DESCRIPTION
Both bots read their queue once and then work through it one post at a time. A maintainer completing or declining a post mid-run leaves the object in hand still saying open, so the bot writes to a closed request.

Both now re-read the status immediately before the write and skip if it has left the open set.

This was always possible but rare. It stopped being rare when the model calls were paced to the provider's free tier: 13 requests a minute instead of 60 turns a 100-post run from about two minutes into eight or more, which widens the window considerably.

