### PR TITLE
fix(notifications): batch collection removal notifications and retry rate limits (#3500)

### DIFF
--- a/apps/server/src/modules/api/lib/httpRetry.spec.ts
+++ b/apps/server/src/modules/api/lib/httpRetry.spec.ts
@@ -1,0 +1,33 @@
+import { AxiosError } from 'axios';
+import { isRetryableRateLimit, rateLimitWaitMs } from './httpRetry';
+
+const failedWith = (
+  status: number,
+  headers: Record<string, string> = {},
+  data?: unknown,
+) => ({ response: { status, headers, data } }) as unknown as AxiosError;
+
+describe('rate-limit retry policy', () => {
+  it('waits out the declared window, not the Retry-After header', () => {
+    // Captured from a live discord.com webhook 429: the header is neither
+    // seconds nor a countdown, while the body and reset-after agree.
+    const discord = failedWith(
+      429,
+      { 'retry-after': '1665', 'x-ratelimit-reset-after': '2' },
+      { retry_after: 0.3 },
+    );
+
+    expect(rateLimitWaitMs(discord)).toBe(2000);
+    expect(isRetryableRateLimit(discord)).toBe(true);
+    // Slack, ntfy and operator webhooks only send the plain header.
+    expect(rateLimitWaitMs(failedWith(429, { 'retry-after': '3' }))).toBe(3000);
+  });
+
+  it('only retries a 429 the limiter will release in time', () => {
+    expect(isRetryableRateLimit(failedWith(429))).toBe(true);
+    expect(
+      isRetryableRateLimit(failedWith(429, {}, { retry_after: 900 })),
+    ).toBe(false);
+    expect(isRetryableRateLimit(failedWith(400))).toBe(false);
+  });
+});

--- a/apps/server/src/modules/api/lib/httpRetry.ts
+++ b/apps/server/src/modules/api/lib/httpRetry.ts
@@ -1,5 +1,58 @@
-import { type AxiosInstance } from 'axios';
-import axiosRetry from 'axios-retry';
+import axios, { type AxiosError, type AxiosInstance } from 'axios';
+import axiosRetry, { type IAxiosRetryConfig } from 'axios-retry';
+
+// Past this the send would be held open too long, and on Discord count against
+// its invalid-request ban threshold, so give up instead.
+const MAX_RATE_LIMIT_WAIT_MS = 60000;
+const RETRY_PADDING_MS = 250;
+
+const toMs = (seconds: unknown): number | undefined => {
+  const value = Number(seconds);
+  return Number.isFinite(value) && value >= 0 ? value * 1000 : undefined;
+};
+
+// RFC 9110 allows an HTTP-date in place of a delta-seconds value.
+const untilMs = (httpDate: unknown): number | undefined => {
+  const at = new Date(String(httpDate)).valueOf();
+  return Number.isFinite(at) ? Math.max(0, at - Date.now()) : undefined;
+};
+
+/**
+ * How long a rate limiter wants us to wait, in ms.
+ *
+ * `Retry-After` is the last resort on purpose: Discord's live webhook 429s send
+ * one that is neither seconds nor a countdown (~1700 while the body says 0.3 and
+ * `x-ratelimit-reset-after` says 2, and it grows while idle). Reading it as
+ * seconds, which is what axios-retry's own `retryAfter` does, turns a sub-second
+ * wait into 28 minutes. Take the longest of the fields that agree, since
+ * retrying inside a window that is still open only earns another 429.
+ */
+export const rateLimitWaitMs = (error: AxiosError): number => {
+  const body =
+    typeof error.response?.data === 'object'
+      ? (error.response.data as {
+          retry_after?: unknown;
+          parameters?: { retry_after?: unknown };
+        })
+      : undefined;
+  const headers = error.response?.headers;
+
+  const declared = Math.max(
+    toMs(body?.retry_after) ?? 0,
+    // Telegram nests it.
+    toMs(body?.parameters?.retry_after) ?? 0,
+    toMs(headers?.['x-ratelimit-reset-after']) ?? 0,
+  );
+  if (declared > 0) return declared;
+
+  // Slack, ntfy and operator-supplied webhooks send a plain one.
+  const header = headers?.['retry-after'];
+  return toMs(header) ?? untilMs(header) ?? 0;
+};
+
+export const isRetryableRateLimit = (error: AxiosError): boolean =>
+  error.response?.status === 429 &&
+  rateLimitWaitMs(error) <= MAX_RATE_LIMIT_WAIT_MS;
 
 /**
  * Apply Maintainerr's standard transient-failure retry policy - 3 attempts
@@ -7,9 +60,26 @@ import axiosRetry from 'axios-retry';
  * every outbound HTTP client (Plex, Emby, the Jellyfin SDK, external-api)
  * retries identically.
  */
-export function applyHttpRetry(instance: AxiosInstance): void {
+export function applyHttpRetry(
+  instance: AxiosInstance,
+  overrides?: Pick<IAxiosRetryConfig, 'retryCondition' | 'retryDelay'>,
+): void {
   axiosRetry(instance, {
     retries: 3,
     retryDelay: axiosRetry.exponentialDelay,
+    ...overrides,
   });
 }
+
+/**
+ * The client every notification agent posts through. A rule run can produce a
+ * burst of sends, and a rate-limited one is otherwise logged and lost - so
+ * retry 429 here, once, rather than per agent.
+ */
+export const rateLimitAwareHttp = axios.create();
+
+applyHttpRetry(rateLimitAwareHttp, {
+  retryCondition: isRetryableRateLimit,
+  retryDelay: (retryCount, error) =>
+    (error ? rateLimitWaitMs(error) : 0) + RETRY_PADDING_MS * retryCount,
+});

--- a/apps/server/src/modules/notifications/agents/discord.spec.ts
+++ b/apps/server/src/modules/notifications/agents/discord.spec.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { createMockLogger } from '../../../../test/utils/data';
 import { Notification } from '../entities/notification.entities';
 import {
@@ -8,12 +8,11 @@ import {
 } from '../notifications-interfaces';
 import DiscordAgent from './discord';
 
-jest.mock('axios', () => ({
-  __esModule: true,
-  default: {
-    post: jest.fn(),
-  },
+jest.mock('../../api/lib/httpRetry', () => ({
+  rateLimitAwareHttp: { post: jest.fn() },
 }));
+
+const { post } = rateLimitAwareHttp as unknown as { post: jest.Mock };
 
 describe('DiscordAgent', () => {
   const webhookUrl = 'https://discord.com/api/webhooks/123/abc';
@@ -34,7 +33,7 @@ describe('DiscordAgent', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (axios.post as jest.Mock).mockResolvedValue({});
+    post.mockResolvedValue({});
   });
 
   it('omits the thumbnail when no image is provided', async () => {
@@ -45,7 +44,7 @@ describe('DiscordAgent', () => {
       message: 'Test message',
     });
 
-    const [, body] = (axios.post as jest.Mock).mock.calls[0];
+    const [, body] = post.mock.calls[0];
     expect(body.embeds[0]).not.toHaveProperty('thumbnail');
   });
 
@@ -58,7 +57,7 @@ describe('DiscordAgent', () => {
       image: 'https://example.com/poster.jpg',
     });
 
-    const [, body] = (axios.post as jest.Mock).mock.calls[0];
+    const [, body] = post.mock.calls[0];
     expect(body.embeds[0].thumbnail).toEqual({
       url: 'https://example.com/poster.jpg',
     });
@@ -73,6 +72,19 @@ describe('DiscordAgent', () => {
     });
 
     expect(result).toBe('Failure: unsupported webhook URL scheme');
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('trims a batched message to the embed description limit', async () => {
+    const agent = createAgent();
+
+    await agent.send(NotificationType.TEST_NOTIFICATION, {
+      subject: 'Test subject',
+      message: 'x'.repeat(5000),
+    });
+
+    const [, body] = post.mock.calls[0];
+    expect(body.embeds[0].description).toHaveLength(4096);
+    expect(body.embeds[0].description.endsWith('\n...')).toBe(true);
   });
 });

--- a/apps/server/src/modules/notifications/agents/discord.ts
+++ b/apps/server/src/modules/notifications/agents/discord.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { Notification } from '../entities/notification.entities';
 import {
@@ -9,6 +9,17 @@ import {
 import { hasNotificationType } from '../notifications.service';
 import type { NotificationAgent, NotificationPayload } from './agent';
 import { validateWebhookUrl } from './webhookUrl';
+
+// https://discord.com/developers/docs/resources/message#embed-object-embed-limits
+const EMBED_TITLE_LIMIT = 256;
+const EMBED_DESCRIPTION_LIMIT = 4096;
+
+const TRUNCATION_MARKER = '\n...';
+
+const truncate = (value: string | undefined, limit: number) =>
+  value && value.length > limit
+    ? `${value.slice(0, limit - TRUNCATION_MARKER.length)}${TRUNCATION_MARKER}`
+    : value;
 
 enum EmbedColors {
   DEFAULT = 0,
@@ -114,8 +125,10 @@ class DiscordAgent implements NotificationAgent {
     //   });
     // }
     return {
-      title: payload.subject,
-      description: payload.message,
+      title: truncate(payload.subject, EMBED_TITLE_LIMIT),
+      // A batch lists every item, and Discord answers 400 - dropping the whole
+      // message - once it outgrows the limit.
+      description: truncate(payload.message, EMBED_DESCRIPTION_LIMIT),
       color,
       timestamp: new Date().toISOString(),
       fields,
@@ -152,7 +165,7 @@ class DiscordAgent implements NotificationAgent {
     this.logger.log('Sending Discord notification');
 
     try {
-      await axios.post(webhookUrl.url, {
+      await rateLimitAwareHttp.post(webhookUrl.url, {
         username: this.getSettings().options.botUsername
           ? this.getSettings().options.botUsername
           : 'Maintainerr',

--- a/apps/server/src/modules/notifications/agents/gotify.ts
+++ b/apps/server/src/modules/notifications/agents/gotify.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { SettingsDataService } from '../../settings/settings-data.service';
 import { Notification } from '../entities/notification.entities';
@@ -84,7 +84,7 @@ class GotifyAgent implements NotificationAgent {
       const endpoint = `${settings.options.url}/message?token=${settings.options.token}`;
       const notificationPayload = this.getNotificationPayload(type, payload);
 
-      await axios.post(endpoint, notificationPayload);
+      await rateLimitAwareHttp.post(endpoint, notificationPayload);
 
       return 'Success';
     } catch (error) {

--- a/apps/server/src/modules/notifications/agents/lunasea.spec.ts
+++ b/apps/server/src/modules/notifications/agents/lunasea.spec.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { createMockLogger } from '../../../../test/utils/data';
 import { Notification } from '../entities/notification.entities';
 import {
@@ -8,12 +8,11 @@ import {
 } from '../notifications-interfaces';
 import LunaSeaAgent from './lunasea';
 
-jest.mock('axios', () => ({
-  __esModule: true,
-  default: {
-    post: jest.fn(),
-  },
+jest.mock('../../api/lib/httpRetry', () => ({
+  rateLimitAwareHttp: { post: jest.fn() },
 }));
+
+const { post } = rateLimitAwareHttp as unknown as { post: jest.Mock };
 
 describe('LunaSeaAgent', () => {
   const createAgent = (webhookUrl: string) => {
@@ -37,7 +36,7 @@ describe('LunaSeaAgent', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (axios.post as jest.Mock).mockResolvedValue({});
+    post.mockResolvedValue({});
   });
 
   it('rejects a non-http(s) webhook URL without posting', async () => {
@@ -49,7 +48,7 @@ describe('LunaSeaAgent', () => {
     });
 
     expect(result).toBe('Failure: unsupported webhook URL scheme');
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalled();
   });
 
   it('posts to the normalised URL for a valid webhook', async () => {
@@ -60,9 +59,7 @@ describe('LunaSeaAgent', () => {
       message: 'Test message',
     });
 
-    expect(axios.post).toHaveBeenCalledTimes(1);
-    expect((axios.post as jest.Mock).mock.calls[0][0]).toBe(
-      'https://example.com/',
-    );
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post.mock.calls[0][0]).toBe('https://example.com/');
   });
 });

--- a/apps/server/src/modules/notifications/agents/lunasea.ts
+++ b/apps/server/src/modules/notifications/agents/lunasea.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { SettingsDataService } from '../../settings/settings-data.service';
 import { Notification } from '../entities/notification.entities';
@@ -69,7 +69,7 @@ class LunaSeaAgent implements NotificationAgent {
     this.logger.log('Sending LunaSea notification');
 
     try {
-      await axios.post(
+      await rateLimitAwareHttp.post(
         webhookUrl.url,
         this.buildPayload(type, payload),
         settings.options.profileName

--- a/apps/server/src/modules/notifications/agents/ntfy.spec.ts
+++ b/apps/server/src/modules/notifications/agents/ntfy.spec.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { createMockLogger } from '../../../../test/utils/data';
 import { Notification } from '../entities/notification.entities';
 import {
@@ -8,12 +8,11 @@ import {
 } from '../notifications-interfaces';
 import NtfyAgent from './ntfy';
 
-jest.mock('axios', () => ({
-  __esModule: true,
-  default: {
-    post: jest.fn(),
-  },
+jest.mock('../../api/lib/httpRetry', () => ({
+  rateLimitAwareHttp: { post: jest.fn() },
 }));
+
+const { post } = rateLimitAwareHttp as unknown as { post: jest.Mock };
 
 describe('NtfyAgent', () => {
   const createAgent = (token?: string, url = 'https://ntfy.sh/') => {
@@ -34,7 +33,7 @@ describe('NtfyAgent', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (axios.post as jest.Mock).mockResolvedValue({});
+    post.mockResolvedValue({});
   });
 
   it('allows public topics without a token', () => {
@@ -52,7 +51,7 @@ describe('NtfyAgent', () => {
     });
 
     expect(result).toBe('Failure: unsupported webhook URL scheme');
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalled();
   });
 
   it('omits the authorization header when no token is configured', async () => {
@@ -63,7 +62,7 @@ describe('NtfyAgent', () => {
       message: 'Test message',
     });
 
-    expect(axios.post).toHaveBeenCalledWith(
+    expect(post).toHaveBeenCalledWith(
       'https://ntfy.sh/maintainerr',
       'Test message',
       {
@@ -83,7 +82,7 @@ describe('NtfyAgent', () => {
       message: 'Test message',
     });
 
-    expect(axios.post).toHaveBeenCalledWith(
+    expect(post).toHaveBeenCalledWith(
       'https://ntfy.sh/maintainerr',
       'Test message',
       {

--- a/apps/server/src/modules/notifications/agents/ntfy.ts
+++ b/apps/server/src/modules/notifications/agents/ntfy.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { SettingsDataService } from '../../settings/settings-data.service';
 import { Notification } from '../entities/notification.entities';
@@ -98,7 +98,7 @@ class NtfyAgent implements NotificationAgent {
         headers.Authorization = `Bearer ${settings.options.token}`;
       }
 
-      await axios.post(endpoint, notificationPayload.message, {
+      await rateLimitAwareHttp.post(endpoint, notificationPayload.message, {
         headers,
       });
 

--- a/apps/server/src/modules/notifications/agents/pushbullet.ts
+++ b/apps/server/src/modules/notifications/agents/pushbullet.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { SettingsDataService } from '../../settings/settings-data.service';
 import { Notification } from '../entities/notification.entities';
@@ -74,7 +74,7 @@ class PushbulletAgent implements NotificationAgent {
       this.logger.log('Sending Pushbullet notification');
 
       try {
-        await axios.post(
+        await rateLimitAwareHttp.post(
           endpoint,
           { ...notificationPayload, channel_tag: settings.options.channelTag },
           {
@@ -104,7 +104,7 @@ class PushbulletAgent implements NotificationAgent {
       this.logger.log('Sending Pushbullet notification');
 
       try {
-        await axios.post(endpoint, notificationPayload, {
+        await rateLimitAwareHttp.post(endpoint, notificationPayload, {
           headers: {
             'Access-Token': settings.options.accessToken,
           },

--- a/apps/server/src/modules/notifications/agents/pushover.ts
+++ b/apps/server/src/modules/notifications/agents/pushover.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { SettingsDataService } from '../../settings/settings-data.service';
 import { Notification } from '../entities/notification.entities';
@@ -129,7 +130,7 @@ class PushoverAgent implements NotificationAgent {
       this.logger.log('Sending Pushover notification');
 
       try {
-        await axios.post(endpoint, {
+        await rateLimitAwareHttp.post(endpoint, {
           ...notificationPayload,
           token: settings.options.accessToken,
           user: settings.options.userToken,

--- a/apps/server/src/modules/notifications/agents/slack.spec.ts
+++ b/apps/server/src/modules/notifications/agents/slack.spec.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { createMockLogger } from '../../../../test/utils/data';
 import { Notification } from '../entities/notification.entities';
 import {
@@ -8,12 +8,11 @@ import {
 } from '../notifications-interfaces';
 import SlackAgent from './slack';
 
-jest.mock('axios', () => ({
-  __esModule: true,
-  default: {
-    post: jest.fn(),
-  },
+jest.mock('../../api/lib/httpRetry', () => ({
+  rateLimitAwareHttp: { post: jest.fn() },
 }));
+
+const { post } = rateLimitAwareHttp as unknown as { post: jest.Mock };
 
 describe('SlackAgent', () => {
   const createAgent = (webhookUrl: string) => {
@@ -37,7 +36,7 @@ describe('SlackAgent', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (axios.post as jest.Mock).mockResolvedValue({});
+    post.mockResolvedValue({});
   });
 
   it('rejects a non-http(s) webhook URL without posting', async () => {
@@ -49,7 +48,7 @@ describe('SlackAgent', () => {
     });
 
     expect(result).toBe('Failure: unsupported webhook URL scheme');
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalled();
   });
 
   it('posts to the normalised URL for a valid webhook', async () => {
@@ -60,9 +59,7 @@ describe('SlackAgent', () => {
       message: 'Test message',
     });
 
-    expect(axios.post).toHaveBeenCalledTimes(1);
-    expect((axios.post as jest.Mock).mock.calls[0][0]).toBe(
-      'https://example.com/',
-    );
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post.mock.calls[0][0]).toBe('https://example.com/');
   });
 });

--- a/apps/server/src/modules/notifications/agents/slack.ts
+++ b/apps/server/src/modules/notifications/agents/slack.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { SettingsDataService } from '../../settings/settings-data.service';
 import { Notification } from '../entities/notification.entities';
@@ -149,7 +149,10 @@ class SlackAgent implements NotificationAgent {
 
     this.logger.log('Sending Slack notification');
     try {
-      await axios.post(webhookUrl.url, this.buildEmbed(type, payload));
+      await rateLimitAwareHttp.post(
+        webhookUrl.url,
+        this.buildEmbed(type, payload),
+      );
 
       return 'Success';
     } catch (error) {

--- a/apps/server/src/modules/notifications/agents/telegram.ts
+++ b/apps/server/src/modules/notifications/agents/telegram.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { SettingsDataService } from '../../settings/settings-data.service';
 import { Notification } from '../entities/notification.entities';
@@ -100,7 +100,7 @@ class TelegramAgent implements NotificationAgent {
       this.logger.log('Sending Telegram notification');
 
       try {
-        await axios.post(endpoint, {
+        await rateLimitAwareHttp.post(endpoint, {
           ...notificationPayload,
           chat_id: settings.options.chatId,
           disable_notification: !!settings.options.sendSilently,

--- a/apps/server/src/modules/notifications/agents/webhook.spec.ts
+++ b/apps/server/src/modules/notifications/agents/webhook.spec.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { createMockLogger } from '../../../../test/utils/data';
 import { Notification } from '../entities/notification.entities';
 import {
@@ -8,12 +8,11 @@ import {
 } from '../notifications-interfaces';
 import WebhookAgent from './webhook';
 
-jest.mock('axios', () => ({
-  __esModule: true,
-  default: {
-    post: jest.fn(),
-  },
+jest.mock('../../api/lib/httpRetry', () => ({
+  rateLimitAwareHttp: { post: jest.fn() },
 }));
+
+const { post } = rateLimitAwareHttp as unknown as { post: jest.Mock };
 
 describe('WebhookAgent', () => {
   const createAgent = (
@@ -41,11 +40,11 @@ describe('WebhookAgent', () => {
     );
   };
 
-  const postedBody = () => (axios.post as jest.Mock).mock.calls[0][1];
+  const postedBody = () => post.mock.calls[0][1];
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (axios.post as jest.Mock).mockResolvedValue({});
+    post.mockResolvedValue({});
   });
 
   it('rejects a non-http(s) webhook URL without posting', async () => {
@@ -57,7 +56,7 @@ describe('WebhookAgent', () => {
     });
 
     expect(result).toBe('Failure: unsupported webhook URL scheme');
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalled();
   });
 
   it('flattens extras onto the posted body', async () => {

--- a/apps/server/src/modules/notifications/agents/webhook.ts
+++ b/apps/server/src/modules/notifications/agents/webhook.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import { get } from 'lodash';
+import { rateLimitAwareHttp } from '../../api/lib/httpRetry';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { SettingsDataService } from '../../settings/settings-data.service';
 import { Notification } from '../entities/notification.entities';
@@ -129,7 +129,7 @@ class WebhookAgent implements NotificationAgent {
     this.logger.log('Sending webhook notification');
 
     try {
-      await axios.post(
+      await rateLimitAwareHttp.post(
         webhookUrl.url,
         this.buildPayload(type, payload),
         settings.options.authHeader

--- a/apps/server/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/server/src/modules/notifications/notifications.service.spec.ts
@@ -641,6 +641,73 @@ describe('NotificationService', () => {
     });
   });
 
+  describe('collection handler run batching', () => {
+    const removedDto = (
+      collectionId: number,
+      collectionName: string,
+      ids: string[],
+    ) =>
+      new CollectionMediaRemovedDto(
+        ids.map((mediaServerId) => ({ mediaServerId })),
+        collectionName,
+        { type: 'collection', value: collectionId },
+        collectionId,
+        7,
+      );
+
+    const runRemovals = async (
+      service: NotificationService,
+      dtos: CollectionMediaRemovedDto[],
+    ) => {
+      (service as any).collectionHandlerStarted();
+      for (const dto of dtos) {
+        await (service as any).collectionMediaRemoved(dto);
+      }
+      await (service as any).collectionHandlerFinished();
+    };
+
+    it('sends one notification per collection, per run', async () => {
+      const { service } = createService();
+      const handle = jest
+        .spyOn(service, 'handleNotification')
+        .mockResolvedValue('Success' as any);
+
+      await runRemovals(service, [
+        removedDto(1, 'Stale Movies', ['m1']),
+        removedDto(1, 'Stale Movies', ['m2']),
+        removedDto(2, 'Stale Shows', ['s1']),
+      ]);
+      // A second run must not resend the first one's items.
+      await runRemovals(service, [removedDto(1, 'Stale Movies', ['m3'])]);
+
+      expect(handle).toHaveBeenCalledTimes(3);
+      expect(handle).toHaveBeenNthCalledWith(
+        1,
+        NotificationType.MEDIA_REMOVED_FROM_COLLECTION,
+        [{ mediaServerId: 'm1' }, { mediaServerId: 'm2' }],
+        'Stale Movies',
+        7,
+        undefined,
+        { type: 'collection', value: 1 },
+      );
+      expect(handle.mock.calls[1][1]).toEqual([{ mediaServerId: 's1' }]);
+      expect(handle.mock.calls[2][1]).toEqual([{ mediaServerId: 'm3' }]);
+    });
+
+    it('sends immediately outside a run', async () => {
+      const { service } = createService();
+      const handle = jest
+        .spyOn(service, 'handleNotification')
+        .mockResolvedValue('Success' as any);
+
+      await (service as any).collectionMediaRemoved(
+        removedDto(1, 'Stale Movies', ['m1']),
+      );
+
+      expect(handle).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('defines content for overlay reverted notifications', () => {
     const { service } = createService();
 

--- a/apps/server/src/modules/notifications/notifications.service.ts
+++ b/apps/server/src/modules/notifications/notifications.service.ts
@@ -80,6 +80,17 @@ export class NotificationService implements OnModuleInit {
   private batchActive = false;
   private readonly batchSeenKeys = new Set<string>();
 
+  // Collection handling acts on one item at a time, so every removal emits its
+  // own CollectionMedia_Removed - one webhook per item, which Discord answers
+  // with 429 and drops. Buffer them for the length of a handler run and send
+  // one notification per collection at the end. Rule runs already batch at the
+  // emitter, so they keep sending immediately.
+  private collectionRunActive = false;
+  private readonly collectionRunRemovals = new Map<
+    number,
+    CollectionMediaRemovedDto
+  >();
+
   constructor(
     @InjectRepository(Notification)
     private readonly notificationRepo: Repository<Notification>,
@@ -1156,6 +1167,31 @@ export class NotificationService implements OnModuleInit {
 
   @OnEvent(MaintainerrEvent.CollectionMedia_Removed)
   private async collectionMediaRemoved(data: CollectionMediaRemovedDto) {
+    if (this.collectionRunActive) {
+      // Appending is enough: an item can only be removed once, so the same id
+      // cannot arrive twice in one run.
+      const buffered = this.collectionRunRemovals.get(data.collectionId);
+      if (buffered) {
+        buffered.mediaItems.push(...data.mediaItems);
+      } else {
+        this.collectionRunRemovals.set(
+          data.collectionId,
+          new CollectionMediaRemovedDto(
+            [...data.mediaItems],
+            data.collectionName,
+            data.identifier,
+            data.collectionId,
+            data.dayAmount,
+          ),
+        );
+      }
+      return;
+    }
+
+    await this.notifyCollectionMediaRemoved(data);
+  }
+
+  private async notifyCollectionMediaRemoved(data: CollectionMediaRemovedDto) {
     const filteredMediaItems = this.dedupeBatchMediaItems(
       MaintainerrEvent.CollectionMedia_Removed,
       data.collectionName,
@@ -1171,6 +1207,23 @@ export class NotificationService implements OnModuleInit {
       undefined,
       data.identifier,
     );
+  }
+
+  @OnEvent(MaintainerrEvent.CollectionHandler_Started)
+  private collectionHandlerStarted() {
+    this.collectionRunRemovals.clear();
+    this.collectionRunActive = true;
+  }
+
+  @OnEvent(MaintainerrEvent.CollectionHandler_Finished)
+  private async collectionHandlerFinished() {
+    this.collectionRunActive = false;
+    const buffered = [...this.collectionRunRemovals.values()];
+    this.collectionRunRemovals.clear();
+
+    for (const data of buffered) {
+      await this.notifyCollectionMediaRemoved(data);
+    }
   }
 
   /**

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -706,6 +706,9 @@ export class RuleExecutorService {
           collectionMedia.length > 0 &&
           shouldCheckRemovals
         ) {
+          // Members the media server collection no longer lists.
+          const droppedByMediaServer: CollectionMediaChange[] = [];
+
           for (const mediaItem of collectionMedia) {
             if (!mediaItem?.mediaServerId) {
               continue;
@@ -726,19 +729,23 @@ export class RuleExecutorService {
               !children ||
               !children.find((e) => mediaItem.mediaServerId === e.id.toString())
             ) {
-              await this.collectionService.removeFromCollection(
-                collection.id,
-                [
-                  {
-                    mediaServerId: mediaItem.mediaServerId,
-                    reason: {
-                      type: 'media_removed_manually',
-                    },
-                  },
-                ] satisfies CollectionMediaChange[],
-                'manual',
-              );
+              droppedByMediaServer.push({
+                mediaServerId: mediaItem.mediaServerId,
+                reason: {
+                  type: 'media_removed_manually',
+                },
+              });
             }
+          }
+
+          // One call for the whole set, so emptying a collection by hand costs
+          // one media-server request and one notification, not N of each.
+          if (droppedByMediaServer.length > 0) {
+            await this.collectionService.removeFromCollection(
+              collection.id,
+              droppedByMediaServer,
+              'manual',
+            );
           }
         }
 


### PR DESCRIPTION
Closes #3500.

A collection handler run acts on one item at a time, so every removal emitted its own `CollectionMedia_Removed`, and every one of those became a webhook. Deleting 19 items sent 19 Discord messages, most of which Discord answered with 429 and the agent then dropped.

| Scenario | Before | After |
| --- | --- | --- |
| Handler run retiring 20 items | 20 webhooks | 1 |
| 5 movies handled via Radarr | 5 removed + 1 handled | 1 + 1 |
| 4 members removed from a BoxSet by hand | 4 media server calls + 4 webhooks | 1 + 1 |
| Send hits a 429 | logged, dropped | retried after the declared wait |

### Batching

Buffered per collection between `CollectionHandler_Started` and `CollectionHandler_Finished` (emitted in the worker's `finally`, so it always fires). This sits in `NotificationService` rather than the worker loop because three producers emit per item in a run: the handled path, the `removed-missing` cleanup, and `pruneSiblingCollections`, which removes from *other* collections. Accumulating in the loop would cover only the first, and would mean threading a flag through `removeFromCollection` and `removeMediaFromOtherCollections`.

Per collection, not per run: notification configs are wired to rule groups and the message names the collection, so merging across collections would send a user items they never subscribed to. `POST /collections/media/handle` (single item) emits no run events and still sends immediately.

The rule executor's manual-removal sync had the same shape and now makes one call for the whole set.

### Rate limits

Agents post through a shared rate-limit aware client in `httpRetry.ts`, next to the existing retry policy. The wait is read from the response body and `x-ratelimit-reset-after`, with `Retry-After` only as a fallback for Slack, ntfy and operator webhooks.

That ordering is deliberate. Live discord.com webhook 429s answer:

```
retry-after: 1665
x-ratelimit-reset-after: 2
{"message":"You are being rate limited.","retry_after":0.3,"global":false}
```

The header is neither seconds nor a countdown: after 75s idle it went *up* (1665 -> 1725 -> 1767) while the other two held. `axios-retry`'s own `retryAfter()` reads it as seconds, which would turn a 2 second wait into 28 minutes. The longest of the agreeing fields is used, since retrying inside a window that is still open only earns another 429.

Discord embeds are truncated to the documented 256/4096 limits, since a batched message lists every item and Discord rejects the whole message with 400 once it outgrows them.

The default policy for Plex, Emby, Jellyfin and external-api is unchanged; 429 retry is opt in via the new overrides parameter.