### PR TITLE
chore: correct the declared Node engines floor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -392,7 +392,7 @@ degrade gracefully.
 
 ### Environment Setup
 
-- **Node.js**: Version 22.13.0+ or 24.11.0+ (the floor is Node 22, raised from TypeORM 1.0.0's 20.19 requirement by the `@eslint-react` lint toolchain, which needs Node 22+; the Docker image and devcontainer ship Node 26)
+- **Node.js**: 22.22.2+, 24.15.0+, or 26+ (root `package.json` `engines` is the source of truth; Docker and the devcontainer ship Node 26)
 - **Package Manager**: Yarn 4.11 (managed via corepack)
 - **Data Directory**: Requires `data/` folder with proper permissions for development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ If you prefer to set up your development environment manually (specific to a Win
 
 - HTML/TypeScript/JavaScript editor
 - [VSCode](https://code.visualstudio.com/) is recommended. Upon opening the project, a few extensions will be automatically recommended for install.
-- [NodeJS](https://nodejs.org/en/download/) (Node 22.x or higher)
+- [NodeJS](https://nodejs.org/en/download/) (Node 22.22.2+, 24.15.0+, or 26+)
 - [Git](https://git-scm.com/downloads)
 
 #### Getting Started

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": "^22.13.0 || >=24.11.0"
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^7.0.0",


### PR DESCRIPTION
The declared floor sat below what the installed dependency tree requires, so Node 22.13.0 through 22.22.1 and 24.11.0 through 24.14.x were advertised as supported while shipped dependencies exclude them. The `@eslint-react` rationale in AGENTS.md was also stale.

| | Before | After |
|---|---|---|
| `engines.node` | `^22.13.0 \|\| >=24.11.0` | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` |

Strictest declarations in the tree:

| Package | `engines.node` |
|---|---|
| jsdom 30.0.1 | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` |
| @semantic-release/changelog 7.0.0, @semantic-release/git 11.0.1 | `^22.22.2 \|\| >=24.15` |
| Lingui 6.6.0 | `>=22.19.0` |
| @babel/core 8.0.1 | `^22.18.0 \|\| >=24.11.0` |

Scanned all 996 installed packages that declare `engines.node`. The corrected range is exactly the set with zero incompatible declarations: 22.22.2 and 24.15.0 are the first versions on their lines that satisfy everything, and 23.x and 25.x are excluded (non-LTS lines that jsdom drops).

| Environment | Node | Satisfies |
|---|---|---|
| CI | 24.19.0 (latest 24.x) | yes |
| Docker image | 26.3.0 | yes |
| Devcontainer | 26 | yes |

Yarn 4 does not enforce `engines`, for the root project or for dependencies, so nothing installs or builds differently. This corrects a claim to contributors.