### PR TITLE
fix(overlays): only draw the countdown on a show the action deletes

### DIFF
--- a/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
@@ -1365,7 +1365,9 @@ describe('OverlayProcessorService', () => {
     expect(eventEmitter.emit).not.toHaveBeenCalled();
   });
   describe('overlay inheritance', () => {
-    const seasonCollection = (arrAction = ServarrAction.DELETE) => {
+    const seasonCollection = (
+      arrAction = ServarrAction.DELETE_SHOW_IF_EMPTY,
+    ) => {
       const collection = createCollection({
         id: 1,
         title: 'Leaving seasons',
@@ -1528,7 +1530,7 @@ describe('OverlayProcessorService', () => {
       );
     });
 
-    it('walks emptied episodes up to their season and its show', async () => {
+    it('walks emptied episodes up to their season, but not to the show', async () => {
       const collection = createCollection({
         id: 1,
         title: 'Leaving episodes',
@@ -1560,7 +1562,6 @@ describe('OverlayProcessorService', () => {
             makeItem('episode-1', 'episode'),
             makeItem('episode-2', 'episode'),
           ],
-          'show-1': [makeItem('season-1', 'season', { index: 1 })],
         }),
       });
       const { service, applySpy } = buildService(mediaServer);
@@ -1571,7 +1572,36 @@ describe('OverlayProcessorService', () => {
         ['episode-1', 'titlecard'],
         ['episode-2', 'titlecard'],
         ['season-1', 'poster'],
-        ['show-1', 'poster'],
+      ]);
+    });
+
+    it('leaves the show alone when the action does not delete it', async () => {
+      const collection = seasonCollection(ServarrAction.DELETE);
+      const mediaServer = makeMediaServer({
+        getMetadataBatch: jest
+          .fn()
+          .mockResolvedValue([
+            makeItem('season-1', 'season', { parentId: 'show-1', index: 1 }),
+            makeItem('season-2', 'season', { parentId: 'show-1', index: 2 }),
+          ]),
+        getChildrenMetadata: childrenOf({
+          'show-1': [
+            makeItem('season-1', 'season', { index: 1 }),
+            makeItem('season-2', 'season', { index: 2 }),
+          ],
+          'season-1': [makeItem('episode-1', 'episode')],
+          'season-2': [makeItem('episode-2', 'episode')],
+        }),
+      });
+      const { service, applySpy } = buildService(mediaServer);
+
+      await service.processCollection(collection as any);
+
+      expect(drawn(applySpy)).toEqual([
+        ['season-1', 'poster'],
+        ['season-2', 'poster'],
+        ['episode-1', 'titlecard'],
+        ['episode-2', 'titlecard'],
       ]);
     });
 

--- a/apps/server/src/modules/overlays/overlay-processor.service.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.ts
@@ -278,14 +278,19 @@ export class OverlayProcessorService {
       for (const descendant of descendants) addTarget(descendant, deleteDate);
     }
 
-    // Up: group the members under the parent that is losing them.
+    // Up: group the members under the parent that is losing them. A show only
+    // counts when the action deletes the show itself - otherwise Sonarr keeps
+    // the series and can re-fill it (#3511). A season has no such escape: it is
+    // not an entity in Sonarr, it goes with its episodes.
+    const actionDeletesShow =
+      collection.arrAction === ServarrAction.DELETE_SHOW_IF_EMPTY;
     const seasonsByShow = new Map<string, CoveredChildren>();
     const episodesBySeason = new Map<string, CoveredChildren>();
     for (const member of presence.found.values()) {
       const deleteDate = memberDates.get(member.id);
       if (!deleteDate || !member.parentId) continue;
 
-      if (member.type === 'season') {
+      if (member.type === 'season' && actionDeletesShow) {
         this.cover(seasonsByShow, member.parentId, member.id, deleteDate);
       }
       if (member.type === 'episode') {
@@ -312,7 +317,7 @@ export class OverlayProcessorService {
       if (!this.isFullyCovered(episodes, covered.ids)) continue;
 
       addTarget({ id: seasonId, type: 'season' } as MediaItem, covered.latest);
-      if (covered.showId) {
+      if (actionDeletesShow && covered.showId) {
         this.cover(seasonsByShow, covered.showId, seasonId, covered.latest);
       }
     }


### PR DESCRIPTION
Fixes #3511. A season rule no longer puts a deletion countdown on the show poster unless the rule is actually set to delete the show.

| Collection + action | Show poster |
|---|---|
| Season + "unmonitor and delete season + delete show if empty" | drawn on, once no season of it is left outside the collection |
| Season + "unmonitor and delete season" / "delete existing episodes" | untouched |
| Episode + "unmonitor and delete episode" | untouched (the emptied season is still drawn on) |
| Show + a deleting action | it is a member, so it has its own countdown |

Everything else is unchanged: downward inheritance, the episode -> season walk (a season is not an entity in Sonarr, it lives and dies with its files), and the coverage, date and revert rules. A show an earlier run drew on is reverted on the next run.

Verified against the real dev stack on all three media servers: with the plain delete action the seasons and their episodes are drawn and the show artwork comes back byte-identical, with "delete show if empty" the show is drawn, and flipping back reverts it.
