### PR TITLE
fix(overlays): only draw a countdown when the action deletes

### DIFF
--- a/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
@@ -1365,9 +1365,7 @@ describe('OverlayProcessorService', () => {
     expect(eventEmitter.emit).not.toHaveBeenCalled();
   });
   describe('overlay inheritance', () => {
-    const seasonCollection = (
-      arrAction = ServarrAction.DELETE_SHOW_IF_EMPTY,
-    ) => {
+    const seasonCollection = (arrAction = ServarrAction.DELETE) => {
       const collection = createCollection({
         id: 1,
         title: 'Leaving seasons',
@@ -1498,9 +1496,7 @@ describe('OverlayProcessorService', () => {
             makeItem('season-3', 'season', { parentId: 'show-2', index: 1 }),
           ]),
         getChildrenMetadata: childrenOf({
-          // Specials are left outside and must not disqualify show-1.
           'show-1': [
-            makeItem('season-0', 'season', { index: 0 }),
             makeItem('season-1', 'season', { index: 1 }),
             makeItem('season-2', 'season', { index: 2 }),
           ],
@@ -1530,7 +1526,34 @@ describe('OverlayProcessorService', () => {
       );
     });
 
-    it('walks emptied episodes up to their season, but not to the show', async () => {
+    it('leaves the show alone when a Specials season stays behind', async () => {
+      const collection = seasonCollection();
+      const mediaServer = makeMediaServer({
+        getMetadataBatch: jest
+          .fn()
+          .mockResolvedValue([
+            makeItem('season-1', 'season', { parentId: 'show-1', index: 1 }),
+            makeItem('season-2', 'season', { parentId: 'show-1', index: 2 }),
+          ]),
+        getChildrenMetadata: childrenOf({
+          'show-1': [
+            makeItem('season-0', 'season', { index: 0 }),
+            makeItem('season-1', 'season', { index: 1 }),
+            makeItem('season-2', 'season', { index: 2 }),
+          ],
+        }),
+      });
+      const { service, applySpy } = buildService(mediaServer);
+
+      await service.processCollection(collection as any);
+
+      expect(drawn(applySpy)).toEqual([
+        ['season-1', 'poster'],
+        ['season-2', 'poster'],
+      ]);
+    });
+
+    it('walks emptied episodes up to their season and its show', async () => {
       const collection = createCollection({
         id: 1,
         title: 'Leaving episodes',
@@ -1562,6 +1585,7 @@ describe('OverlayProcessorService', () => {
             makeItem('episode-1', 'episode'),
             makeItem('episode-2', 'episode'),
           ],
+          'show-1': [makeItem('season-1', 'season', { index: 1 })],
         }),
       });
       const { service, applySpy } = buildService(mediaServer);
@@ -1572,51 +1596,25 @@ describe('OverlayProcessorService', () => {
         ['episode-1', 'titlecard'],
         ['episode-2', 'titlecard'],
         ['season-1', 'poster'],
+        ['show-1', 'poster'],
       ]);
     });
 
-    it('leaves the show alone when the action does not delete it', async () => {
-      const collection = seasonCollection(ServarrAction.DELETE);
-      const mediaServer = makeMediaServer({
-        getMetadataBatch: jest
-          .fn()
-          .mockResolvedValue([
-            makeItem('season-1', 'season', { parentId: 'show-1', index: 1 }),
-            makeItem('season-2', 'season', { parentId: 'show-1', index: 2 }),
-          ]),
-        getChildrenMetadata: childrenOf({
-          'show-1': [
-            makeItem('season-1', 'season', { index: 1 }),
-            makeItem('season-2', 'season', { index: 2 }),
-          ],
-          'season-1': [makeItem('episode-1', 'episode')],
-          'season-2': [makeItem('episode-2', 'episode')],
-        }),
-      });
-      const { service, applySpy } = buildService(mediaServer);
-
-      await service.processCollection(collection as any);
-
-      expect(drawn(applySpy)).toEqual([
-        ['season-1', 'poster'],
-        ['season-2', 'poster'],
-        ['episode-1', 'titlecard'],
-        ['episode-2', 'titlecard'],
-      ]);
-    });
-
-    it('inherits nothing for an action that keeps the files, and reverts what it drew before', async () => {
+    it('draws nothing for an action that keeps the files, and reverts what it drew before', async () => {
       const collection = seasonCollection(ServarrAction.UNMONITOR);
       const stateService = {
         getItemState: jest.fn().mockResolvedValue(null),
-        getAllStates: jest
-          .fn()
-          .mockResolvedValue([{ collectionId: 1, mediaServerId: 'show-1' }]),
+        // A member and an inherited parent, both drawn while the collection
+        // still deleted.
+        getAllStates: jest.fn().mockResolvedValue([
+          { collectionId: 1, mediaServerId: 'season-1' },
+          { collectionId: 1, mediaServerId: 'show-1' },
+        ]),
         removeState: jest.fn().mockResolvedValue(undefined),
       };
       const getMetadataBatch = jest.fn();
       const mediaServer = makeMediaServer({ getMetadataBatch });
-      const { service } = buildService(mediaServer, {
+      const { service, applySpy } = buildService(mediaServer, {
         stateService,
         collectionRepos: makeCollectionRepos([collection]),
       });
@@ -1630,8 +1628,20 @@ describe('OverlayProcessorService', () => {
       const result = await service.processAllCollections();
 
       expect(getMetadataBatch).not.toHaveBeenCalled();
+      expect(applySpy).not.toHaveBeenCalled();
+      expect(stateService.removeState).toHaveBeenCalledWith(1, 'season-1');
       expect(stateService.removeState).toHaveBeenCalledWith(1, 'show-1');
-      expect(result.reverted).toBe(1);
+      expect(result.reverted).toBe(2);
+    });
+
+    it('draws nothing when a single collection is processed on its own', async () => {
+      const collection = seasonCollection(ServarrAction.DO_NOTHING);
+      const mediaServer = makeMediaServer({ getMetadataBatch: jest.fn() });
+      const { service, applySpy } = buildService(mediaServer);
+
+      await service.processCollection(collection as any);
+
+      expect(applySpy).not.toHaveBeenCalled();
     });
 
     it('leaves a show that is itself in an overlay collection to its own countdown', async () => {
@@ -1640,7 +1650,7 @@ describe('OverlayProcessorService', () => {
         id: 2,
         title: 'Leaving shows',
         type: 'show',
-        arrAction: ServarrAction.DO_NOTHING,
+        arrAction: ServarrAction.DELETE,
         deleteAfterDays: 30,
         overlayTemplateId: null,
       });
@@ -1650,13 +1660,24 @@ describe('OverlayProcessorService', () => {
           addDate: new Date('2026-04-01T00:00:00.000Z'),
         }),
       ];
+      // Both collections read presence now, so answer per id.
+      const items: Record<string, MediaItem> = {
+        'season-1': makeItem('season-1', 'season', {
+          parentId: 'show-1',
+          index: 1,
+        }),
+        'season-2': makeItem('season-2', 'season', {
+          parentId: 'show-1',
+          index: 2,
+        }),
+        'show-1': makeItem('show-1', 'show'),
+      };
       const mediaServer = makeMediaServer({
         getMetadataBatch: jest
           .fn()
-          .mockResolvedValue([
-            makeItem('season-1', 'season', { parentId: 'show-1', index: 1 }),
-            makeItem('season-2', 'season', { parentId: 'show-1', index: 2 }),
-          ]),
+          .mockImplementation((ids: string[]) =>
+            ids.map((id) => items[id]).filter(Boolean),
+          ),
         getChildrenMetadata: childrenOf({
           'show-1': [
             makeItem('season-1', 'season', { index: 1 }),

--- a/apps/server/src/modules/overlays/overlay-processor.service.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.ts
@@ -116,6 +116,22 @@ export class OverlayProcessorService {
     return Math.max(0, Math.ceil(diff / (1000 * 60 * 60 * 24)));
   }
 
+  /**
+   * A countdown only tells the truth when the collection takes the media on
+   * that date. An unmonitor, a quality-profile change or "do nothing" never
+   * does, so a collection set to one of those draws nothing at all - not its
+   * members, and nothing that would have inherited from them (#3511).
+   */
+  private deletesOnSchedule(collection: Collection): boolean {
+    return (
+      collection.deleteAfterDays != null &&
+      (collection.arrAction === ServarrAction.DELETE ||
+        collection.arrAction === ServarrAction.DELETE_SHOW_IF_EMPTY ||
+        collection.arrAction === ServarrAction.UNMONITOR_DELETE_ALL ||
+        collection.arrAction === ServarrAction.UNMONITOR_DELETE_EXISTING)
+    );
+  }
+
   private getMemberTargets(
     collection: Collection & { collectionMedia: CollectionMedia[] },
   ): OverlayTarget[] {
@@ -134,16 +150,6 @@ export class OverlayProcessorService {
   }
 
   // ── Overlay inheritance ───────────────────────────────────────────────────
-
-  /** Only a deletion takes other items with it; an unmonitor leaves them. */
-  private actionDeletesFiles(action: ServarrAction): boolean {
-    return (
-      action === ServarrAction.DELETE ||
-      action === ServarrAction.DELETE_SHOW_IF_EMPTY ||
-      action === ServarrAction.UNMONITOR_DELETE_ALL ||
-      action === ServarrAction.UNMONITOR_DELETE_EXISTING
-    );
-  }
 
   /**
    * Null when the server could not be asked. throwOnError: an empty list reads
@@ -183,22 +189,14 @@ export class OverlayProcessorService {
   }
 
   /**
-   * A leftover special does not keep a parent alive - rules routinely skip
-   * season 0. A season with no index is not a special but Jellyfin/Emby's
-   * permanent "Season Unknown", so it still has to be covered.
+   * Every child covered, or the parent stays in the library and must not be
+   * drawn on. Specials are no exception: a season 0 that keeps its episode
+   * files keeps the show, countdown expired and all (#3511).
    */
   private isFullyCovered(children: MediaItem[], covered: Set<string>): boolean {
-    let matched = 0;
-    for (const child of children) {
-      if (covered.has(child.id)) {
-        matched++;
-        continue;
-      }
-      if (child.type === 'season' && child.index === 0) continue;
-      return false;
-    }
-    // No match at all: no children, or only uncovered specials.
-    return matched > 0;
+    return (
+      children.length > 0 && children.every((child) => covered.has(child.id))
+    );
   }
 
   /**
@@ -213,13 +211,8 @@ export class OverlayProcessorService {
   private async collectInheritedTargets(
     collection: Collection & { collectionMedia: CollectionMedia[] },
   ): Promise<{ targets: OverlayTarget[]; complete: boolean }> {
-    if (
-      collection.type === 'movie' ||
-      collection.deleteAfterDays == null ||
-      !this.actionDeletesFiles(collection.arrAction)
-    ) {
-      return { targets: [], complete: true };
-    }
+    // Callers only reach this for a collection that deletes on a schedule.
+    if (collection.type === 'movie') return { targets: [], complete: true };
 
     const memberDates = new Map<string, Date>();
     for (const member of this.getMemberTargets(collection)) {
@@ -278,19 +271,14 @@ export class OverlayProcessorService {
       for (const descendant of descendants) addTarget(descendant, deleteDate);
     }
 
-    // Up: group the members under the parent that is losing them. A show only
-    // counts when the action deletes the show itself - otherwise Sonarr keeps
-    // the series and can re-fill it (#3511). A season has no such escape: it is
-    // not an entity in Sonarr, it goes with its episodes.
-    const actionDeletesShow =
-      collection.arrAction === ServarrAction.DELETE_SHOW_IF_EMPTY;
+    // Up: group the members under the parent that is losing them.
     const seasonsByShow = new Map<string, CoveredChildren>();
     const episodesBySeason = new Map<string, CoveredChildren>();
     for (const member of presence.found.values()) {
       const deleteDate = memberDates.get(member.id);
       if (!deleteDate || !member.parentId) continue;
 
-      if (member.type === 'season' && actionDeletesShow) {
+      if (member.type === 'season') {
         this.cover(seasonsByShow, member.parentId, member.id, deleteDate);
       }
       if (member.type === 'episode') {
@@ -317,7 +305,7 @@ export class OverlayProcessorService {
       if (!this.isFullyCovered(episodes, covered.ids)) continue;
 
       addTarget({ id: seasonId, type: 'season' } as MediaItem, covered.latest);
-      if (actionDeletesShow && covered.showId) {
+      if (covered.showId) {
         this.cover(seasonsByShow, covered.showId, seasonId, covered.latest);
       }
     }
@@ -371,9 +359,13 @@ export class OverlayProcessorService {
   private async getOverlayCollections(): Promise<
     (Collection & { collectionMedia: CollectionMedia[] })[]
   > {
-    const collections = (await this.collectionRepo.find({
-      where: { overlayEnabled: true, isActive: true },
-    })) as (Collection & { collectionMedia: CollectionMedia[] })[];
+    // Collections that never delete are dropped here rather than skipped later,
+    // so the run also reverts whatever they drew before their action changed.
+    const collections = (
+      (await this.collectionRepo.find({
+        where: { overlayEnabled: true, isActive: true },
+      })) as (Collection & { collectionMedia: CollectionMedia[] })[]
+    ).filter((collection) => this.deletesOnSchedule(collection));
 
     for (const collection of collections) {
       collection.collectionMedia = await this.collectionMediaRepo.find({
@@ -537,9 +529,9 @@ export class OverlayProcessorService {
       );
     }
 
-    if (collection.deleteAfterDays == null) {
+    if (!this.deletesOnSchedule(collection)) {
       this.logger.debug(
-        `Collection "${collection.title}" has no deleteAfterDays set, skipping`,
+        `Collection "${collection.title}" has no scheduled deletion to count down to, skipping`,
       );
       return result;
     }
@@ -719,13 +711,9 @@ export class OverlayProcessorService {
       this.eventEmitter.emit(MaintainerrEvent.OverlayHandler_Started);
       this.logger.log('=== Overlay processor started ===');
 
-      // Get all collections with overlay enabled
+      // An empty list still runs: what an earlier run drew has to come off once
+      // its collection stops drawing, and the revert loop below is what does it.
       const collections = await this.getOverlayCollections();
-
-      if (!collections.length) {
-        this.logger.log('No collections have overlays enabled');
-        return totalResult;
-      }
 
       this.logger.log(
         `Processing ${collections.length} overlay-enabled collection(s)`,


### PR DESCRIPTION
Fixes #3511. Overlays only appear on media that is actually going to be deleted, and a rule that stops deleting takes its overlays back off on the next run. Reverts the show guard from #3514, which read the issue the wrong way round.

### Which actions draw at all

| Sonarr - season | Overlay |
|---|---|
| Unmonitor and delete season | yes |
| Unmonitor and delete season + delete show if empty | yes |
| Unmonitor and delete existing episodes | yes |
| Unmonitor season + unmonitor show if empty | no |
| Unmonitor season and keep files | no |
| Do nothing | no |

The same test everywhere else: show and movie rules draw for "delete" and "delete all / existing episodes", never for "keep files", "do nothing" or "change quality profile and search"; episode rules draw for "delete" only.

### What is in the collection, and what gets an overlay

| In the collection | Drawn on |
|---|---|
| A show | the show, every season of it, every episode of those seasons |
| A season, other seasons stay | that season, its episodes |
| All seasons of a show | each season, all their episodes, and the show |
| All seasons except a leftover Specials | the seasons and their episodes, not the show |
| An episode, other episodes stay | that episode |
| All episodes of a season | each episode, and the season |
| All episodes of a season that was the show's last | each episode, the season, and the show |
| A movie | the movie |
| An item that is also in another overlay collection | drawn once, by the collection it is in - its own countdown wins |

A member shows its own add date plus the rule's delete-after days, anything below it shows that member's date, and a parent that empties shows the last of its children to go. Episodes get the title card template, everything else the poster.

The Specials row is the one behaviour change on this side: a season 0 that stays keeps its episode files, so the show stays in the library and must not carry a countdown that expires while its poster is still there. Deleting a season never touches specials - only a show-level delete does - so the show is drawn only when every season it has, specials included, is in the collection.

### When nothing is drawn, and when something is taken back

| Situation | Result |
|---|---|
| Action is unmonitor, unmonitor-if-empty, do nothing or change quality profile | nothing is drawn, members included, and no media server call is made |
| No delete-after days, overlays off, or the rule is inactive | nothing |
| A rule that used to draw is switched to one of the above | everything it drew is reverted on the next run, originals restored |
| The media server cannot be read, or one branch of the walk fails | what is drawn stays; the branches that could be read still update |
| Sonarr adds a season, so the show is no longer emptying | the show's overlay comes off next run, and returns if that season matches too |
| An item leaves the collection or its deletion is postponed | its overlay is reverted, and any parent that depended on it loses its own |

Exercised end to end against real Plex, Jellyfin and Emby: a "keep files" rule draws nothing and makes no media server call, switching it to "delete season" draws the seasons, their episodes and the show once no season is left outside, and switching it to "do nothing" reverts all of it with the artwork byte-identical to the originals.
