### PR TITLE
fix(ci): pin the CODEOWNERS guard, attribute release notes from git, harden the AI client

### DIFF
--- a/.github/workflows/docs_drift.yml
+++ b/.github/workflows/docs_drift.yml
@@ -132,6 +132,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
           AI_MODEL: ${{ vars.AI_MODEL }}
+          AI_MODEL_REASONING_EFFORT: ${{ vars.AI_MODEL_REASONING_EFFORT }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           OUTPUT_PATH: ${{ github.workspace }}/.drift-report.md
         run: node tools/docs-drift-ai.mjs

--- a/.github/workflows/fider-pre-existing-scan.yml
+++ b/.github/workflows/fider-pre-existing-scan.yml
@@ -57,6 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
           AI_MODEL: ${{ vars.AI_MODEL }}
+          AI_MODEL_REASONING_EFFORT: ${{ vars.AI_MODEL_REASONING_EFFORT }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           DRY_RUN: ${{ inputs.dry_run }}
           FORCE_REEVAL: ${{ inputs.force_reeval }}

--- a/.github/workflows/fider-re-evaluate.yml
+++ b/.github/workflows/fider-re-evaluate.yml
@@ -47,6 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
           AI_MODEL: ${{ vars.AI_MODEL }}
+          AI_MODEL_REASONING_EFFORT: ${{ vars.AI_MODEL_REASONING_EFFORT }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
           FORCE_REEVAL: 'true'

--- a/.github/workflows/fider-triage.yml
+++ b/.github/workflows/fider-triage.yml
@@ -40,6 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
           AI_MODEL: ${{ vars.AI_MODEL }}
+          AI_MODEL_REASONING_EFFORT: ${{ vars.AI_MODEL_REASONING_EFFORT }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
           DISCORD_FIDER_BOT_WEBHOOK: ${{ secrets.DISCORD_FIDER_BOT_WEBHOOK }}

--- a/.github/workflows/guard-manual.yml
+++ b/.github/workflows/guard-manual.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Check out repository
         if: ${{ inputs.enabled && inputs.allowed == '__CODEOWNERS__' }}
         uses: actions/checkout@v7
+        with:
+          # Callers triggered by pull_request_review check out refs/pull/N/merge
+          # by default, so a pull request could add its own author to CODEOWNERS
+          # and then pass the gate that decides whether it may be merged with
+          # admin rights. The owner list only counts once it is on the default
+          # branch.
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Resolve allowed actors
         id: allowed

--- a/.github/workflows/release_5_publish.yml
+++ b/.github/workflows/release_5_publish.yml
@@ -92,6 +92,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
           AI_MODEL: ${{ vars.AI_MODEL }}
+          AI_MODEL_REASONING_EFFORT: ${{ vars.AI_MODEL_REASONING_EFFORT }}
           DRY_RUN: ${{ github.event.inputs.dry-run-semantic-release }}
         run: |
           if [ "$DRY_RUN" == "true" ]; then

--- a/.github/workflows/weblate_review.yml
+++ b/.github/workflows/weblate_review.yml
@@ -71,6 +71,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
           AI_MODEL: ${{ vars.AI_MODEL }}
+          AI_MODEL_REASONING_EFFORT: ${{ vars.AI_MODEL_REASONING_EFFORT }}
         run: |
           node tools/i18n/back-translate.mjs \
             --base "origin/${{ github.event.pull_request.base.ref }}" \

--- a/tools/ai/model-client.mjs
+++ b/tools/ai/model-client.mjs
@@ -20,6 +20,18 @@ export const MODEL_ENDPOINT =
 
 export const DEFAULT_MODEL = process.env.AI_MODEL || 'gemini-3.1-flash-lite';
 
+/**
+ * How much the model may think before answering, as OpenAI's `reasoning_effort`
+ * ('none' | 'minimal' | 'low' | 'medium' | 'high'), which the compatibility
+ * layer maps onto Gemini's thinking levels.
+ *
+ * Empty means "send no field at all". Gemini then thinks dynamically, sizing
+ * the effort to the request against a per-model default, which is what every
+ * caller gets unless it opts in or the repository variable is set.
+ */
+export const DEFAULT_REASONING_EFFORT =
+  process.env.AI_MODEL_REASONING_EFFORT || '';
+
 export const modelToken = () => process.env.AI_MODEL_API_KEY || '';
 
 export const hasModelAccess = () => modelToken() !== '';
@@ -54,22 +66,72 @@ export const throttleModelCall = async () => {
   lastCallAt = Date.now();
 };
 
+const UNKNOWN_FIELD_MARKER = 'Unknown name "';
+
+/**
+ * Google's compatibility layer rejects any field it does not know rather than
+ * ignoring it, answering 400 with `Invalid JSON payload received. Unknown name
+ * "store": Cannot find field.` Pull the field name back out so the caller can
+ * drop it and retry instead of losing the run over an optional parameter.
+ */
+const unknownField = (body = '') => {
+  const start = body.indexOf(UNKNOWN_FIELD_MARKER);
+  if (start === -1) return '';
+  const from = start + UNKNOWN_FIELD_MARKER.length;
+  const end = body.indexOf('"', from);
+  return end === -1 ? '' : body.slice(from, end);
+};
+
+// Every optional field could be rejected in turn; the cap stops a provider that
+// answers 400 for something else from looping forever.
+const MAX_FIELD_STRIPS = 4;
+
+const log = (msg) => process.stderr.write(`[model-client] ${msg}\n`);
+
 /**
  * One chat completion, paced for the free tier. Throws on a non-2xx so callers
  * can retry or report; returns the assistant message content, trimmed.
+ *
+ * Temperature defaults to 0: every tool in this repo wants the same answer for
+ * the same input, not a fresh sample.
  */
 export const callModel = async (
   messages,
-  { model = DEFAULT_MODEL, temperature = 0.1, token = modelToken() } = {},
+  {
+    model = DEFAULT_MODEL,
+    temperature = 0,
+    token = modelToken(),
+    reasoningEffort = DEFAULT_REASONING_EFFORT,
+  } = {},
 ) => {
-  await throttleModelCall();
-  const res = await fetch(MODEL_ENDPOINT, {
-    method: 'POST',
-    headers: modelHeaders(token),
-    body: JSON.stringify({ model, messages, temperature }),
-  });
-  if (!res.ok) {
+  const payload = { model, messages, temperature };
+  if (reasoningEffort) payload.reasoning_effort = reasoningEffort;
+
+  for (let stripped = 0; ; stripped += 1) {
+    await throttleModelCall();
+    const res = await fetch(MODEL_ENDPOINT, {
+      method: 'POST',
+      headers: modelHeaders(token),
+      body: JSON.stringify(payload),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      return (data.choices?.[0]?.message?.content || '').trim();
+    }
+
     const body = await res.text();
+    const rejected = res.status === 400 ? unknownField(body) : '';
+    if (
+      rejected &&
+      Object.hasOwn(payload, rejected) &&
+      stripped < MAX_FIELD_STRIPS
+    ) {
+      delete payload[rejected];
+      log(`endpoint rejected "${rejected}"; retrying without it`);
+      continue;
+    }
+
     // Model names get retired; make the fix obvious rather than cryptic.
     const hint =
       res.status === 404
@@ -77,6 +139,4 @@ export const callModel = async (
         : '';
     throw new Error(`Model endpoint ${res.status}${hint}: ${body}`);
   }
-  const data = await res.json();
-  return (data.choices?.[0]?.message?.content || '').trim();
 };

--- a/tools/generate-release-notes.mjs
+++ b/tools/generate-release-notes.mjs
@@ -8,7 +8,11 @@ const MAX_MIGRATIONS_TOTAL_CHARS = 12000;
 const MAX_PR_BODY_CHARS = 400;
 const MAX_ORPHAN_BODY_CHARS = 300;
 const MIGRATION_PATH_PREFIX = "apps/server/src/database/migrations/";
-import { callModel, hasModelAccess } from "./ai/model-client.mjs";
+import {
+  DEFAULT_REASONING_EFFORT,
+  callModel,
+  hasModelAccess,
+} from "./ai/model-client.mjs";
 const DEP_SUBJECT_RE = /^build\(deps(?:-dev)?\):/i;
 const CHORE_SUBJECT_RE = /^chore(?:\([^)]*\))?!?:/i;
 const SYNC_SUBJECT_RE = /^chore:\s*sync\s+development\s+to\s+main/i;
@@ -464,7 +468,9 @@ const generateNotes = async (messages) =>
       // Rule 3 is the one this tool gets wrong when it guesses. Checking every
       // citation against the commit list is reasoning work, and this runs once
       // per release, so buy the thinking rather than the cheapest answer.
-      reasoningEffort: "high",
+      // AI_MODEL_REASONING_EFFORT still wins, so dialling it back stays a
+      // repository-variable change rather than a pull request.
+      reasoningEffort: DEFAULT_REASONING_EFFORT || "high",
     }),
   );
 

--- a/tools/generate-release-notes.mjs
+++ b/tools/generate-release-notes.mjs
@@ -8,12 +8,7 @@ const MAX_MIGRATIONS_TOTAL_CHARS = 12000;
 const MAX_PR_BODY_CHARS = 400;
 const MAX_ORPHAN_BODY_CHARS = 300;
 const MIGRATION_PATH_PREFIX = "apps/server/src/database/migrations/";
-import {
-  MODEL_ENDPOINT,
-  hasModelAccess,
-  modelHeaders,
-  throttleModelCall,
-} from "./ai/model-client.mjs";
+import { callModel, hasModelAccess } from "./ai/model-client.mjs";
 const DEP_SUBJECT_RE = /^build\(deps(?:-dev)?\):/i;
 const CHORE_SUBJECT_RE = /^chore(?:\([^)]*\))?!?:/i;
 const SYNC_SUBJECT_RE = /^chore:\s*sync\s+development\s+to\s+main/i;
@@ -35,7 +30,9 @@ const {
   RELEASE_NOTES_MODEL = process.env.AI_MODEL || "gemini-3.1-flash-lite",
 } = process.env;
 
-const modelToken = GITHUB_TOKEN || GH_TOKEN || "";
+// For api.github.com, not for the model endpoint - that one reads
+// AI_MODEL_API_KEY through the shared client.
+const githubToken = GITHUB_TOKEN || GH_TOKEN || "";
 
 const log = (msg) => process.stderr.write(`[release-notes] ${msg}\n`);
 
@@ -170,7 +167,7 @@ export const buildLocalNewContributorsSection = (
 
 const fetchNewContributors = async (prMeta) => {
   const fallback = buildLocalNewContributorsSection(prMeta);
-  if (!modelToken || !repo || !nextVersion || !effectiveLastTag) {
+  if (!githubToken || !repo || !nextVersion || !effectiveLastTag) {
     return fallback;
   }
   try {
@@ -179,7 +176,7 @@ const fetchNewContributors = async (prMeta) => {
       {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${modelToken}`,
+          Authorization: `Bearer ${githubToken}`,
           Accept: "application/vnd.github+json",
           "X-GitHub-Api-Version": "2022-11-28",
           "Content-Type": "application/json",
@@ -217,7 +214,7 @@ const parseCommits = () => {
   const raw = runGit([
     "log",
     range,
-    `--format=%s${FIELD_SEP}%b${REC_SEP}`,
+    `--format=%H${FIELD_SEP}%s${FIELD_SEP}%b${REC_SEP}`,
     "--no-merges",
     "-n",
     String(MAX_COMMITS),
@@ -227,10 +224,11 @@ const parseCommits = () => {
     .map((c) => c.trim())
     .filter(Boolean)
     .map((entry) => {
-      const [subject, body = ""] = entry.split(FIELD_SEP);
+      const [sha, subject, body = ""] = entry.split(FIELD_SEP);
       const prMatch = subject.match(/\(#(\d+)\)\s*$/);
       const cleanedBody = cleanCommitBody(body);
       return {
+        sha,
         subject,
         pr: prMatch ? Number(prMatch[1]) : null,
         cleanSubject: subject.replace(/\s*\(#\d+\)\s*$/, ""),
@@ -240,6 +238,73 @@ const parseCommits = () => {
             : cleanedBody,
       };
     });
+};
+
+const MERGE_PR_PREFIX = "Merge pull request #";
+// A sync merge carries a whole branch rather than one pull request's work, so
+// it must never become the attribution for the commits flowing through it.
+const SYNC_HEAD_BRANCHES = new Set(["development", "main"]);
+
+/** The pull request number from a `Merge pull request #N from owner/branch` subject. */
+const parseMergePr = (subject = "") => {
+  if (!subject.startsWith(MERGE_PR_PREFIX)) return null;
+
+  const rest = subject.slice(MERGE_PR_PREFIX.length);
+  const spaceAt = rest.indexOf(" ");
+  const number = Number(spaceAt === -1 ? rest : rest.slice(0, spaceAt));
+  if (!Number.isInteger(number) || number <= 0) return null;
+
+  const fromAt = rest.indexOf(" from ");
+  const headRef =
+    fromAt === -1 ? "" : rest.slice(fromAt + " from ".length).trim();
+  const slashAt = headRef.indexOf("/");
+  const branch = slashAt === -1 ? headRef : headRef.slice(slashAt + 1);
+  if (SYNC_HEAD_BRANCHES.has(branch)) return null;
+
+  return number;
+};
+
+/**
+ * A commit only carries `(#NNN)` when its pull request was squash-merged. One
+ * merged with a merge commit leaves the number on the merge commit, which
+ * `--no-merges` drops, and the bullet then reaches the model with no PR at all
+ * - which is when it starts borrowing a neighbouring number. Walk the ancestry
+ * path instead and take the first real pull-request merge that contains it.
+ */
+const resolvePrNumbers = (commits) => {
+  const orphans = commits.filter((c) => !c.pr && c.sha);
+  if (!orphans.length) return commits;
+
+  let resolved = 0;
+  for (const commit of orphans) {
+    let merges = "";
+    try {
+      merges = runGit([
+        "log",
+        "--ancestry-path",
+        "--merges",
+        "--reverse",
+        "--format=%s",
+        `${commit.sha}..${nextHead}`,
+      ]);
+    } catch {
+      continue;
+    }
+
+    for (const subject of merges.split("\n")) {
+      const number = parseMergePr(subject.trim());
+      if (number) {
+        commit.pr = number;
+        resolved += 1;
+        break;
+      }
+    }
+  }
+
+  log(
+    `resolved ${resolved}/${orphans.length} commits without a squash-merge suffix to a pull request`,
+  );
+  return commits;
 };
 
 const changedFiles = () => {
@@ -392,19 +457,16 @@ const stripOuterFence = (s) => {
   return trimmed;
 };
 
-const callModel = async (payload) => {
-  await throttleModelCall();
-  const res = await fetch(MODEL_ENDPOINT, {
-    method: "POST",
-    headers: modelHeaders(),
-    body: JSON.stringify(payload),
-  });
-  if (!res.ok) {
-    throw new Error(`Model endpoint ${res.status}: ${await res.text()}`);
-  }
-  const data = await res.json();
-  return stripOuterFence(data.choices?.[0]?.message?.content ?? "");
-};
+const generateNotes = async (messages) =>
+  stripOuterFence(
+    await callModel(messages, {
+      model: RELEASE_NOTES_MODEL,
+      // Rule 3 is the one this tool gets wrong when it guesses. Checking every
+      // citation against the commit list is reasoning work, and this runs once
+      // per release, so buy the thinking rather than the cheapest answer.
+      reasoningEffort: "high",
+    }),
+  );
 
 const buildPrompt = ({ main, deps, syncs, prMeta, migrationDetails }) => {
   const emittedPrBodies = new Set();
@@ -472,7 +534,7 @@ const buildPrompt = ({ main, deps, syncs, prMeta, migrationDetails }) => {
 };
 
 const main = async () => {
-  const commits = parseCommits();
+  const commits = resolvePrNumbers(parseCommits());
   log(`range=${range} commits=${commits.length} model=${RELEASE_NOTES_MODEL}`);
   const header = buildHeader();
   const { deps, syncs, main: mainCommits } = partitionCommits(commits);
@@ -525,25 +587,8 @@ const main = async () => {
     { role: "user", content: prompt },
   ];
 
-  const tryCall = async (payload) => {
-    try {
-      return await callModel(payload);
-    } catch (err) {
-      if (/temperature/i.test(err.message) && "temperature" in payload) {
-        log("model rejected temperature parameter; retrying without it");
-        const { temperature, ...rest } = payload;
-        return callModel(rest);
-      }
-      throw err;
-    }
-  };
-
   try {
-    const notes = await tryCall({
-      model: RELEASE_NOTES_MODEL,
-      messages,
-      temperature: 0.1,
-    });
+    const notes = await generateNotes(messages);
     if (!notes) throw new Error("empty model output");
     process.stdout.write(`${header}${notes}${footer}\n`);
   } catch (err) {

--- a/tools/i18n/back-translate.mjs
+++ b/tools/i18n/back-translate.mjs
@@ -18,10 +18,8 @@ import { execFileSync } from 'node:child_process';
 import { readdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import {
-  MODEL_ENDPOINT,
+  callModel as sharedCallModel,
   hasModelAccess,
-  modelHeaders,
-  throttleModelCall,
 } from '../ai/model-client.mjs';
 import { icuArguments, parsePo, readPo } from './po.mjs';
 
@@ -70,23 +68,8 @@ if (!hasModelAccess()) {
   process.exit(0);
 }
 
-const callModel = async (messages) => {
-  await throttleModelCall();
-  const res = await fetch(MODEL_ENDPOINT, {
-    method: 'POST',
-    headers: modelHeaders(),
-    body: JSON.stringify({
-      model: I18N_REVIEW_MODEL,
-      messages,
-      temperature: 0,
-    }),
-  });
-  if (!res.ok) {
-    throw new Error(`Model endpoint ${res.status}: ${await res.text()}`);
-  }
-  const data = await res.json();
-  return (data.choices?.[0]?.message?.content || '').trim();
-};
+const callModel = (messages) =>
+  sharedCallModel(messages, { model: I18N_REVIEW_MODEL });
 
 /** Translations as they stood at a git ref, so we can review only what changed. */
 const baselineFor = (file) => {


### PR DESCRIPTION
Three CI fixes found while checking the v3.23.0 release notes. Separable if you want them split.

## 1. The guard read CODEOWNERS from the pull request it was gating

`guard-manual.yml` checked out whatever ref the triggering event pointed at.

| Trigger | Callers | Ref the guard read |
|---|---|---|
| `pull_request_review` | `weblate_merge`, `release_2_queue_push_pr_to_main` | `refs/pull/N/merge`, so the pull request's own copy |
| `workflow_run` | `release_2_5_execute_push_pr_to_main` | default branch, already fine |
| `workflow_dispatch` | 14 others | the dispatched ref, and dispatching already needs write access |

`weblate_merge.yml` merges with `gh pr merge --admin`, so a pull request could widen the owner list that gates its own admin merge. The checkout is now pinned to the default branch. CODEOWNERS is byte-identical on `main` and `development`, so no existing caller changes behaviour, and no workflow gains a guard it did not already have.

## 2. Release-note bullets were attributed by guesswork

A commit only carries `(#NNN)` when its pull request was squash-merged. Merged with a merge commit, the number lives on the merge commit, which `--no-merges` drops. Those bullets reached the model unattributed and it borrowed a neighbouring number.

v3.23.0 credited "Replaced custom CODEOWNERS parsing in CI with standard guard workflows" to **#3487**, which is the Weblate back-translation work and touches no CODEOWNERS logic. It landed in **#3499**. Prompt rule 3 already forbade this, so the fix removes the opportunity rather than rewording the rule.

`resolvePrNumbers` walks `git log --ancestry-path --merges` for each unattributed commit and takes the first real pull-request merge containing it, skipping sync merges from `development` and `main`. On `v3.22.1..v3.23.0` that attributes 13 of 13 previously orphaned commits, and the bullet above now reads `(#3499)`.

## 3. AI client hardening

| Change | Why |
|---|---|
| Strip-and-retry on `400 Unknown name "x"` | Google's layer rejects unknown fields instead of ignoring them, so one unsupported parameter loses the run. Replaces a hand-rolled retry that only knew `temperature`. |
| `temperature` defaults to 0 | Same input should give the same answer; 3 of 4 tools already passed 0. |
| `reasoning_effort` support, via `AI_MODEL_REASONING_EFFORT` | Matches how `AI_MODEL` became a variable rather than a pull request. Unset by default, so Gemini keeps thinking dynamically. Release notes opt in at `high`. |
| `generate-release-notes` and `back-translate` use the shared client | Drops two duplicate clients; both gain the retry. |

`fider-triage.mjs` keeps its own call shape: it has a consecutive-failure ladder and makes far more calls than the rest.

Verified against the [OpenAI compatibility](https://ai.google.dev/gemini-api/docs/openai) docs: `reasoning_effort` is supported, values `none | minimal | low | medium | high`, and omitting it leaves the model on its per-model default.

## Unrelated, but found on the way

`vars.AI_MODEL` does not exist (`total_count: 0`), so every tool runs on the `gemini-3.1-flash-lite` code default. That model is current and stable, but if a different tier was intended, the repository variable still needs creating.
