### PR TITLE
fix(ci): retry a busy model endpoint instead of falling back

### DIFF
--- a/tools/ai/model-client.mjs
+++ b/tools/ai/model-client.mjs
@@ -86,11 +86,25 @@ const unknownField = (body = '') => {
 // answers 400 for something else from looping forever.
 const MAX_FIELD_STRIPS = 4;
 
+/**
+ * Statuses worth another attempt. The free tier answers 429 when it is being
+ * paced too hard and 503 when the model itself is busy, and both clear on their
+ * own. Without this a few busy seconds silently downgrade a release to the
+ * fallback notes, which is what happened to 3.23.0.
+ */
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+// 2s, 4s, 8s, 16s: half a minute of patience, which is nothing next to a
+// release, and short enough that a genuinely dead endpoint still reports fast.
+const MAX_RETRIES = Number(process.env.AI_MODEL_MAX_RETRIES ?? 4);
+const RETRY_BASE_MS = Number(process.env.AI_MODEL_RETRY_BASE_MS ?? 2000);
+
 const log = (msg) => process.stderr.write(`[model-client] ${msg}\n`);
 
 /**
- * One chat completion, paced for the free tier. Throws on a non-2xx so callers
- * can retry or report; returns the assistant message content, trimmed.
+ * One chat completion, paced for the free tier. Retries a busy endpoint with
+ * exponential backoff and throws once it stops being worth waiting for, so a
+ * caller only sees a failure it cannot recover from.
  *
  * Temperature defaults to 0: every tool in this repo wants the same answer for
  * the same input, not a fresh sample.
@@ -107,7 +121,12 @@ export const callModel = async (
   const payload = { model, messages, temperature };
   if (reasoningEffort) payload.reasoning_effort = reasoningEffort;
 
-  for (let stripped = 0; ; stripped += 1) {
+  // Counted separately: dropping a rejected field is not an attempt at the same
+  // request, so a stripped field must not spend the transient-failure budget.
+  let stripped = 0;
+  let retries = 0;
+
+  for (;;) {
     await throttleModelCall();
     const res = await fetch(MODEL_ENDPOINT, {
       method: 'POST',
@@ -127,8 +146,19 @@ export const callModel = async (
       Object.hasOwn(payload, rejected) &&
       stripped < MAX_FIELD_STRIPS
     ) {
+      stripped += 1;
       delete payload[rejected];
       log(`endpoint rejected "${rejected}"; retrying without it`);
+      continue;
+    }
+
+    if (RETRYABLE_STATUSES.has(res.status) && retries < MAX_RETRIES) {
+      const waitMs = RETRY_BASE_MS * 2 ** retries;
+      retries += 1;
+      log(
+        `endpoint ${res.status}; retry ${retries}/${MAX_RETRIES} in ${waitMs}ms`,
+      );
+      await sleep(waitMs);
       continue;
     }
 


### PR DESCRIPTION
3.23.0's notes published as raw commit subjects rather than prose. The cause, from the job log:

```
[release-notes] model call failed: Model endpoint 503: {
  "error": { "code": 503,
    "message": "This model is currently experiencing high demand...",
    "status": "UNAVAILABLE" }}; emitting fallback notes
```

`callModel` threw on the first attempt, `generate-release-notes` caught it and emitted its non-AI fallback. A few busy seconds cost the release its notes, and nothing surfaced why unless you opened the log. The free tier is exactly where capacity 503s are expected.

## Change

Retry `429` and `5xx` with exponential backoff: 2s, 4s, 8s, 16s. Short enough that a genuinely dead endpoint still reports quickly, and both bounds are env overridable (`AI_MODEL_MAX_RETRIES`, `AI_MODEL_RETRY_BASE_MS`) matching the existing `AI_MODEL_MIN_GAP_MS`.

Field strips and transient retries are now counted separately — dropping a rejected field is not another attempt at the same request, so it must not spend the retry budget.

## Verified

Stubbed-fetch harness driving the real `callModel`:

| Case | Result |
|---|---|
| 503, 503, then success | returns content, 3 calls |
| 429 then success | returns content, 2 calls |
| persistent 503 | throws after 1 + MAX_RETRIES = 5 calls |
| 404 | throws at once with the AI_MODEL hint, 1 call |
| 400 unknown field | strips it and retries, 2 calls (unchanged) |
| 400 other | throws at once, 1 call |

All four AI tools share this client and get the retry. `fider-triage.mjs` keeps its own failure ladder and is untouched.
