### PR TITLE
fix(overlays): keep template overlays inside the visible region of odd-aspect artwork

### DIFF
--- a/apps/server/src/modules/overlays/overlay-render.service.spec.ts
+++ b/apps/server/src/modules/overlays/overlay-render.service.spec.ts
@@ -239,6 +239,64 @@ describe('OverlayRenderService', () => {
     expect(calledWith[3]).toBe(2);
   });
 
+  it('maps elements into the centered canvas-aspect region of odd-aspect artwork (issue #3533)', async () => {
+    const logger = createMockLogger();
+    const service = new OverlayRenderService(logger);
+
+    // 4:3 still with a 16:9 titlecard canvas. Clients cover-crop the still
+    // to 16:9 (visible rows 90..630 of 720), so the pill must land there.
+    const posterBuffer = await sharp({
+      create: {
+        width: 960,
+        height: 720,
+        channels: 3,
+        background: '#ffffff',
+      },
+    })
+      .jpeg()
+      .toBuffer();
+
+    const elements: TemplateElements = [
+      {
+        id: 'pill-bg',
+        type: 'shape',
+        x: 40,
+        y: 40,
+        width: 480,
+        height: 70,
+        rotation: 0,
+        layerOrder: 0,
+        opacity: 1,
+        visible: true,
+        shapeType: 'rectangle',
+        fillColor: '#ff0000',
+        strokeColor: null,
+        strokeWidth: 0,
+        cornerRadius: 0,
+      },
+    ];
+
+    const result = await service.renderFromTemplate(
+      posterBuffer,
+      elements,
+      1920,
+      1080,
+      {
+        deleteDate: new Date('2026-04-27T00:00:00.000Z'),
+        daysLeft: 14,
+      },
+    );
+
+    const { data, info } = await sharp(Buffer.from(result.buffer))
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+
+    // scale 0.5, offsetY 90: pill occupies y 110..145 (visible band),
+    // not y 20..55 where the old full-image stretch placed it.
+    expect(isRedPixel(data, info.width, info.channels, 140, 127)).toBe(true);
+    expect(isRedPixel(data, info.width, info.channels, 140, 45)).toBe(false);
+  });
+
   it('rotates elements around top-left pivot to preserve template placement', async () => {
     const logger = createMockLogger();
     const service = new OverlayRenderService(logger);

--- a/apps/server/src/modules/overlays/overlay-render.service.ts
+++ b/apps/server/src/modules/overlays/overlay-render.service.ts
@@ -522,15 +522,14 @@ export class OverlayRenderService {
     const imgW = meta.width!;
     const imgH = meta.height!;
 
-    // Scale factor: template canvas → actual poster dimensions.
-    // Geometry (positions/sizes) use `scaleX`/`scaleY` to map to pixel
-    // coordinates. Style values (fontSize, padding, radii, strokeWidth)
-    // should scale uniformly to preserve visual proportions when the
-    // poster and template aspect ratios differ. Use the smaller axis
-    // scale to avoid overstretching style metrics.
-    const scaleX = imgW / canvasWidth;
-    const scaleY = imgH / canvasHeight;
-    const uniformScale = Math.min(scaleX, scaleY);
+    // Map the template canvas onto the largest centered canvas-aspect
+    // region of the artwork instead of stretching it over the full image.
+    // Media-server clients cover-crop artwork to the canvas shape when
+    // rendering cards, so anything drawn outside that region is invisible
+    // (#3533: 4:3 or 21:9 episode stills on a 16:9 titlecard canvas).
+    const uniformScale = Math.min(imgW / canvasWidth, imgH / canvasHeight);
+    const offsetX = Math.round((imgW - canvasWidth * uniformScale) / 2);
+    const offsetY = Math.round((imgH - canvasHeight * uniformScale) / 2);
 
     // Sort elements by layerOrder, then render bottom-up
     const sorted = [...elements]
@@ -540,10 +539,10 @@ export class OverlayRenderService {
     const layers: Array<{ input: Buffer; left: number; top: number }> = [];
 
     for (const el of sorted) {
-      const sx = Math.round(el.x * scaleX);
-      const sy = Math.round(el.y * scaleY);
-      const sw = Math.max(1, Math.round(el.width * scaleX));
-      const sh = Math.max(1, Math.round(el.height * scaleY));
+      const sx = offsetX + Math.round(el.x * uniformScale);
+      const sy = offsetY + Math.round(el.y * uniformScale);
+      const sw = Math.max(1, Math.round(el.width * uniformScale));
+      const sh = Math.max(1, Math.round(el.height * uniformScale));
 
       let layerBuf: Buffer | null = null;
 


### PR DESCRIPTION
Fixes #3533.

Plex and the other media servers show episode images in a fixed 16:9 box. When the image itself is not 16:9 (old shows often have 4:3 images), the app cuts away the top and bottom (or the sides) to make it fit. Maintainerr drew the overlay across the whole image, so on a 4:3 image the pill ended up in the part that gets cut away and was invisible. Checked against a real Plex server: the cut is always centered and happens in the Plex app itself, not on the server.

The fix: the overlay is now drawn inside the part of the image that stays visible after that cut. For normal images (16:9 stills, standard posters) the output is pixel for pixel the same as before.

Checked on the real dev stack for all three servers: overlay applied by a real run, image downloaded back from the server, pill position measured:

| Server | Image | Result |
|---|---|---|
| Plex | 4:3 still, before fix | pill in the cut-away area, invisible in Plex (screenshot: blank card) |
| Plex | 4:3 still, after fix | pill fully visible in Plex |
| Plex | 16:9 still | unchanged, old and new output are identical |
| Jellyfin | standard 2:3 poster | pill exactly where the template puts it, unchanged |
| Emby | 4:3 still | pill fully visible, same position as on Plex |

Reverting restored the original images unchanged on every server.

Note: `OverlayRenderService.renderOverlay` and its helpers are no longer used anywhere since the template rework; left untouched here, can be removed in a separate cleanup.