### PR TITLE
fix(overlays): propagate episode countdowns to the series when Plex hides seasons

### DIFF
--- a/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
@@ -1600,6 +1600,55 @@ describe('OverlayProcessorService', () => {
       ]);
     });
 
+    it('recovers the season through the show when episodes carry no season link (issue #3534)', async () => {
+      const collection = createCollection({
+        id: 1,
+        title: 'Leaving episodes',
+        type: 'episode',
+        arrAction: ServarrAction.DELETE,
+        deleteAfterDays: 5,
+        overlayTemplateId: null,
+      });
+      collection.collectionMedia = [
+        createCollectionMedia(collection, {
+          mediaServerId: 'episode-1',
+          addDate: new Date('2026-04-01T00:00:00.000Z'),
+        }),
+        createCollectionMedia(collection, {
+          mediaServerId: 'episode-2',
+          addDate: new Date('2026-04-01T00:00:00.000Z'),
+        }),
+      ];
+      // Plex "Seasons: Hide" strips parentId from episodes; the show id and
+      // the season number remain.
+      const parents = { grandparentId: 'show-1', parentIndex: 1 };
+      const mediaServer = makeMediaServer({
+        getMetadataBatch: jest
+          .fn()
+          .mockResolvedValue([
+            makeItem('episode-1', 'episode', parents),
+            makeItem('episode-2', 'episode', parents),
+          ]),
+        getChildrenMetadata: childrenOf({
+          'season-1': [
+            makeItem('episode-1', 'episode'),
+            makeItem('episode-2', 'episode'),
+          ],
+          'show-1': [makeItem('season-1', 'season', { index: 1 })],
+        }),
+      });
+      const { service, applySpy } = buildService(mediaServer);
+
+      await service.processCollection(collection as any);
+
+      expect(drawn(applySpy)).toEqual([
+        ['episode-1', 'titlecard'],
+        ['episode-2', 'titlecard'],
+        ['season-1', 'poster'],
+        ['show-1', 'poster'],
+      ]);
+    });
+
     it('draws nothing for an action that keeps the files, and reverts what it drew before', async () => {
       const collection = seasonCollection(ServarrAction.UNMONITOR);
       const stateService = {

--- a/apps/server/src/modules/overlays/overlay-processor.service.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.ts
@@ -274,17 +274,38 @@ export class OverlayProcessorService {
     // Up: group the members under the parent that is losing them.
     const seasonsByShow = new Map<string, CoveredChildren>();
     const episodesBySeason = new Map<string, CoveredChildren>();
+    const seasonsOfShow = new Map<string, MediaItem[] | null>();
     for (const member of presence.found.values()) {
       const deleteDate = memberDates.get(member.id);
-      if (!deleteDate || !member.parentId) continue;
+      if (!deleteDate) continue;
 
-      if (member.type === 'season') {
+      if (member.type === 'season' && member.parentId) {
         this.cover(seasonsByShow, member.parentId, member.id, deleteDate);
       }
       if (member.type === 'episode') {
+        let seasonId = member.parentId;
+        if (!seasonId && member.grandparentId && member.parentIndex != null) {
+          // Plex omits the episode -> season link when the show hides its
+          // seasons (Seasons: Hide, #3534). The show and the season number
+          // survive, so recover the season from the show's children.
+          if (!seasonsOfShow.has(member.grandparentId)) {
+            seasonsOfShow.set(
+              member.grandparentId,
+              await this.readChildren(
+                mediaServer,
+                member.grandparentId,
+                'season',
+              ),
+            );
+          }
+          const seasons = seasonsOfShow.get(member.grandparentId);
+          if (!seasons) complete = false;
+          seasonId = seasons?.find((s) => s.index === member.parentIndex)?.id;
+        }
+        if (!seasonId) continue;
         this.cover(
           episodesBySeason,
-          member.parentId,
+          seasonId,
           member.id,
           deleteDate,
           member.grandparentId,
@@ -311,7 +332,9 @@ export class OverlayProcessorService {
     }
 
     for (const [showId, covered] of seasonsByShow) {
-      const seasons = await this.readChildren(mediaServer, showId, 'season');
+      const seasons =
+        seasonsOfShow.get(showId) ??
+        (await this.readChildren(mediaServer, showId, 'season'));
       if (!seasons) {
         complete = false;
         continue;


### PR DESCRIPTION
Fixes #3534.

When a series is set to "Seasons: Hide" in Plex, Plex stops reporting which season an episode belongs to (checked against a real server: the episode keeps its show id and season number, but the season id field disappears and the item is marked `skipParent`). The overlay walk that promotes expiring episodes up to their season and series relied on that season id, so every episode of such a show was silently dropped and the series poster never got the countdown - even when every episode was expiring.

The fix: when an episode arrives without a season id but with a show id and a season number, the season is looked up from the show's own season list (one extra lookup per affected show, remembered for the rest of the run). Shows that display seasons normally take exactly the same path as before, and Jellyfin and Emby always deliver the season id (checked live on both), so nothing changes for them.

Checked on the real dev stack, acting as an end user (Playwright) with the fix running:

| Step | Result |
|---|---|
| Set Seasons: Hide in Plex Web, build the collection and press Run Now in the Maintainerr UI, before the fix | episodes overlaid, series poster untouched |
| Same flow, after the fix | season and series promoted, series poster shows the countdown in Plex Web |
| Same collection with seasons visible | unchanged, same items promoted as before |
| Jellyfin and Emby runs of the same collection | unchanged, same items promoted as before |

A hidden season still gets its (invisible) overlay, matching the rule from #3511 that an overlay marks everything that leaves the server. Full test suite passes.