### PR TITLE
fix(i18n): reject catalog entries that do not compile as ICU MessageFormat

### DIFF
--- a/apps/ui/src/locales/catalog-icu.spec.tsx
+++ b/apps/ui/src/locales/catalog-icu.spec.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/react'
 import { readdirSync, readFileSync } from 'node:fs'
 import path from 'node:path'
+import { validateIcu } from 'pofile-ts'
 import { describe, expect, it } from 'vitest'
 import {
   icuArgumentKind,
@@ -143,6 +144,32 @@ describe('translation catalogs', () => {
 
     const broken = findBrokenMessages(translations)
     expect(broken, explain(broken)).toEqual([])
+  })
+})
+
+describe('ICU MessageFormat validity', () => {
+  const catalogs = readdirSync(localesDir).filter((name) =>
+    name.endsWith('.po'),
+  )
+
+  // A message that will not compile as ICU (a renamed plural category, a
+  // missing `other`, mangled syntax) keeps its argument names, so placeholder
+  // parity passes - but Lingui then prints the raw source on screen. The render
+  // checks above miss it: the fallback text still contains the argument name.
+  // validate-catalogs rejects it; this enforces the same on the real catalogs.
+  it.each(catalogs)('%s compiles as ICU MessageFormat', (name) => {
+    const invalid = parsePo(readFileSync(path.join(localesDir, name), 'utf8'))
+      .flatMap((entry: { msgid: string; msgstr: string }) => [
+        entry.msgid,
+        entry.msgstr,
+      ])
+      .filter((text: string) => text.length > 0 && !validateIcu(text).valid)
+    expect(invalid).toEqual([])
+  })
+
+  it('flags a renamed plural category, accepts a valid one', () => {
+    expect(validateIcu('{n, plural, one {# x} andra {# y}}').valid).toBe(false)
+    expect(validateIcu('{n, plural, one {# x} other {# y}}').valid).toBe(true)
   })
 })
 

--- a/tools/i18n/validate-catalogs.mjs
+++ b/tools/i18n/validate-catalogs.mjs
@@ -10,6 +10,9 @@
  *   reorder or hide text (direction marks U+200E/U+200F and joiners
  *   U+200C/U+200D stay allowed - RTL and complex scripts need them);
  * - Zalgo combining runs and oversized entries, which overflow adjacent UI;
+ * - a message that does not compile as ICU MessageFormat (a renamed plural
+ *   category, a missing `other`, mangled syntax) - it keeps its argument names
+ *   so placeholder parity passes, but the runtime prints the raw source;
  * - a translation that introduces a URL marker the source does not carry
  *   (phishing via translated copy);
  * - any URL marker in a source message at all - URLs live in code and reach
@@ -31,6 +34,7 @@
 import { execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+import { validateIcu } from 'pofile-ts';
 import {
   icuArguments,
   parsePo,
@@ -259,6 +263,21 @@ const rejectPlural = (entry, location) => {
   return true;
 };
 
+// The message must compile as ICU MessageFormat. A translation that renames a
+// plural category (`other` -> `andra`), drops the required `other`, or mangles
+// the syntax keeps its argument names intact - so the placeholder check passes
+// - but Lingui then fails to compile it and prints the raw
+// `{clearedCollectionMedia, plural, ...}` source on screen. `validateIcu` is the
+// same parser Lingui compiles through, and returns valid for plain (non-ICU)
+// text, so a catalog that passes here renders. Weblate's own ICU check only
+// warns; it does not block a save, which is why this repo-side copy exists.
+const icuError = (text) => {
+  const result = validateIcu(text);
+  return result.valid
+    ? null
+    : (result.errors[0]?.message ?? 'invalid ICU MessageFormat');
+};
+
 for (const entry of sourceEntries) {
   if (rejectPlural(entry, sourceLocation)) continue;
   const sourceMarker = markerIn(entry.msgid);
@@ -288,6 +307,14 @@ for (const entry of sourceEntries) {
       `${sourceLocation}:${entry.line}\n` +
         `    source: ${entry.msgid}\n` +
         `    has an unbalanced rich-text slot - every <n> needs its </n>`,
+    );
+  }
+  const sourceIcu = icuError(entry.msgid);
+  if (sourceIcu) {
+    errors.push(
+      `${sourceLocation}:${entry.line}\n` +
+        `    source: ${entry.msgid}\n` +
+        `    is not valid ICU MessageFormat - ${sourceIcu}`,
     );
   }
   if (entry.msgstr !== '' && entry.msgstr !== entry.msgid) {
@@ -351,6 +378,17 @@ for (const file of files) {
           `    source:      ${entry.msgid}\n` +
           `    translation: ${entry.msgstr}\n` +
           `    introduces "${introducedMarker}" - a translation must never add a URL`,
+      );
+      continue;
+    }
+
+    const translationIcu = icuError(entry.msgstr);
+    if (translationIcu) {
+      errors.push(
+        `${location}:${entry.line}\n` +
+          `    source:      ${entry.msgid}\n` +
+          `    translation: ${entry.msgstr}\n` +
+          `    is not valid ICU MessageFormat - ${translationIcu}`,
       );
       continue;
     }


### PR DESCRIPTION
## Problem

A translation that renames a plural category (`other` -> `andra`), drops the required `other`, or otherwise mangles ICU syntax keeps its argument names intact - so placeholder parity passes - but Lingui cannot compile it and renders the raw `{clearedCollectionMedia, plural, ...}` source on screen.

Every layer missed it:

| Layer | Result |
|---|---|
| `validate-catalogs` (CI gate) | passed - only checks argument-name parity, not the plural category |
| `catalog-icu.spec` render check | missed - the raw fallback still contains the argument name |
| Weblate `icu-message-format` | warns, but does not block a translator's Save |

So a broken plural could be saved in Weblate, pushed in a translation PR, pass every check, and ship.

## Fix

`validate-catalogs` now runs each source `msgid` and translation `msgstr` through `validateIcu` from `pofile-ts` (the parser Lingui compiles through), rejecting anything that will not compile. It returns valid for plain non-ICU text, so it adds no false positives.

`catalog-icu.spec` gains an `it.each` that enforces the same on every real catalog, closing that spec's blind spot.

## Verified

- 0 false positives across all 15293 real catalog strings (2310 with ICU).
- The `other` -> `andra` breakage is now rejected: `Missing 'other' clause`.
- A valid plural still passes; real catalogs still pass `i18n:validate`.
- Full `turbo test` green (uncached).