### PR TITLE
fix(ci): install pofile-ts before back-translation so the review job stops crashing

### DIFF
--- a/.github/workflows/weblate_review.yml
+++ b/.github/workflows/weblate_review.yml
@@ -126,6 +126,19 @@ jobs:
               labels,
             })
 
+      - name: Activate corepack
+        if: ${{ github.event.pull_request.user.login == 'hosted-weblate[bot]' }}
+        run: |
+          corepack install
+          corepack enable
+
+      # back-translate imports tools/i18n/po.mjs, which decodes through
+      # pofile-ts. Focusing the root workspace installs that dependency without
+      # building apps/server's native canvas, which back-translation never uses.
+      - name: Install the back-translation dependencies
+        if: ${{ github.event.pull_request.user.login == 'hosted-weblate[bot]' }}
+        run: yarn workspaces focus
+
       - name: Back-translate changed strings
         if: ${{ github.event.pull_request.user.login == 'hosted-weblate[bot]' }}
         env:


### PR DESCRIPTION
## Problem

`tools/i18n/po.mjs` now decodes catalogs through `pofile-ts` (from #3510), but `weblate_review.yml` runs `back-translate.mjs` - which imports `po.mjs` - **without installing any dependencies**. So the **Back-translation review** check crashed on the first real Weblate translation PR (#3545):

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'pofile-ts'
  imported from .../tools/i18n/po.mjs
```

(`weblate_catalog.yml` runs `yarn --immutable` so its checks pass; `weblate_review.yml` never installed anything - it was self-contained only while `po.mjs` was hand-rolled.)

## Fix

Add corepack + `yarn workspaces focus` before the back-translate step. Focusing the root workspace installs `pofile-ts` (a root devDependency) **without** building `apps/server`'s native canvas, which back-translation never touches - so no apt libraries and no heavy build, unlike a full `yarn --immutable`.

## Verified

In a fresh worktree off `origin/development` (simulating the CI checkout):
- `yarn workspaces focus` installs `pofile-ts` in ~2s, **canvas absent** (no native build).
- `back-translate.mjs` then imports `po.mjs` and runs (skips cleanly on no AI key instead of crashing).

Re-running the check on #3545 after this merges will make it pass.