### PR TITLE
fix(i18n): reject translations that change an argument's ICU structure

### DIFF
--- a/.github/instructions/i18n.instructions.md
+++ b/.github/instructions/i18n.instructions.md
@@ -168,7 +168,11 @@ user's browser after an automated merge pipeline.
   set (overrides, embeddings and isolates), invisible characters (zero
   width space, word joiner, soft hyphen, Braille blank, BOM, interlinear
   annotation, the Tags block), Zalgo combining runs, entries over 1000
-  characters, any translation that introduces a URL marker (`://`, the
+  characters, any message that does not compile as ICU MessageFormat, any
+  translation that keeps an argument's name but changes its structure (a
+  plural rewritten as a plain value, a plural category the locale needs
+  dropped, a number format stripped, a select branch dropped or added),
+  any translation that introduces a URL marker (`://`, the
   fullwidth-colon homoglyph, `www.`, `mailto:`, `tel:`) absent from its
   source, and any source message containing a URL marker at all. Do not
   weaken it: it is the line that holds even if Weblate-side checks are

--- a/apps/ui/src/locales/catalog-icu.spec.tsx
+++ b/apps/ui/src/locales/catalog-icu.spec.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest'
 import {
   icuArgumentKind,
   icuArguments,
+  icuStructureProblems,
   parsePo,
   richTextSlots,
 } from '../../../../tools/i18n/po.mjs'
@@ -170,6 +171,45 @@ describe('ICU MessageFormat validity', () => {
   it('flags a renamed plural category, accepts a valid one', () => {
     expect(validateIcu('{n, plural, one {# x} andra {# y}}').valid).toBe(false)
     expect(validateIcu('{n, plural, one {# x} other {# y}}').valid).toBe(true)
+  })
+
+  // Valid ICU can still change an argument's structure behind its name: a
+  // plural rewritten as plain `{count}` renders the same wording at every
+  // count, a dropped `one` renders "1 saker", a stripped `percent` format
+  // shows 0.42 instead of 42 %. All compile, so the checks above pass them.
+  it.each(catalogs)('%s keeps every argument structure', (name) => {
+    const locale = path.basename(name, '.po')
+    const broken = parsePo(readFileSync(path.join(localesDir, name), 'utf8'))
+      .filter((entry: { msgstr: string }) => entry.msgstr.length > 0)
+      .flatMap((entry: { msgid: string; msgstr: string }) =>
+        icuStructureProblems(entry.msgid, entry.msgstr, locale),
+      )
+    expect(broken).toEqual([])
+  })
+
+  it('flags a structure change, accepts a locale-shaped plural', () => {
+    const plural = '{n, plural, one {# item} other {# items}}'
+    expect(icuStructureProblems(plural, '{n} saker', 'sv')).not.toEqual([])
+    expect(
+      icuStructureProblems(plural, '{n, plural, other {# saker}}', 'sv'),
+    ).not.toEqual([])
+    expect(
+      icuStructureProblems('{p, number, percent}', '{p}', 'sv'),
+    ).not.toEqual([])
+    // The parser accepts extension types like `list`, but the runtime has no
+    // formatter for them and throws mid-render.
+    expect(icuStructureProblems('Hello {x}', '{x, list}', 'sv')).not.toEqual([])
+    // Japanese has no `one` category and French is not forced to add `many`.
+    expect(
+      icuStructureProblems(plural, '{n, plural, other {# ko}}', 'ja'),
+    ).toEqual([])
+    expect(
+      icuStructureProblems(
+        plural,
+        '{n, plural, one {# fichier} other {# fichiers}}',
+        'fr',
+      ),
+    ).toEqual([])
   })
 })
 

--- a/tools/i18n/po.mjs
+++ b/tools/i18n/po.mjs
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { parsePo as parseLinguiPo } from 'pofile-ts';
+import { parseIcu, parsePo as parseLinguiPo } from 'pofile-ts';
 
 /**
  * Start line of every PO entry block, in file order, so a validator error can
@@ -206,6 +206,146 @@ export const icuArguments = (text) => {
     if (text[j] === '}' || text[j] === ',') names.add(name);
   }
   return names;
+};
+
+// How one argument shapes its value, from the parsed AST. `kind` separates
+// cardinal and ordinal plurals (the parser stores both as "plural" nodes);
+// `categories` holds the plural/select branch keywords, `style` the
+// number/date/time format. Later duplicates of a name win, matching how the
+// runtime resolves a repeated argument.
+const structuresIn = (nodes, byName) => {
+  for (const node of nodes) {
+    if (node.type === 'plural' || node.type === 'select') {
+      const ordinal = node.type === 'plural' && node.pluralType === 'ordinal';
+      byName.set(node.value, {
+        kind: ordinal ? 'selectordinal' : node.type,
+        style: null,
+        offset: node.type === 'plural' ? node.offset : 0,
+        categories: new Set(Object.keys(node.options)),
+      });
+      for (const option of Object.values(node.options)) {
+        structuresIn(option.value, byName);
+      }
+    } else if (node.type === 'tag') {
+      structuresIn(node.children, byName);
+    } else if (node.type !== 'literal' && node.type !== 'pound') {
+      // argument, number, date, time - and the parser's extension types
+      // (list, duration, ago, name), which pofile-ts accepts but the Lingui
+      // runtime has no formatter for: it throws mid-render. Recording them
+      // means converting a plain `{x}` into one is a structure change.
+      byName.set(node.value, {
+        kind: node.type,
+        style: node.style ?? null,
+        offset: 0,
+        categories: null,
+      });
+    }
+  }
+  return byName;
+};
+
+const describeStructure = ({ kind, style }) => {
+  if (kind === 'plural') return 'a plural';
+  if (kind === 'selectordinal') return 'an ordinal plural';
+  if (kind === 'select') return 'a select';
+  if (kind === 'argument') return 'a plain argument';
+  return style ? `a ${kind} formatted as "${style}"` : `an unformatted ${kind}`;
+};
+
+// `=0`-style exact matches are a translator's own refinement; keywords are
+// what the locale's grammar selects between.
+const keywordsOf = (categories) =>
+  new Set([...categories].filter((key) => !key.startsWith('=')));
+
+const pluralCategoriesFor = (locale, kind) => {
+  try {
+    return new Set(
+      new Intl.PluralRules(locale.replaceAll('_', '-'), {
+        type: kind === 'selectordinal' ? 'ordinal' : 'cardinal',
+      }).resolvedOptions().pluralCategories,
+    );
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Ways a translation changes an ICU argument's structure while keeping its
+ * name, so both the compile check and placeholder parity pass.
+ *
+ * Each survives as valid ICU yet renders subtly wrong text: a plural rewritten
+ * as `{count}` shows the same wording for every count, a dropped `one` branch
+ * shows "1 items", a stripped `percent` format loses the % sign, a dropped
+ * select branch shows its `other` text. The plural-category rule is
+ * source-relative and locale-aware: the translation must keep every category
+ * the source distinguishes that exists in the target locale (Japanese
+ * legitimately collapses to `other` alone), and may only use categories the
+ * locale's grammar can ever select (a `few` branch in Swedish is dead text).
+ * Messages that do not parse are skipped - the compile check owns those.
+ */
+export const icuStructureProblems = (source, translation, locale) => {
+  const sourceParse = parseIcu(source);
+  const translationParse = parseIcu(translation);
+  if (!sourceParse.success || !translationParse.success) return [];
+
+  const sourceShapes = structuresIn(sourceParse.ast, new Map());
+  const translationShapes = structuresIn(translationParse.ast, new Map());
+  const problems = [];
+
+  for (const [name, shape] of translationShapes) {
+    const expected = sourceShapes.get(name);
+    if (!expected) continue;
+
+    if (expected.kind !== shape.kind || expected.style !== shape.style) {
+      problems.push(
+        `"${name}" is ${describeStructure(expected)} in the source but ${describeStructure(shape)} in the translation`,
+      );
+      continue;
+    }
+
+    if (expected.offset !== shape.offset) {
+      problems.push(
+        `"${name}" changes the plural offset from ${expected.offset} to ${shape.offset} - every # renders a shifted count`,
+      );
+    }
+
+    if (shape.kind === 'plural' || shape.kind === 'selectordinal') {
+      const localeCategories = pluralCategoriesFor(locale, shape.kind);
+      if (!localeCategories) continue;
+      const actual = keywordsOf(shape.categories);
+      for (const category of keywordsOf(expected.categories)) {
+        if (localeCategories.has(category) && !actual.has(category)) {
+          problems.push(
+            `"${name}" is missing the plural category "${category}" - those counts fall back to "other" and render the wrong grammar`,
+          );
+        }
+      }
+      for (const category of actual) {
+        if (!localeCategories.has(category)) {
+          problems.push(
+            `"${name}" uses the plural category "${category}", which "${locale}" never selects - that branch is dead text`,
+          );
+        }
+      }
+    } else if (shape.kind === 'select') {
+      for (const branch of expected.categories) {
+        if (!shape.categories.has(branch)) {
+          problems.push(
+            `"${name}" is missing the select branch "${branch}" - that value renders the "other" text`,
+          );
+        }
+      }
+      for (const branch of shape.categories) {
+        if (!expected.categories.has(branch)) {
+          problems.push(
+            `"${name}" adds the select branch "${branch}", which the app never passes`,
+          );
+        }
+      }
+    }
+  }
+
+  return problems;
 };
 
 /**

--- a/tools/i18n/validate-catalogs.mjs
+++ b/tools/i18n/validate-catalogs.mjs
@@ -13,6 +13,10 @@
  * - a message that does not compile as ICU MessageFormat (a renamed plural
  *   category, a missing `other`, mangled syntax) - it keeps its argument names
  *   so placeholder parity passes, but the runtime prints the raw source;
+ * - a translation that keeps an argument's name but changes its structure (a
+ *   plural rewritten as a plain value, a dropped plural category the locale
+ *   needs, a stripped number format, a dropped select branch) - it compiles
+ *   and passes parity, then renders believable text with the wrong grammar;
  * - a translation that introduces a URL marker the source does not carry
  *   (phishing via translated copy);
  * - any URL marker in a source message at all - URLs live in code and reach
@@ -37,6 +41,7 @@ import path from 'node:path';
 import { validateIcu } from 'pofile-ts';
 import {
   icuArguments,
+  icuStructureProblems,
   parsePo,
   poShapeProblems,
   readPo,
@@ -448,6 +453,23 @@ for (const file of files) {
           `    rich-text slot ${parts.join(' and ')}`,
       );
       continue;
+    }
+
+    // Same argument names, but a different shape behind one of them: a plural
+    // rewritten as a plain `{count}`, a dropped `one` category, a stripped
+    // number format. All compile and pass parity, then render believable text
+    // with the wrong grammar or formatting.
+    for (const problem of icuStructureProblems(
+      entry.msgid,
+      entry.msgstr,
+      locale,
+    )) {
+      errors.push(
+        `${location}:${entry.line}\n` +
+          `    source:      ${entry.msgid}\n` +
+          `    translation: ${entry.msgstr}\n` +
+          `    ${problem}`,
+      );
     }
 
     if (entry.msgstr === entry.msgid) {


### PR DESCRIPTION
A translation can keep an argument's name, compile as valid ICU, and still change what the argument does. Every existing check passes it, and the app then renders believable text that is wrong. This adds a structural comparison between each source message and its translation.

Closed cases, each proven through the real Lingui runtime:

| Translation change | Passed before | Renders |
| --- | --- | --- |
| Plural rewritten as plain `{count}` | yes | same wording at every count |
| Plural drops a category the locale needs (`one`) | yes | "1 saker" |
| Number format stripped (`{p, number, percent}` to `{p}`) | yes | "0.42" instead of "42 %" |
| Select branch dropped or added | yes | wrong branch text |
| Plural offset changed | yes | every `#` shows a shifted count |
| Cardinal/ordinal plural swapped | yes | wrong form selection |
| Plain argument converted to a parser extension type (`{x, list}`) | yes | **crashes the render** - `validateIcu` accepts these but the Lingui runtime has no formatter for them |

The plural-category rule is locale-aware and source-relative, so it does not block legitimate shapes: the translation must keep every category the source distinguishes that exists in the target locale, and may only use categories the locale's grammar can select. Japanese collapsing to `other` alone passes, French is not forced to add CLDR's `many`, Polish may add `few`/`many`, and a `few` branch in Swedish is rejected as dead text.

| Verification | Result |
| --- | --- |
| Red-team matrix through the real validator (15 attack shapes, 10 legitimate shapes) | all rejected / all accepted |
| All 13 real catalogs, including the merged #3545 Weblate batch (1088 Spanish and 40 Swedish translations, 41 translated plurals) | 0 false positives |
| Runtime reproduction via `@lingui/core` | wrong renders confirmed for each class |
| `catalog-icu.spec.tsx`, full UI suite, full `yarn test` | green |
