### PR TITLE
fix(overlays): stop the manual run erroring, and make reset able to undo everything it drew

### DIFF
--- a/apps/server/src/modules/collections/collections.controller.ts
+++ b/apps/server/src/modules/collections/collections.controller.ts
@@ -9,6 +9,7 @@ import {
   CollectionPosterUploadResponse,
   CollectionLogMeta,
   CollectionMediaSortField,
+  DELETE_AFTER_MAX_DAYS,
   ECollectionLogType,
   MediaItemType,
   MediaItemTypes,
@@ -157,7 +158,12 @@ const collectionBaseShape = {
   listExclusions: z.boolean().optional(),
   cleanupLeftoverFolders: z.boolean().optional(),
   forceSeerr: z.boolean().optional(),
-  deleteAfterDays: z.coerce.number().int().optional(),
+  deleteAfterDays: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(DELETE_AFTER_MAX_DAYS)
+    .optional(),
   manualCollection: z.boolean().optional(),
   manualCollectionName: z.string().optional().nullable(),
   keepLogsForMonths: z.coerce.number().int().optional(),

--- a/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
@@ -148,6 +148,58 @@ describe('OverlayProcessorService', () => {
     expect(result.processed).toBe(1);
   });
 
+  it('draws nothing when the collection window cannot name a day', async () => {
+    const settingsService = {
+      getSettings: jest.fn().mockResolvedValue({ enabled: true }),
+    };
+    const stateService = { getItemState: jest.fn().mockResolvedValue(null) };
+    const templateService = {
+      resolveForCollection: jest.fn().mockResolvedValue(makeTemplate()),
+    };
+    const provider = makeProvider();
+
+    const service = new OverlayProcessorService(
+      makeProviderFactory(provider) as any,
+      makeMediaServerFactory() as any,
+      {} as any,
+      {} as any,
+      settingsService as any,
+      stateService as any,
+      {} as any,
+      templateService as any,
+      { emit: jest.fn() } as any,
+      createMockLogger(),
+    );
+
+    // Out of Date's range: the sum used to be an Invalid Date, which is truthy,
+    // so it reached the artwork as "Leaving Invalid Date" (#3549).
+    const collection = createCollection({
+      id: 1,
+      title: 'Impossible window',
+      type: 'movie',
+      deleteAfterDays: 999999999,
+      overlayTemplateId: null,
+    });
+    collection.collectionMedia = [
+      createCollectionMedia(collection, {
+        mediaServerId: 'media-1',
+        addDate: new Date('2026-04-01T00:00:00.000Z'),
+      }),
+    ];
+
+    jest.spyOn(service, 'applyTemplateOverlay').mockResolvedValue(true);
+
+    const result = await service.processCollection(collection as any);
+
+    expect(service.applyTemplateOverlay).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      processed: 0,
+      reverted: 0,
+      skipped: 0,
+      errors: 0,
+    });
+  });
+
   it('resolves a titlecard template when the collection is of type episode', async () => {
     const settingsService = {
       getSettings: jest.fn().mockResolvedValue({ enabled: true }),
@@ -809,6 +861,8 @@ describe('OverlayProcessorService', () => {
       .spyOn(service as any, 'deleteOriginalPoster')
       .mockImplementation(() => {});
 
+    jest.spyOn(service as any, 'listBackedUpItemIds').mockReturnValue([]);
+
     await service.resetAllOverlays();
 
     expect(stateService.removeState).toHaveBeenNthCalledWith(1, 1, 'media-1');
@@ -831,6 +885,124 @@ describe('OverlayProcessorService', () => {
         ([eventName]) => eventName === MaintainerrEvent.Overlay_Reverted,
       ),
     ).toHaveLength(1);
+  });
+
+  it('drops the backup it just took when the render fails, so reset cannot restore it', async () => {
+    const provider = makeProvider({
+      downloadImage: jest.fn().mockResolvedValue(Buffer.from('poster')),
+    });
+    const renderService = {
+      renderFromTemplate: jest
+        .fn()
+        .mockRejectedValue(new Error('sharp missing')),
+    };
+
+    const service = new OverlayProcessorService(
+      makeProviderFactory(provider) as any,
+      makeMediaServerFactory() as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      renderService as any,
+      {} as any,
+      { emit: jest.fn() } as any,
+      createMockLogger(),
+    );
+
+    jest.spyOn(service as any, 'loadOriginalPoster').mockReturnValue(null);
+    const saveOriginal = jest
+      .spyOn(service as any, 'saveOriginalPoster')
+      .mockResolvedValue('/backup.jpg');
+    const deleteOriginal = jest
+      .spyOn(service as any, 'deleteOriginalPoster')
+      .mockImplementation(() => {});
+
+    const applied = await service.applyTemplateOverlay(
+      'media-1',
+      1,
+      new Date(),
+      makeTemplate(),
+      provider as any,
+    );
+
+    expect(applied).toBe(false);
+    expect(saveOriginal).toHaveBeenCalled();
+    expect(deleteOriginal).toHaveBeenCalledWith('media-1');
+    expect(provider.uploadImage).not.toHaveBeenCalled();
+  });
+
+  it('restores a saved original that no state row claims during reset-all', async () => {
+    const stateService = {
+      getAllStates: jest
+        .fn()
+        .mockResolvedValue([{ collectionId: 1, mediaServerId: 'media-1' }]),
+      removeState: jest.fn().mockResolvedValue(undefined),
+    };
+    const provider = makeProvider();
+    const collectionRepos = makeCollectionRepos([]);
+
+    const service = new OverlayProcessorService(
+      makeProviderFactory(provider) as any,
+      makeMediaServerFactory() as any,
+      collectionRepos.collectionRepo as any,
+      collectionRepos.collectionMediaRepo as any,
+      {} as any,
+      stateService as any,
+      {} as any,
+      {} as any,
+      { emit: jest.fn() } as any,
+      createMockLogger(),
+    );
+
+    // media-2 was uploaded but its state write failed: without this, nothing
+    // ever takes it off the media server again (#3549).
+    jest
+      .spyOn(service as any, 'listBackedUpItemIds')
+      .mockReturnValue(['media-1', 'media-2']);
+    jest
+      .spyOn(service as any, 'loadOriginalPoster')
+      .mockReturnValue(Buffer.from('poster'));
+    jest
+      .spyOn(service as any, 'deleteOriginalPoster')
+      .mockImplementation(() => {});
+
+    await service.resetAllOverlays();
+
+    expect(provider.uploadImage).toHaveBeenCalledTimes(2);
+    expect(provider.uploadImage).toHaveBeenNthCalledWith(
+      2,
+      'media-2',
+      expect.any(Buffer),
+      'image/jpeg',
+    );
+    expect(stateService.removeState).toHaveBeenCalledTimes(1);
+    expect(stateService.removeState).toHaveBeenCalledWith(1, 'media-1');
+  });
+
+  it('leaves a run alone when reset is asked for while one is in progress', async () => {
+    const stateService = { getAllStates: jest.fn() };
+    const provider = makeProvider();
+
+    const service = new OverlayProcessorService(
+      makeProviderFactory(provider) as any,
+      makeMediaServerFactory() as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      stateService as any,
+      {} as any,
+      {} as any,
+      { emit: jest.fn() } as any,
+      createMockLogger(),
+    );
+
+    service.status = 'running';
+
+    await service.resetAllOverlays();
+
+    expect(stateService.getAllStates).not.toHaveBeenCalled();
+    expect(service.status).toBe('running');
   });
 
   it('keeps overlay state on reset when individual uploads fail so retries are possible', async () => {
@@ -866,6 +1038,8 @@ describe('OverlayProcessorService', () => {
     const deleteSpy = jest
       .spyOn(service as any, 'deleteOriginalPoster')
       .mockImplementation(() => {});
+
+    jest.spyOn(service as any, 'listBackedUpItemIds').mockReturnValue([]);
 
     await service.resetAllOverlays();
 
@@ -911,6 +1085,8 @@ describe('OverlayProcessorService', () => {
     jest
       .spyOn(service as any, 'deleteOriginalPoster')
       .mockImplementation(() => {});
+
+    jest.spyOn(service as any, 'listBackedUpItemIds').mockReturnValue([]);
 
     await service.resetAllOverlays();
 

--- a/apps/server/src/modules/overlays/overlay-processor.service.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.ts
@@ -100,6 +100,12 @@ export class OverlayProcessorService {
 
   // ── Date helpers ──────────────────────────────────────────────────────────
 
+  /**
+   * Null when the window cannot name a day. `DELETE_AFTER_MAX_DAYS` bounds it
+   * where it is entered, but the rule-group body is not schema-validated, so
+   * this stays the invariant: an Invalid Date is truthy and would be drawn as
+   * "Leaving Invalid Date" (#3549).
+   */
   private getDeleteDate(
     addDate: string | Date,
     deleteAfterDays: number | null,
@@ -107,7 +113,7 @@ export class OverlayProcessorService {
     if (deleteAfterDays == null) return null;
     const d = new Date(addDate);
     d.setDate(d.getDate() + deleteAfterDays);
-    return d;
+    return Number.isNaN(d.getTime()) ? null : d;
   }
 
   private getDaysLeft(deleteDate: Date): number {
@@ -349,13 +355,12 @@ export class OverlayProcessorService {
 
   // ── Poster backup helpers ─────────────────────────────────────────────────
 
+  private getOriginalsDir(): string {
+    return path.join(this.dataDir, 'overlays', 'originals');
+  }
+
   private getOriginalPosterPath(mediaServerId: string): string {
-    return path.join(
-      this.dataDir,
-      'overlays',
-      'originals',
-      `${mediaServerId}.jpg`,
-    );
+    return path.join(this.getOriginalsDir(), `${mediaServerId}.jpg`);
   }
 
   private async saveOriginalPoster(
@@ -377,6 +382,17 @@ export class OverlayProcessorService {
   private deleteOriginalPoster(mediaServerId: string): void {
     const p = this.getOriginalPosterPath(mediaServerId);
     if (fs.existsSync(p)) fs.unlinkSync(p);
+  }
+
+  /** Every item whose original poster is still saved on disk. */
+  private listBackedUpItemIds(): string[] {
+    const dir = this.getOriginalsDir();
+    if (!fs.existsSync(dir)) return [];
+    const suffix = '.jpg';
+    return fs
+      .readdirSync(dir)
+      .filter((name) => name.length > suffix.length && name.endsWith(suffix))
+      .map((name) => name.slice(0, -suffix.length));
   }
 
   private async getOverlayCollections(): Promise<
@@ -416,17 +432,23 @@ export class OverlayProcessorService {
    *  - Backup on disk, upload succeeds → clear backup and state (revert done).
    */
   private async revertItemInternal(
-    collectionId: number,
+    collectionId: number | null,
     mediaServerId: string,
     provider: IOverlayProvider,
   ): Promise<RevertItemResult> {
+    // Null for a saved poster no state row claims - there is nothing to clear.
+    const clearState = () =>
+      collectionId == null
+        ? Promise.resolve()
+        : this.stateService.removeState(collectionId, mediaServerId);
+
     const originalBuf = this.loadOriginalPoster(mediaServerId);
 
     if (!originalBuf) {
       this.logger.warn(
         `No saved original poster for ${mediaServerId}, cannot restore`,
       );
-      await this.stateService.removeState(collectionId, mediaServerId);
+      await clearState();
       return 'no-backup';
     }
 
@@ -448,7 +470,7 @@ export class OverlayProcessorService {
         `Item ${mediaServerId} no longer exists on the media server, dropping overlay state and backup`,
       );
       this.deleteOriginalPoster(mediaServerId);
-      await this.stateService.removeState(collectionId, mediaServerId);
+      await clearState();
       return 'item-gone';
     }
 
@@ -464,7 +486,7 @@ export class OverlayProcessorService {
 
     this.logger.log(`Restored original poster for item ${mediaServerId}`);
     this.deleteOriginalPoster(mediaServerId);
-    await this.stateService.removeState(collectionId, mediaServerId);
+    await clearState();
     return 'restored';
   }
 
@@ -743,10 +765,12 @@ export class OverlayProcessorService {
       );
 
       // Every id the overlay-enabled collections draw on: members + inherited.
+      // Read from the member targets, not the raw membership, so a member the
+      // run no longer draws on has its old overlay reverted below.
       const allCurrentItemIds = new Set<string>();
       for (const coll of collections) {
-        for (const item of coll.collectionMedia) {
-          allCurrentItemIds.add(item.mediaServerId);
+        for (const member of this.getMemberTargets(coll)) {
+          allCurrentItemIds.add(member.itemId);
         }
       }
 
@@ -854,46 +878,84 @@ export class OverlayProcessorService {
 
   // ── Reset all overlays ────────────────────────────────────────────────────
 
+  /**
+   * Takes the same running flag as a run: a reset restores originals and drops
+   * the backups a concurrent run would be reading, so the two must never
+   * interleave. The controller's own check cannot guarantee that on its own.
+   */
   async resetAllOverlays(): Promise<void> {
-    this.logger.warn('Resetting all overlays...');
-
-    const provider = await this.providerFactory.getProvider();
-    if (!provider) {
-      this.logger.warn(
-        'Cannot reset overlays: no overlay provider for configured media server',
-      );
+    if (this.status === 'running') {
+      this.logger.warn('Overlay processor is already running, skipping reset');
       return;
     }
 
-    const allStates = await this.stateService.getAllStates();
-    const revertedMediaItems: { mediaServerId: string }[] = [];
-    for (const state of allStates) {
-      try {
-        const result = await this.revertItemInternal(
-          state.collectionId,
-          state.mediaServerId,
-          provider,
-        );
+    this.status = 'running';
+    this.logger.warn('Resetting all overlays...');
+    // Reported through the same summary as a run, so a reset that could not
+    // restore everything cannot read as a clean success.
+    const summary = this.createEmptyResult();
 
-        if (result === 'restored') {
-          this.addUniqueMediaItem(revertedMediaItems, state.mediaServerId);
-        }
-      } catch (error) {
+    try {
+      const provider = await this.providerFactory.getProvider();
+      if (!provider) {
         this.logger.warn(
-          `Failed to reset overlay for ${state.mediaServerId}; keeping state for retry`,
+          'Cannot reset overlays: no overlay provider for configured media server',
         );
-        this.logger.debug(error);
+        return;
       }
-    }
 
-    if (revertedMediaItems.length > 0) {
-      this.eventEmitter.emit(
-        MaintainerrEvent.Overlay_Reverted,
-        new OverlayRevertedDto(revertedMediaItems, 'All Collections'),
-      );
-    }
+      const allStates = await this.stateService.getAllStates();
+      const tracked = new Set(allStates.map((state) => state.mediaServerId));
+      // A saved original no state row claims is an upload whose state write
+      // failed; the backup is the only record left that the artwork may have
+      // been changed, so reset owns it too (#3549).
+      const targets = [
+        ...allStates.map((state) => ({
+          collectionId: state.collectionId as number | null,
+          mediaServerId: state.mediaServerId,
+        })),
+        ...this.listBackedUpItemIds()
+          .filter((mediaServerId) => !tracked.has(mediaServerId))
+          .map((mediaServerId) => ({ collectionId: null, mediaServerId })),
+      ];
 
-    this.logger.log('Overlay reset complete');
+      const revertedMediaItems: { mediaServerId: string }[] = [];
+      for (const target of targets) {
+        try {
+          const result = await this.revertItemInternal(
+            target.collectionId,
+            target.mediaServerId,
+            provider,
+          );
+
+          if (result === 'restored') {
+            this.addUniqueMediaItem(revertedMediaItems, target.mediaServerId);
+            summary.reverted++;
+          } else if (result === 'failed') {
+            summary.errors++;
+          }
+        } catch (error) {
+          this.logger.warn(
+            `Failed to reset overlay for ${target.mediaServerId}; keeping state for retry`,
+          );
+          this.logger.debug(error);
+          summary.errors++;
+        }
+      }
+
+      if (revertedMediaItems.length > 0) {
+        this.eventEmitter.emit(
+          MaintainerrEvent.Overlay_Reverted,
+          new OverlayRevertedDto(revertedMediaItems, 'All Collections'),
+        );
+      }
+
+      this.logger.log('Overlay reset complete');
+    } finally {
+      this.status = 'idle';
+      this.lastRun = new Date();
+      this.lastResult = summary;
+    }
   }
 
   // ── Template-based overlay application ────────────────────────────────────
@@ -951,6 +1013,10 @@ export class OverlayProcessorService {
         `Template overlay rendering failed for ${itemId}: ${error instanceof Error ? error.message : String(error)}`,
       );
       this.logger.debug(error);
+      // Nothing was uploaded, so a backup this pass just took records no
+      // change. Leaving it would have reset restoring - and on Plex selecting
+      // - a poster the item still has.
+      if (!savedOriginal) this.deleteOriginalPoster(itemId);
       return false;
     }
 

--- a/apps/server/src/modules/overlays/overlays.controller.spec.ts
+++ b/apps/server/src/modules/overlays/overlays.controller.spec.ts
@@ -303,22 +303,41 @@ describe('OverlaysController', () => {
     );
   });
 
-  it('forwards global force-processing requests to the processor', async () => {
-    const result = { processed: 1, reverted: 0, skipped: 0, errors: 0 };
-    processorService.processAllCollections.mockResolvedValue(result);
+  it('answers a global force-processing request without waiting for the run', () => {
+    let finish: () => void = () => undefined;
+    processorService.processAllCollections.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finish = resolve;
+      }),
+    );
 
-    await expect(controller.processAll({ force: true })).resolves.toBe(result);
+    // Answering before the run finishes is what keeps a response timeout from
+    // reading a still-running job as a failure (#3549).
+    expect(controller.processAll({ force: true })).toBeUndefined();
 
     expect(processorService.processAllCollections).toHaveBeenCalledWith(true);
+    finish();
   });
 
-  it('defaults global process requests to non-force mode', async () => {
-    const result = { processed: 0, reverted: 0, skipped: 1, errors: 0 };
-    processorService.processAllCollections.mockResolvedValue(result);
+  it('defaults global process requests to non-force mode', () => {
+    processorService.processAllCollections.mockResolvedValue(undefined);
 
-    await controller.processAll({});
+    controller.processAll({});
 
     expect(processorService.processAllCollections).toHaveBeenCalledWith(false);
+  });
+
+  it('rejects a global process request with 409 while a run is in progress', () => {
+    processorService.status = 'running';
+
+    expect(() => controller.processAll({})).toThrow(
+      expect.objectContaining({
+        status: 409,
+        response: 'An overlay run is already in progress',
+      }),
+    );
+
+    expect(processorService.processAllCollections).not.toHaveBeenCalled();
   });
 
   it('processes collection requests without force mode', async () => {
@@ -336,21 +355,23 @@ describe('OverlaysController', () => {
     expect(processorService.processCollection).toHaveBeenCalledWith(collection);
   });
 
-  it('allows reset while overlays are globally disabled', async () => {
+  it('allows reset while overlays are globally disabled', () => {
     processorService.resetAllOverlays.mockResolvedValue(undefined);
 
-    await expect(controller.resetAll()).resolves.toEqual({ success: true });
+    expect(controller.resetAll()).toBeUndefined();
 
     expect(processorService.resetAllOverlays).toHaveBeenCalled();
   });
 
-  it('rejects reset with 409 while a processor run is in progress', async () => {
+  it('rejects reset with 409 while a processor run is in progress', () => {
     processorService.status = 'running';
 
-    await expect(controller.resetAll()).rejects.toMatchObject({
-      status: 409,
-      response: 'Overlay processing is already running',
-    });
+    expect(() => controller.resetAll()).toThrow(
+      expect.objectContaining({
+        status: 409,
+        response: 'An overlay run is already in progress',
+      }),
+    );
 
     expect(processorService.resetAllOverlays).not.toHaveBeenCalled();
   });

--- a/apps/server/src/modules/overlays/overlays.controller.ts
+++ b/apps/server/src/modules/overlays/overlays.controller.ts
@@ -21,6 +21,7 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
   HttpException,
   HttpStatus,
   Param,
@@ -196,21 +197,27 @@ export class OverlaysController {
     };
   }
 
+  /**
+   * Started, not awaited. A full run outlives any browser or reverse-proxy
+   * response timeout, and a severed response read as a failed run while the
+   * run itself carried on (#3549). Callers follow it on GET status.
+   */
   @Post('process')
-  async processAll(
+  @HttpCode(HttpStatus.ACCEPTED)
+  processAll(
     @Body(new ZodValidationPipe(overlayProcessRequestSchema))
     request: OverlayProcessRequest,
   ) {
     if (this.processorService.status === 'running') {
       throw new HttpException(
-        'Overlay processing is already running',
+        'An overlay run is already in progress',
         HttpStatus.CONFLICT,
       );
     }
-    const result = await this.processorService.processAllCollections(
-      request.force ?? false,
-    );
-    return result;
+
+    this.processorService
+      .processAllCollections(request.force ?? false)
+      .catch((error) => this.logger.error('Overlay processing failed', error));
   }
 
   @Post('process/:collectionId')
@@ -219,7 +226,7 @@ export class OverlaysController {
   ) {
     if (this.processorService.status === 'running') {
       throw new HttpException(
-        'Overlay processing is already running',
+        'An overlay run is already in progress',
         HttpStatus.CONFLICT,
       );
     }
@@ -251,15 +258,18 @@ export class OverlaysController {
   }
 
   @Delete('reset')
-  async resetAll() {
+  @HttpCode(HttpStatus.ACCEPTED)
+  resetAll() {
     if (this.processorService.status === 'running') {
       throw new HttpException(
-        'Overlay processing is already running',
+        'An overlay run is already in progress',
         HttpStatus.CONFLICT,
       );
     }
-    await this.processorService.resetAllOverlays();
-    return { success: true };
+
+    this.processorService
+      .resetAllOverlays()
+      .catch((error) => this.logger.error('Overlay reset failed', error));
   }
 
   // ── Fonts ───────────────────────────────────────────────────────────────

--- a/apps/server/src/modules/rules/rules.service.setRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.setRules.spec.ts
@@ -100,6 +100,56 @@ describe('RulesService.setRules', () => {
     jest.clearAllMocks();
   });
 
+  // The overlay countdown turns this window into a real date; past Date range
+  // it drew "Leaving Invalid Date" on the artwork (#3549). Nothing else
+  // schema-validates the rule-group body.
+  it('refuses a deletion window that cannot become a real date', async () => {
+    const createCollection = jest.fn();
+    const service = createRulesService({
+      collectionService: { createCollection },
+      mediaServerFactory: createMediaServerFactory(),
+    });
+
+    const result = await service.setRules({
+      libraryId: '1',
+      name: 'Impossible window',
+      description: '',
+      useRules: true,
+      isActive: true,
+      rules: validRules,
+      collection: { keepLogsForMonths: 6, deleteAfterDays: 99999999 },
+    } as any);
+
+    expect(result.code).toBe(0);
+    expect(result.message).toContain('36500');
+    expect(createCollection).not.toHaveBeenCalled();
+  });
+
+  // Editing an existing rule group is the common path, and it validates
+  // separately from create.
+  it('refuses an impossible deletion window on update too', async () => {
+    const updateCollection = jest.fn();
+    const service = createRulesService({
+      collectionService: { updateCollection },
+      mediaServerFactory: createMediaServerFactory(),
+    });
+
+    const result = await service.updateRules({
+      id: 1,
+      libraryId: '1',
+      name: 'Impossible window',
+      description: '',
+      useRules: true,
+      isActive: true,
+      rules: validRules,
+      collection: { keepLogsForMonths: 6, deleteAfterDays: 99999999 },
+    } as any);
+
+    expect(result.code).toBe(0);
+    expect(result.message).toContain('36500');
+    expect(updateCollection).not.toHaveBeenCalled();
+  });
+
   // Without the user, a saved rule would skip every item at run time.
   // The community list is public and shared between installs; a rule must not
   // carry the uploader's media-server user into it.

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -1,6 +1,7 @@
 import {
   type BulkMediaItemResult,
   type BulkMediaResponse,
+  DELETE_AFTER_MAX_DAYS,
   ECollectionLogType,
   isPerUserProperty,
   leftoverCleanupScope,
@@ -425,6 +426,10 @@ export class RulesService {
       if (managerState.code !== 1) {
         return managerState;
       }
+      const windowState = this.validateDeletionWindow(params);
+      if (windowState.code !== 1) {
+        return windowState;
+      }
       let state: ReturnStatus = this.createReturnStatus(true, 'Success');
       const knownUsernames = await this.getKnownUsernames(
         params.rules as RuleDto[],
@@ -558,6 +563,10 @@ export class RulesService {
       const managerState = this.validateSingleShowManager(params);
       if (managerState.code !== 1) {
         return managerState;
+      }
+      const windowState = this.validateDeletionWindow(params);
+      if (windowState.code !== 1) {
+        return windowState;
       }
       let state: ReturnStatus = this.createReturnStatus(true, 'Success');
       // Same gate getKnownUsernames applies internally: no rule names a user,
@@ -1898,6 +1907,26 @@ export class RulesService {
       return this.createReturnStatus(
         false,
         'A collection can be managed by either Sonarr or Sportarr, not both',
+      );
+    }
+    return this.createReturnStatus(true, 'Success');
+  }
+
+  /**
+   * The overlay countdown turns this window into a real date, so a value past
+   * Date range would draw "Leaving Invalid Date" on the artwork (#3549). The
+   * rule-group body is not schema-validated, so the bound is checked here as
+   * well as in the form.
+   */
+  private validateDeletionWindow(params: RuleGroupDto): ReturnStatus {
+    const days = params.collection?.deleteAfterDays;
+    if (
+      days != null &&
+      (!Number.isInteger(days) || days < 0 || days > DELETE_AFTER_MAX_DAYS)
+    ) {
+      return this.createReturnStatus(
+        false,
+        `Take action after days must be a whole number between 0 and ${DELETE_AFTER_MAX_DAYS}`,
       );
     }
     return this.createReturnStatus(true, 'Success');

--- a/apps/ui/src/api/overlays.spec.ts
+++ b/apps/ui/src/api/overlays.spec.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import GetApiHandler from '../utils/ApiHandler'
+import { waitForOverlayRun } from './overlays'
+
+vi.mock('../utils/ApiHandler', () => ({
+  default: vi.fn(),
+  API_BASE_PATH: '',
+  DeleteApiHandler: vi.fn(),
+  PostApiHandler: vi.fn(),
+  PutApiHandler: vi.fn(),
+}))
+
+const getMock = vi.mocked(GetApiHandler)
+
+const status = (state: 'idle' | 'running' | 'error', reverted = 0) => ({
+  status: state,
+  lastRun: '2026-08-19T00:00:00.000Z',
+  lastResult: { processed: 0, reverted, skipped: 0, errors: 0 },
+})
+
+describe('waitForOverlayRun', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    getMock.mockReset()
+  })
+
+  it('polls until the run is no longer in progress, then answers its summary', async () => {
+    getMock
+      .mockResolvedValueOnce(status('running'))
+      .mockResolvedValueOnce(status('running'))
+      .mockResolvedValueOnce(status('idle', 6))
+
+    const pending = waitForOverlayRun()
+    await vi.runAllTimersAsync()
+
+    await expect(pending).resolves.toMatchObject({
+      status: 'idle',
+      lastResult: { reverted: 6 },
+    })
+    expect(getMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops on a failed run rather than polling forever', async () => {
+    getMock.mockResolvedValueOnce(status('error'))
+
+    await expect(waitForOverlayRun()).resolves.toMatchObject({
+      status: 'error',
+    })
+    expect(getMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/ui/src/api/overlays.ts
+++ b/apps/ui/src/api/overlays.ts
@@ -137,26 +137,39 @@ export const deleteOverlayImage = (imageName: string) =>
     `/overlays/images/${encodeURIComponent(imageName)}`,
   )
 
+export type OverlayRunStatus = {
+  status: 'idle' | 'running' | 'error'
+  lastRun: string | null
+  lastResult: OverlayProcessorRunResult | null
+}
+
+// Both endpoints answer as soon as the work is started, so the caller follows
+// it here instead of holding a request open for the whole run.
 export const processAllOverlays = (options?: { force?: boolean }) =>
-  PostApiHandler<OverlayProcessorRunResult>(
+  PostApiHandler<void>(
     '/overlays/process',
     options?.force ? { force: true } : {},
   )
 
-export const resetAllOverlays = () =>
-  DeleteApiHandler<{ success: boolean }>('/overlays/reset')
+export const resetAllOverlays = () => DeleteApiHandler<void>('/overlays/reset')
 
 export const getOverlayStatus = () =>
-  GetApiHandler<{
-    status: string
-    lastRun: string | null
-    lastResult: {
-      processed: number
-      reverted: number
-      skipped: number
-      errors: number
-    } | null
-  }>('/overlays/status')
+  GetApiHandler<OverlayRunStatus>('/overlays/status')
+
+const OVERLAY_STATUS_POLL_MS = 2000
+
+/**
+ * Resolve once no overlay work is in progress. The run is already marked as
+ * running by the time the start request answers, so the first poll cannot read
+ * the previous run's result.
+ */
+export const waitForOverlayRun = async (): Promise<OverlayRunStatus> => {
+  for (;;) {
+    const status = await getOverlayStatus()
+    if (status.status !== 'running') return status
+    await new Promise((resolve) => setTimeout(resolve, OVERLAY_STATUS_POLL_MS))
+  }
+}
 
 // ── Template API ──────────────────────────────────────────────────────────
 

--- a/apps/ui/src/components/Common/ConfirmActionButton.tsx
+++ b/apps/ui/src/components/Common/ConfirmActionButton.tsx
@@ -8,7 +8,7 @@ import PendingButton from './PendingButton'
 
 interface ConfirmActionButtonProps {
   buttonLabel: string
-  buttonIcon: ReactNode
+  buttonIcon?: ReactNode
   buttonType?: ButtonType
   buttonClassName?: string
   // Destructive callers pass 'danger' so the dialog's confirm carries the

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -13,6 +13,7 @@ import {
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
   Application,
+  DELETE_AFTER_MAX_DAYS,
   isValidMediaItemType,
   leftoverCleanupScope,
   MediaItemType,
@@ -363,6 +364,10 @@ export const ruleGroupFormSchema = z
           })
           .min(0, {
             error: () => globalT`Take action after days must be 0 or greater`,
+          })
+          .max(DELETE_AFTER_MAX_DAYS, {
+            error: () =>
+              globalT`Take action after days must be ${{ max: DELETE_AFTER_MAX_DAYS }} or less`,
           })
           .optional(),
       )
@@ -1485,6 +1490,8 @@ const AddModal = (props: AddModal) => {
                             <Input
                               type="number"
                               id="collection_deleteDays"
+                              min={0}
+                              max={DELETE_AFTER_MAX_DAYS}
                               {...register('deleteAfterDays')}
                             />
                           </div>

--- a/apps/ui/src/components/Settings/Overlays/index.spec.tsx
+++ b/apps/ui/src/components/Settings/Overlays/index.spec.tsx
@@ -6,6 +6,7 @@ import OverlaySettings from './index'
 const getOverlaySettings = vi.fn()
 const processAllOverlays = vi.fn()
 const resetAllOverlays = vi.fn()
+const waitForOverlayRun = vi.fn()
 const updateOverlaySettings = vi.fn()
 const navigate = vi.fn()
 
@@ -14,6 +15,7 @@ vi.mock('../../../api/overlays', () => ({
   processAllOverlays: (options?: { force?: boolean }) =>
     processAllOverlays(options),
   resetAllOverlays: () => resetAllOverlays(),
+  waitForOverlayRun: () => waitForOverlayRun(),
   useUpdateOverlaySettings: () => ({
     mutateAsync: updateOverlaySettings,
   }),
@@ -32,6 +34,7 @@ describe('OverlaySettings', () => {
     getOverlaySettings.mockReset()
     processAllOverlays.mockReset()
     resetAllOverlays.mockReset()
+    waitForOverlayRun.mockReset()
     updateOverlaySettings.mockReset()
     navigate.mockReset()
 
@@ -40,13 +43,13 @@ describe('OverlaySettings', () => {
       enabled: true,
       cronSchedule: '0 2 * * *',
     })
-    processAllOverlays.mockResolvedValue({
-      processed: 3,
-      reverted: 1,
-      skipped: 2,
-      errors: 0,
+    processAllOverlays.mockResolvedValue(undefined)
+    resetAllOverlays.mockResolvedValue(undefined)
+    waitForOverlayRun.mockResolvedValue({
+      status: 'idle',
+      lastRun: '2026-08-19T00:00:00.000Z',
+      lastResult: { processed: 3, reverted: 1, skipped: 2, errors: 0 },
     })
-    resetAllOverlays.mockResolvedValue({ success: true })
     updateOverlaySettings.mockImplementation(async (payload) => payload)
   })
 
@@ -70,6 +73,43 @@ describe('OverlaySettings', () => {
         'Processed: 3, Reverted: 1, Skipped: 2, Errors: 0',
       ),
     ).toBeTruthy()
+  })
+
+  it('shows why a manual run was refused instead of a generic failure', async () => {
+    processAllOverlays.mockRejectedValue(
+      Object.assign(new Error('Request failed with status code 409'), {
+        isAxiosError: true,
+        response: {
+          status: 409,
+          data: { message: 'Overlay processing is already running' },
+        },
+      }),
+    )
+
+    render(<OverlaySettings />)
+
+    const runNow = await screen.findByRole('button', { name: 'Run Now' })
+    await waitFor(() =>
+      expect((runNow as HTMLButtonElement).disabled).toBe(false),
+    )
+    fireEvent.click(runNow)
+
+    expect(
+      await screen.findByText('Overlay processing is already running'),
+    ).toBeTruthy()
+  })
+
+  it('reports the reset only once the run it started has finished', async () => {
+    render(<OverlaySettings />)
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Reset All Overlays' }),
+    )
+    fireEvent.click(await screen.findByRole('button', { name: 'Reset' }))
+
+    await waitFor(() => expect(resetAllOverlays).toHaveBeenCalled())
+    expect(waitForOverlayRun).toHaveBeenCalled()
+    expect(await screen.findByText('All overlays have been reset')).toBeTruthy()
   })
 
   it('keeps reset available even when overlays are not enabled on the server', async () => {

--- a/apps/ui/src/components/Settings/Overlays/index.tsx
+++ b/apps/ui/src/components/Settings/Overlays/index.tsx
@@ -14,9 +14,12 @@ import {
   processAllOverlays,
   resetAllOverlays,
   useUpdateOverlaySettings,
+  waitForOverlayRun,
 } from '../../../api/overlays'
+import { getApiErrorMessage } from '../../../utils/ApiError'
 import { formatOverlayProcessSummary } from '../../../utils/overlayProcessResult'
 import Button from '../../Common/Button'
+import ConfirmActionButton from '../../Common/ConfirmActionButton'
 import DocsButton from '../../Common/DocsButton'
 import Modal from '../../Common/Modal'
 import PageControlRow from '../../Common/PageControlRow'
@@ -73,8 +76,6 @@ const OverlaySettings = () => {
   const { t } = useLingui()
   const navigate = useNavigate()
   const [processing, setProcessing] = useState(false)
-  const [resetting, setResetting] = useState(false)
-  const [confirmResetOpen, setConfirmResetOpen] = useState(false)
   const [missingCronModalOpen, setMissingCronModalOpen] = useState(false)
 
   const {
@@ -136,29 +137,31 @@ const OverlaySettings = () => {
   const handleProcessAll = async () => {
     setProcessing(true)
     try {
-      const result = await processAllOverlays({ force: true })
-      showInfo(formatOverlayProcessSummary(result))
-    } catch {
-      showError(t`Failed to process overlays`)
+      await processAllOverlays({ force: true })
+      const { status, lastResult } = await waitForOverlayRun()
+      // A run that died mid-way leaves no summary, or a zeroed one that reads
+      // as a clean pass; the status is the only thing that says otherwise.
+      if (status === 'error' || !lastResult) {
+        showError(t`Failed to process overlays`)
+      } else {
+        showInfo(formatOverlayProcessSummary(lastResult))
+      }
+    } catch (error) {
+      showError(getApiErrorMessage(error, t`Failed to process overlays`))
     } finally {
       setProcessing(false)
     }
   }
 
-  const handleResetAllRequest = () => {
-    setConfirmResetOpen(true)
-  }
-
-  const handleResetAllConfirm = async () => {
-    setConfirmResetOpen(false)
-    setResetting(true)
-    try {
-      await resetAllOverlays()
+  const handleResetAll = async () => {
+    await resetAllOverlays()
+    // Items whose artwork could not be restored keep their state for a later
+    // retry, so a plain success would hide them.
+    const { lastResult } = await waitForOverlayRun()
+    if (lastResult?.errors) {
+      showInfo(formatOverlayProcessSummary(lastResult))
+    } else {
       showSuccess(t`All overlays have been reset`)
-    } catch {
-      showError(t`Failed to reset overlays`)
-    } finally {
-      setResetting(false)
     }
   }
 
@@ -225,16 +228,27 @@ const OverlaySettings = () => {
                       />
                     </span>
                     <span className="flex rounded-md shadow-xs">
-                      <Button
+                      <ConfirmActionButton
+                        buttonLabel={t`Reset All Overlays`}
                         buttonType="danger"
-                        type="button"
-                        onClick={handleResetAllRequest}
-                        disabled={processing || resetting}
+                        confirmButtonType="danger"
+                        modalTitle={t`Restore original artwork for all collections?`}
+                        modalSize="sm"
+                        confirmLabel={t`Reset`}
+                        pendingLabel={t`Resetting...`}
+                        disabled={processing}
+                        errorMessage={t`Failed to reset overlays`}
+                        errorLogSummary="Failed to reset overlays"
+                        errorContext="OverlaySettings.handleResetAll"
+                        onConfirm={handleResetAll}
                       >
-                        <span>
-                          {resetting ? t`Resetting...` : t`Reset All Overlays`}
-                        </span>
-                      </Button>
+                        <p>
+                          <Trans>
+                            This will revert every applied overlay and restore
+                            the original posters for all collections.
+                          </Trans>
+                        </p>
+                      </ConfirmActionButton>
                     </span>
                   </>
                 }
@@ -253,30 +267,6 @@ const OverlaySettings = () => {
           </form>
         </div>
       </div>
-
-      {confirmResetOpen && (
-        <Modal
-          title={t`Restore original artwork for all collections?`}
-          size="sm"
-          onCancel={() => setConfirmResetOpen(false)}
-          footerActions={
-            <Button
-              buttonType="danger"
-              className="ml-3"
-              onClick={() => void handleResetAllConfirm()}
-            >
-              <Trans>Reset</Trans>
-            </Button>
-          }
-        >
-          <p>
-            <Trans>
-              This will revert every applied overlay and restore the original
-              posters for all collections.
-            </Trans>
-          </p>
-        </Modal>
-      )}
 
       {missingCronModalOpen && (
         <Modal

--- a/apps/ui/src/locales/cs.po
+++ b/apps/ui/src/locales/cs.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr ""
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr ""
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr ""
 

--- a/apps/ui/src/locales/da.po
+++ b/apps/ui/src/locales/da.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr ""
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr ""
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr ""
 

--- a/apps/ui/src/locales/de.po
+++ b/apps/ui/src/locales/de.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr ""
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr ""
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr ""
 

--- a/apps/ui/src/locales/en.po
+++ b/apps/ui/src/locales/en.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr "Take action after days is required for this action"
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr "Take action after days must be {max} or less"
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr "Take action after days must be 0 or greater"
 

--- a/apps/ui/src/locales/es.po
+++ b/apps/ui/src/locales/es.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr "Ejecutar la acción después de (días) es obligatorio para esta acción"
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr ""
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr "Ejecutar la acción después de (días) debe ser 0 o mayor"
 

--- a/apps/ui/src/locales/fi.po
+++ b/apps/ui/src/locales/fi.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr ""
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr ""
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr ""
 

--- a/apps/ui/src/locales/fr.po
+++ b/apps/ui/src/locales/fr.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr ""
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr ""
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr ""
 

--- a/apps/ui/src/locales/it.po
+++ b/apps/ui/src/locales/it.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr ""
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr ""
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr ""
 

--- a/apps/ui/src/locales/nb.po
+++ b/apps/ui/src/locales/nb.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr ""
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr ""
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr ""
 

--- a/apps/ui/src/locales/nl.po
+++ b/apps/ui/src/locales/nl.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr ""
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr ""
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr ""
 

--- a/apps/ui/src/locales/pl.po
+++ b/apps/ui/src/locales/pl.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr ""
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr ""
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr ""
 

--- a/apps/ui/src/locales/pt.po
+++ b/apps/ui/src/locales/pt.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr ""
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr ""
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr ""
 

--- a/apps/ui/src/locales/sv.po
+++ b/apps/ui/src/locales/sv.po
@@ -3809,6 +3809,10 @@ msgid "Take action after days is required for this action"
 msgstr "Utför åtgärden efter (dagar) är obligatoriskt för den här åtgärden"
 
 #: src/components/Rules/RuleGroup/AddModal/index.tsx
+msgid "Take action after days must be {max} or less"
+msgstr ""
+
+#: src/components/Rules/RuleGroup/AddModal/index.tsx
 msgid "Take action after days must be 0 or greater"
 msgstr "Utför åtgärden efter (dagar) måste vara 0 eller större"
 

--- a/packages/contracts/src/collections/index.ts
+++ b/packages/contracts/src/collections/index.ts
@@ -21,3 +21,10 @@ export const COLLECTION_POSTER_MAX_LABEL = IMAGE_UPLOAD_MAX_LABEL
 // the resulting date well within Date range.
 export const POSTPONE_MIN_DAYS = 1
 export const POSTPONE_MAX_DAYS = 3650
+
+// Upper bound for a collection's deletion window. Several places turn it into
+// a real date (addDate + days), and past about 1e8 days that lands outside
+// Date range: an Invalid Date, which is truthy, so it reached the overlay
+// artwork as "Leaving Invalid Date" (#3549). A century is far beyond any
+// retention policy, and everything under it is a valid date.
+export const DELETE_AFTER_MAX_DAYS = 36500


### PR DESCRIPTION
Fixes #3549, plus two reports that turned out to share its cause: overlays that reset would not remove, and posters reading "Leaving Invalid Date".

## Causes

| Symptom | Cause |
| --- | --- |
| "Failed to process overlays" on Run now, nothing in the logs, work continues | `POST /api/overlays/process` held the request open for the whole run. A browser or proxy timeout, or a 409 from a cron run already in flight, read as a failure. A 409 is not logged, hence the silent logs. |
| Reset errors right after | Same 409, and the UI showed a fixed sentence instead of what the server said. |
| "Leaving Invalid Date" on artwork | `deleteAfterDays` was unbounded. Past about 1e8 days, `addDate + days` leaves Date range, and an Invalid Date is truthy, so nothing filtered it. |
| An overlay reset cannot remove | Same date. `daysLeft` became NaN, `markProcessed(NaN)` died with `SQLITE_ERROR: no such column: NaN`, so the poster was uploaded with no state row. Reset only ever looked at state rows. |
| Reset racing the cron | `resetAllOverlays` had no running flag; the controller check was TOCTOU. |

The overflow threshold is 99,979,317 days, so eight nines is enough. Nothing else that reads `deleteAfterDays` builds a `Date` from it, which is why only overlays showed it.

## Changes

| Area | Change |
| --- | --- |
| `packages/contracts` | `DELETE_AFTER_MAX_DAYS = 36500`, beside `POSTPONE_MAX_DAYS`, which bounds the same column for the same reason |
| Rule form, `PUT /api/collections`, `setRules`, `updateRules` | Enforce the bound. Both rules paths are needed: the rule-group body carries a plain DTO, so the global Zod pipe skips it |
| `OverlayProcessorService.getDeleteDate` | Returns null on an invalid result, as the invariant behind the bound |
| `OverlaysController` | Process and reset start the work and answer 202, matching `POST /api/collections/handle` |
| `Settings/Overlays` | Polls `GET /api/overlays/status`, reports the run summary, and surfaces the server's message via `getApiErrorMessage`. Reset uses the shared `ConfirmActionButton` |
| `resetAllOverlays` | Takes the running flag, and restores saved originals that no state row claims |
| `applyTemplateOverlay` | Deletes a backup it took itself when the render fails, since nothing was uploaded |
| `processAllCollections` | Builds the current-id set from member targets, so a member it no longer draws on is reverted |

## Notes

- `POST /api/overlays/process` and `DELETE /api/overlays/reset` no longer return a body. Neither is used outside the UI.
- The 409 message is now "An overlay run is already in progress", which stays true while a reset holds the flag.
- Not changed, on purpose: `revertCollection` keeps no running flag (it has an internal caller, and the next run's revert pass self-heals), and the client-side countdown in Calendar and Overview still does unguarded date math for values stored before the bound.
