### PR TITLE
fix(ui): fix layout viewport overflow, clipped panel labels, and sort order

### DIFF
--- a/apps/ui/src/components/Calendar/index.tsx
+++ b/apps/ui/src/components/Calendar/index.tsx
@@ -412,12 +412,14 @@ const Calendar = () => {
                   </div>
 
                   {totalScheduledCount > 0 && (
-                    <Badge badgeType="maintainerrdark">
-                      <Plural
-                        value={totalScheduledCount}
-                        one="# scheduled"
-                        other="# scheduled"
-                      />
+                    <Badge badgeType="maintainerrdark" className="min-w-0">
+                      <span className="truncate">
+                        <Plural
+                          value={totalScheduledCount}
+                          one="# scheduled"
+                          other="# scheduled"
+                        />
+                      </span>
                     </Badge>
                   )}
                 </div>

--- a/apps/ui/src/components/Common/MediaLibrarySortControl.tsx
+++ b/apps/ui/src/components/Common/MediaLibrarySortControl.tsx
@@ -91,6 +91,10 @@ const getMediaLibrarySortOptions = (
     )
   }
 
+  options.push(
+    createMediaLibrarySortOption('title.desc', globalT`Title (Z-A) Descending`),
+  )
+
   if (includeStudioSort) {
     options.push(
       createMediaLibrarySortOption(
@@ -107,7 +111,6 @@ const getMediaLibrarySortOptions = (
   // The air-date pair is spelled out per library type rather than composed
   // from a shared noun, so each reads naturally once translated.
   options.push(
-    createMediaLibrarySortOption('title.desc', globalT`Title (Z-A) Descending`),
     createMediaLibrarySortOption(
       'airDate.desc',
       libraryType === 'show'

--- a/apps/ui/src/components/Layout/index.tsx
+++ b/apps/ui/src/components/Layout/index.tsx
@@ -80,7 +80,6 @@ const LayoutShell: React.FC<LayoutShellProps> = ({ children }) => {
           <div className="relative inset-0 h-full w-full bg-linear-to-t from-zinc-900 to-transparent" />
         </div>
         <NavBar open={navBarOpen} setClosed={handleNavbar}></NavBar>
-        <div className="relative mb-16 flex w-0 min-w-0 flex-1 flex-col lg:ml-64"></div>
         <div
           className={`searchbar fixed top-0 right-0 left-0 z-10 flex shrink-0 bg-transparent transition duration-300 lg:ml-64`}
         >
@@ -109,7 +108,7 @@ const LayoutShell: React.FC<LayoutShellProps> = ({ children }) => {
         </div>
 
         <main
-          className="relative top-16 mt-2 w-full focus:outline-hidden"
+          className="relative top-16 mt-2 mb-16 w-0 min-w-0 flex-1 focus:outline-hidden lg:ml-64"
           tabIndex={0}
         >
           <div className="mb-6">

--- a/apps/ui/src/components/OverlayEditor/PropertiesPanel.tsx
+++ b/apps/ui/src/components/OverlayEditor/PropertiesPanel.tsx
@@ -595,7 +595,7 @@ function NumberField({
 }) {
   return (
     <label className="flex items-center gap-1.5">
-      <span className="w-12 shrink-0 text-zinc-400">{label}</span>
+      <span className="min-w-12 shrink-0 text-zinc-400">{label}</span>
       <Input
         name={`number-${label}`}
         type="number"
@@ -620,7 +620,7 @@ function TextField({
 }) {
   return (
     <label className="flex items-center gap-1.5">
-      <span className="w-12 shrink-0 text-zinc-400">{label}</span>
+      <span className="min-w-12 shrink-0 text-zinc-400">{label}</span>
       <Input
         name={`text-${label}`}
         type="text"
@@ -645,7 +645,7 @@ function ColorField({
   return (
     <>
       <label className="flex items-center gap-1.5">
-        <span className="w-12 shrink-0 text-zinc-400">{label}</span>
+        <span className="min-w-12 shrink-0 text-zinc-400">{label}</span>
         <button
           type="button"
           aria-label={t`Choose a color for ${{ fieldLabel: label }}`}
@@ -687,7 +687,7 @@ function SelectField({
 }) {
   return (
     <label className="flex items-center gap-1.5">
-      <span className="w-12 shrink-0 text-zinc-400">{label}</span>
+      <span className="min-w-12 shrink-0 text-zinc-400">{label}</span>
       <Select
         name={`select-${label}`}
         value={value}

--- a/apps/ui/src/components/OverlayEditor/ResourceField.tsx
+++ b/apps/ui/src/components/OverlayEditor/ResourceField.tsx
@@ -56,7 +56,7 @@ export function ResourceField({
 
   return (
     <label className="flex items-center gap-1.5">
-      <span className="w-12 shrink-0 text-zinc-400">{label}</span>
+      <span className="min-w-12 shrink-0 text-zinc-400">{label}</span>
       <Select
         name={`resource-${label}`}
         value={known ? value : ''}


### PR DESCRIPTION
Four UI defects surfaced by the Swedish localisation sweep, three of them older than the translations.

| Fix | Cause | Measured before / after (1280px viewport, sv) |
| --- | --- | --- |
| Every page overflowed horizontally | `Layout` shipped an empty wrapper div since the first frontend commit (2022): the div carrying `w-0 min-w-0 flex-1 lg:ml-64` wrapped nothing while `main` sat beside it with `w-full`, sizing itself to the full viewport and painting 241px past it | settings pages 1521px wide / all 21 routes fit exactly |
| Overlay editor properties labels hard-clipped | fixed `w-12` (48px) label column; Swedish labels need up to 100px ("Konturbredd") | 12 clipped labels / 0, inputs flex-shrink instead |
| Calendar scheduled-count badge painted into the next day cell | `whitespace-nowrap` badge in an unclippable cell | 168px content in a 134px cell / contained, ellipsizes when tight |
| Sort dropdown ordered Title asc, Studio asc, Studio desc, Title desc | #3393 inserted the studio pair between the title pair | pairs grouped: Title, Studio, date, rating, watch count |

The layout fix folds the dead wrapper's sizing into `main` itself; no structural additions. Verified with Playwright against the running stack in Swedish and English: no horizontal scroll on any route, no clipped labels in either overlay editor panel, calendar cells contained, dropdown grouped.
