### PR TITLE
fix(ci): honour the pinned server on BoxSet reports, and fix misleading no-label logging

### DIFF
--- a/.github/workflows/media_server_labels.yml
+++ b/.github/workflows/media_server_labels.yml
@@ -92,7 +92,6 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           AI_MODEL_API_KEY: ${{ secrets.AI_MODEL_API_KEY }}
-          AI_MODEL_ENDPOINT: ${{ vars.AI_MODEL_ENDPOINT }}
           AI_MODEL: ${{ vars.AI_MODEL }}
           AI_MODEL_REASONING_EFFORT: ${{ vars.AI_MODEL_REASONING_EFFORT }}
           ITEM_NUMBERS: ${{ github.event_name == 'workflow_dispatch' && inputs.item_numbers || '' }}

--- a/tools/media-server-labeler.mjs
+++ b/tools/media-server-labeler.mjs
@@ -245,8 +245,11 @@ Traps:
    without proving it: an item purely about the Tautulli API is about Tautulli. These
    arrive flagged adjacentOnly. Tracearr is the one to watch - it is also a watch-history
    service, but it binds to whichever media server you run, so it hints at NONE of them.
-3. "BoxSet" belongs to both Jellyfin and Emby, which share an API lineage, so it
-   usually earns both labels unless the text pins it to one. It is never a Plex term.
+3. "BoxSet" is Jellyfin and Emby vocabulary and never a Plex term, but the shared
+   lineage does NOT mean both labels by default. Decide on what the text names: if it
+   names only one of the two, label ONLY that one, even though the code behind it is
+   shared - the reporter is telling you which server they actually run. Label both only
+   when the text names both, or names neither and the change is plainly in shared code.
 4. Jellyfin and Emby share code paths here. Shared logic earns both; a fix guarded by
    an emby-only branch earns only emby.
 5. Plex is the original backend. Jellyfin arrived in PR #2330 (Feb 2026) and Emby in
@@ -467,11 +470,15 @@ const main = async () => {
       }
     }
 
+    // "no labels" must mean the model found none, not that the item already carried
+    // them - conflating the two makes a working run read as a broken one.
     const outcome = add.length
       ? `${dryRun ? 'would add' : 'added'} ${add.join(', ')}`
       : withheld.length
         ? `withheld ${withheld.join(', ')} (low confidence)`
-        : 'no labels';
+        : verdict.labels.length
+          ? `already carries ${verdict.labels.join(', ')}`
+          : 'no labels';
     log(`#${number}: ${outcome} - ${verdict.why}`);
   }
 
@@ -486,7 +493,9 @@ const main = async () => {
           ? r.add.join(', ')
           : r.withheld.length
             ? `_withheld: ${r.withheld.join(', ')}_`
-            : '_none_';
+            : r.verdict.labels.length
+              ? `_already carries: ${r.verdict.labels.join(', ')}_`
+              : '_none_';
         return `| #${r.number} | ${verdict} | ${r.verdict.confidence} | ${r.verdict.why.split('|').join('\\|')} |`;
       }),
     ];


### PR DESCRIPTION
Both problems were found by running #3562 against real issues in production.

## 1. A Jellyfin BoxSet report earned jellyfin + emby

A test issue naming Jellyfin three times, and Emby never, came back with both labels. The model's stated reason:

> The issue concerns BoxSet handling, which is shared logic between Jellyfin and Emby.

The rule already carried the right exception, but it trailed the salient phrase:

> `"BoxSet" belongs to both Jellyfin and Emby ... so it usually earns both labels unless the text pins it to one.`

`gemini-3.1-flash-lite` followed the general rule and skipped the trailing clause. The rule now leads with the decision procedure instead of the generalisation: name one server, get one label, however shared the code behind it is.

## 2. An already-labelled item logged "no labels"

A dry run over three already-labelled items reported `no labels` for each, while the `why` on the same line correctly identified the server. `no labels` is also what the model says when it genuinely finds nothing, so a healthy run read as a broken one.

| Case | Before | After |
| --- | --- | --- |
| Model found nothing | `no labels` | `no labels` |
| Item already carries it | `no labels` | `already carries jellyfin` |

Same distinction in the step summary. No behaviour change: labelling was additive and correct in both cases, only the reporting was wrong.

## Verification

| Suite | Result |
| --- | --- |
| Plumbing and reporting | 14/14, including two new assertions on the already-carries path |
| Event payload paths | 9/9 |

The BoxSet wording change is a prompt change, so it needs one production dry run against a BoxSet item to confirm, which cannot be done from a branch. Worth a `workflow_dispatch` with `dry_run: true` against #3550 after merge.