### PR TITLE
fix(ci): gate every label on a precision check before it is emitted

### DIFF
--- a/tools/media-server-labeler.mjs
+++ b/tools/media-server-labeler.mjs
@@ -227,12 +227,35 @@ integration or behaviour:
 - the bug happens on that server, or is caused by how that server behaves
 - the change is scoped to that server or must be implemented per-server
 - it is setup, configuration, authentication or connection trouble for that server
-- the diff touches that server's files or its settings UI
+- the diff changes how that server behaves, in its own files or its settings UI
 
 Do NOT label a server that is only mentioned in passing: background colour on a bug
 that is plainly in the rule engine, the scheduler, the UI or a migration; an unrelated
 line inside a pasted log; a "supports Plex/Jellyfin/Emby" capability blurb; or the
 unfilled template line marked [UNFILLED TEMPLATE LINE], which is worth nothing.
+
+Before you emit a label, test it. For each label you are about to apply, ask: would a
+maintainer open THAT SERVER'S OWN integration code to resolve this item? If not, drop it.
+Drop the label when any of these is true:
+
+a. The server appears only in the reporter's environment - a "Server:" line, a "Device"
+   section, a version string, "I run X". That is background, not the defect.
+b. The server appears only as a branch name, a rule-option string, a capability list, a
+   README blurb, or an unfilled template line.
+c. The item is really about an adjacent service - Seerr, Tautulli, Streamystats, Tracearr -
+   and that service's own code is what changes. Needing Jellyfin in order to run Jellyseerr
+   does not make a Jellyseerr request a Jellyfin item.
+d. The whole diff sits in shared code - rule engine, scheduler, notifications, collection
+   bookkeeping, comparators - AND nothing in the item turns on how that server itself
+   behaves. Judge by where the fix lives, not where the symptom was seen. This one has a
+   limit: when the item does turn on that server's own behaviour - a BoxSet it re-resolves,
+   a URL shape it rejects, an id only it issues, an endpoint only it serves - the label
+   stands even though the fix lands in shared code.
+e. The change is behaviour-neutral for that server: a rename, a lint or formatting pass, a
+   framework or dependency upgrade, a type-only change, or a release sync. These sweep
+   server files without changing how any server behaves, however many paths they touch.
+
+Only when none of a to e applies does the label stand.
 
 Return no labels when nothing points at a specific server. That is the correct and
 common answer - most rule-engine, UI, docs, CI, dependency and *arr/Seerr work is


### PR DESCRIPTION
Measured against the live workflow, not guessed. A stratified 78-item `workflow_dispatch` dry run was scored against the verdicts the three-pass backfill adjudicated.

| Metric | Result |
| --- | --- |
| Exact agreement | 82% |
| Labels missed | **0** |
| Labels over-applied | 14 |

Recall was perfect. The entire error budget was precision.

## What was going wrong

| Class | Count | Example | Rule existed? |
| --- | --- | --- | --- |
| Behaviour-neutral sweep or release sync | 5 | `chore: sync development to main` earned plex + emby; `upgrade code to React 18` earned plex for touching `Settings/Plex/index.tsx` | partly |
| Reporter's environment line | 3 | "explicitly identifies their media server as Plex in the device information section" | yes |
| Adjacent service | 3 | a Tautulli connection failure earned plex; a Jellyseerr request earned jellyfin | yes |
| Shared code, title names a server | 2 | `fix: Improve notification msg when Plex item non-existent`, one file, `notifications.service.ts` | no |
| Branch name only | 1 | `jellyfin-dev weekened reportings` | no |

Five of the fourteen broke rules the prompt already stated. Stating a rule once as prose in a numbered list is not enough for the model this runs on, so this is a structural change rather than more prose.

## The change

Each label must now clear five drop conditions before it is emitted, and the label only stands if none apply. The file-touch criterion is qualified to match: the diff has to change how the server *behaves*, not merely cross its paths.

The shared-code condition is deliberately bounded, because an unbounded version swallowed real per-server behaviour in testing: a BoxSet the server re-resolves, a URL shape it rejects, or an id only it issues still earns the label even when the fix lands in shared code.

## Verification

33 adversarial cases - the 8 the backfill's two passes disagreed on, all 14 production failures, and 11 synthetic pull requests - each answered by three independent blind runs, with the answer key kept outside the directory they can read.

| | Before | After |
| --- | --- | --- |
| Unanimous and correct | 16/22 (73%) | **29/33 (88%)** |
| Unanimous but wrong | 4 | 2 |
| Unstable across runs | 2 | 2 |

All 14 production failures now answer correctly. Local suites: 14/14 plumbing, 9/9 event paths.

Two residuals remain and both are judgement calls rather than clear defects. On #3422 all three runs independently considered the per-server carve-out and rejected it, because Jellyfin and Emby are two entries in a ten-service sweep; that reading looks better than the backfill's, so the expectation is probably the thing that is wrong there.

Worth repeating the caveat that mattered last time: the harness runs a stronger model than production. A like-for-like re-run of the same 78-item sample after merge is what actually confirms this.