### PR TITLE
fix(media-server): stop collections being matched as movies (#3550)

### DIFF
--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -796,6 +796,101 @@ describe('EmbyAdapterService', () => {
     });
   });
 
+  // #3550: a library grouping films into collections answered a Movie-typed
+  // listing with BoxSet rows, which the mapper turns into a movie with no
+  // external IDs.
+  describe('listings drop kinds the query did not ask for', () => {
+    beforeEach(() => {
+      http.get.mockResolvedValue({
+        data: {
+          Items: [
+            { Id: 'movie-1', Type: 'Movie' },
+            { Id: 'boxset-1', Type: 'BoxSet' },
+          ],
+          TotalRecordCount: 2,
+        },
+      });
+    });
+
+    it.each([
+      [
+        'getLibraryContents',
+        async () =>
+          (
+            await service.getLibraryContents('library-1', {
+              offset: 0,
+              limit: 30,
+              type: 'movie' as const,
+            })
+          ).items,
+      ],
+      [
+        'searchLibraryContents',
+        () => service.searchLibraryContents('library-1', 'query', 'movie'),
+      ],
+      ['searchContent', () => service.searchContent('query')],
+    ])('%s drops the BoxSet row', async (_method, read) => {
+      expect((await read()).map((item) => item.id)).toEqual(['movie-1']);
+    });
+
+    // /Users/{id}/Items/Latest groups episodes under their series, so an
+    // Episode request answers with Series rows (Emby 4.9.5). Filtering to the
+    // requested kinds alone would empty recently-added TV.
+    it('getRecentlyAdded keeps grouped Series rows', async () => {
+      http.get.mockResolvedValue({
+        data: [
+          { Id: 'series-1', Type: 'Series' },
+          { Id: 'boxset-1', Type: 'BoxSet' },
+        ],
+      });
+
+      const items = await service.getRecentlyAdded('library-1', { limit: 10 });
+
+      expect(items.map((item) => item.id)).toEqual(['series-1']);
+    });
+  });
+
+  // Every library-scoped Emby query opts out of BoxSet collapsing, as
+  // JELLYFIN_LIBRARY_QUERY_DEFAULTS does on the Jellyfin side (#2554, #3550).
+  describe('library queries opt out of BoxSet collapsing', () => {
+    beforeEach(() => {
+      http.get.mockResolvedValue({ data: { Items: [], TotalRecordCount: 0 } });
+    });
+
+    it.each([
+      [
+        'getLibraryContents',
+        () => service.getLibraryContents('library-1', { offset: 0, limit: 30 }),
+      ],
+      [
+        'getLibraryContentCount',
+        () => service.getLibraryContentCount('library-1', 'movie'),
+      ],
+      [
+        'searchLibraryContents',
+        () => service.searchLibraryContents('library-1', 'query', 'movie'),
+      ],
+      ['searchContent', () => service.searchContent('query')],
+      [
+        'findRandomItem',
+        () => service.findRandomItem(['library-1'], ['Movie']),
+      ],
+      [
+        'getRecentlyAdded',
+        () => {
+          http.get.mockResolvedValue({ data: [] });
+          return service.getRecentlyAdded('library-1', { limit: 10 });
+        },
+      ],
+    ])('%s opts out', async (_method, read) => {
+      await read();
+
+      expect(http.get.mock.calls.at(-1)?.[1]?.params).toEqual(
+        expect.objectContaining({ CollapseBoxSetItems: false }),
+      );
+    });
+  });
+
   describe('getLibraryContents', () => {
     it('uses Emby native studio sorting', async () => {
       http.get

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -24,6 +24,7 @@ import { SettingsDataService } from '../../../settings/settings-data.service';
 import { EmbyApi } from '../../emby-api/emby-api.helper';
 import cacheManager, { type Cache } from '../../lib/cache';
 import { resolveContextActionIds } from '../context-action.util';
+import { onlyRequestedItemKinds } from '../item-kinds.util';
 import { supportsFeature } from '../media-server.constants';
 import type {
   IMediaServerService,
@@ -348,13 +349,14 @@ export class EmbyAdapterService implements IMediaServerService {
     const offset = options?.offset ?? 0;
 
     try {
+      const includeItemTypes = options?.type
+        ? EmbyMapper.toEmbyItemKind(options.type)
+        : 'Movie,Series';
       const { data } = await this.http.get<EmbyItemsQueryResponse>('/Items', {
         params: {
           ParentId: libraryId,
           Recursive: true,
-          IncludeItemTypes: options?.type
-            ? EmbyMapper.toEmbyItemKind(options.type)
-            : 'Movie,Series',
+          IncludeItemTypes: includeItemTypes,
           Fields: 'ProviderIds,DateCreated,Overview,Tags',
           SortBy: this.toEmbySortBy(options?.sort),
           SortOrder: options?.sortOrder === 'desc' ? 'Descending' : 'Ascending',
@@ -364,7 +366,9 @@ export class EmbyAdapterService implements IMediaServerService {
         },
       });
       return {
-        items: (data.Items ?? []).map(EmbyMapper.toMediaItem),
+        items: onlyRequestedItemKinds(data.Items, includeItemTypes).map(
+          EmbyMapper.toMediaItem,
+        ),
         totalSize: data.TotalRecordCount ?? data.Items?.length ?? 0,
         offset,
         limit,
@@ -395,6 +399,7 @@ export class EmbyAdapterService implements IMediaServerService {
             : 'Movie,Series',
           Limit: 0,
           EnableTotalRecordCount: true,
+          ...this.libraryQueryDefaults(),
         },
       });
       return data.TotalRecordCount ?? 0;
@@ -415,19 +420,23 @@ export class EmbyAdapterService implements IMediaServerService {
   ): Promise<MediaItem[]> {
     if (!this.http) return [];
     try {
+      const includeItemTypes = type
+        ? EmbyMapper.toEmbyItemKind(type)
+        : 'Movie,Series';
       const { data } = await this.http.get<EmbyItemsQueryResponse>('/Items', {
         params: {
           ParentId: libraryId,
           Recursive: true,
           SearchTerm: query,
-          IncludeItemTypes: type
-            ? EmbyMapper.toEmbyItemKind(type)
-            : 'Movie,Series',
+          IncludeItemTypes: includeItemTypes,
           Fields: 'ProviderIds,DateCreated,Overview',
           Limit: EMBY_BATCH_SIZE.DEFAULT_PAGE_SIZE,
+          ...this.libraryQueryDefaults(),
         },
       });
-      return (data.Items ?? []).map(EmbyMapper.toMediaItem);
+      return onlyRequestedItemKinds(data.Items, includeItemTypes).map(
+        EmbyMapper.toMediaItem,
+      );
     } catch (error) {
       this.logger.debug(
         `Emby searchLibraryContents failed: ${formatConnectionFailureMessage(error, 'Connection failed')}`,
@@ -747,20 +756,31 @@ export class EmbyAdapterService implements IMediaServerService {
       return [];
     }
     try {
+      const includeItemTypes = options?.type
+        ? EmbyMapper.toEmbyItemKind(options.type)
+        : 'Movie,Episode';
+      // Latest groups episodes under their series, so an Episode request comes
+      // back as Series rows (Emby 4.9.5). Allow the grouped kind through: the
+      // filter is here to drop BoxSets, not to unpick grouping.
+      const returnedItemTypes = includeItemTypes.includes('Episode')
+        ? `${includeItemTypes},Series`
+        : includeItemTypes;
       const { data } = await this.http.get<EmbyBaseItemDto[]>(
         `/Users/${this.embyUserId}/Items/Latest`,
         {
           params: {
             ParentId: libraryId,
-            IncludeItemTypes: options?.type
-              ? EmbyMapper.toEmbyItemKind(options.type)
-              : 'Movie,Episode',
+            IncludeItemTypes: includeItemTypes,
             Fields: 'ProviderIds,DateCreated,Overview',
             Limit: options?.limit ?? 20,
+            ...this.libraryQueryDefaults(),
           },
         },
       );
-      return (Array.isArray(data) ? data : []).map(EmbyMapper.toMediaItem);
+      return onlyRequestedItemKinds(
+        Array.isArray(data) ? data : [],
+        returnedItemTypes,
+      ).map(EmbyMapper.toMediaItem);
     } catch (error) {
       this.logger.debug(
         `Emby getRecentlyAdded(${libraryId}) failed: ${formatConnectionFailureMessage(error, 'Connection failed')}`,
@@ -772,16 +792,20 @@ export class EmbyAdapterService implements IMediaServerService {
   async searchContent(query: string): Promise<MediaItem[]> {
     if (!this.http) return [];
     try {
+      const includeItemTypes = 'Movie,Series,Episode';
       const { data } = await this.http.get<EmbyItemsQueryResponse>('/Items', {
         params: {
           Recursive: true,
           SearchTerm: query,
-          IncludeItemTypes: 'Movie,Series,Episode',
+          IncludeItemTypes: includeItemTypes,
           Fields: 'ProviderIds,DateCreated,Overview,Studios',
           Limit: EMBY_BATCH_SIZE.DEFAULT_PAGE_SIZE,
+          ...this.libraryQueryDefaults(),
         },
       });
-      return (data.Items ?? []).map(EmbyMapper.toMediaItem);
+      return onlyRequestedItemKinds(data.Items, includeItemTypes).map(
+        EmbyMapper.toMediaItem,
+      );
     } catch (error) {
       this.logger.debug(
         `Emby searchContent failed: ${formatConnectionFailureMessage(error, 'Connection failed')}`,
@@ -816,6 +840,7 @@ export class EmbyAdapterService implements IMediaServerService {
           ExcludeLocationTypes: 'Virtual',
           Fields: 'ProviderIds,DateCreated,Overview',
           ImageTypeLimit: 1,
+          ...this.libraryQueryDefaults(),
         },
       });
       return data.Items?.[0] ?? null;
@@ -1835,6 +1860,12 @@ export class EmbyAdapterService implements IMediaServerService {
     }
   }
 
+  /**
+   * Spread into every library-scoped query that surfaces real media items.
+   * Without it, a library that groups films into collections answers with the
+   * BoxSet instead of its members (#2554), and reportedly alongside them
+   * (#3550). Mirrors JELLYFIN_LIBRARY_QUERY_DEFAULTS.
+   */
   private libraryQueryDefaults(): Record<string, unknown> {
     return { CollapseBoxSetItems: false };
   }

--- a/apps/server/src/modules/api/media-server/item-kinds.util.spec.ts
+++ b/apps/server/src/modules/api/media-server/item-kinds.util.spec.ts
@@ -1,0 +1,19 @@
+import { onlyRequestedItemKinds } from './item-kinds.util';
+
+describe('onlyRequestedItemKinds', () => {
+  const movie = { Id: 'm1', Type: 'Movie' };
+  const boxSet = { Id: 'b1', Type: 'BoxSet' };
+  const untyped: { Id: string; Type?: string } = { Id: 'u1' };
+
+  it('keeps only requested kinds, from an array or an Emby type string', () => {
+    expect(onlyRequestedItemKinds([movie, boxSet], ['Movie'])).toEqual([movie]);
+    expect(onlyRequestedItemKinds([movie, boxSet], 'Movie,Series')).toEqual([
+      movie,
+    ]);
+  });
+
+  it('tolerates a missing list and rows without a Type', () => {
+    expect(onlyRequestedItemKinds(undefined, ['Movie'])).toEqual([]);
+    expect(onlyRequestedItemKinds([untyped], ['Movie'])).toEqual([]);
+  });
+});

--- a/apps/server/src/modules/api/media-server/item-kinds.util.ts
+++ b/apps/server/src/modules/api/media-server/item-kinds.util.ts
@@ -1,0 +1,22 @@
+/**
+ * Keep only rows whose Type is one of the kinds the request asked for.
+ *
+ * #3550: with collapseBoxSetItems=true a Movie-typed listing answers with the
+ * BoxSet in place of its members (verified on Jellyfin 12.0.0; 10.11.11 and
+ * Emby 4.9.5 do not collapse). Both mappers map an unknown kind to 'movie', so
+ * such a row enters rule matching as deletable media with no external IDs.
+ * Every listing sends collapseBoxSetItems=false; this guards them if a server
+ * ignores it.
+ *
+ * Takes the Jellyfin SDK's BaseItemKind[] or Emby's IncludeItemTypes string, so
+ * call sites pass the value they queried with.
+ */
+export const onlyRequestedItemKinds = <T extends { Type?: string | null }>(
+  items: T[] | null | undefined,
+  kinds: string | readonly string[],
+): T[] => {
+  const allowed = typeof kinds === 'string' ? kinds.split(',') : kinds;
+  return (items ?? []).filter(
+    (item) => !!item.Type && allowed.includes(item.Type),
+  );
+};

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -719,6 +719,53 @@ describe('JellyfinAdapterService', () => {
     });
   });
 
+  // #3550: a library grouping films into collections answered a Movie-typed
+  // listing with BoxSet rows, which the mapper turns into a movie with no
+  // external IDs.
+  describe('listings drop kinds the query did not ask for', () => {
+    beforeEach(async () => {
+      settingsDataService.getSettings.mockResolvedValue({
+        ...mockSettings,
+        jellyfin_user_id: 'user-1',
+      } as unknown as Awaited<ReturnType<SettingsDataService['getSettings']>>);
+      await service.initialize();
+      jellyfinApiMocks.getItems.mockResolvedValue({
+        data: {
+          Items: [
+            { Id: 'movie-1', Type: 'Movie' },
+            { Id: 'boxset-1', Type: 'BoxSet' },
+          ],
+          TotalRecordCount: 2,
+        },
+      });
+    });
+
+    it.each([
+      [
+        'getLibraryContents',
+        async () =>
+          (
+            await service.getLibraryContents('library-1', {
+              offset: 0,
+              limit: 30,
+              type: 'movie' as const,
+            })
+          ).items,
+      ],
+      [
+        'searchLibraryContents',
+        () => service.searchLibraryContents('library-1', 'query', 'movie'),
+      ],
+      [
+        'getRecentlyAdded',
+        () => service.getRecentlyAdded('library-1', { limit: 10 }),
+      ],
+      ['searchContent', () => service.searchContent('query')],
+    ])('%s drops the BoxSet row', async (_method, read) => {
+      expect((await read()).map((item) => item.id)).toEqual(['movie-1']);
+    });
+  });
+
   describe('getLibraries', () => {
     beforeEach(async () => {
       settingsDataService.getSettings.mockResolvedValue(

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -64,6 +64,7 @@ import {
   isForeignServerId,
 } from '../media-server-id.utils';
 import { resolveContextActionIds } from '../context-action.util';
+import { onlyRequestedItemKinds } from '../item-kinds.util';
 import { supportsFeature } from '../media-server.constants';
 import type {
   IMediaServerService,
@@ -796,6 +797,9 @@ export class JellyfinAdapterService implements IMediaServerService {
 
     try {
       const userId = await this.getUserId();
+      const includeItemTypes = JellyfinMapper.toBaseItemKinds(
+        options?.type ? [options.type] : undefined,
+      );
       const response = await this.retryLibraryRequestOnce(
         `get Jellyfin library contents for ${libraryId}`,
         async () =>
@@ -808,9 +812,7 @@ export class JellyfinAdapterService implements IMediaServerService {
             limit: options?.limit || JELLYFIN_BATCH_SIZE.DEFAULT_PAGE_SIZE,
             // Keep library listings lean. Full metadata is fetched lazily via /meta/:id.
             fields: [...JELLYFIN_LIBRARY_LIST_FIELDS],
-            includeItemTypes: options?.type
-              ? JellyfinMapper.toBaseItemKinds([options.type])
-              : [BaseItemKind.Movie, BaseItemKind.Series],
+            includeItemTypes,
             enableUserData: true,
             sortBy: [toJellyfinSortBy(options?.sort)],
             sortOrder: [
@@ -821,7 +823,10 @@ export class JellyfinAdapterService implements IMediaServerService {
           }),
       );
 
-      const items = (response.data.Items || []).map(JellyfinMapper.toMediaItem);
+      const items = onlyRequestedItemKinds(
+        response.data.Items,
+        includeItemTypes,
+      ).map(JellyfinMapper.toMediaItem);
 
       return {
         items,
@@ -852,9 +857,9 @@ export class JellyfinAdapterService implements IMediaServerService {
         parentId: libraryId,
         recursive: true,
         limit: 0,
-        includeItemTypes: type
-          ? JellyfinMapper.toBaseItemKinds([type])
-          : [BaseItemKind.Movie, BaseItemKind.Series],
+        includeItemTypes: JellyfinMapper.toBaseItemKinds(
+          type ? [type] : undefined,
+        ),
       });
 
       return response.data.TotalRecordCount || 0;
@@ -875,6 +880,9 @@ export class JellyfinAdapterService implements IMediaServerService {
 
     try {
       const userId = await this.getUserId();
+      const includeItemTypes = JellyfinMapper.toBaseItemKinds(
+        type ? [type] : undefined,
+      );
       const response = await getItemsApi(this.api).getItems({
         ...JELLYFIN_LIBRARY_QUERY_DEFAULTS,
         userId,
@@ -887,13 +895,13 @@ export class JellyfinAdapterService implements IMediaServerService {
           ItemFields.DateCreated,
           ItemFields.MediaSources,
         ],
-        includeItemTypes: type
-          ? JellyfinMapper.toBaseItemKinds([type])
-          : [BaseItemKind.Movie, BaseItemKind.Series],
+        includeItemTypes,
         enableUserData: true,
       });
 
-      return (response.data.Items || []).map(JellyfinMapper.toMediaItem);
+      return onlyRequestedItemKinds(response.data.Items, includeItemTypes).map(
+        JellyfinMapper.toMediaItem,
+      );
     } catch (error) {
       this.logLibraryError(libraryId, 'search library', error);
       return [];
@@ -1145,6 +1153,9 @@ export class JellyfinAdapterService implements IMediaServerService {
 
     try {
       const userId = await this.getUserId();
+      const includeItemTypes = JellyfinMapper.toBaseItemKinds(
+        options?.type ? [options.type] : undefined,
+      );
       const response = await getItemsApi(this.api).getItems({
         ...JELLYFIN_LIBRARY_QUERY_DEFAULTS,
         userId,
@@ -1153,9 +1164,7 @@ export class JellyfinAdapterService implements IMediaServerService {
         sortBy: [ItemSortBy.DateCreated],
         sortOrder: [SortOrder.Descending],
         limit: options?.limit || 50,
-        includeItemTypes: options?.type
-          ? JellyfinMapper.toBaseItemKinds([options.type])
-          : [BaseItemKind.Movie, BaseItemKind.Series],
+        includeItemTypes,
         fields: [
           ItemFields.ProviderIds,
           ItemFields.Path,
@@ -1164,7 +1173,9 @@ export class JellyfinAdapterService implements IMediaServerService {
         enableUserData: true,
       });
 
-      return (response.data.Items || []).map(JellyfinMapper.toMediaItem);
+      return onlyRequestedItemKinds(response.data.Items, includeItemTypes).map(
+        JellyfinMapper.toMediaItem,
+      );
     } catch (error) {
       this.logLibraryError(libraryId, 'get recently added', error);
       return [];
@@ -1176,6 +1187,11 @@ export class JellyfinAdapterService implements IMediaServerService {
 
     try {
       const userId = await this.getUserId();
+      const includeItemTypes = [
+        BaseItemKind.Movie,
+        BaseItemKind.Series,
+        BaseItemKind.Episode,
+      ];
       const response = await getItemsApi(this.api).getItems({
         ...JELLYFIN_LIBRARY_QUERY_DEFAULTS,
         userId,
@@ -1188,16 +1204,14 @@ export class JellyfinAdapterService implements IMediaServerService {
           ItemFields.MediaSources,
           ItemFields.Studios,
         ],
-        includeItemTypes: [
-          BaseItemKind.Movie,
-          BaseItemKind.Series,
-          BaseItemKind.Episode,
-        ],
+        includeItemTypes,
         limit: 50,
         enableUserData: true,
       });
 
-      return (response.data.Items || []).map(JellyfinMapper.toMediaItem);
+      return onlyRequestedItemKinds(response.data.Items, includeItemTypes).map(
+        JellyfinMapper.toMediaItem,
+      );
     } catch (error) {
       this.logger.error('Failed to search Jellyfin content');
       this.logger.debug(error);

--- a/apps/server/src/modules/api/media-server/media-server.controller.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-server.controller.spec.ts
@@ -255,6 +255,51 @@ describe('MediaServerController', () => {
       });
     });
 
+    // A page comes back short when the adapter drops a row of a kind the query
+    // did not ask for (#3550), so the next page re-reads the difference.
+    it('does not duplicate the overlap after a short page', async () => {
+      const showItem = (id: string, title: string): MediaItem => ({
+        id,
+        title,
+        guid: `guid-${id}`,
+        type: 'show',
+        addedAt: new Date(),
+        providerIds: {},
+        mediaSources: [],
+        library: { id: 'lib1', title: 'Shows' },
+      });
+      const alpha = showItem('1', 'Alpha');
+      const zulu = showItem('2', 'Zulu');
+      const bravo = showItem('3', 'Bravo');
+
+      mockMediaServerService.getLibraryContents
+        .mockResolvedValueOnce({
+          items: [alpha, zulu],
+          totalSize: 3,
+          offset: 0,
+          limit: 250,
+        })
+        .mockResolvedValueOnce({
+          items: [zulu, bravo],
+          totalSize: 3,
+          offset: 2,
+          limit: 250,
+        });
+      mediaItemEnrichmentService.enrichItems.mockResolvedValueOnce([
+        alpha,
+        zulu,
+        bravo,
+      ]);
+
+      await controller.getLibraryContent('lib1', 1, 10, 'show', 'excluded');
+
+      expect(mediaItemEnrichmentService.enrichItems).toHaveBeenCalledWith([
+        alpha,
+        zulu,
+        bravo,
+      ]);
+    });
+
     it('should warn when status sorting requires a large pre-pagination fetch', async () => {
       const alpha = {
         id: '1',

--- a/apps/server/src/modules/api/media-server/media-server.controller.ts
+++ b/apps/server/src/modules/api/media-server/media-server.controller.ts
@@ -170,6 +170,7 @@ export class MediaServerController {
     }
 
     const allItems: MediaItem[] = [];
+    const seenIds = new Set<string>();
     let nextOffset = 0;
     let totalSize = 0;
 
@@ -194,7 +195,15 @@ export class MediaServerController {
         break;
       }
 
-      allItems.push(...result.items);
+      // Adapters drop rows of a kind the query did not ask for (#3550), so a
+      // page can come back short. Resuming where the rows ended never skips
+      // items; the overlap that costs is dropped here.
+      for (const item of result.items) {
+        if (!seenIds.has(item.id)) {
+          seenIds.add(item.id);
+          allItems.push(item);
+        }
+      }
       nextOffset += result.items.length;
 
       if (allItems.length >= maintainerrServerSortHardCap) {

--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -105,6 +105,10 @@ export interface IMediaServerService {
    * An empty page means the server confirmed there are no (more) items -
    * never "the read failed".
    *
+   * A page can hold fewer items than the limit asked for, mid-library: rows of
+   * a kind the query did not ask for are dropped (#3550). Page by offset
+   * window or resume from the rows returned; a short page is not the end.
+   *
    * @throws Error on any failure to read the page (connection, 4xx/5xx).
    * Like getCollectionChildren: a fabricated empty page would read as
    * end-of-library and let rule evaluation truncate silently, mass-removing


### PR DESCRIPTION
Maintainerr's own sync collections are no longer picked up as movies by rules, so they stop landing in a collection with a null `tmdbId` and aborting every deletion in the run (#3550).

Jellyfin answers a Movie-typed library query with the collection in place of its members when the library groups films into collections, and both mappers read that unknown kind as a movie.

| Server | Movie-typed listing, no param | `collapseBoxSetItems=false` |
| --- | --- | --- |
| Jellyfin 10.11.11, grouping **on** | **3 collection rows, zero movies** | 5 movies |
| Jellyfin 10.11.11, grouping off | 5 movies | 5 movies |
| Jellyfin 12.0.0, grouping off | 5 movies (collapses on `=true`) | 5 movies |
| Emby 4.9.5 | 5 movies | 5 movies |

The divergence is not the version. Jellyfin honours an explicit `collapseBoxSetItems` ahead of its own grouping setting on both branches (`Folder.CollapseBoxSetItems`, identical code), so the parameter is what protects us. Without it, 10.11 collapses in memory only when the server's grouping config says so, while 12 collapses in the new database query path, where an empty collapse-type list reads as "collapse everything" and only name filters are re-applied afterwards, never the type filter.

### Changed

- Emby now sends `CollapseBoxSetItems=false` on the content count, library search, recently added, global search and random-item reads. It carried the parameter on only two of its seven library queries; Jellyfin has sent it everywhere since #2870.
- Every library listing drops rows of a kind it did not ask for, so a server that ignores the parameter still cannot feed a collection into rule matching.
- Emby's recently-added endpoint groups episodes under their series, so that path keeps the grouped kind. Filtering it to the requested kinds alone empties recently added TV.
- A page can now come back short, so the status-sorted library page discards the overlap it re-reads when it resumes where the rows ended. It keeps resuming that way rather than advancing by the requested window, which would assume every server honours the window exactly, and the interface documents that a short page is not the end of the library.

Verified against the dev stack: Jellyfin 12 behind a proxy that forces collapsing on hands back the collection row, and both `/api/media-server/library/:id/content` and the overview page then show only the movies. With the guard removed the collection comes back as `type: movie` with no provider IDs, which is the reported failure. Emby recently added still lists shows.

Paging was checked at a scale no dev library reaches, against a stand-in upstream: a 602-row library with two collection rows mid-page returns 600 unique items with nothing missing or duplicated, a page-by-page walk at the rule executor's offsets covers the same 600 with no gaps, an 850-row library whose entire first window is collections still returns all 600, and a 500 injected mid-walk fails the request closed instead of truncating it. On `development` the same harness returns every collection row, so it catches both failure modes.

Worth noting for triage: on 3.23.0, pointed at a 10.11.11 server with grouping enabled, the API and the overview page return only movies, because every Jellyfin query already sends the parameter. The reporter's symptom matches a build that does not send it, which is every version before 3.11.1 and matches the 3.10.1 they also mention. Worth asking them to re-confirm on 3.23.0 and to say whether "Group films into collections" is on.
