### PR TITLE
docs(project-notes): record what Jellyfin 12 changes for this codebase

### DIFF
--- a/.github/instructions/project-notes.instructions.md
+++ b/.github/instructions/project-notes.instructions.md
@@ -350,6 +350,24 @@ Quick checks (Jellyfin server configured):
   `jellyfin-adapter.service.spec.ts` fabricates SDK-shaped errors instead
   (`createSdkAxiosError`). Emby is unaffected - its axios instance comes from
   the server's own import.
+- **Jellyfin 12 reports `Version: 12.0.0`, and nothing may compare that
+  string.** Upstream dropped the leading `10.`, so `10.12` became `12.0`. The
+  adapter stores and logs the version as an opaque string
+  (`jellyfin-adapter.service.ts` L231 and L348) and no code path compares it,
+  which is the only reason 12 works unchanged. Keep it that way: a naive
+  comparison against `"10.11"` reads `12.0.0` as older. `getLibrariesStorage`
+  is the shape to copy - it decides on the response status of
+  `GET /System/Info/Storage`, not on a version number.
+- **Jellyfin 12 rejects `X-Emby-Token` and `?api_key=` with 401.** Only
+  `Authorization: MediaBrowser Token="<key>"` is accepted, while 10.11 still
+  honours all three, so a script that works against one server 401s against the
+  other. `@jellyfin/sdk` sends the header form and no Jellyfin call in this repo
+  builds its own URL (images go through `getImageApi`), so this reaches users'
+  own scripts rather than Maintainerr, and it is worth naming in a support
+  reply. Checked against 12.0-rc5 with 10.11.11 as a control: public system
+  info, users, media folders, item listings and `GET /System/Info/Storage` all
+  answer on both, on the pinned `@jellyfin/sdk` 0.13.0. The one behaviour that
+  does differ is BoxSet collapsing (#3550).
 
 ---
 


### PR DESCRIPTION
Records what Jellyfin 12 changes for this codebase, so the next person touching the adapter does not have to rediscover it. Replaces #3570, whose claims I re-verified against 12.0-rc5 with 10.11.11 as a control before writing this up.

| Claim | Verdict |
| --- | --- |
| 12.0-rc5 reports `Version: 12.0.0` | confirmed, image label `12.0-rc5`, digest `e55a3a7f09c5` |
| SDK calls pass on 12 (public system info, users, media folders, item listings) | confirmed, exercised through the running server on the pinned SDK |
| `GET /System/Info/Storage` answers on 12 | confirmed, 200 on 12 and on 10.11.11 |
| No SDK bump needed: npm latest stable is 0.13.0 | confirmed, dist-tags `latest` 0.13.0, everything newer is `0.0.0-unstable.*` |
| Version string is passed through, never compared | confirmed, `jellyfin-adapter.service.ts` L231 and L348, and no version comparison exists anywhere in the repo |
| 12 rejects `X-Emby-Token` and `?api_key=` with 401 | confirmed, 401 on both, while 10.11.11 accepts all three schemes |
| No direct-header Jellyfin call in `apps/` or `packages/` | confirmed, images go through `getImageApi`, nothing builds its own URL |
| BoxSet collapse differs on 12 | confirmed, and traced: `Folder.CollapseBoxSetItems` is identical on both branches and short-circuits on an explicit parameter, so `false` holds everywhere. Without it, 10.11 collapses only when the server's grouping config says so, while 12 collapses in the database path where an empty collapse-type list reads as "collapse everything". Verified on both servers, including 10.11.11 with grouping on, which answered a Movie listing with collection rows only |

The Docker packaging notes in #3570 are the only part I could not check: Docker Hub is off this environment's egress allowlist, so the tag claims stand on the compose file's own comments. They are operational rather than code knowledge, so they stay there rather than moving into the repo.

No code change: 12 needs none today. The note exists to keep it that way, since the compatibility rests on nothing ever comparing the version string.
