### PR TITLE
docs(project-notes): explain what makes Jellyfin collection collapsing safe

### DIFF
--- a/.github/instructions/project-notes.instructions.md
+++ b/.github/instructions/project-notes.instructions.md
@@ -366,8 +366,20 @@ Quick checks (Jellyfin server configured):
   own scripts rather than Maintainerr, and it is worth naming in a support
   reply. Checked against 12.0-rc5 with 10.11.11 as a control: public system
   info, users, media folders, item listings and `GET /System/Info/Storage` all
-  answer on both, on the pinned `@jellyfin/sdk` 0.13.0. The one behaviour that
-  does differ is BoxSet collapsing (#3550).
+  answer on both, on the pinned `@jellyfin/sdk` 0.13.0.
+- **Collection collapsing is where 12 does behave differently, and
+  `collapseBoxSetItems=false` is what makes that safe.**
+  `Folder.CollapseBoxSetItems` is identical on both branches and short-circuits
+  on an explicit parameter, so `false` beats the server's own grouping setting
+  everywhere - which is the only reason a grouped library does not feed
+  collections into rule matching. Without the parameter the two diverge: 10.11
+  collapses in memory and only when `EnableGroupingMoviesIntoCollections` is on,
+  while 12 collapses in the new database query path, where the empty
+  collapse-type list you get with grouping off reads as "collapse everything"
+  and only name filters are re-applied after the substitution, never the type
+  filter. So on 12 a Movie-typed listing can answer with BoxSet rows on a
+  default-configured server. Send the parameter on every library-scoped query;
+  never rely on the server's grouping setting being off (#3550).
 
 ---
 


### PR DESCRIPTION
Follow-up to #3572, which said only that collection collapsing "differs" on Jellyfin 12. Tracing Jellyfin's source and testing both servers shows that framing was wrong, and the correction matters for #3550.

| Query | 10.11.11, grouping on | 10.11.11, grouping off | 12.0.0, grouping off |
| --- | --- | --- | --- |
| Movie listing, no parameter | **collections only, zero movies** | movies | movies |
| `collapseBoxSetItems=true` | collections only | movies | **collections substituted** |
| `collapseBoxSetItems=false` | movies | movies | movies |

`Folder.CollapseBoxSetItems` is identical on `release-10.11.z` and `master`, and both short-circuit on an explicit parameter (`param.HasValue` returns `param.Value && ...`). So the parameter, not the version, is what protects a grouped library from answering a Movie query with collections. Without it the two diverge: 10.11 collapses in memory and only when `EnableGroupingMoviesIntoCollections` is set, while 12 collapses in the database query path, where the empty collapse-type list that grouping-off produces reads as "collapse everything" and only name filters are re-applied after the substitution, never the type filter.

The practical upshot is the one in the note: send the parameter on every library-scoped query and never rely on the server's grouping setting. That is exactly the gap #3571 closes on the Emby side.

Verified against Jellyfin's source on both branches and live against 10.11.11 and 12.0-rc5, including toggling the grouping config on 10.11.11 and restoring it.
