### PR TITLE
fix(overlays): queue a revert behind the run, and guard the countdown math (#3558)

### DIFF
--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -7,6 +7,7 @@ import {
   compareMediaItemsBySort,
   type CompareMediaItemsOptions,
   ECollectionLogType,
+  getCollectionDeleteDate,
   isMediaType,
   MaintainerrEvent,
   MediaCollection,
@@ -275,13 +276,10 @@ export class CollectionsService {
 
     // Surface the resulting deadline (addDate + deleteAfterDays) so the caller
     // can confirm it. Null when the collection has no deletion window.
-    let deletionDate: Date | null = null;
-    if (collection.deleteAfterDays != null) {
-      deletionDate = new Date(newAddDate);
-      deletionDate.setDate(
-        deletionDate.getDate() + +collection.deleteAfterDays,
-      );
-    }
+    const deletionDate = getCollectionDeleteDate(
+      newAddDate,
+      collection.deleteAfterDays,
+    );
 
     return {
       collectionId,

--- a/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.spec.ts
@@ -11,6 +11,10 @@ import {
   createCollectionMedia,
   createMockLogger,
 } from '../../../test/utils/data';
+import {
+  ExecutionLockService,
+  OVERLAY_EXECUTION_LOCK_KEY,
+} from '../tasks/execution-lock.service';
 import { OverlayProcessorService } from './overlay-processor.service';
 
 const makeTemplate = (
@@ -114,6 +118,7 @@ describe('OverlayProcessorService', () => {
       templateService as any,
       { emit: jest.fn() } as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     const collection = createCollection({
@@ -169,6 +174,7 @@ describe('OverlayProcessorService', () => {
       templateService as any,
       { emit: jest.fn() } as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     // Out of Date's range: the sum used to be an Invalid Date, which is truthy,
@@ -225,6 +231,7 @@ describe('OverlayProcessorService', () => {
       templateService as any,
       { emit: jest.fn() } as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     const collection = createCollection({
@@ -283,6 +290,7 @@ describe('OverlayProcessorService', () => {
       templateService as any,
       { emit: jest.fn() } as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     const collection = createCollection({
@@ -337,6 +345,7 @@ describe('OverlayProcessorService', () => {
       templateService as any,
       { emit: jest.fn() } as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     const collection = createCollection({
@@ -397,6 +406,7 @@ describe('OverlayProcessorService', () => {
       templateService as any,
       { emit: jest.fn() } as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     const collection = createCollection({
@@ -481,6 +491,7 @@ describe('OverlayProcessorService', () => {
       templateService as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest.spyOn(service, 'applyTemplateOverlay').mockResolvedValue(true);
@@ -537,6 +548,7 @@ describe('OverlayProcessorService', () => {
       templateService as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest.spyOn(service, 'applyTemplateOverlay').mockResolvedValue(true);
@@ -603,6 +615,7 @@ describe('OverlayProcessorService', () => {
       templateService as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest.spyOn(service, 'applyTemplateOverlay').mockResolvedValue(true);
@@ -685,6 +698,7 @@ describe('OverlayProcessorService', () => {
       templateService as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest.spyOn(service, 'applyTemplateOverlay').mockResolvedValue(true);
@@ -718,6 +732,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     const result = await service.processAllCollections();
@@ -753,6 +768,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     const result = await service.processAllCollections();
@@ -800,6 +816,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest
@@ -852,6 +869,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest
@@ -908,6 +926,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       { emit: jest.fn() } as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest.spyOn(service as any, 'loadOriginalPoster').mockReturnValue(null);
@@ -953,6 +972,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       { emit: jest.fn() } as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     // media-2 was uploaded but its state write failed: without this, nothing
@@ -983,6 +1003,7 @@ describe('OverlayProcessorService', () => {
   it('leaves a run alone when reset is asked for while one is in progress', async () => {
     const stateService = { getAllStates: jest.fn() };
     const provider = makeProvider();
+    const executionLock = new ExecutionLockService();
 
     const service = new OverlayProcessorService(
       makeProviderFactory(provider) as any,
@@ -995,14 +1016,18 @@ describe('OverlayProcessorService', () => {
       {} as any,
       { emit: jest.fn() } as any,
       createMockLogger(),
+      executionLock,
     );
 
+    // The lock is what a run holds, so that is what reset has to find taken.
+    const runHolds = executionLock.tryAcquire(OVERLAY_EXECUTION_LOCK_KEY)!;
     service.status = 'running';
 
     await service.resetAllOverlays();
 
     expect(stateService.getAllStates).not.toHaveBeenCalled();
     expect(service.status).toBe('running');
+    runHolds();
   });
 
   it('keeps overlay state on reset when individual uploads fail so retries are possible', async () => {
@@ -1030,6 +1055,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest
@@ -1077,6 +1103,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest
@@ -1097,6 +1124,90 @@ describe('OverlayProcessorService', () => {
         collectionName: 'All Collections',
       }),
     );
+  });
+
+  // The caller deletes the collection next and the state rows cascade with it,
+  // so a revert that is skipped leaves overlays nothing can take off (#3558).
+  it('queues a revert behind the work in flight, and keeps the name', async () => {
+    const stateService = {
+      getCollectionStates: jest
+        .fn()
+        .mockResolvedValue([{ mediaServerId: 'media-1' }]),
+      removeState: jest.fn().mockResolvedValue(undefined),
+    };
+    const collectionRepos = makeCollectionRepos([
+      { id: 7, type: 'movie', title: 'Target collection' },
+    ]);
+    const executionLock = new ExecutionLockService();
+    const service = new OverlayProcessorService(
+      makeProviderFactory(makeProvider()) as any,
+      makeMediaServerFactory() as any,
+      collectionRepos.collectionRepo as any,
+      collectionRepos.collectionMediaRepo as any,
+      {} as any,
+      stateService as any,
+      {} as any,
+      {} as any,
+      { emit: jest.fn() } as any,
+      createMockLogger(),
+      executionLock,
+    );
+    const revert = jest
+      .spyOn(service as any, 'revertMultipleItems')
+      .mockResolvedValue(undefined);
+
+    const runHolds = executionLock.tryAcquire(OVERLAY_EXECUTION_LOCK_KEY)!;
+    const count = await service.revertCollection(7);
+
+    expect(count).toBe(1);
+    expect(revert).not.toHaveBeenCalled();
+
+    runHolds();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(revert).toHaveBeenCalledWith(
+      7,
+      [{ mediaServerId: 'media-1' }],
+      'Target collection',
+    );
+  });
+
+  it('holds the lock while reverting, and gives it back', async () => {
+    const stateService = {
+      getCollectionStates: jest
+        .fn()
+        .mockResolvedValue([{ mediaServerId: 'media-1' }]),
+      removeState: jest.fn().mockResolvedValue(undefined),
+    };
+    const collectionRepos = makeCollectionRepos([
+      { id: 7, type: 'movie', title: 'Target collection' },
+    ]);
+    const executionLock = new ExecutionLockService();
+    const service = new OverlayProcessorService(
+      makeProviderFactory(makeProvider()) as any,
+      makeMediaServerFactory() as any,
+      collectionRepos.collectionRepo as any,
+      collectionRepos.collectionMediaRepo as any,
+      {} as any,
+      stateService as any,
+      {} as any,
+      {} as any,
+      { emit: jest.fn() } as any,
+      createMockLogger(),
+      executionLock,
+    );
+    let lockedDuringRevert: boolean | undefined;
+    jest
+      .spyOn(service as any, 'revertMultipleItems')
+      .mockImplementation(async () => {
+        lockedDuringRevert =
+          executionLock.tryAcquire(OVERLAY_EXECUTION_LOCK_KEY) === null;
+      });
+
+    await service.revertCollection(7);
+
+    expect(lockedDuringRevert).toBe(true);
+    expect(executionLock.tryAcquire(OVERLAY_EXECUTION_LOCK_KEY)).not.toBeNull();
   });
 
   it('emits one aggregated overlay reverted notification for revertCollection', async () => {
@@ -1127,6 +1238,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest
@@ -1182,6 +1294,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest
@@ -1227,6 +1340,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest
@@ -1281,6 +1395,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest
@@ -1337,6 +1452,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest
@@ -1386,6 +1502,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest.spyOn(service as any, 'loadOriginalPoster').mockReturnValue(null);
@@ -1423,6 +1540,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest
@@ -1481,6 +1599,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     jest
@@ -1524,6 +1643,7 @@ describe('OverlayProcessorService', () => {
       {} as any,
       eventEmitter as any,
       createMockLogger(),
+      new ExecutionLockService(),
     );
 
     // No original poster stored → revertItemInternal reports no restore
@@ -1601,6 +1721,7 @@ describe('OverlayProcessorService', () => {
         templateService as any,
         { emit: jest.fn() } as any,
         createMockLogger(),
+        new ExecutionLockService(),
       );
       const applySpy = jest
         .spyOn(service, 'applyTemplateOverlay')

--- a/apps/server/src/modules/overlays/overlay-processor.service.ts
+++ b/apps/server/src/modules/overlays/overlay-processor.service.ts
@@ -1,4 +1,5 @@
 import {
+  getCollectionDeleteDate,
   MaintainerrEvent,
   MediaItem,
   MediaItemType,
@@ -16,6 +17,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Repository } from 'typeorm';
 import { dataDir as configDataDir } from '../../app/config/dataDir';
+import {
+  ExecutionLockService,
+  OVERLAY_EXECUTION_LOCK_KEY,
+} from '../tasks/execution-lock.service';
 import { resolveDescendants } from '../api/media-server/context-action.util';
 import { readItemPresence } from '../api/media-server/item-presence.util';
 import { MediaServerFactory } from '../api/media-server/media-server.factory';
@@ -93,28 +98,13 @@ export class OverlayProcessorService {
     private readonly templateService: OverlayTemplateService,
     private readonly eventEmitter: EventEmitter2,
     private readonly logger: MaintainerrLogger,
+    private readonly executionLock: ExecutionLockService,
   ) {
     this.logger.setContext(OverlayProcessorService.name);
     this.dataDir = configDataDir;
   }
 
   // ── Date helpers ──────────────────────────────────────────────────────────
-
-  /**
-   * Null when the window cannot name a day. `DELETE_AFTER_MAX_DAYS` bounds it
-   * where it is entered, but the rule-group body is not schema-validated, so
-   * this stays the invariant: an Invalid Date is truthy and would be drawn as
-   * "Leaving Invalid Date" (#3549).
-   */
-  private getDeleteDate(
-    addDate: string | Date,
-    deleteAfterDays: number | null,
-  ): Date | null {
-    if (deleteAfterDays == null) return null;
-    const d = new Date(addDate);
-    d.setDate(d.getDate() + deleteAfterDays);
-    return Number.isNaN(d.getTime()) ? null : d;
-  }
 
   private getDaysLeft(deleteDate: Date): number {
     const now = new Date();
@@ -144,7 +134,7 @@ export class OverlayProcessorService {
     const mode = overlayModeForType(collection.type);
     const targets: OverlayTarget[] = [];
     for (const media of collection.collectionMedia) {
-      const deleteDate = this.getDeleteDate(
+      const deleteDate = getCollectionDeleteDate(
         media.addDate,
         collection.deleteAfterDays,
       );
@@ -490,10 +480,69 @@ export class OverlayProcessorService {
     return 'restored';
   }
 
+  /**
+   * A revert restores originals and deletes the backups a run is reading, so
+   * the two must not interleave, the same reason a reset takes the lock. It
+   * cannot skip like a run does, though: the caller deletes the collection
+   * next and the state rows cascade with it, so a revert that never happens
+   * leaves an overlay that nothing can take off afterwards - neither a later
+   * run nor a reset, since both work from those rows (#3558).
+   *
+   * So it queues instead, on the same lock the runs take. The ids and the name
+   * are read here, before the rows go, and the revert works from those.
+   */
   async revertCollection(collectionId: number): Promise<number> {
     const states = await this.stateService.getCollectionStates(collectionId);
-    await this.revertMultipleItems(collectionId, states);
+    const collectionName = (
+      await this.collectionRepo.findOne({ where: { id: collectionId } })
+    )?.title;
+
+    const release = this.executionLock.tryAcquire(OVERLAY_EXECUTION_LOCK_KEY);
+    if (!release) {
+      // Queued rather than awaited: the caller is a collection delete, which
+      // should not hang for the length of a run.
+      this.logger.log(
+        `Overlay processor is busy; reverting ${states.length} overlay(s) when it frees up`,
+      );
+      void this.revertWhenFree(collectionId, states, collectionName);
+      return states.length;
+    }
+
+    await this.revertHolding(release, collectionId, states, collectionName);
     return states.length;
+  }
+
+  private async revertWhenFree(
+    collectionId: number,
+    states: { mediaServerId: string }[],
+    collectionName?: string,
+  ): Promise<void> {
+    const release = await this.executionLock.acquire(
+      OVERLAY_EXECUTION_LOCK_KEY,
+    );
+    try {
+      await this.revertHolding(release, collectionId, states, collectionName);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to revert the overlays of "${collectionName ?? collectionId}"`,
+      );
+      this.logger.debug(error);
+    }
+  }
+
+  private async revertHolding(
+    release: () => void,
+    collectionId: number,
+    states: { mediaServerId: string }[],
+    collectionName?: string,
+  ): Promise<void> {
+    this.status = 'running';
+    try {
+      await this.revertMultipleItems(collectionId, states, collectionName);
+    } finally {
+      this.status = 'idle';
+      release();
+    }
   }
 
   /**
@@ -704,7 +753,8 @@ export class OverlayProcessorService {
     collection: Collection & { collectionMedia: CollectionMedia[] },
     force = false,
   ): Promise<ProcessorRunResult> {
-    if (this.status === 'running') {
+    const release = this.executionLock.tryAcquire(OVERLAY_EXECUTION_LOCK_KEY);
+    if (!release) {
       this.logger.warn('Overlay processor is already running, skipping');
       return this.createEmptyResult();
     }
@@ -715,13 +765,15 @@ export class OverlayProcessorService {
       return await this.processCollectionInternal(collection, { force });
     } finally {
       this.status = 'idle';
+      release();
     }
   }
 
   // ── Process all enabled collections ───────────────────────────────────────
 
   async processAllCollections(force = false): Promise<ProcessorRunResult> {
-    if (this.status === 'running') {
+    const release = this.executionLock.tryAcquire(OVERLAY_EXECUTION_LOCK_KEY);
+    if (!release) {
       this.logger.warn('Overlay processor is already running, skipping');
       return this.createEmptyResult();
     }
@@ -869,6 +921,7 @@ export class OverlayProcessorService {
       finalStatus = 'error';
     } finally {
       this.status = finalStatus;
+      release();
       this.lastRun = new Date();
       this.lastResult = totalResult;
     }
@@ -879,12 +932,13 @@ export class OverlayProcessorService {
   // ── Reset all overlays ────────────────────────────────────────────────────
 
   /**
-   * Takes the same running flag as a run: a reset restores originals and drops
+   * Takes the same lock as a run: a reset restores originals and drops
    * the backups a concurrent run would be reading, so the two must never
    * interleave. The controller's own check cannot guarantee that on its own.
    */
   async resetAllOverlays(): Promise<void> {
-    if (this.status === 'running') {
+    const release = this.executionLock.tryAcquire(OVERLAY_EXECUTION_LOCK_KEY);
+    if (!release) {
       this.logger.warn('Overlay processor is already running, skipping reset');
       return;
     }
@@ -953,6 +1007,7 @@ export class OverlayProcessorService {
       this.logger.log('Overlay reset complete');
     } finally {
       this.status = 'idle';
+      release();
       this.lastRun = new Date();
       this.lastResult = summary;
     }

--- a/apps/server/src/modules/tasks/execution-lock.service.ts
+++ b/apps/server/src/modules/tasks/execution-lock.service.ts
@@ -2,6 +2,10 @@ import { Injectable } from '@nestjs/common';
 
 export const RULES_COLLECTIONS_EXECUTION_LOCK_KEY = 'rules-collections-lock';
 
+// Overlay runs, resets and reverts all read and write the same posters and
+// backups, so they take turns on this one.
+export const OVERLAY_EXECUTION_LOCK_KEY = 'overlay-lock';
+
 /*
  * A lightweight async lock for coordinating exclusive execution between tasks.
  * Acquiring returns a release function that must be called in a finally block.

--- a/apps/ui/src/api/calendar.spec.ts
+++ b/apps/ui/src/api/calendar.spec.ts
@@ -1,0 +1,28 @@
+import { ServarrAction } from '@maintainerr/contracts'
+import { describe, expect, it } from 'vitest'
+import { buildCalendarDays } from './calendar'
+import type { ICollection } from '../components/Collection'
+
+const collection = (deleteAfterDays: number): ICollection =>
+  ({
+    id: 1,
+    title: 'Sample collection',
+    type: 'movie',
+    arrAction: ServarrAction.DELETE,
+    deleteAfterDays,
+    media: [{ id: 1, addDate: '2026-01-01T00:00:00.000Z' }],
+  }) as unknown as ICollection
+
+describe('buildCalendarDays', () => {
+  it('schedules an item on its deletion day', () => {
+    const days = buildCalendarDays([collection(7)])
+
+    expect(days.map((day) => day.dayKey)).toEqual(['2026-01-08'])
+  })
+
+  // A window saved before DELETE_AFTER_MAX_DAYS bounded it has no real date,
+  // and the key used to come out as NaN-NaN-NaN (#3558).
+  it('skips a window that lands outside Date range', () => {
+    expect(buildCalendarDays([collection(999999999)])).toEqual([])
+  })
+})

--- a/apps/ui/src/api/calendar.ts
+++ b/apps/ui/src/api/calendar.ts
@@ -1,6 +1,10 @@
 import { i18n } from '@lingui/core'
 import { plural, t } from '@lingui/core/macro'
-import { MediaItemType, ServarrAction } from '@maintainerr/contracts'
+import {
+  getCollectionDeleteDate,
+  MediaItemType,
+  ServarrAction,
+} from '@maintainerr/contracts'
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 import type { ICollection, ICollectionMedia } from '../components/Collection'
 import GetApiHandler from '../utils/ApiHandler'
@@ -213,7 +217,7 @@ const getActionKey = (collection: ICollection): CalendarActionKey => {
   return getGenericActionKey(action)
 }
 
-const buildCalendarDays = (collections: ICollection[] | undefined) => {
+export const buildCalendarDays = (collections: ICollection[] | undefined) => {
   const itemsByKey = new Map<string, CalendarEntry[]>()
 
   if (!collections) {
@@ -235,8 +239,13 @@ const buildCalendarDays = (collections: ICollection[] | undefined) => {
         return
       }
 
-      const deleteDate = startOfDay(new Date(media.addDate))
-      deleteDate.setDate(deleteDate.getDate() + deleteAfterDays)
+      const deleteDate = getCollectionDeleteDate(
+        startOfDay(new Date(media.addDate)),
+        deleteAfterDays,
+      )
+      if (!deleteDate) {
+        return
+      }
 
       const key = `${deleteDate.getFullYear()}-${pad2(deleteDate.getMonth() + 1)}-${pad2(deleteDate.getDate())}`
       const actionKey = getActionKey(collection)

--- a/apps/ui/src/components/Overview/Content/index.tsx
+++ b/apps/ui/src/components/Overview/Content/index.tsx
@@ -1,5 +1,6 @@
 import { Trans, useLingui } from '@lingui/react/macro'
 import {
+  getCollectionDeleteDate,
   type MediaItem,
   type MediaItemWithParent,
   type MediaProviderIds,
@@ -105,10 +106,15 @@ const OverviewContent = (props: IOverviewContent) => {
       return undefined
     }
 
-    const date = new Date(collectionData.addDate)
-    date.setDate(date.getDate() + resolvedCollection.deleteAfterDays)
+    const deleteDate = getCollectionDeleteDate(
+      collectionData.addDate,
+      resolvedCollection.deleteAfterDays,
+    )
+    if (!deleteDate) {
+      return undefined
+    }
 
-    const diffTime = date.getTime() - new Date().getTime()
+    const diffTime = deleteDate.getTime() - new Date().getTime()
     return Math.ceil(diffTime / (1000 * 60 * 60 * 24))
   }
 

--- a/packages/contracts/src/collections/index.ts
+++ b/packages/contracts/src/collections/index.ts
@@ -28,3 +28,20 @@ export const POSTPONE_MAX_DAYS = 3650
 // artwork as "Leaving Invalid Date" (#3549). A century is far beyond any
 // retention policy, and everything under it is a valid date.
 export const DELETE_AFTER_MAX_DAYS = 36500
+
+/**
+ * The day a collection acts on an item, or null when that day does not exist.
+ * A window saved before DELETE_AFTER_MAX_DAYS bounded it puts addDate + days
+ * outside Date range, and an Invalid Date is truthy, so callers that do this
+ * arithmetic themselves render NaN instead of nothing (#3549, #3558). Shared so
+ * the server and the UI cannot drift on it.
+ */
+export const getCollectionDeleteDate = (
+  addDate: string | Date,
+  deleteAfterDays: number | null | undefined,
+): Date | null => {
+  if (deleteAfterDays == null) return null
+  const deleteDate = new Date(addDate)
+  deleteDate.setDate(deleteDate.getDate() + deleteAfterDays)
+  return Number.isNaN(deleteDate.getTime()) ? null : deleteDate
+}


### PR DESCRIPTION
Closes the two follow-ups from #3558. Deleting a collection can no longer leave an overlay applied that nothing is able to take off, and a legacy retention window no longer renders NaN in the overview or the calendar.

### Revert versus a run in flight

`revertCollection` could interleave with a run, and the flag that `resetAllOverlays` takes was the wrong tool for it: a skipped revert is worse than a raced one.

| | Before | After |
| --- | --- | --- |
| Processor idle | reverts, a run can start underneath it | reverts holding the lock |
| Run in flight | interleaves with the run | queues, and reverts when the run releases |
| Two deletes in one run | n/a | both queue, FIFO, one at a time |

It queues on `ExecutionLockService`, the lock the postpone endpoint already waits on, rather than on a status poll of its own: overlay runs, resets and reverts now share an overlay key, the runs claiming it without waiting so a second run still skips exactly as before. The reason a revert queues rather than skips: the caller deletes the collection immediately afterwards, `OverlayItemState` cascades with it, and both recovery paths (the run's stale-state sweep and `resetAllOverlays`) work from those rows. So an overlay left applied at that moment is permanent, and the media server has to be asked to refresh the artwork. The ids and the collection name are read before the rows go, so the deferred revert still restores the right posters and still names the collection in its notification.

### Countdown date math

`getDeleteDate` on the server returned null when `addDate + deleteAfterDays` leaves Date range, while the overview grid and the calendar repeated the arithmetic without that guard, so an install carrying a window saved before `DELETE_AFTER_MAX_DAYS` existed rendered a NaN badge and bucketed calendar entries under `NaN-NaN-NaN`. Four callers now share `getCollectionDeleteDate` from contracts, which answers with null when the window names no day: the overlay targets, the overview badge, the calendar, and the deadline the postpone endpoint reports back, which was doing the same arithmetic in `collections.service`. The manual-collection countdown in `media-item-enrichment` is deliberately left alone, since it works in milliseconds and never builds a Date.

Existing out-of-range values are left in place: 36500 days and 999999999 both mean "never" in practice, so rewriting them would change what the user asked for without changing what happens.

### Verified against the dev stack, not only in tests

A collection carrying a legacy 999999999-day window, with three real Jellyfin movies in it:

| Check | Result |
| --- | --- |
| Collection page, guard removed | every card renders a `NAN` badge |
| Collection page, guard in place | no badge, no error |
| `POST /api/collections/media/postpone` | answers `deletionDate: null` rather than an invalid date |
| Revert fired at a live overlay run, before the fix | reverted nothing, three real posters left overlaid with state rows a delete would cascade away |
| Same race, after the fix | request returns in 19ms, the run finishes uninterrupted, all three posters restored to their original `sha1` the moment it releases |

The calendar half is a data-level fix only: an invalid bucket key never matched a rendered day, so the entry was silently dropped before and is skipped deliberately now.

Full suite green (9/9 tasks). The three new tests were each run against the unfixed code first: the revert tests fail without the defer and the flag, and the calendar test reproduces the old `NaN-NaN-NaN` key.
