### PR TITLE
fix(exclusions): apply the *arr exclusion tag with several instances configured

### DIFF
--- a/apps/server/src/modules/actions/servarr-tag.service.spec.ts
+++ b/apps/server/src/modules/actions/servarr-tag.service.spec.ts
@@ -37,6 +37,15 @@ describe('ServarrTagService', () => {
         { providerKey: service === 'radarr' ? 'tmdb' : 'tvdb', id: 100 },
       ],
     );
+
+    // One configured instance of each; exclusion tagging reads these to know
+    // which instances to cover.
+    settings.getRadarrSettings.mockResolvedValue([
+      { id: 1, serverName: 'Radarr' },
+    ] as any);
+    settings.getSonarrSettings.mockResolvedValue([
+      { id: 1, serverName: 'Sonarr' },
+    ] as any);
   });
 
   describe('Behavior A - membership tagging', () => {
@@ -439,7 +448,9 @@ describe('ServarrTagService', () => {
       jest
         .spyOn(radarr, 'getMovieByTmdbId')
         .mockResolvedValue(createRadarrMovie({ id: 31 }));
-      jest.spyOn(radarr, 'ensureTag').mockResolvedValue(9);
+      jest
+        .spyOn(radarr, 'getTags')
+        .mockResolvedValue([{ id: 9, label: 'dnd' }]);
       settings.radarr_tag_exclusions = true;
       settings.radarr_exclusion_tag = 'dnd';
       settings.radarr_untag_on_unexclude = true;
@@ -447,9 +458,11 @@ describe('ServarrTagService', () => {
       await service.removeExclusionTag(movieTarget, { radarrSettingsId: 1 });
 
       expect(radarr.setMovieTags).toHaveBeenCalledWith([31], 9, 'remove');
+      // A removal must not create the label it is trying to strip.
+      expect(radarr.ensureTag).not.toHaveBeenCalled();
     });
 
-    it('skips when no *arr instance is associated (e.g. a global exclusion)', async () => {
+    it('skips when the collection names no *arr instance', async () => {
       const radarr = mockRadarrApi(servarrService, logger);
       settings.radarr_tag_exclusions = true;
       settings.radarr_exclusion_tag = 'dnd';
@@ -460,6 +473,40 @@ describe('ServarrTagService', () => {
       });
 
       expect(radarr.ensureTag).not.toHaveBeenCalled();
+    });
+
+    // A global exclusion names no instance. Picking one is impossible, and
+    // skipping left multi-instance setups (a 4K + HD Radarr split) untagged,
+    // so it covers them all and tags wherever the item is actually tracked.
+    it('a global exclusion tags every instance tracking the item, and only those', async () => {
+      const tracking = mockRadarrApi(servarrService, logger);
+      const other = mockRadarrApi(servarrService, logger);
+      jest
+        .spyOn(tracking, 'getMovieByTmdbId')
+        .mockResolvedValue(createRadarrMovie({ id: 30 }));
+      jest.spyOn(tracking, 'ensureTag').mockResolvedValue(9);
+      // The second instance confirms it doesn't track the movie.
+      jest.spyOn(other, 'getMovieByTmdbId').mockResolvedValue(null);
+      servarrService.getRadarrApiClient.mockImplementation(async (id) =>
+        id === 1 ? tracking : other,
+      );
+      settings.getRadarrSettings.mockResolvedValue([
+        { id: 1, serverName: 'HD' },
+        { id: 2, serverName: '4K' },
+      ] as any);
+      settings.radarr_tag_exclusions = true;
+      settings.radarr_exclusion_tag = 'dnd';
+
+      await service.applyExclusionTag(movieTarget);
+
+      expect(tracking.setMovieTags).toHaveBeenCalledWith([30], 9, 'add');
+      expect(other.setMovieTags).not.toHaveBeenCalled();
+      // No stray label created in an instance that doesn't hold the movie.
+      expect(other.ensureTag).not.toHaveBeenCalled();
+      // The item is resolved once, not per instance.
+      expect(
+        metadataService.resolveLookupCandidatesForService,
+      ).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/server/src/modules/actions/servarr-tag.service.ts
+++ b/apps/server/src/modules/actions/servarr-tag.service.ts
@@ -5,7 +5,10 @@ import { SonarrApi } from '../api/servarr-api/helpers/sonarr.helper';
 import { ServarrService } from '../api/servarr-api/servarr.service';
 import { Collection } from '../collections/entities/collection.entities';
 import { MaintainerrLogger } from '../logging/logs.service';
-import { findMetadataLookupMatch } from '../metadata/metadata-lookup.util';
+import {
+  findMetadataLookupMatch,
+  MetadataLookupCandidate,
+} from '../metadata/metadata-lookup.util';
 import { MetadataService } from '../metadata/metadata.service';
 import { SettingsDataService } from '../settings/settings-data.service';
 
@@ -48,7 +51,8 @@ const EDITOR_BATCH_SIZE = 100;
  * - **Exclusion (Behavior B,
  *   https://features.maintainerr.info/posts/81):** when an item is excluded, the
  *   matching *arr entity gets a protective tag (default "dnd"); removal on
- *   un-exclude is opt-in.
+ *   un-exclude is opt-in. A collection exclusion targets that collection's
+ *   instance, a global one every configured instance that tracks the item.
  *
  * Everything here is strictly best-effort: it logs and swallows failures, never
  * throws, never mutates collection membership, and resolves items with the #3125
@@ -235,14 +239,14 @@ export class ServarrTagService {
 
   /**
    * Behavior B - apply the protective exclusion tag to the excluded item's *arr
-   * entity. No-ops unless exclusion tagging is enabled. The caller resolves the
-   * instance: a collection-scoped exclusion uses its rule group's collection, a
-   * global one the single configured instance (skipped when ambiguous). Adding on
-   * exclude is unconditional when enabled.
+   * entity. No-ops unless exclusion tagging is enabled. `instance` scopes a
+   * collection exclusion to its rule group's instance; omitting it (a global
+   * exclusion) covers every configured instance. Adding on exclude is
+   * unconditional when enabled.
    */
   public async applyExclusionTag(
     target: ExclusionTagTarget,
-    instance: ArrInstanceRef,
+    instance?: ArrInstanceRef,
   ): Promise<void> {
     if (!this.exclusionTaggingEnabled(target.type)) {
       return;
@@ -259,7 +263,7 @@ export class ServarrTagService {
    */
   public async removeExclusionTag(
     target: ExclusionTagTarget,
-    instance: ArrInstanceRef,
+    instance?: ArrInstanceRef,
   ): Promise<void> {
     if (!this.exclusionUntaggingEnabled(target.type)) {
       return;
@@ -269,7 +273,7 @@ export class ServarrTagService {
 
   private async tagExclusionTarget(
     target: ExclusionTagTarget,
-    instance: ArrInstanceRef,
+    instance: ArrInstanceRef | undefined,
     mode: 'add' | 'remove',
   ): Promise<void> {
     try {
@@ -277,17 +281,6 @@ export class ServarrTagService {
       if (!service) {
         this.logger.debug(
           `Skipping *arr exclusion tagging for item ${target.mediaServerId}: type '${target.type}' is not taggable (movie/show only).`,
-        );
-        return;
-      }
-
-      const settingsId =
-        service === 'radarr'
-          ? instance.radarrSettingsId
-          : instance.sonarrSettingsId;
-      if (!settingsId) {
-        this.logger.debug(
-          `Skipping *arr exclusion tagging for item ${target.mediaServerId}: no ${service} instance associated with the exclusion.`,
         );
         return;
       }
@@ -302,36 +295,65 @@ export class ServarrTagService {
         return;
       }
 
-      const client = await this.getClient(service, settingsId);
-      if (!client) {
-        return;
-      }
-
-      const tagId = await client.ensureTag(label);
-      if (tagId === undefined) {
-        this.logger.warn(
-          `Couldn't ensure ${service} tag '${label}'; skipping exclusion ${mode} for item ${target.mediaServerId}.`,
+      const instances = await this.exclusionInstances(service, instance);
+      if (instances.length === 0) {
+        this.logger.debug(
+          `Skipping *arr exclusion tagging for item ${target.mediaServerId}: no ${service} instance associated with the exclusion.`,
         );
         return;
       }
 
-      const arrId = await this.resolveArrId(client, service, target);
-      if (arrId == null) {
-        // undefined = transient (retried on the next exclude/un-exclude),
-        // null = the item isn't tracked in *arr - nothing to tag either way.
-        return;
+      // Resolved once and reused: the candidate ids describe the item, not the
+      // instance, so a fan-out must not re-read its metadata per instance.
+      const candidates = await this.lookupCandidates(target, service);
+
+      const tagged: string[] = [];
+      let matched = false;
+      for (const settings of instances) {
+        const client = await this.getClient(service, settings.id);
+        if (!client) {
+          continue;
+        }
+
+        const arrId = await this.matchArrId(client, service, candidates);
+        if (arrId == null) {
+          // undefined = transient (retried on the next exclude/un-exclude),
+          // null = this instance doesn't track the item - nothing to tag.
+          continue;
+        }
+
+        matched = true;
+
+        // Created only on add, and only after the match, so an instance that
+        // doesn't hold the item never gets a stray label. A removal looks the
+        // label up instead: an instance without it has nothing to strip.
+        const tagId =
+          mode === 'add'
+            ? await client.ensureTag(label)
+            : await this.findTagId(client, label);
+        if (tagId === undefined) {
+          if (mode === 'add') {
+            this.logger.warn(
+              `Couldn't ensure ${service} tag '${label}' on '${settings.serverName}'; skipping exclusion add for item ${target.mediaServerId}.`,
+            );
+          }
+          continue;
+        }
+
+        if ((await this.writeTags(client, service, [arrId], tagId, mode)) > 0) {
+          tagged.push(settings.serverName);
+        }
       }
 
-      const written = await this.writeTags(
-        client,
-        service,
-        [arrId],
-        tagId,
-        mode,
-      );
-      if (written > 0) {
+      if (tagged.length > 0) {
         this.logger.log(
-          `${mode === 'add' ? 'Applied' : 'Removed'} ${service} exclusion tag '${label}' ${mode === 'add' ? 'to' : 'from'} item ${target.mediaServerId}.`,
+          `${mode === 'add' ? 'Applied' : 'Removed'} ${service} exclusion tag '${label}' ${mode === 'add' ? 'to' : 'from'} item ${target.mediaServerId} on ${tagged.join(', ')}.`,
+        );
+      } else if (!matched) {
+        // The write failing is already reported by the *arr client, so only the
+        // "nothing to tag" outcome needs a line of its own.
+        this.logger.debug(
+          `No ${service} match for item ${target.mediaServerId} on ${instances.map((settings) => settings.serverName).join(', ')}; exclusion tag ${mode} skipped.`,
         );
       }
     } catch (error) {
@@ -340,6 +362,47 @@ export class ServarrTagService {
       );
       this.logger.debug(error);
     }
+  }
+
+  /** An existing tag's id, without creating it. */
+  private async findTagId(
+    client: RadarrApi | SonarrApi,
+    label: string,
+  ): Promise<number | undefined> {
+    const target = label.toLowerCase();
+    return (await client.getTags()).find(
+      (tag) => tag.label?.toLowerCase() === target,
+    )?.id;
+  }
+
+  /**
+   * The instances an exclusion tags: the one its collection is bound to, or -
+   * for a global exclusion, which has no collection to inherit from - every
+   * configured instance of the service, so the item is tagged wherever it is
+   * actually tracked.
+   */
+  private async exclusionInstances(
+    service: ArrService,
+    instance: ArrInstanceRef | undefined,
+  ): Promise<{ id: number; serverName: string }[]> {
+    const configured =
+      service === 'radarr'
+        ? await this.settings.getRadarrSettings()
+        : await this.settings.getSonarrSettings();
+    // The getters answer with an error DTO instead of throwing.
+    const all = Array.isArray(configured) ? configured : [];
+
+    if (!instance) {
+      return all;
+    }
+
+    const settingsId =
+      service === 'radarr'
+        ? instance.radarrSettingsId
+        : instance.sonarrSettingsId;
+    return settingsId
+      ? all.filter((settings) => settings.id === settingsId)
+      : [];
   }
 
   private serviceForType(
@@ -409,15 +472,34 @@ export class ServarrTagService {
     service: ArrService,
     item: ArrTagItem,
   ): Promise<number | null | undefined> {
-    const candidates =
-      await this.metadataService.resolveLookupCandidatesForService(
-        item.mediaServerId,
-        service,
-        {
-          ...(item.tmdbId != null ? { tmdb: item.tmdbId } : {}),
-          ...(item.tvdbId != null ? { tvdb: item.tvdbId } : {}),
-        },
-      );
+    return this.matchArrId(
+      client,
+      service,
+      await this.lookupCandidates(item, service),
+    );
+  }
+
+  /** The item's provider ids to look up, cached ids included as fallbacks. */
+  private lookupCandidates(
+    item: ArrTagItem,
+    service: ArrService,
+  ): Promise<MetadataLookupCandidate[]> {
+    return this.metadataService.resolveLookupCandidatesForService(
+      item.mediaServerId,
+      service,
+      {
+        ...(item.tmdbId != null ? { tmdb: item.tmdbId } : {}),
+        ...(item.tvdbId != null ? { tvdb: item.tvdbId } : {}),
+      },
+    );
+  }
+
+  /** Match resolved candidates against one instance; see `resolveArrId`. */
+  private async matchArrId(
+    client: RadarrApi | SonarrApi,
+    service: ArrService,
+    candidates: MetadataLookupCandidate[],
+  ): Promise<number | null | undefined> {
     if (candidates.length === 0) {
       return null;
     }

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
@@ -341,7 +341,7 @@ describe('RadarrApi', () => {
       jest.spyOn(api as any, 'getWithoutCache').mockResolvedValue([]);
 
       await expect(api.getMovieByTmdbId(123)).resolves.toBeNull();
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         'Could not find Movie with TMDb id 123 in Radarr',
       );
     });

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
@@ -103,7 +103,9 @@ export class RadarrApi extends ServarrApi<{ movieId: number }> {
       }
 
       if (!response[0]) {
-        this.logger.warn(`Could not find Movie with TMDb id ${id} in Radarr`);
+        // Not an error: #3125 made "not tracked" a normal outcome, and an
+        // exclusion tag fans out over every instance, so most answer this.
+        this.logger.debug(`Could not find Movie with TMDb id ${id} in Radarr`);
         return null;
       }
 

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
@@ -288,7 +288,7 @@ describe('SonarrApi', () => {
       jest.spyOn(sonarrApi as any, 'getWithoutCache').mockResolvedValue([]);
 
       await expect(sonarrApi.getSeriesByTvdbId(555)).resolves.toBeNull();
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         'Could not retrieve show by tvdb ID 555',
       );
     });

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
@@ -159,7 +159,9 @@ export class SonarrApi extends ServarrApi<{
       }
 
       if (!response[0]) {
-        this.logger.warn(`Could not retrieve show by tvdb ID ${id}`);
+        // Not an error: #3125 made "not tracked" a normal outcome, and an
+        // exclusion tag fans out over every instance, so most answer this.
+        this.logger.debug(`Could not retrieve show by tvdb ID ${id}`);
         return null;
       }
 

--- a/apps/server/src/modules/rules/rules.service.exclusions.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.exclusions.spec.ts
@@ -18,8 +18,6 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
     collectionService?: any;
     mediaServerFactory?: any;
     servarrTagService?: any;
-    radarrSettingsRepo?: any;
-    sonarrSettingsRepo?: any;
   }) => {
     const exclusionRepo = overrides?.exclusionRepo ?? {
       find: jest.fn().mockResolvedValue([]),
@@ -27,12 +25,6 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
       delete: jest.fn().mockResolvedValue(undefined),
       // default: no exclusion survives a removal, so the shared-tag guard passes
       count: jest.fn().mockResolvedValue(0),
-    };
-    const radarrSettingsRepo = overrides?.radarrSettingsRepo ?? {
-      find: jest.fn().mockResolvedValue([]),
-    };
-    const sonarrSettingsRepo = overrides?.sonarrSettingsRepo ?? {
-      find: jest.fn().mockResolvedValue([]),
     };
     const collectionMediaRepository = overrides?.collectionMediaRepository ?? {
       findOne: jest.fn().mockResolvedValue(undefined),
@@ -56,8 +48,8 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
       {} as any, // communityRuleKarmaRepository
       exclusionRepo as any,
       {} as any, // settingsRepo
-      radarrSettingsRepo as any,
-      sonarrSettingsRepo as any,
+      {} as any, // radarrSettingsRepo
+      {} as any, // sonarrSettingsRepo
       {} as any, // sportarrSettingsRepo
       collectionService as any,
       mediaServerFactory as any,
@@ -79,8 +71,6 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
       collectionService,
       mediaServerFactory,
       servarrTagService,
-      radarrSettingsRepo,
-      sonarrSettingsRepo,
     };
   };
 
@@ -321,7 +311,10 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
     );
   });
 
-  it('setExclusion(global) tags the single configured radarr instance', async () => {
+  // A global exclusion has no collection to inherit an instance from, so it
+  // names none: the tag service covers every configured instance, which is what
+  // makes the tag land for users running more than one Radarr/Sonarr.
+  it("setExclusion(global) names no instance, and passes the item's cached ids", async () => {
     const exclusionRepo = {
       findOne: jest.fn().mockResolvedValue(undefined),
       save: jest.fn().mockResolvedValue(undefined),
@@ -335,8 +328,9 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
     const mediaServerFactory = {
       getService: jest.fn().mockResolvedValue(mediaServer),
     };
-    const radarrSettingsRepo = {
-      find: jest.fn().mockResolvedValue([{ id: 3 }]),
+    // Any collection_media row for the item carries its provider ids.
+    const collectionMediaRepository = {
+      findOne: jest.fn().mockResolvedValue({ tmdbId: 4242, tvdbId: null }),
     };
     const servarrTagService = createMockServarrTagService();
     servarrTagService.anyExclusionTaggingEnabled.mockReturnValue(true);
@@ -344,48 +338,19 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
     const { service } = createService({
       exclusionRepo,
       mediaServerFactory,
-      radarrSettingsRepo,
+      collectionMediaRepository,
       servarrTagService,
     });
 
     await service.setExclusion({ mediaId: 'movie-1' } as any);
 
     expect(servarrTagService.applyExclusionTag).toHaveBeenCalledWith(
-      expect.objectContaining({ mediaServerId: 'movie-1', type: 'movie' }),
-      { radarrSettingsId: 3 },
+      { mediaServerId: 'movie-1', type: 'movie', tmdbId: 4242, tvdbId: null },
+      undefined,
     );
-  });
-
-  it('setExclusion(global) does not tag when several radarr instances exist (ambiguous)', async () => {
-    const exclusionRepo = {
-      findOne: jest.fn().mockResolvedValue(undefined),
-      save: jest.fn().mockResolvedValue(undefined),
-      delete: jest.fn().mockResolvedValue(undefined),
-      count: jest.fn().mockResolvedValue(0),
-    };
-    const mediaServer = {
-      getMetadata: jest.fn().mockResolvedValue({ type: 'movie' }),
-      getAllIdsForContextAction: jest.fn().mockResolvedValue(['movie-1']),
-    };
-    const mediaServerFactory = {
-      getService: jest.fn().mockResolvedValue(mediaServer),
-    };
-    const radarrSettingsRepo = {
-      find: jest.fn().mockResolvedValue([{ id: 3 }, { id: 4 }]),
-    };
-    const servarrTagService = createMockServarrTagService();
-    servarrTagService.anyExclusionTaggingEnabled.mockReturnValue(true);
-
-    const { service } = createService({
-      exclusionRepo,
-      mediaServerFactory,
-      radarrSettingsRepo,
-      servarrTagService,
+    expect(collectionMediaRepository.findOne).toHaveBeenCalledWith({
+      where: { mediaServerId: 'movie-1' },
     });
-
-    await service.setExclusion({ mediaId: 'movie-1' } as any);
-
-    expect(servarrTagService.applyExclusionTag).not.toHaveBeenCalled();
   });
 
   it('removeExclusionWitData removes the tag for the top-level item (the media-modal remove path)', async () => {
@@ -400,16 +365,12 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
     const mediaServerFactory = {
       getService: jest.fn().mockResolvedValue(mediaServer),
     };
-    const radarrSettingsRepo = {
-      find: jest.fn().mockResolvedValue([{ id: 3 }]),
-    };
     const servarrTagService = createMockServarrTagService();
     servarrTagService.anyExclusionUntaggingEnabled.mockReturnValue(true);
 
     const { service } = createService({
       exclusionRepo,
       mediaServerFactory,
-      radarrSettingsRepo,
       servarrTagService,
     });
 
@@ -420,7 +381,7 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
 
     expect(servarrTagService.removeExclusionTag).toHaveBeenCalledWith(
       expect.objectContaining({ mediaServerId: 'movie-1', type: 'movie' }),
-      { radarrSettingsId: 3 },
+      undefined,
     );
   });
 
@@ -436,16 +397,12 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
     const mediaServerFactory = {
       getService: jest.fn().mockResolvedValue(mediaServer),
     };
-    const sonarrSettingsRepo = {
-      find: jest.fn().mockResolvedValue([{ id: 9 }]),
-    };
     const servarrTagService = createMockServarrTagService();
     servarrTagService.anyExclusionUntaggingEnabled.mockReturnValue(true);
 
     const { service } = createService({
       exclusionRepo,
       mediaServerFactory,
-      sonarrSettingsRepo,
       servarrTagService,
     });
 
@@ -453,7 +410,7 @@ describe('RulesService exclusions - global (null ruleGroupId) handling', () => {
 
     expect(servarrTagService.removeExclusionTag).toHaveBeenCalledWith(
       expect.objectContaining({ mediaServerId: 'show-1', type: 'show' }),
-      { sonarrSettingsId: 9 },
+      undefined,
     );
   });
 

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -906,53 +906,37 @@ export class RulesService {
 
   // The provider ids cached on a collection_media row, used as *arr tag
   // resolution fallbacks (Behavior B) so an item resolves even when its
-  // media-server metadata omits tmdb/tvdb. Returns nulls when not found.
+  // media-server metadata omits tmdb/tvdb. A global exclusion has no collection
+  // to read, so any row for the item serves - the ids describe the item itself.
+  // Returns nulls when not found.
   private async getCollectionMediaProviderIds(
-    collectionId: number,
     mediaServerId: string,
+    collectionId?: number,
   ): Promise<{ tmdbId?: number | null; tvdbId?: number | null }> {
     const row = await this.collectionMediaRepository.findOne({
-      where: { collectionId, mediaServerId },
+      where: { mediaServerId, ...(collectionId ? { collectionId } : {}) },
     });
     return { tmdbId: row?.tmdbId ?? null, tvdbId: row?.tvdbId ?? null };
-  }
-
-  // Behavior B: resolve the single configured *arr instance for a GLOBAL
-  // exclusion (no collection). Skipped (null) when none or several instances of
-  // the item's type exist, since the tag target would then be ambiguous.
-  private async resolveGlobalExclusionInstance(
-    type: MediaItemType | undefined,
-  ): Promise<{ radarrSettingsId?: number; sonarrSettingsId?: number } | null> {
-    if (type === 'movie') {
-      const all = await this.radarrSettingsRepo.find();
-      return all.length === 1 ? { radarrSettingsId: all[0].id } : null;
-    }
-    if (type === 'show') {
-      const all = await this.sonarrSettingsRepo.find();
-      return all.length === 1 ? { sonarrSettingsId: all[0].id } : null;
-    }
-    return null;
   }
 
   // Behavior B: apply or remove the protective *arr tag for one excluded
   // top-level item, shared by every exclusion entry/exit path (scoped + global,
   // POST + DELETE). The settings gate is checked by the caller. A scoped exclusion
   // takes its instance and (authoritative, non-null) type from the rule group's
-  // collection; a global one resolves the single configured instance. Removal is
-  // conservative and must run AFTER the rows are deleted: it leaves the tag in
-  // place if any exclusion for the item survives (another rule group or a global
-  // one), so a still-excluded item keeps its protection - last-exclusion-wins.
+  // collection; a global one has none, and is left for ServarrTagService to cover
+  // across every configured instance. Removal is conservative and must run AFTER
+  // the rows are deleted: it leaves the tag in place if any exclusion for the item
+  // survives (another rule group or a global one), so a still-excluded item keeps
+  // its protection - last-exclusion-wins.
   private async syncExclusionTag(
     mode: 'add' | 'remove',
     item: { mediaServerId: string; type: MediaItemType | undefined },
     collectionId: number | undefined,
   ): Promise<void> {
-    let instance: {
-      radarrSettingsId?: number | null;
-      sonarrSettingsId?: number | null;
-    } | null;
+    let instance:
+      | { radarrSettingsId?: number | null; sonarrSettingsId?: number | null }
+      | undefined;
     let type = item.type;
-    let hints: { tmdbId?: number | null; tvdbId?: number | null } = {};
 
     if (collectionId) {
       const collection =
@@ -967,15 +951,6 @@ export class RulesService {
       // collection.type is always set; prefer it over the exclusion row's nullable
       // type (old rows predate the type column) so the right service is chosen.
       type = collection.type ?? item.type;
-      hints = await this.getCollectionMediaProviderIds(
-        collectionId,
-        item.mediaServerId,
-      );
-    } else {
-      instance = await this.resolveGlobalExclusionInstance(item.type);
-      if (!instance) {
-        return;
-      }
     }
 
     if (mode === 'remove') {
@@ -987,6 +962,10 @@ export class RulesService {
       }
     }
 
+    const hints = await this.getCollectionMediaProviderIds(
+      item.mediaServerId,
+      collectionId,
+    );
     const target = { mediaServerId: item.mediaServerId, type, ...hints };
     if (mode === 'add') {
       await this.servarrTagService.applyExclusionTag(target, instance);
@@ -1688,9 +1667,8 @@ export class RulesService {
 
       // Behavior B (https://features.maintainerr.info/posts/81): opt-in removal of
       // the protective *arr tag once every exclusion for the item is cleared.
-      // Global instance resolution; the guard always passes (no rows remain).
-      // Known limitation: with multiple *arr instances the global resolver is
-      // ambiguous (skips), so a scoped-excluded item's tag may linger here.
+      // Instance-wide, so a scoped exclusion's tag is cleared too; the guard
+      // always passes (no rows remain).
       if (this.servarrTagService.anyExclusionUntaggingEnabled()) {
         await this.syncExclusionTag(
           'remove',


### PR DESCRIPTION
Reported on Discord: "Tag excluded content" is on, the exclusion lands in Maintainerr, but no tag ever appears in Radarr.

A global exclusion ("All collections") has no collection to inherit an instance from, so [#3162](https://github.com/Maintainerr/Maintainerr/pull/3162) resolved *the single configured instance* and returned `null` when the count was anything else, with no log line. Every multi-instance setup (a 4K plus HD split) got nothing, on both exclude and un-exclude, while the API still answered `code: 1`.

## What changed

| Area | Before | After |
| --- | --- | --- |
| Global exclusion | Tagged only with exactly one instance configured, otherwise skipped silently | Covers every configured instance, tagging wherever the item actually resolves |
| Collection exclusion | Its collection's instance | Unchanged |
| Un-exclude | Same single-instance limit, so tags were stranded | Cleared from every instance holding the item |
| Item resolution | Per instance | Resolved once, matched per instance |
| Tag creation | `ensureTag` before the match, on add and remove alike | Only on add, only after a match, so a non-holding instance never gets a stray label |
| Logs | Three silent skip paths | An INFO naming the instances written, or a DEBUG naming the instances checked |
| Provider-id hints | Collection-scoped only | Global too |

`resolveGlobalExclusionInstance` is gone. The *arr "not tracked" lookup line drops from `warn` to `debug`: it is a normal outcome under the [#3125](https://github.com/Maintainerr/Maintainerr/issues/3125) contract and a fan-out makes every non-holding instance emit one. The transient-failure `warn` is untouched.

No migration, no contract change, no UI change.

## Verification

Live against the dev stack (Jellyfin plus real Radarr and Sonarr, each paired with an empty stand-in instance that logs every request it receives):

| Case | Result |
| --- | --- |
| Movie global exclude / un-exclude, two Radarr | Tag applied and removed on the holding instance |
| Show global exclude / un-exclude, two Sonarr | Same on the series path |
| Empty instance, both directions | Received only `GET /movie?tmdbId=`; no tag read, create, or write |
| Item no instance tracks | `No radarr match for item X on <instances>; exclusion tag add skipped.` |
| Collection-scoped exclude, two Radarr | Still only its own instance |
| One instance unreachable | Transient skip, the reachable instance still tagged |
| Full UI path | Overview select, Add/Exclude, All collections; tag confirmed in Radarr's own Tags page, then removed |
