### PR TITLE
fix(collections): keep a shared collection when a crucial setting changes

### DIFF
--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -108,6 +108,7 @@ describe('CollectionsService', () => {
       itemExists: jest.fn().mockResolvedValue(true),
       removeFromCollection: jest.fn().mockResolvedValue(undefined),
       deleteCollection: jest.fn().mockResolvedValue(undefined),
+      cleanupCollectionForLibrary: jest.fn().mockResolvedValue(undefined),
       updateCollection: jest.fn().mockResolvedValue(undefined),
     } as unknown as Mocked<IMediaServerService>;
 
@@ -4447,6 +4448,60 @@ describe('CollectionsService', () => {
       } as any);
 
       expect(mediaServer.updateCollection).not.toHaveBeenCalled();
+    });
+
+    // A crucial setting change repurposes the collection, so its media server
+    // collection is released first. A sibling rule group pointing at the same
+    // one must keep it (#2766); otherwise the old library is cleaned up.
+    it('releases the old library when nothing else shares the collection', async () => {
+      const collection = createCollection({
+        id: 60,
+        libraryId: 'old-library',
+        mediaServerId: 'server-collection',
+        manualCollection: true,
+      });
+      collectionRepo.count.mockResolvedValue(0);
+
+      const released =
+        await service.releaseMediaServerCollectionForReset(collection);
+
+      expect(released).toBe(true);
+      expect(mediaServer.cleanupCollectionForLibrary).toHaveBeenCalledWith(
+        'server-collection',
+        'old-library',
+        true,
+      );
+    });
+
+    it('leaves a shared collection standing on a crucial setting change', async () => {
+      const collection = createCollection({
+        id: 61,
+        libraryId: 'old-library',
+        mediaServerId: 'shared-collection',
+      });
+      collectionRepo.count.mockResolvedValue(1);
+      collectionRepo.find.mockResolvedValue([
+        createCollection({ id: 89, mediaServerId: 'shared-collection' }),
+      ]);
+      ruleRemovalRepo.createQueryBuilder.mockReturnValue(
+        makeRuleRemovalQb([]) as any,
+      );
+      collectionMediaRepo.find.mockImplementation(async (options: any) =>
+        options?.where?.collectionId === 61
+          ? [createCollectionMedia(collection, { mediaServerId: 'item-1' })]
+          : [],
+      );
+      mediaServer.removeBatchFromCollection.mockResolvedValue([]);
+
+      const released =
+        await service.releaseMediaServerCollectionForReset(collection);
+
+      expect(released).toBe(true);
+      expect(mediaServer.cleanupCollectionForLibrary).not.toHaveBeenCalled();
+      expect(mediaServer.removeBatchFromCollection).toHaveBeenCalledWith(
+        'shared-collection',
+        ['item-1'],
+      );
     });
 
     it('stopMediaServerSync removes the media server collection and clears the link', async () => {

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -2211,9 +2211,21 @@ export class CollectionsService {
               dbCollection.manualCollectionName ||
             collection.libraryId !== dbCollection.libraryId
           ) {
-            if (!dbCollection.manualCollection) {
-              // Don't remove the collections if it was a manual one
-              await mediaServer.deleteCollection(dbCollection.mediaServerId);
+            // A manual collection is left alone entirely; one a sibling rule
+            // group shares is left standing with only this collection's items
+            // taken out (#2766). The link is dropped either way, so say when
+            // something was left behind.
+            if (
+              !(
+                await this.deleteMediaServerCollection(
+                  dbCollection,
+                  'resetting',
+                )
+              ).ok
+            ) {
+              this.logger.warn(
+                `Media server collection ${dbCollection.mediaServerId} for '${dbCollection.title}' may need to be removed manually`,
+              );
             }
             collection.mediaServerId = null;
           }
@@ -3981,6 +3993,39 @@ export class CollectionsService {
       this.logger.warn(
         `Could not take '${collection.title}' out of the media server collection it shares - keeping the link so the next run retries`,
       );
+      this.logger.debug(error);
+      return false;
+    }
+  }
+
+  /**
+   * Release this collection's media server collection before a crucial setting
+   * change repurposes it. A sibling rule group may point at the same collection,
+   * so that one is left standing with only this collection's items taken out;
+   * otherwise the old library's items are cleaned up, which drops a per-library
+   * collection outright. Must run before the local rows go, since those are how
+   * we know which items are ours. False means something was left behind.
+   */
+  public async releaseMediaServerCollectionForReset(
+    collection: Collection,
+  ): Promise<boolean> {
+    if (!collection.mediaServerId) {
+      return true;
+    }
+
+    if (await this.isMediaServerCollectionShared(collection)) {
+      return this.leaveSharedMediaServerCollection(collection);
+    }
+
+    try {
+      const mediaServer = await this.getMediaServer();
+      await mediaServer.cleanupCollectionForLibrary(
+        collection.mediaServerId,
+        collection.libraryId,
+        !!collection.manualCollection,
+      );
+      return true;
+    } catch (error) {
       this.logger.debug(error);
       return false;
     }

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -661,34 +661,28 @@ export class RulesService {
                 group.collectionId,
               )) ?? [];
           }
+          // Release the media server collection BEFORE the rows go: leaving a
+          // collection a sibling shares takes only this collection's items out,
+          // and the rows are how we know which ones are ours. dbCollection still
+          // carries the OLD library, which is what has to be cleaned up.
+          const released =
+            await this.collectionService.releaseMediaServerCollectionForReset(
+              dbCollection,
+            );
+
+          if (!released) {
+            // The link is dropped below either way, so a failure here leaves a
+            // collection behind that Maintainerr no longer tracks. Say so: it
+            // has to be removed by hand.
+            this.logger.warn(
+              `Failed to clean up media server collection ${dbCollection.mediaServerId} for '${dbCollection.title}' - it may need to be removed manually`,
+            );
+          }
+
           await this.collectionMediaRepository.delete({
             collectionId: group.collectionId,
           });
 
-          // Clean up the media server collection if it exists, then clear mediaServerId.
-          // For Jellyfin: removes only items from this library, keeps the collection
-          //   if other libraries still have items in it (shared manual collections).
-          // For Plex: collections are per-library, so the entire collection is deleted.
-          if (dbCollection.mediaServerId) {
-            const mediaServer = await this.getMediaServer();
-            try {
-              // Use the OLD library ID - we're cleaning up items that belonged
-              // to the previous library, not the one the rule is moving to.
-              await mediaServer.cleanupCollectionForLibrary(
-                dbCollection.mediaServerId,
-                dbCollection.libraryId,
-                !!dbCollection.manualCollection,
-              );
-            } catch (error) {
-              // The link is dropped below either way, so a failure here leaves
-              // a collection behind that Maintainerr no longer tracks. Say so:
-              // it has to be removed by hand.
-              this.logger.warn(
-                `Failed to clean up media server collection ${dbCollection.mediaServerId} for '${dbCollection.title}' - it may need to be removed manually`,
-              );
-              this.logger.debug(error);
-            }
-          }
           await this.collectionService.saveCollection({
             ...dbCollection,
             mediaServerId: null,

--- a/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
@@ -337,6 +337,7 @@ describe('RulesService.updateRules', () => {
     const collectionService = {
       getCollection: jest.fn().mockResolvedValue(dbCollection),
       saveCollection: jest.fn().mockResolvedValue(undefined),
+      releaseMediaServerCollectionForReset: jest.fn().mockResolvedValue(true),
       addLogRecord: jest.fn().mockResolvedValue(undefined),
       updateCollection: jest.fn().mockResolvedValue({
         dbCollection: { id: 42 },
@@ -386,11 +387,10 @@ describe('RulesService.updateRules', () => {
       notifications: [],
     } as any);
 
-    expect(mediaServer.cleanupCollectionForLibrary).toHaveBeenCalledWith(
-      'server-collection-id',
-      'old-library',
-      true,
-    );
+    // the old library and the manual flag travel on dbCollection
+    expect(
+      collectionService.releaseMediaServerCollectionForReset,
+    ).toHaveBeenCalledWith(dbCollection);
     expect(collectionMediaRepository.delete).toHaveBeenCalledWith({
       collectionId: group.collectionId,
     });
@@ -433,6 +433,7 @@ describe('RulesService.updateRules', () => {
     const collectionService = {
       getCollection: jest.fn().mockResolvedValue(dbCollection),
       saveCollection: jest.fn().mockResolvedValue(undefined),
+      releaseMediaServerCollectionForReset: jest.fn().mockResolvedValue(true),
       addLogRecord: jest.fn().mockResolvedValue(undefined),
       updateCollection: jest
         .fn()
@@ -499,6 +500,7 @@ describe('RulesService.updateRules', () => {
       const collectionService = {
         getCollection: jest.fn().mockResolvedValue({ id: 42 }),
         saveCollection: jest.fn().mockResolvedValue(undefined),
+        releaseMediaServerCollectionForReset: jest.fn().mockResolvedValue(true),
         addLogRecord: jest.fn().mockResolvedValue(undefined),
         updateCollection: jest
           .fn()
@@ -576,6 +578,7 @@ describe('RulesService.updateRules', () => {
     const collectionService = {
       getCollection: jest.fn().mockResolvedValue(dbCollection),
       saveCollection: jest.fn().mockResolvedValue(undefined),
+      releaseMediaServerCollectionForReset: jest.fn().mockResolvedValue(true),
       addLogRecord: jest.fn().mockResolvedValue(undefined),
       updateCollection: jest.fn().mockResolvedValue({
         dbCollection: freshCollection,
@@ -717,6 +720,7 @@ describe('RulesService.updateRules', () => {
     const collectionService = {
       getCollection: jest.fn().mockResolvedValue(dbCollection),
       saveCollection: jest.fn().mockResolvedValue(undefined),
+      releaseMediaServerCollectionForReset: jest.fn().mockResolvedValue(true),
       addLogRecord: jest.fn().mockResolvedValue(undefined),
       updateCollection: jest
         .fn()
@@ -800,6 +804,7 @@ describe('RulesService.updateRules', () => {
     const collectionService = {
       getCollection: jest.fn().mockResolvedValue(dbCollection),
       saveCollection: jest.fn().mockResolvedValue(undefined),
+      releaseMediaServerCollectionForReset: jest.fn().mockResolvedValue(true),
       addLogRecord: jest.fn().mockResolvedValue(undefined),
       updateCollection: jest
         .fn()
@@ -945,6 +950,7 @@ describe('RulesService.updateRules', () => {
       const collectionService = {
         getCollection: jest.fn().mockResolvedValue(dbCollection),
         saveCollection: jest.fn().mockResolvedValue(undefined),
+        releaseMediaServerCollectionForReset: jest.fn().mockResolvedValue(true),
         addLogRecord: jest.fn().mockResolvedValue(undefined),
         updateCollection: jest
           .fn()


### PR DESCRIPTION
Changing a rule group's media type, library or custom-collection setting no longer wipes out the collection on your media server when a second rule group with the same name is also using it.

Maintainerr links a collection by title, so two rule groups sharing a name end up on one collection on the server. Changing any of those settings tears that collection down, and both teardown paths treated it as belonging to the rule group being changed.

| path | before | after |
| --- | --- | --- |
| `updateCollection` | deleted the collection outright | leaves it standing, and only the changing group's items come out |
| `updateRules` | cleaned up the old library, which strips the other group's items (Plex: deletes the collection) | same when nothing else uses it, otherwise only the changing group's items come out |
| custom collection | never deleted | unchanged |

`updateRules` now releases the collection before deleting its member rows rather than after, because those rows are how we know which items belong to this group, and it no longer reaches for the media server itself.

### Scope

Pre-existing, dating to ec002892 (Dec 2025); the same shape #2766 and #3344 fixed elsewhere. Split out of #3579 rather than folded in, since it is on a path that feature never takes. It reuses the shared-teardown helper that landed with #3579.

### Verified

Real Jellyfin, Plex and Emby: two same-named groups matching different films, then a media-type change on one. Before, the collection was deleted and the other group left pointing at a dead id; after, it survives holding exactly that group's films. Custom collections and the single-owner path checked for parity against the pre-change build.
