### PR TITLE
feat(collections): surface deletionDate in overlay-data media

### DIFF
--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -3116,11 +3116,27 @@ describe('CollectionsService', () => {
   });
 
   it('returns full collection media for the explicit overlay data endpoint', async () => {
-    const firstCollection = createCollection({ id: 1, title: 'First' });
-    const secondCollection = createCollection({ id: 2, title: 'Second' });
+    const firstCollection = createCollection({
+      id: 1,
+      title: 'First',
+      deleteAfterDays: 30,
+    });
+    const secondCollection = createCollection({
+      id: 2,
+      title: 'Second',
+      deleteAfterDays: null,
+    });
+    const firstAddDate = new Date(2026, 7, 1); // Aug 1
+    const secondAddDate = new Date(2026, 7, 2); // Aug 2
     const firstCollectionMedia = [
-      createCollectionMedia(firstCollection, { mediaServerId: 'item-1' }),
-      createCollectionMedia(firstCollection, { mediaServerId: 'item-2' }),
+      createCollectionMedia(firstCollection, {
+        mediaServerId: 'item-1',
+        addDate: firstAddDate,
+      }),
+      createCollectionMedia(firstCollection, {
+        mediaServerId: 'item-2',
+        addDate: secondAddDate,
+      }),
     ];
     const secondCollectionMedia = [
       createCollectionMedia(secondCollection, { mediaServerId: 'item-3' }),
@@ -3151,12 +3167,28 @@ describe('CollectionsService', () => {
     expect(result).toEqual([
       expect.objectContaining({
         id: firstCollection.id,
-        media: firstCollectionMedia,
+        media: [
+          expect.objectContaining({
+            mediaServerId: 'item-1',
+            // addDate + deleteAfterDays (30 days), matching the overlay processor.
+            deletionDate: new Date(2026, 7, 31),
+          }),
+          expect.objectContaining({
+            mediaServerId: 'item-2',
+            deletionDate: new Date(2026, 8, 1),
+          }),
+        ],
         mediaCount: firstCollectionMedia.length,
       }),
       expect.objectContaining({
         id: secondCollection.id,
-        media: secondCollectionMedia,
+        media: [
+          expect.objectContaining({
+            mediaServerId: 'item-3',
+            // No deletion window -> no deletion date.
+            deletionDate: null,
+          }),
+        ],
         mediaCount: secondCollectionMedia.length,
       }),
     ]);

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -1942,7 +1942,16 @@ export class CollectionsService {
 
         return {
           ...collection,
-          media,
+          // Surface the per-member deletion date (addDate + deleteAfterDays) so
+          // helper integrations can render "leaving soon" without re-deriving
+          // the arithmetic, matching the overlay processor's own countdown.
+          media: media.map((member) => ({
+            ...member,
+            deletionDate: getCollectionDeleteDate(
+              member.addDate,
+              collection.deleteAfterDays,
+            ),
+          })),
           mediaCount: media.length,
         };
       });


### PR DESCRIPTION
## Summary

Extends the existing `GET /api/collections/overlay-data` response with each member's `deletionDate`, derived as `addDate + deleteAfterDays` via the shared `getCollectionDeleteDate` helper.

The [jellyfin-plugin-leaving-soon](https://github.com/ramonskie/jellyfin-plugin-leaving-soon) polls this endpoint (per the direction in #3521 — use `/overlay-data` rather than a new endpoint). It currently has to re-derive the deletion date from `addDate` + `deleteAfterDays`; surfacing it server-side keeps the helper integration in sync with the exact arithmetic the overlay processor already uses internally, so a "leaving soon" countdown and the overlay countdown can never drift.

## What changed

- `collections.service.ts`: `getCollectionsForOverlayData` now maps each member to `{ ...member, deletionDate }` using `getCollectionDeleteDate(member.addDate, collection.deleteAfterDays)` — the same helper the overlay processor uses (overlay-processor.service.ts:137). A member of a collection with no deletion window gets `deletionDate: null`.
- `collections.service.spec.ts`: the overlay-data spec now pins `addDate`/`deleteAfterDays` and asserts the derived `deletionDate` (and `null` without a window).

## Notes

- Pure additive: existing consumers of `/overlay-data` (media array with `mediaServerId`, `addDate`, `tmdbId`, ...) are unchanged, each member just gains `deletionDate`.
- No new endpoint, no new setting, no feature flag — per the review direction in #3521.
