### PR TITLE
chore(ci): run every workflow on Node 26

### DIFF
--- a/.github/workflows/api_spec_drift.yml
+++ b/.github/workflows/api_spec_drift.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 26
 
       - name: Activate corepack
         run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 26
 
       - name: Activate corepack
         run: |

--- a/.github/workflows/docs_drift.yml
+++ b/.github/workflows/docs_drift.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 26
 
       - name: Resolve base ref
         id: base

--- a/.github/workflows/fider-invite-codeowners.yml
+++ b/.github/workflows/fider-invite-codeowners.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 26
 
       - name: Invite CODEOWNERS to Fider
         env:

--- a/.github/workflows/fider-move-enhancements.yml
+++ b/.github/workflows/fider-move-enhancements.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 26
 
       - name: Move enhancement issues to Fider
         env:

--- a/.github/workflows/fider-pre-existing-scan.yml
+++ b/.github/workflows/fider-pre-existing-scan.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 26
 
       - name: Run Fider triage (pre-existing scan)
         env:

--- a/.github/workflows/fider-re-evaluate.yml
+++ b/.github/workflows/fider-re-evaluate.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 26
 
       - name: Run Fider triage (force re-eval)
         env:

--- a/.github/workflows/fider-stale.yml
+++ b/.github/workflows/fider-stale.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 26
 
       - name: Run Fider stale sweep
         env:

--- a/.github/workflows/fider-triage.yml
+++ b/.github/workflows/fider-triage.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 26
 
       - name: Run Fider triage
         env:

--- a/.github/workflows/media_server_labels.yml
+++ b/.github/workflows/media_server_labels.yml
@@ -85,7 +85,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 26
 
       - name: Apply media server labels
         env:

--- a/.github/workflows/release_5_publish.yml
+++ b/.github/workflows/release_5_publish.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 26
       - name: Activate corepack
         run: |
           corepack install

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 26
 
       - name: Activate corepack
         run: |

--- a/.github/workflows/weblate_catalog.yml
+++ b/.github/workflows/weblate_catalog.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 26
       - name: Activate corepack
         run: |
           corepack install

--- a/.github/workflows/weblate_review.yml
+++ b/.github/workflows/weblate_review.yml
@@ -100,7 +100,7 @@ jobs:
         if: ${{ github.event.pull_request.user.login == 'hosted-weblate[bot]' }}
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 26
 
       - name: Label the pull request
         uses: actions/github-script@v9

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ GitHub quality workflows include a separate YAML lint job:
 yamllint -s .
 ```
 
-The formatting, TypeScript lint, and test workflows use Node.js 24, then run:
+The formatting, TypeScript lint, and test workflows use Node.js 26, then run:
 
 ```bash
 corepack install
@@ -402,7 +402,7 @@ degrade gracefully.
 
 ### Environment Setup
 
-- **Node.js**: 22.22.2+, 24.15.0+, or 26+ (root `package.json` `engines` is the source of truth; Docker and the devcontainer ship Node 26)
+- **Node.js**: 26+ (root `package.json` `engines` is the source of truth; Docker, the devcontainer and every workflow ship Node 26)
 - **Package Manager**: Yarn 4.11 (managed via corepack)
 - **Data Directory**: Requires `data/` folder with proper permissions for development
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -225,7 +225,7 @@ Closest quality gates should run in this order where applicable: lint,
 typecheck, tests, then build. For doc-only changes, a targeted Prettier check is
 usually enough.
 
-GitHub CI mirrors the root workspace workflow on Node.js 24: the formatting
+GitHub CI mirrors the root workspace workflow on Node.js 26: the formatting
 and TypeScript lint jobs run `corepack install`, `corepack enable`, and
 `yarn --immutable`, while the quality workflow also includes a separate
 `yaml-lint` job running `yamllint -s .`; the test workflow builds `packages/*`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ If you prefer to set up your development environment manually (specific to a Win
 
 - HTML/TypeScript/JavaScript editor
 - [VSCode](https://code.visualstudio.com/) is recommended. Upon opening the project, a few extensions will be automatically recommended for install.
-- [NodeJS](https://nodejs.org/en/download/) (Node 22.22.2+, 24.15.0+, or 26+)
+- [NodeJS](https://nodejs.org/en/download/) (Node 26+)
 - [Git](https://git-scm.com/downloads)
 
 #### Getting Started


### PR DESCRIPTION
Closes #3591.

The image ships Node 26 (`Dockerfile:1`) and `engines` requires `>=26.0.0`, but fourteen workflows still installed 22 or 24. Parts of CI were running on a runtime we do not ship, `run_tests.yml` among them. Three docs still described the old range as well.

### Workflows, 14 files

| Was on 24 | Was on 22 |
| --- | --- |
| `api_spec_drift.yml` | `docs_drift.yml` |
| `copilot-setup-steps.yml` | `fider-invite-codeowners.yml` |
| `media_server_labels.yml` | `fider-move-enhancements.yml` |
| `release_5_publish.yml` | `fider-pre-existing-scan.yml` |
| `run_tests.yml` | `fider-re-evaluate.yml` |
| `weblate_catalog.yml` | `fider-stale.yml` |
| `weblate_review.yml` | `fider-triage.yml` |

### Docs, 3 files

| File | Was |
| --- | --- |
| `AGENTS.md` | "workflows use Node.js 24", and an engines range of "22.22.2+, 24.15.0+, or 26+" |
| `ARCHITECTURE.md` | "CI mirrors the root workspace workflow on Node.js 24" |
| `CONTRIBUTING.md` | "Node 22.22.2+, 24.15.0+, or 26+" |

### Checked

Every `node-version` in `.github/workflows` now reads 26 (17 of them), all 27 workflow files parse, `engines` is `>=26.0.0`, both Dockerfiles and the devcontainer are 26, and `@types/node` is `^26` in all three manifests. A repo-wide grep finds no remaining reference to Node 18/20/22/24 outside `yarn.lock`, where the hits are unrelated package versions such as `@octokit/openapi-types@^24.2.0`.

Worth knowing: Node 26 is Current, not LTS until October 2026. That was already true of the shipped image, so this aligns CI with production rather than moving anything onto a newer runtime.
