### PR TITLE
fix(ui): one shared close on every modal, always on screen

### DIFF
--- a/apps/ui/src/components/Collection/CollectionDetail/CollectionInfo/CollectionLogsTable.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/CollectionInfo/CollectionLogsTable.tsx
@@ -28,7 +28,6 @@ interface CollectionLogsTableProps {
           meta:
             | CollectionLogMetaMediaAddedByRule
             | CollectionLogMetaMediaRemovedByRule
-          title: string
         }
       | undefined,
   ) => void
@@ -138,10 +137,7 @@ const CollectionLogsTable = ({
                           onClick={() => {
                             if (!isMetaActionedByRule(row.meta)) return
 
-                            onShowMeta({
-                              meta: row.meta,
-                              title: row.message,
-                            })
+                            onShowMeta({ meta: row.meta })
                           }}
                         >
                           <DocumentTextIcon className="h-5 w-5" />

--- a/apps/ui/src/components/Collection/CollectionDetail/CollectionInfo/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/CollectionInfo/index.tsx
@@ -11,14 +11,13 @@ import {
   CollectionLogMetaMediaRemovedByRule,
   ECollectionLogType,
 } from '@maintainerr/contracts'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import YAML from 'yaml'
 import { ICollection } from '../..'
 import { collectionLogTypeLabels } from './collectionLogLabels'
 import CollectionLogsTable from './CollectionLogsTable'
 import useDebouncedState from '../../../..//hooks/useDebouncedState'
 import Alert from '../../../Common/Alert'
-import Button from '../../../Common/Button'
 import LazyMonacoEditor from '../../../Common/LazyMonacoEditor'
 import Modal from '../../../Common/Modal'
 import { FieldJoin, Input, InputAdornment } from '../../../Forms/Input'
@@ -36,8 +35,7 @@ const CollectionInfo = (props: ICollectionInfo) => {
   const [currentFilter, setCurrentFilter] = useState<ECollectionLogType | -1>(
     -1,
   )
-  const [showMeta, setShowMeta] =
-    useState<Pick<LogMetaModalProps, 'meta' | 'title'>>()
+  const [showMeta, setShowMeta] = useState<Pick<LogMetaModalProps, 'meta'>>()
 
   return (
     <>
@@ -252,30 +250,15 @@ export default CollectionInfo
 
 interface LogMetaModalProps {
   onClose: () => void
-  title: string
   meta: CollectionLogMetaMediaAddedByRule | CollectionLogMetaMediaRemovedByRule
 }
 
 const LogMetaModal = (props: LogMetaModalProps) => {
   const { t } = useLingui()
-  const editorRef = useRef(undefined)
-
-  function handleEditorDidMount(editor: any) {
-    editorRef.current = editor
-  }
 
   return (
     <div className={'h-full w-full'}>
-      <Modal
-        loading={false}
-        backgroundClickable={false}
-        title={t`Metadata`}
-        footerActions={
-          <Button buttonType="primary" className="ml-3" onClick={props.onClose}>
-            <Trans>Close</Trans>
-          </Button>
-        }
-      >
+      <Modal title={t`Metadata`} onCancel={props.onClose} cancelText={t`Close`}>
         <div className="h-[80vh] overflow-hidden">
           <div className="mt-1">
             <Alert type="info">
@@ -302,7 +285,6 @@ const LogMetaModal = (props: LogMetaModalProps) => {
               defaultLanguage="yaml"
               theme="vs-dark"
               value={YAML.stringify(props.meta.data)}
-              onMount={handleEditorDidMount}
             />
           </div>
         </div>

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
@@ -6,10 +6,10 @@ import {
   type MediaItemType,
   type MediaProviderIds,
 } from '@maintainerr/contracts'
-import { XIcon } from '@heroicons/react/solid'
 import { Trans, useLingui } from '@lingui/react/macro'
 import React, { memo, useEffect, useMemo, useState } from 'react'
 import { useMetadataOverview } from '../../../../api/metadata'
+import useCloseOnEscape from '../../../../hooks/useCloseOnEscape'
 import { useLockBodyScroll } from '../../../../hooks/useLockBodyScroll'
 import { useMediaServerType } from '../../../../hooks/useMediaServerType'
 import GetApiHandler from '../../../../utils/ApiHandler'
@@ -19,7 +19,7 @@ import {
   buildProviderUrl,
   mediaTypeLabel,
 } from '../../../../utils/mediaTypeUtils'
-import { modalCloseButtonClassName } from '../../Modal'
+import Button from '../../Button'
 import LoadingSpinner from '../../LoadingSpinner'
 import StreamystatsStatsPanel from './StreamystatsStatsPanel'
 import {
@@ -194,6 +194,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
     const { t } = useLingui()
 
     useLockBodyScroll(true)
+    useCloseOnEscape(true, onClose)
 
     const { isPlex, isJellyfin, isEmby } = useMediaServerType()
     const [loading, setLoading] = useState<boolean>(true)
@@ -570,30 +571,20 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
       <div
         className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-3"
         onClick={onClose}
-        // The close button is a phone affordance and a pointer closes this from
-        // the backdrop, so Escape is what a keyboard is left with - same handler
-        // the shared Modal carries.
-        onKeyDown={(event) => {
-          if (event.key === 'Escape') {
-            onClose()
-          }
-        }}
       >
+        {/* A column, like the shared Modal: only the body scrolls, so the
+            actions and the close stay on screen on a phone, where the sheet
+            fills the height. */}
         <div
-          className="relative max-h-[90vh] w-full max-w-4xl overflow-auto rounded-xl bg-zinc-800 shadow-lg"
+          className="relative flex max-h-[90vh] w-full max-w-4xl flex-col overflow-hidden rounded-xl bg-zinc-800 shadow-lg"
           onClick={(event) => event.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
+          aria-label={title}
         >
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label={t`Close`}
-            className={`${modalCloseButtonClassName} sm:hidden`}
-          >
-            <XIcon className="h-5 w-5" />
-          </button>
           {/* Short on a small phone: at h-72 the backdrop took two thirds of
               the sheet and pushed the title and summary below the fold. */}
-          <div className="relative h-40 w-full overflow-hidden p-2 sm:h-72 xl:h-96">
+          <div className="relative h-40 w-full shrink-0 overflow-hidden p-2 sm:h-72 xl:h-96">
             <div
               className="h-full w-full rounded-xl bg-cover bg-center bg-no-repeat"
               style={{
@@ -662,11 +653,6 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
                   </div>
                 ) : undefined}
               </div>
-              {/* The close button only exists on a phone, and takes this
-                  corner: the first row keeps its height as a spacer so the
-                  logos below stay clear of it, and drops its own logo - that id
-                  is a link in the body. Padding the column instead left a blank
-                  channel beside every logo. */}
               <div className="flex flex-col items-end">
                 <div className="max-w-fit grow">
                   <div className="flex h-8 w-32 justify-end">
@@ -675,7 +661,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
                         href={providerLogo.href}
                         target="_blank"
                         rel="noreferrer"
-                        className="hidden h-full w-full sm:block"
+                        className="block h-full w-full"
                       >
                         <img
                           src={providerLogo.logo}
@@ -795,7 +781,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
               </div>
             </div>
           </div>
-          <div className="p-4">
+          <div className="flex-1 overflow-y-auto p-4">
             <div className="flex items-center justify-between border-b border-zinc-700 pb-4">
               <div>
                 <h2 className="text-xl font-semibold text-gray-100">
@@ -887,52 +873,54 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
                 ) : null}
               </div>
             ) : undefined}
-
-            {/* Wraps: side by side these actions are wider than a phone, and
-                the sheet scrolled sideways to reach the last one. */}
-            <div className="mt-6 mr-0.5 flex flex-row flex-wrap items-center justify-between gap-4">
-              {providerIds &&
-                ['movie', 'show'].includes(mediaType) &&
-                (providerIds.tmdb?.length ||
-                  providerIds.imdb?.length ||
-                  providerIds.tvdb?.length) && (
-                  <div className="flex flex-wrap items-center gap-1 text-xs text-zinc-400">
-                    {(['tmdb', 'imdb', 'tvdb'] as const).flatMap((provider) =>
-                      (providerIds[provider] ?? []).map((id) => (
-                        <ProviderIdBadge
-                          key={`${provider}-${id}`}
-                          provider={provider}
-                          providerId={id}
-                          mediaType={mediaType}
-                        />
-                      )),
-                    )}
-                    {showBackdropProviderBadge && backdropProviderKey && (
+          </div>
+          {/* Wraps: side by side these actions are wider than a phone, and
+              the sheet scrolled sideways to reach the last one. */}
+          <div className="flex shrink-0 flex-row flex-wrap items-center justify-between gap-4 border-t border-zinc-700 p-4">
+            {providerIds &&
+              ['movie', 'show'].includes(mediaType) &&
+              (providerIds.tmdb?.length ||
+                providerIds.imdb?.length ||
+                providerIds.tvdb?.length) && (
+                <div className="flex flex-wrap items-center gap-1 text-xs text-zinc-400">
+                  {(['tmdb', 'imdb', 'tvdb'] as const).flatMap((provider) =>
+                    (providerIds[provider] ?? []).map((id) => (
                       <ProviderIdBadge
-                        key={`${backdropProviderKey}-${backdropResult.providerId}`}
-                        provider={backdropProviderKey}
-                        providerId={String(backdropResult.providerId)}
+                        key={`${provider}-${id}`}
+                        provider={provider}
+                        providerId={id}
                         mediaType={mediaType}
                       />
-                    )}
-                  </div>
-                )}
-              <div className="ml-auto flex flex-wrap justify-end gap-3">
-                {canPostpone ? (
-                  <PostponeButton
-                    collection={collection}
-                    mediaServerId={id}
-                    onPostponed={onCollectionItemPostponed}
-                  />
-                ) : null}
-                {canTriggerRuleAction ? (
-                  <TriggerRuleButton
-                    collection={collection}
-                    mediaServerId={id}
-                    onHandled={onCollectionItemRemoved}
-                  />
-                ) : null}
-              </div>
+                    )),
+                  )}
+                  {showBackdropProviderBadge && backdropProviderKey && (
+                    <ProviderIdBadge
+                      key={`${backdropProviderKey}-${backdropResult.providerId}`}
+                      provider={backdropProviderKey}
+                      providerId={String(backdropResult.providerId)}
+                      mediaType={mediaType}
+                    />
+                  )}
+                </div>
+              )}
+            <div className="ml-auto flex flex-wrap justify-end gap-3">
+              {canPostpone ? (
+                <PostponeButton
+                  collection={collection}
+                  mediaServerId={id}
+                  onPostponed={onCollectionItemPostponed}
+                />
+              ) : null}
+              {canTriggerRuleAction ? (
+                <TriggerRuleButton
+                  collection={collection}
+                  mediaServerId={id}
+                  onHandled={onCollectionItemRemoved}
+                />
+              ) : null}
+              <Button buttonType="default" onClick={onClose} type="button">
+                <Trans>Close</Trans>
+              </Button>
             </div>
           </div>
         </div>

--- a/apps/ui/src/components/Common/Modal/index.spec.tsx
+++ b/apps/ui/src/components/Common/Modal/index.spec.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '../../../test-utils/render'
+import Modal from '.'
+
+describe('Modal', () => {
+  it('closes with the shared footer button and nothing else', () => {
+    const onCancel = vi.fn()
+
+    render(
+      <Modal title="Warning" onCancel={onCancel}>
+        <p>body</p>
+      </Modal>,
+    )
+
+    // One close control, in the footer - the top-right X is gone.
+    const closes = screen.getAllByRole('button', { name: 'Cancel' })
+    expect(closes).toHaveLength(1)
+
+    fireEvent.click(closes[0])
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the close reachable while loading, and holds back the actions', () => {
+    const onCancel = vi.fn()
+
+    render(
+      <Modal
+        title="Notification Agents"
+        onCancel={onCancel}
+        loading
+        footerActions={<button type="button">OK</button>}
+      >
+        <p>body</p>
+      </Modal>,
+    )
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'OK' })).toBe(null)
+  })
+
+  it('closes on Escape, unless the modal opted out of casual dismissal', () => {
+    const dismissable = vi.fn()
+    const { unmount } = render(
+      <Modal title="Warning" onCancel={dismissable}>
+        <p>body</p>
+      </Modal>,
+    )
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(dismissable).toHaveBeenCalledTimes(1)
+    unmount()
+
+    const guarded = vi.fn()
+    render(
+      <Modal title="Test Media" onCancel={guarded} backgroundClickable={false}>
+        <p>body</p>
+      </Modal>,
+    )
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(guarded).not.toHaveBeenCalled()
+  })
+
+  it('gives nested modals their own heading id and closes only the top one', () => {
+    const outer = vi.fn()
+    const inner = vi.fn()
+
+    render(
+      <Modal title="Add / Remove Media" onCancel={outer}>
+        <Modal title="Confirm Global Exclusion" onCancel={inner}>
+          <p>body</p>
+        </Modal>
+      </Modal>,
+    )
+
+    const [outerLabel, innerLabel] = screen
+      .getAllByRole('dialog')
+      .map((dialog) => dialog.getAttribute('aria-labelledby'))
+    expect(outerLabel).not.toBe(innerLabel)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(inner).toHaveBeenCalledTimes(1)
+    expect(outer).not.toHaveBeenCalled()
+  })
+})

--- a/apps/ui/src/components/Common/Modal/index.tsx
+++ b/apps/ui/src/components/Common/Modal/index.tsx
@@ -1,20 +1,12 @@
 import { Transition } from '@headlessui/react'
-import { XIcon } from '@heroicons/react/solid'
-import { Trans, useLingui } from '@lingui/react/macro'
-import React, { MouseEvent, ReactNode, useRef } from 'react'
+import { Trans } from '@lingui/react/macro'
+import React, { MouseEvent, ReactNode, useId, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import useClickOutside from '../../../hooks/useClickOutside'
+import useCloseOnEscape from '../../../hooks/useCloseOnEscape'
 import { useLockBodyScroll } from '../../../hooks/useLockBodyScroll'
 import Button, { ButtonType } from '../Button'
 import LoadingSpinner from '../LoadingSpinner'
-
-/**
- * Shared with the media backdrop modal, which builds its own overlay, so both
- * look and sit the same. Add `sm:hidden` where a footer Cancel already covers
- * the wider screens.
- */
-export const modalCloseButtonClassName =
-  'absolute top-3 right-3 z-20 cursor-pointer rounded-full border border-zinc-600 bg-zinc-800/90 p-2 text-zinc-300 shadow-md transition hover:text-white focus:text-white focus:outline-hidden'
 
 interface ModalProps {
   title?: string
@@ -25,14 +17,12 @@ interface ModalProps {
   backgroundClickable?: boolean
   iconSvg?: ReactNode
   loading?: boolean
-  backdrop?: string
   children: React.ReactNode
   footerActions?: ReactNode
   size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl'
 }
 
 const maxWidthMap = {
-  xs: 'sm:max-w-xs',
   sm: 'sm:max-w-sm',
   md: 'sm:max-w-md',
   lg: 'sm:max-w-lg',
@@ -41,8 +31,6 @@ const maxWidthMap = {
   '3xl': 'sm:max-w-3xl',
   '4xl': 'sm:max-w-4xl',
   '5xl': 'sm:max-w-5xl',
-  '6xl': 'sm:max-w-6xl',
-  '7xl': 'sm:max-w-7xl',
 }
 
 const Modal: React.FC<ModalProps> = ({
@@ -58,93 +46,66 @@ const Modal: React.FC<ModalProps> = ({
   footerActions,
   size = '3xl',
 }) => {
-  const { t } = useLingui()
+  const headlineId = useId()
   const modalRef = useRef<HTMLDivElement>(null)
+  const dismissable = typeof onCancel === 'function' && backgroundClickable
   useClickOutside(modalRef, () => {
-    if (typeof onCancel === 'function' && backgroundClickable) {
+    if (dismissable) {
       onCancel()
     }
   })
+  useCloseOnEscape(dismissable, () => onCancel?.())
   useLockBodyScroll(true, disableScrollLock)
 
   return createPortal(
-    <div
-      className="fixed top-0 right-0 bottom-0 left-0 z-50 flex h-full w-full items-center justify-center bg-zinc-800/70"
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          if (typeof onCancel === 'function' && backgroundClickable) {
-            onCancel()
-          }
-        }
-      }}
-    >
-      <Transition
-        as="div"
-        className="absolute"
-        enter="transition opacity-0 duration-1000 transform scale-75"
-        enterFrom="opacity-0 scale-75"
-        enterTo="opacity-100 scale-100"
-        leave="transition opacity-100 duration-300"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-        show={loading}
-      >
-        <LoadingSpinner />
-      </Transition>
+    <div className="fixed top-0 right-0 bottom-0 left-0 z-50 flex h-full w-full items-center justify-center bg-zinc-800/70">
+      {/* A column, so the body is the only part that scrolls and the footer -
+          which carries the close - stays on screen however tall the content
+          gets. */}
       <Transition
         appear
         as="div"
-        className={`relative inline-block w-full transform overflow-auto bg-zinc-700 px-4 pt-5 pb-4 text-left align-bottom shadow-xl ring-1 ring-zinc-700 transition duration-300 sm:my-8 ${maxWidthMap[size]} sm:rounded-lg sm:align-middle`}
+        className={`relative flex max-h-full w-full transform flex-col overflow-hidden bg-zinc-700 text-left shadow-xl ring-1 ring-zinc-700 transition duration-300 sm:max-h-[calc(100%-4rem)] ${maxWidthMap[size]} sm:rounded-lg`}
         enterFrom="scale-75 opacity-0"
         enterTo="scale-100 opacity-100"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-        show={!loading}
+        show
         role="dialog"
         aria-modal="true"
-        aria-labelledby="modal-headline"
-        style={{
-          maxHeight: 'calc(100% - env(safe-area-inset-top) * 2)',
-        }}
+        aria-labelledby={title ? headlineId : undefined}
         ref={modalRef}
       >
-        {typeof onCancel === 'function' && (
-          <button
-            type="button"
-            onClick={onCancel}
-            aria-label={t`Close`}
-            className={`${modalCloseButtonClassName} sm:hidden`}
-          >
-            <XIcon className="h-5 w-5" />
-          </button>
-        )}
-        {/* Padded both sides below `sm`, so the close button takes its room
-            without pushing the centred title off centre. */}
-        <div className="relative overflow-x-hidden px-8 sm:flex sm:items-center sm:px-0">
-          {iconSvg && <div className="modal-icon">{iconSvg}</div>}
-          <div
-            className={`mt-3 truncate text-center text-white sm:mt-0 sm:text-left ${
-              iconSvg ? 'sm:ml-4' : 'sm:mb-4'
-            }`}
-          >
-            {title && (
-              <span
-                className="truncate text-lg leading-6 font-bold"
-                id="modal-headline"
-              >
-                {title}
-              </span>
-            )}
-          </div>
-        </div>
-        {children && (
-          <div className="relative mt-4 text-sm leading-5 text-zinc-300">
-            {children}
+        {(title || iconSvg) && (
+          <div className="shrink-0 px-4 pt-5 sm:flex sm:items-center">
+            {iconSvg && <div className="modal-icon">{iconSvg}</div>}
+            <div
+              className={`mt-3 truncate text-center text-white sm:mt-0 sm:text-left ${
+                iconSvg ? 'sm:ml-4' : ''
+              }`}
+            >
+              {title && (
+                <span
+                  className="truncate text-lg leading-6 font-bold"
+                  id={headlineId}
+                >
+                  {title}
+                </span>
+              )}
+            </div>
           </div>
         )}
+        {/* Loading keeps the shell rather than replacing it with a bare
+            spinner: the close has to stay reachable for a fetch that never
+            comes back, and the actions have nothing to act on yet. */}
+        {(loading || children) && (
+          <div className="flex-1 overflow-y-auto px-4 py-4 text-sm leading-5 text-zinc-300">
+            {loading ? <LoadingSpinner /> : children}
+          </div>
+        )}
+        {/* Wraps: a footer with a save and a test beside the close is wider
+            than a phone, and the panel no longer scrolls sideways to it. */}
         {(onCancel || footerActions) && (
-          <div className="relative mt-5 flex flex-row-reverse justify-center sm:mt-4 sm:justify-start">
-            {footerActions}
+          <div className="flex shrink-0 flex-row-reverse flex-wrap justify-center gap-y-2 border-t border-zinc-600 p-4 sm:justify-start">
+            {loading ? undefined : footerActions}
             {typeof onCancel === 'function' && (
               <Button
                 buttonType={cancelButtonType}

--- a/apps/ui/src/components/Settings/About/Releases/index.tsx
+++ b/apps/ui/src/components/Settings/About/Releases/index.tsx
@@ -63,26 +63,24 @@ const Release = ({ currentVersion, release, isLatest }: ReleaseProps) => {
   return (
     <div className="flex w-full flex-col space-y-3 rounded-md bg-zinc-700 px-4 py-2 shadow-md ring-1 ring-gray-700 sm:flex-row sm:space-y-0 sm:space-x-3">
       {isModalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <Modal
-            onCancel={() => setIsModalOpen(false)}
-            title={translate`${{ version: release.name }} Changelog`}
-            cancelText={translate`Close`}
-            footerActions={
-              <Button
-                buttonType="primary"
-                className="ml-3"
-                onClick={() => window.open(release.html_url, '_blank')}
-              >
-                <Trans>View on GitHub</Trans>
-              </Button>
-            }
-          >
-            <div className="prose:sm prose">
-              <ReactMarkdown>{release.body}</ReactMarkdown>
-            </div>
-          </Modal>
-        </div>
+        <Modal
+          onCancel={() => setIsModalOpen(false)}
+          title={translate`${{ version: release.name }} Changelog`}
+          cancelText={translate`Close`}
+          footerActions={
+            <Button
+              buttonType="primary"
+              className="ml-3"
+              onClick={() => window.open(release.html_url, '_blank')}
+            >
+              <Trans>View on GitHub</Trans>
+            </Button>
+          }
+        >
+          <div className="prose:sm prose">
+            <ReactMarkdown>{release.body}</ReactMarkdown>
+          </div>
+        </Modal>
       )}
       <div className="flex w-full grow items-center justify-center space-x-2 truncate sm:justify-start">
         <span className="truncate text-lg font-bold">

--- a/apps/ui/src/components/Settings/MediaServerSelector/index.tsx
+++ b/apps/ui/src/components/Settings/MediaServerSelector/index.tsx
@@ -280,24 +280,21 @@ const MediaServerSelector = ({
       {/* Confirmation Modal */}
       {showConfirmModal && (
         <Modal
-          onCancel={isSwitchComplete ? undefined : handleCancelSwitch}
-          cancelText={isSwitchComplete ? undefined : t`Cancel`}
+          onCancel={isSwitchComplete ? handleFinish : handleCancelSwitch}
+          cancelText={isSwitchComplete ? t`Done` : t`Cancel`}
+          cancelButtonType={isSwitchComplete ? 'primary' : 'default'}
           loading={isSwitchPending}
           footerActions={
-            <Button
-              buttonType={isSwitchComplete ? 'primary' : 'danger'}
-              className="ml-3"
-              onClick={() =>
-                void (isSwitchComplete ? handleFinish() : handleConfirmSwitch())
-              }
-              disabled={isSwitchPending && !isSwitchComplete}
-            >
-              {isSwitchComplete
-                ? t`Done`
-                : isSwitchPending
-                  ? t`Switching...`
-                  : t`Switch`}
-            </Button>
+            isSwitchComplete ? undefined : (
+              <Button
+                buttonType="danger"
+                className="ml-3"
+                onClick={() => void handleConfirmSwitch()}
+                disabled={isSwitchPending}
+              >
+                {isSwitchPending ? t`Switching...` : t`Switch`}
+              </Button>
+            )
           }
         >
           <div className="text-zinc-100">

--- a/apps/ui/src/components/Settings/Radarr/index.tsx
+++ b/apps/ui/src/components/Settings/Radarr/index.tsx
@@ -9,13 +9,13 @@ import GetApiHandler, { DeleteApiHandler } from '../../../utils/ApiHandler'
 import { logClientError } from '../../../utils/ClientLogger'
 import { ICollection } from '../../Collection'
 import Button from '../../Common/Button'
-import Modal from '../../Common/Modal'
 import {
   SettingsFeedbackAlert,
   useSettingsFeedback,
 } from '../useSettingsFeedback'
 import ExclusionTagSettings from '../Servarr/ExclusionTagSettings'
 import ServarrSettingsModal from '../Servarr/ServarrSettingsModal'
+import ServerInUseModal from '../Servarr/ServerInUseModal'
 
 type DeleteRadarrSettingResponseDto =
   | {
@@ -207,36 +207,10 @@ const RadarrSettings = () => {
         />
       )}
       {collectionsInUseWarning ? (
-        <Modal
-          title={t`Server in-use`}
-          size="sm"
-          footerActions={
-            <Button
-              buttonType="primary"
-              className="ml-3"
-              onClick={() => setCollectionsInUseWarning(undefined)}
-            >
-              <Trans>Ok</Trans>
-            </Button>
-          }
-        >
-          <p>
-            <Trans>
-              This server is currently being used by the following rules:
-            </Trans>
-          </p>
-          <ul className="mb-4 list-inside list-disc">
-            {collectionsInUseWarning.map((x) => (
-              <li key={x.id}>{x.title}</li>
-            ))}
-          </ul>
-          <p>
-            <Trans>
-              You must re-assign these rules to a different server before
-              deleting.
-            </Trans>
-          </p>
-        </Modal>
+        <ServerInUseModal
+          collections={collectionsInUseWarning}
+          onClose={() => setCollectionsInUseWarning(undefined)}
+        />
       ) : undefined}
     </>
   )

--- a/apps/ui/src/components/Settings/Servarr/ServerInUseModal.tsx
+++ b/apps/ui/src/components/Settings/Servarr/ServerInUseModal.tsx
@@ -1,0 +1,45 @@
+import { Trans, useLingui } from '@lingui/react/macro'
+import { ICollection } from '../../Collection'
+import Modal from '../../Common/Modal'
+
+interface ServerInUseModalProps {
+  collections: ICollection[]
+  onClose: () => void
+}
+
+/**
+ * Refuses a Servarr server deletion while rule groups still point at it.
+ * Shared by the Radarr, Sonarr and Sportarr settings pages, which get the
+ * same list back from their delete endpoint.
+ */
+const ServerInUseModal = ({ collections, onClose }: ServerInUseModalProps) => {
+  const { t } = useLingui()
+
+  return (
+    <Modal
+      title={t`Server in-use`}
+      size="sm"
+      onCancel={onClose}
+      cancelText={t`Ok`}
+      cancelButtonType="primary"
+    >
+      <p>
+        <Trans>
+          This server is currently being used by the following rules:
+        </Trans>
+      </p>
+      <ul className="mb-4 list-inside list-disc">
+        {collections.map((collection) => (
+          <li key={collection.id}>{collection.title}</li>
+        ))}
+      </ul>
+      <p>
+        <Trans>
+          You must re-assign these rules to a different server before deleting.
+        </Trans>
+      </p>
+    </Modal>
+  )
+}
+
+export default ServerInUseModal

--- a/apps/ui/src/components/Settings/Sonarr/index.tsx
+++ b/apps/ui/src/components/Settings/Sonarr/index.tsx
@@ -9,13 +9,13 @@ import GetApiHandler, { DeleteApiHandler } from '../../../utils/ApiHandler'
 import { logClientError } from '../../../utils/ClientLogger'
 import { ICollection } from '../../Collection'
 import Button from '../../Common/Button'
-import Modal from '../../Common/Modal'
 import {
   SettingsFeedbackAlert,
   useSettingsFeedback,
 } from '../useSettingsFeedback'
 import ExclusionTagSettings from '../Servarr/ExclusionTagSettings'
 import ServarrSettingsModal from '../Servarr/ServarrSettingsModal'
+import ServerInUseModal from '../Servarr/ServerInUseModal'
 
 type DeleteSonarrSettingResponseDto =
   | {
@@ -207,36 +207,10 @@ const SonarrSettings = () => {
         />
       )}
       {collectionsInUseWarning ? (
-        <Modal
-          title={t`Server in-use`}
-          size="sm"
-          footerActions={
-            <Button
-              buttonType="primary"
-              className="ml-3"
-              onClick={() => setCollectionsInUseWarning(undefined)}
-            >
-              <Trans>Ok</Trans>
-            </Button>
-          }
-        >
-          <p>
-            <Trans>
-              This server is currently being used by the following rules:
-            </Trans>
-          </p>
-          <ul className="mb-4 list-inside list-disc">
-            {collectionsInUseWarning.map((x) => (
-              <li key={x.id}>{x.title}</li>
-            ))}
-          </ul>
-          <p>
-            <Trans>
-              You must re-assign these rules to a different server before
-              deleting.
-            </Trans>
-          </p>
-        </Modal>
+        <ServerInUseModal
+          collections={collectionsInUseWarning}
+          onClose={() => setCollectionsInUseWarning(undefined)}
+        />
       ) : undefined}
     </>
   )

--- a/apps/ui/src/components/Settings/Sportarr/index.tsx
+++ b/apps/ui/src/components/Settings/Sportarr/index.tsx
@@ -9,12 +9,12 @@ import GetApiHandler, { DeleteApiHandler } from '../../../utils/ApiHandler'
 import { logClientError } from '../../../utils/ClientLogger'
 import { ICollection } from '../../Collection'
 import Button from '../../Common/Button'
-import Modal from '../../Common/Modal'
 import {
   SettingsFeedbackAlert,
   useSettingsFeedback,
 } from '../useSettingsFeedback'
 import ServarrSettingsModal from '../Servarr/ServarrSettingsModal'
+import ServerInUseModal from '../Servarr/ServerInUseModal'
 
 type DeleteSportarrSettingResponseDto =
   | {
@@ -204,36 +204,10 @@ const SportarrSettings = () => {
         />
       )}
       {collectionsInUseWarning ? (
-        <Modal
-          title={t`Server in-use`}
-          size="sm"
-          footerActions={
-            <Button
-              buttonType="primary"
-              className="ml-3"
-              onClick={() => setCollectionsInUseWarning(undefined)}
-            >
-              <Trans>Ok</Trans>
-            </Button>
-          }
-        >
-          <p>
-            <Trans>
-              This server is currently being used by the following rules:
-            </Trans>
-          </p>
-          <ul className="mb-4 list-inside list-disc">
-            {collectionsInUseWarning.map((x) => (
-              <li key={x.id}>{x.title}</li>
-            ))}
-          </ul>
-          <p>
-            <Trans>
-              You must re-assign these rules to a different server before
-              deleting.
-            </Trans>
-          </p>
-        </Modal>
+        <ServerInUseModal
+          collections={collectionsInUseWarning}
+          onClose={() => setCollectionsInUseWarning(undefined)}
+        />
       ) : undefined}
     </>
   )

--- a/apps/ui/src/components/Settings/index.tsx
+++ b/apps/ui/src/components/Settings/index.tsx
@@ -16,7 +16,6 @@ import {
   hasSelectedMediaServerType,
 } from '../../hooks/useMediaServerType'
 import Alert from '../Common/Alert'
-import Button from '../Common/Button'
 import LoadingSpinner from '../Common/LoadingSpinner'
 import Modal from '../Common/Modal'
 import {
@@ -316,15 +315,9 @@ const SettingsWrapper = () => {
             title={t`Welcome to Maintainerr!`}
             backgroundClickable={false}
             size="md"
-            footerActions={
-              <Button
-                buttonType="primary"
-                className="ml-3"
-                onClick={() => setHasDismissedSetupWelcome(true)}
-              >
-                <Trans>Let&apos;s get started</Trans>
-              </Button>
-            }
+            onCancel={() => setHasDismissedSetupWelcome(true)}
+            cancelText={t`Let's get started`}
+            cancelButtonType="primary"
           >
             <div className="space-y-4 text-zinc-100">
               <div className="rounded-md border border-info-500/40 bg-info-900/30 p-4 backdrop-blur-sm">

--- a/apps/ui/src/components/StorageMetrics/index.tsx
+++ b/apps/ui/src/components/StorageMetrics/index.tsx
@@ -661,6 +661,7 @@ const MediaServerSection: React.FC<MediaServerSectionProps> = ({
           footerActions={
             <Button
               buttonType="primary"
+              className="ml-3"
               onClick={() => {
                 void handleConfirm()
               }}

--- a/apps/ui/src/hooks/useCloseOnEscape.ts
+++ b/apps/ui/src/hooks/useCloseOnEscape.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from 'react'
+
+// Only the innermost dialog answers Escape, so a nested one does not close its
+// parent along with itself. Ranked on first render, not on mount: effects run
+// child-before-parent, which would invert a pair that mounts in one commit.
+let nextDepth = 0
+const openDialogs = new Set<number>()
+
+/**
+ * Closes a dialog on Escape.
+ *
+ * The listener sits on the document rather than the dialog element: a keydown
+ * handler on the panel only fires while focus is inside it, and a dialog is
+ * usually opened from a trigger that keeps focus.
+ */
+const useCloseOnEscape = (enabled: boolean, onEscape: () => void): void => {
+  const [depth] = useState(() => nextDepth++)
+  const escapeRef = useRef(onEscape)
+
+  useEffect(() => {
+    escapeRef.current = onEscape
+  })
+
+  useEffect(() => {
+    if (!enabled) return
+
+    openDialogs.add(depth)
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && Math.max(...openDialogs) === depth) {
+        escapeRef.current()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      openDialogs.delete(depth)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [enabled, depth])
+}
+
+export default useCloseOnEscape

--- a/apps/ui/src/locales/cs.po
+++ b/apps/ui/src/locales/cs.po
@@ -750,7 +750,6 @@ msgstr ""
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr ""
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr ""
 
@@ -3528,9 +3525,7 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr ""
 
@@ -4113,9 +4108,7 @@ msgstr ""
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr ""
 
@@ -4631,9 +4624,7 @@ msgstr ""
 msgid "You have already submitted karma for this rule."
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr ""
 

--- a/apps/ui/src/locales/da.po
+++ b/apps/ui/src/locales/da.po
@@ -750,7 +750,6 @@ msgstr ""
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr ""
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr ""
 
@@ -3528,9 +3525,7 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr ""
 
@@ -4113,9 +4108,7 @@ msgstr ""
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr ""
 
@@ -4631,9 +4624,7 @@ msgstr ""
 msgid "You have already submitted karma for this rule."
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr ""
 

--- a/apps/ui/src/locales/de.po
+++ b/apps/ui/src/locales/de.po
@@ -750,7 +750,6 @@ msgstr ""
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr ""
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr ""
 
@@ -3528,9 +3525,7 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr ""
 
@@ -4113,9 +4108,7 @@ msgstr ""
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr ""
 
@@ -4631,9 +4624,7 @@ msgstr ""
 msgid "You have already submitted karma for this rule."
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr ""
 

--- a/apps/ui/src/locales/en.po
+++ b/apps/ui/src/locales/en.po
@@ -750,7 +750,6 @@ msgstr "Clone rule - Maintainerr"
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr "Off by default so a manually-set tag is never stripped. When on, Maintainerr removes only this label when an item is un-excluded."
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr "Ok"
 
@@ -3528,9 +3525,7 @@ msgstr "Send anonymous usage data"
 msgid "Server"
 msgstr "Server"
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr "Server in-use"
 
@@ -4113,9 +4108,7 @@ msgstr "This is the exact report your server would send, stored only as anonymou
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr "This server is currently being used by the following rules:"
 
@@ -4631,9 +4624,7 @@ msgstr "You can try going back or reloading the page. If the problem persists, p
 msgid "You have already submitted karma for this rule."
 msgstr "You have already submitted karma for this rule."
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr "You must re-assign these rules to a different server before deleting."
 

--- a/apps/ui/src/locales/es.po
+++ b/apps/ui/src/locales/es.po
@@ -750,7 +750,6 @@ msgstr "Clonar regla - Maintainerr"
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr "Está desactivado de forma predeterminada, por lo que una etiqueta configurada manualmente nunca se elimina. Cuando está activado, Maintainerr elimina solo esta etiqueta cuando un elemento no está excluido."
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr "Aceptar"
 
@@ -3528,9 +3525,7 @@ msgstr ""
 msgid "Server"
 msgstr "Servidor"
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr "Servidor en uso"
 
@@ -4113,9 +4108,7 @@ msgstr ""
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr "Este elemento está excluido <0>globalmente</0>. Al eliminar esta exclusión se aplicará el cambio a todas las colecciones."
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr "Este servidor está siendo utilizado actualmente por las siguientes reglas:"
 
@@ -4631,9 +4624,7 @@ msgstr "Puedes intentar volver atrás o actualizar la página. Si el problema pe
 msgid "You have already submitted karma for this rule."
 msgstr "Ya has enviado karma para esta regla."
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr "Debe reasignar estas reglas a un servidor diferente antes de eliminarlas."
 

--- a/apps/ui/src/locales/fi.po
+++ b/apps/ui/src/locales/fi.po
@@ -750,7 +750,6 @@ msgstr ""
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr ""
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr ""
 
@@ -3528,9 +3525,7 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr ""
 
@@ -4113,9 +4108,7 @@ msgstr ""
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr ""
 
@@ -4631,9 +4624,7 @@ msgstr ""
 msgid "You have already submitted karma for this rule."
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr ""
 

--- a/apps/ui/src/locales/fr.po
+++ b/apps/ui/src/locales/fr.po
@@ -750,7 +750,6 @@ msgstr ""
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr ""
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr ""
 
@@ -3528,9 +3525,7 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr ""
 
@@ -4113,9 +4108,7 @@ msgstr ""
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr ""
 
@@ -4631,9 +4624,7 @@ msgstr ""
 msgid "You have already submitted karma for this rule."
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr ""
 

--- a/apps/ui/src/locales/it.po
+++ b/apps/ui/src/locales/it.po
@@ -750,7 +750,6 @@ msgstr ""
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr ""
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr ""
 
@@ -3528,9 +3525,7 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr ""
 
@@ -4113,9 +4108,7 @@ msgstr ""
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr ""
 
@@ -4631,9 +4624,7 @@ msgstr ""
 msgid "You have already submitted karma for this rule."
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr ""
 

--- a/apps/ui/src/locales/nb.po
+++ b/apps/ui/src/locales/nb.po
@@ -750,7 +750,6 @@ msgstr ""
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr ""
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr ""
 
@@ -3528,9 +3525,7 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr ""
 
@@ -4113,9 +4108,7 @@ msgstr ""
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr ""
 
@@ -4631,9 +4624,7 @@ msgstr ""
 msgid "You have already submitted karma for this rule."
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr ""
 

--- a/apps/ui/src/locales/nl.po
+++ b/apps/ui/src/locales/nl.po
@@ -750,7 +750,6 @@ msgstr ""
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr ""
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr ""
 
@@ -3528,9 +3525,7 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr ""
 
@@ -4113,9 +4108,7 @@ msgstr ""
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr ""
 
@@ -4631,9 +4624,7 @@ msgstr ""
 msgid "You have already submitted karma for this rule."
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr ""
 

--- a/apps/ui/src/locales/pl.po
+++ b/apps/ui/src/locales/pl.po
@@ -750,7 +750,6 @@ msgstr ""
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr ""
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr ""
 
@@ -3528,9 +3525,7 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr ""
 
@@ -4113,9 +4108,7 @@ msgstr ""
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr ""
 
@@ -4631,9 +4624,7 @@ msgstr ""
 msgid "You have already submitted karma for this rule."
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr ""
 

--- a/apps/ui/src/locales/pt.po
+++ b/apps/ui/src/locales/pt.po
@@ -750,7 +750,6 @@ msgstr ""
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr ""
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr ""
 
@@ -3528,9 +3525,7 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr ""
 
@@ -4113,9 +4108,7 @@ msgstr ""
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr ""
 
@@ -4631,9 +4624,7 @@ msgstr ""
 msgid "You have already submitted karma for this rule."
 msgstr ""
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr ""
 

--- a/apps/ui/src/locales/sv.po
+++ b/apps/ui/src/locales/sv.po
@@ -750,7 +750,6 @@ msgstr "Klona regel - Maintainerr"
 #: src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
 #: src/components/Common/CommunityRuleModal/index.tsx
 #: src/components/Common/MediaCard/MediaModal/index.tsx
-#: src/components/Common/Modal/index.tsx
 #: src/components/Login/Emby/EmbyLoginButton.tsx
 #: src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
 #: src/components/Settings/About/Releases/index.tsx
@@ -2767,9 +2766,7 @@ msgid "Off by default so a manually-set tag is never stripped. When on, Maintain
 msgstr "Av som standard så att en manuellt satt tagg aldrig tas bort. När det är på tar Maintainerr bara bort den här taggen när ett objekts exkludering tas bort."
 
 #: src/components/Collection/CollectionDetail/RemoveFromCollectionButton/index.tsx
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Ok"
 msgstr "OK"
 
@@ -3528,9 +3525,7 @@ msgstr ""
 msgid "Server"
 msgstr "Server"
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "Server in-use"
 msgstr "Servern används"
 
@@ -4113,9 +4108,7 @@ msgstr ""
 msgid "This item is excluded <0>globally</0>. Removing this exclusion will apply the change to all collections"
 msgstr "Det här objektet är exkluderat <0>globalt</0>. Om exkluderingen tas bort gäller ändringen alla samlingar"
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "This server is currently being used by the following rules:"
 msgstr "Den här servern används just nu av följande regler:"
 
@@ -4631,9 +4624,7 @@ msgstr "Du kan försöka gå tillbaka eller ladda om sidan. Om problemet kvarst�
 msgid "You have already submitted karma for this rule."
 msgstr "Du har redan gett karma för den här regeln."
 
-#: src/components/Settings/Radarr/index.tsx
-#: src/components/Settings/Sonarr/index.tsx
-#: src/components/Settings/Sportarr/index.tsx
+#: src/components/Settings/Servarr/ServerInUseModal.tsx
 msgid "You must re-assign these rules to a different server before deleting."
 msgstr "Du måste flytta de här reglerna till en annan server innan du raderar."
 

--- a/apps/ui/src/pages/OverlayTemplateEditorPage.tsx
+++ b/apps/ui/src/pages/OverlayTemplateEditorPage.tsx
@@ -661,7 +661,9 @@ const OverlayTemplateEditor = ({ routeId }: { routeId: string }) => {
         <Modal
           title={t`Save preset as a copy`}
           size="sm"
-          onCancel={saving ? undefined : () => setCopyModalOpen(false)}
+          onCancel={() => {
+            if (!saving) setCopyModalOpen(false)
+          }}
           footerActions={
             <Button
               buttonType="primary"


### PR DESCRIPTION
The top-right X added in #3443 is `sm:hidden`, so **above 640px no modal has a close control of its own**. Below 640px the button is `absolute` inside the panel's own scroll box, so it scrolls out of view like any other content. The footer Cancel scrolled away with it, which left several dialogs with no reachable way out.

The panel is now a column - fixed header, scrolling body, pinned footer carrying the shared close. The X is gone.

## Reproduced before the change, on the running stack

| Dialog | Viewport | Symptom |
| --- | --- | --- |
| Release changelog | 1440x900 | no close on screen at all; footer 700px below the fold |
| Yaml Rule Editor | 1024x500 | Cancel at y=551 in a 500px viewport |
| Log metadata | 360x480 | unclosable: one footer Close below the fold, no Escape, no backdrop |
| Media detail | any >=640px | X not rendered, footer Close removed in #3443, so only the backdrop closed it |
| Server in-use (x3) | any | single `Ok`, no Escape, no backdrop, no X |
| Any `loading` modal | any | panel unmounted behind a bare spinner: no close, scroll lock still held |

## Changes

| Area | Change |
| --- | --- |
| `Modal` | flex column; body is the only scroller; footer pinned and wraps below `sm` |
| `Modal` | X and `modalCloseButtonClassName` removed |
| `Modal` | `loading` keeps the shell and holds back `footerActions` instead of unmounting the panel |
| `Modal` | `useId` per dialog: a nested modal was announced with its parent's title |
| `useCloseOnEscape` | Escape moves to a document listener; dialogs ranked on first render so a nested one closes alone |
| `MediaModal` | `role`/`aria-modal`/name added, footer Close back beside Postpone, sheet is a column |
| 5 call sites | faked a close with their own footer button and passed no `onCancel`; now `cancelText` + `cancelButtonType` |
| `ServerInUseModal` | the three byte-identical Servarr blocks become one shared component |
| `Releases` | dropped the second full-screen scrim wrapping a modal that portals its own |

## Why Escape needed fixing

#3443 removed the media modal's footer Close "with Escape covering the keyboard". Escape never worked: the handler sat on a non-focusable div, so it only fired once focus was already inside the dialog, and a dialog is opened from a trigger that keeps focus.

## Verified

Playwright against the live Jellyfin stack, every modal at 1440x900, 390x844, 320x400 and 200x260 (smallest Chromium accepts). Close visible and in-viewport in all of them; Escape and the scroll-lock release confirmed; the `loading` window captured with a MutationObserver showing the Cancel present throughout.

Catalogs re-extracted: no message added or removed, only source references moved.
