### PR TITLE
fix(telemetry): only ask installs that predate the setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,6 @@ We checked, and reporting by default is normal for tools like ours. Where we dif
 | Identifies your install | Yes, a permanent id per install | No, no id at all         |
 | Sees your IP address    | Yes, the receiving service does | No, never read or stored |
 | How often               | Every action                    | Once a week              |
-| Asks you first          | No                              | Yes, once                |
 
 The exact shape of a report is one TypeScript interface, [`TelemetryPing`](packages/contracts/src/telemetry/telemetryEvent.ts). What happens to it after it arrives is documented in the [collector repository](https://github.com/Maintainerr/telemetry-collector), and the [dashboard](https://telemetry.maintainerr.info) shows what it adds up to.
 

--- a/apps/server/src/database/migration-tests/migrations.spec.ts
+++ b/apps/server/src/database/migration-tests/migrations.spec.ts
@@ -181,6 +181,38 @@ describe('database migrations', () => {
     expect(src).toContain('CREATE TABLE "temporary_settings"');
   });
 
+  // The rebuild in (3) drops and recreates the table, so its INSERT...SELECT is
+  // the only thing carrying an existing install's settings across. Every other
+  // test here migrates an empty DB, where a rebuild that copies nothing looks
+  // identical to one that copies correctly.
+  it('carry an existing settings row through the newest rebuild', async () => {
+    const newest = all[all.length - 1];
+    const ds = await makeDS(all.slice(0, -1).map((m) => m.cls)).initialize();
+    try {
+      await ds.runMigrations();
+      await ds.query(
+        `INSERT INTO settings ("apikey", "media_server_type", "jellyfin_api_key") VALUES ('key', 'jellyfin', 'jf')`,
+      );
+
+      const runner = ds.createQueryRunner();
+      await new newest.cls().up(runner);
+      await runner.release();
+
+      const rows = await ds.query(`SELECT * FROM settings`);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        apikey: 'key',
+        media_server_type: 'jellyfin',
+        jellyfin_api_key: 'jf',
+        // Grandfathered: the carry-over leaves the new column unset, which is
+        // what the consent prompt keys on.
+        telemetryEnabled: null,
+      });
+    } finally {
+      await ds.destroy();
+    }
+  });
+
   // We don't revert the whole chain: several pre-existing migrations have
   // non-reversible down() paths (production only ever migrates up). We do confirm
   // the newest migration's down() is symmetric - the regression this catches when

--- a/apps/server/src/modules/settings/entities/settings.entities.ts
+++ b/apps/server/src/modules/settings/entities/settings.entities.ts
@@ -11,7 +11,7 @@ export class Settings implements SettingDto {
   @PrimaryGeneratedColumn()
   id: number;
 
-  // clientId is set explicitly via randomUUID() in SettingsOperationsService.init()
+  // clientId is set explicitly via randomUUID() in SettingsDataService.init()
   @Column({ nullable: true })
   clientId: string;
 
@@ -168,10 +168,10 @@ export class Settings implements SettingDto {
   @Column({ type: 'boolean', nullable: false, default: false })
   sonarr_untag_on_unexclude: boolean;
 
-  // Anonymous weekly telemetry (https://telemetry.maintainerr.info). Null means
-  // nobody has answered the prompt yet, and reports: every install starts
-  // there, new or upgraded, and is asked once in the web interface. Only an
-  // explicit false stops it. TELEMETRY=off overrides this without touching the
+  // Anonymous weekly telemetry (https://telemetry.maintainerr.info). Null is an
+  // install that predates the setting: it reports, and is asked once in the web
+  // interface. New installs are created with true and are never asked. Only an
+  // explicit false stops it. TELEMETRY=off overrides without touching the
   // database.
   @Column({ type: 'boolean', nullable: true, default: null })
   telemetryEnabled: boolean | null;

--- a/apps/server/src/modules/settings/settings-data.service.spec.ts
+++ b/apps/server/src/modules/settings/settings-data.service.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed, type Mocked } from '@suites/unit';
+import { Repository } from 'typeorm';
+import { Settings } from './entities/settings.entities';
+import { SettingsDataService } from './settings-data.service';
+
+describe('SettingsDataService', () => {
+  let service: SettingsDataService;
+  let settingsRepo: Mocked<Repository<Settings>>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(SettingsDataService).compile();
+
+    service = unit;
+    settingsRepo = unitRef.get('SettingsRepository');
+  });
+
+  // Null is reserved for rows the telemetry migration carried over, which are
+  // the only ones the consent prompt should appear for.
+  it('answers telemetry when it creates the initial settings row', async () => {
+    settingsRepo.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(
+        Object.assign(new Settings(), { id: 1, telemetryEnabled: true }),
+      );
+
+    await service.init();
+
+    expect(settingsRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ telemetryEnabled: true }),
+    );
+    expect(service.telemetryEnabled).toBe(true);
+  });
+
+  it('leaves an existing row unanswered', async () => {
+    settingsRepo.findOne.mockResolvedValue(
+      Object.assign(new Settings(), {
+        id: 1,
+        media_server_type: 'plex',
+        plex_auth_token: 'token',
+        telemetryEnabled: null,
+      }),
+    );
+
+    await service.init();
+
+    expect(settingsRepo.insert).not.toHaveBeenCalled();
+    expect(service.telemetryEnabled).toBeNull();
+  });
+});

--- a/apps/server/src/modules/settings/settings-data.service.ts
+++ b/apps/server/src/modules/settings/settings-data.service.ts
@@ -249,6 +249,10 @@ export class SettingsDataService implements SettingDto {
       await this.settingsRepo.insert({
         apikey: this.generateApiKey(),
         clientId: randomUUID(),
+        // Seeded here rather than as a column default, which would rebuild
+        // the table on every existing install to hold a value only a new row
+        // can take. Null stays "predates the setting, still to be asked".
+        telemetryEnabled: true,
       });
       await this.init();
     }

--- a/apps/server/src/modules/telemetry/telemetry.service.ts
+++ b/apps/server/src/modules/telemetry/telemetry.service.ts
@@ -99,9 +99,9 @@ export class TelemetryService {
   }
 
   /**
-   * Null means nobody has answered the prompt yet, which reports: a census only
-   * some people take part in describes only those people. Only an explicit
-   * `false` stops it. TELEMETRY=off wins over the setting.
+   * Null - an install that predates the setting - reports: a census only some
+   * people take part in describes only those people. Only an explicit `false`
+   * stops it. TELEMETRY=off wins over the setting.
    */
   enabled(): boolean {
     return this.forcedOff() ? false : this.settings.telemetryEnabled !== false;

--- a/apps/ui/src/components/Layout/TelemetryConsentModal.spec.tsx
+++ b/apps/ui/src/components/Layout/TelemetryConsentModal.spec.tsx
@@ -44,12 +44,14 @@ vi.mock('../Common/PayloadViewer', () => ({
   },
 }))
 
+let isPending = false
+
 vi.mock('../../api/settings', () => ({
   useSettings: () => ({ data: currentSettings }),
   useTelemetryPreview: () => ({ data: preview }),
   useUpdateTelemetrySetting: () => ({
     mutateAsync: updateTelemetrySetting,
-    isPending: false,
+    isPending,
   }),
 }))
 
@@ -58,6 +60,7 @@ describe('TelemetryConsentModal', () => {
     updateTelemetrySetting.mockReset()
     updateTelemetrySetting.mockResolvedValue({ code: 1 })
     currentSettings = { ...CONFIGURED, telemetryEnabled: null }
+    isPending = false
   })
 
   it.each([
@@ -102,6 +105,17 @@ describe('TelemetryConsentModal', () => {
 
     expect(editorValue).toBe(JSON.stringify(preview, null, 2))
     expect(editorValue).not.toContain('sample')
+  })
+
+  // A write in flight must not blank the prompt and leave the opt-out as the
+  // only button, which is what a shared-Modal `loading` does.
+  it('keeps the payload and both buttons while the answer is saving', () => {
+    isPending = true
+
+    renderModal()
+
+    expect(screen.getByRole('button', { name: 'Keep it on' })).toBeTruthy()
+    expect(editorValue).toBe(JSON.stringify(preview, null, 2))
   })
 
   it('records keeping it on so it is not asked again', async () => {

--- a/apps/ui/src/components/Layout/TelemetryConsentModal.tsx
+++ b/apps/ui/src/components/Layout/TelemetryConsentModal.tsx
@@ -18,9 +18,9 @@ const TERM_IP = 'IP'
 const TERM_MAC = 'MAC'
 
 /**
- * Telemetry is stored as null - "not answered yet" - on every install, and
- * reports until it is turned off, so this prompt is the opt-out. It waits for
- * media server setup to finish rather than interrupting it.
+ * Null is an install that predates the setting, and it reports until turned
+ * off, so this prompt is their opt-out. New installs start on and never see
+ * it. Waits for media server setup rather than interrupting it.
  *
  * Switching it off happens on the settings page, beside the payload it applies
  * to. Nothing is recorded on that path, so an install that leaves without
@@ -32,19 +32,21 @@ const TelemetryConsentModal = () => {
   const { data: settings } = useSettings()
   const { mutateAsync: updateTelemetrySetting, isPending } =
     useUpdateTelemetrySetting()
-  const { data: preview } = useTelemetryPreview()
-  // The weekly block only: the sampled one rides along a few times a year and
-  // has its own panel on the settings page.
-  const { sample, ...weekly } = preview ?? {}
   // The modal lives in Layout, so without this it stays over the page it just
   // sent the user to, scroll locked and the toggle unreachable.
   const [dismissed, setDismissed] = useState(false)
+  const prompting =
+    !dismissed &&
+    settings?.telemetryEnabled === null &&
+    hasCompletedMediaServerSetup(settings)
+  // Mounted on every page, so the payload is only fetched for the installs
+  // that can still be asked.
+  const { data: preview } = useTelemetryPreview({ enabled: prompting })
+  // The weekly block only: the sampled one rides along a few times a year and
+  // has its own panel on the settings page.
+  const { sample, ...weekly } = preview ?? {}
 
-  if (
-    dismissed ||
-    settings?.telemetryEnabled !== null ||
-    !hasCompletedMediaServerSetup(settings)
-  ) {
+  if (!prompting) {
     return null
   }
 
@@ -61,7 +63,6 @@ const TelemetryConsentModal = () => {
     <Modal
       title={t`Help shape Maintainerr?`}
       backgroundClickable={false}
-      loading={isPending}
       size="lg"
       cancelText={t`Turn it off in settings`}
       onCancel={() => {
@@ -74,6 +75,7 @@ const TelemetryConsentModal = () => {
         <Button
           buttonType="primary"
           className="ml-3"
+          disabled={isPending}
           onClick={() => void keepOn()}
         >
           <Trans>Keep it on</Trans>


### PR DESCRIPTION
The telemetry consent prompt is for installs upgrading from a release that predates the setting. New installs start with it already answered.

| Install | `telemetryEnabled` after boot | Prompt |
| --- | --- | --- |
| New | `true`, set when the initial settings row is created | Not shown |
| Upgrading | `null`, carried over by the migration | Shown once |

Three drive-by fixes in the same area: the prompt no longer passes the shared `Modal` `loading` prop while saving, the payload preview is only fetched when the prompt can actually be shown, and the migration matrix now populates a settings row before migrating.

Exercised against a real Jellyfin install: empty database, and a database rewound through the migration.