### PR TITLE
fix(ui): dialog follow-ups to the shared close

### DIFF
--- a/apps/ui/src/components/Common/LazyModalBoundary.spec.tsx
+++ b/apps/ui/src/components/Common/LazyModalBoundary.spec.tsx
@@ -1,0 +1,34 @@
+import { lazy } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { __resetLockBodyScrollForTests } from '../../hooks/useLockBodyScroll'
+import { fireEvent, render, screen } from '../../test-utils/render'
+import LazyModalBoundary from './LazyModalBoundary'
+
+vi.mock('./LoadingSpinner', () => ({
+  default: () => <div data-testid="loading-spinner" />,
+}))
+
+// A chunk that never arrives keeps the boundary in its fallback.
+const NeverLoads = lazy(() => new Promise<never>(() => {}))
+
+describe('LazyModalBoundary', () => {
+  afterEach(() => {
+    __resetLockBodyScrollForTests()
+  })
+
+  it('dims and locks the page behind the delayed spinner, with no dialog', () => {
+    const onCancel = vi.fn()
+    render(
+      <LazyModalBoundary onCancel={onCancel}>
+        <NeverLoads />
+      </LazyModalBoundary>,
+    )
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(screen.getByTestId('loading-spinner')).toBeTruthy()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/ui/src/components/Common/LazyModalBoundary.tsx
+++ b/apps/ui/src/components/Common/LazyModalBoundary.tsx
@@ -1,39 +1,34 @@
 import { type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import useCloseOnEscape from '../../hooks/useCloseOnEscape'
+import { useLockBodyScroll } from '../../hooks/useLockBodyScroll'
 import LazyBoundary from './LazyBoundary'
-import Modal from './Modal'
+import LoadingSpinner from './LoadingSpinner'
 
 interface LazyModalBoundaryProps {
   children: ReactNode
   onCancel?: () => void
-  title?: string
-  size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl'
-  backgroundClickable?: boolean
 }
 
-const LazyModalBoundary = ({
-  children,
-  onCancel,
-  title,
-  size,
-  backgroundClickable,
-}: LazyModalBoundaryProps) => {
-  return (
-    <LazyBoundary
-      fallback={
-        <Modal
-          loading
-          title={title}
-          size={size}
-          onCancel={onCancel}
-          backgroundClickable={backgroundClickable}
-        >
-          <div />
-        </Modal>
-      }
-    >
-      {children}
-    </LazyBoundary>
+// The backdrop and the delayed spinner while the chunk loads. A Modal shell
+// has its own footer and height, so it would be swapped for the real dialog
+// rather than filled in.
+const Backdrop = ({ onCancel }: { onCancel?: () => void }) => {
+  useLockBodyScroll(true)
+  useCloseOnEscape(typeof onCancel === 'function', () => onCancel?.())
+
+  return createPortal(
+    <div className="modal-backdrop">
+      <LoadingSpinner />
+    </div>,
+    document.body,
   )
 }
+
+const LazyModalBoundary = ({ children, onCancel }: LazyModalBoundaryProps) => (
+  <LazyBoundary fallback={<Backdrop onCancel={onCancel} />}>
+    {children}
+  </LazyBoundary>
+)
 
 export default LazyModalBoundary

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
@@ -581,7 +581,10 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
         >
           {/* Short on a small phone: at h-72 the backdrop took two thirds of
               the sheet and pushed the title and summary below the fold. */}
-          <div className="relative h-40 w-full shrink-0 overflow-hidden p-2 sm:h-72 xl:h-96">
+          {/* Capped by height too: the sm height is keyed on width, so a phone
+              in landscape got the tablet backdrop and it pushed the footer
+              out of the sheet. */}
+          <div className="relative h-40 max-h-[50vh] w-full shrink-0 overflow-hidden p-2 sm:h-72 xl:h-96">
             <div
               className="h-full w-full rounded-xl bg-cover bg-center bg-no-repeat"
               style={{

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
@@ -876,7 +876,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
           </div>
           {/* Wraps: side by side these actions are wider than a phone, and
               the sheet scrolled sideways to reach the last one. */}
-          <div className="flex shrink-0 flex-row flex-wrap items-center justify-between gap-4 border-t border-zinc-700 p-4">
+          <div className="flex shrink-0 flex-row flex-wrap items-center justify-between gap-4 p-4">
             {providerIds &&
               ['movie', 'show'].includes(mediaType) &&
               (providerIds.tmdb?.length ||

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
@@ -568,10 +568,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
       )
 
     return (
-      <div
-        className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-3"
-        onClick={onClose}
-      >
+      <div className="modal-backdrop px-3" onClick={onClose}>
         {/* A column, like the shared Modal: only the body scrolls, so the
             actions and the close stay on screen on a phone, where the sheet
             fills the height. */}

--- a/apps/ui/src/components/Common/Modal/index.tsx
+++ b/apps/ui/src/components/Common/Modal/index.tsx
@@ -58,7 +58,7 @@ const Modal: React.FC<ModalProps> = ({
   useLockBodyScroll(true, disableScrollLock)
 
   return createPortal(
-    <div className="fixed top-0 right-0 bottom-0 left-0 z-50 flex h-full w-full items-center justify-center bg-zinc-800/70">
+    <div className="modal-backdrop">
       {/* A column, so the body is the only part that scrolls and the footer -
           which carries the close - stays on screen however tall the content
           gets. */}

--- a/apps/ui/src/components/Common/Modal/index.tsx
+++ b/apps/ui/src/components/Common/Modal/index.tsx
@@ -104,7 +104,7 @@ const Modal: React.FC<ModalProps> = ({
         {/* Wraps: a footer with a save and a test beside the close is wider
             than a phone, and the panel no longer scrolls sideways to it. */}
         {(onCancel || footerActions) && (
-          <div className="flex shrink-0 flex-row-reverse flex-wrap justify-center gap-y-2 border-t border-zinc-600 p-4 sm:justify-start">
+          <div className="flex shrink-0 flex-row-reverse flex-wrap justify-center gap-y-2 p-4 sm:justify-start">
             {loading ? undefined : footerActions}
             {typeof onCancel === 'function' && (
               <Button

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/ConfigureNotificationModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/ConfigureNotificationModal/index.tsx
@@ -2,6 +2,7 @@ import { Trans, useLingui } from '@lingui/react/macro'
 import { useEffect, useState } from 'react'
 import GetApiHandler from '../../../../../utils/ApiHandler'
 import Button from '../../../../Common/Button'
+import { SmallLoadingSpinner } from '../../../../Common/LoadingSpinner'
 import Modal from '../../../../Common/Modal'
 import ToggleItem from '../../../../Common/ToggleButton'
 import type { AgentConfiguration } from '../../../../Settings/Notifications/CreateNotificationModal'
@@ -33,7 +34,6 @@ const ConfigureNotificationModal = (props: ConfigureNotificationModal) => {
 
   return (
     <Modal
-      loading={isLoading}
       backgroundClickable={false}
       onCancel={() => props.onCancel()}
       title={t`Notification Agents`}
@@ -42,6 +42,7 @@ const ConfigureNotificationModal = (props: ConfigureNotificationModal) => {
         <Button
           buttonType="primary"
           className="ml-3"
+          disabled={isLoading}
           onClick={() => props.onSuccess(activatedNotifications)}
         >
           <Trans>OK</Trans>
@@ -57,6 +58,9 @@ const ConfigureNotificationModal = (props: ConfigureNotificationModal) => {
             </label>
             <div className="form-input">
               <div className="form-input-field flex flex-col gap-2">
+                {/* Immediate: the delayed spinner may just have shown for
+                    the chunk, and a fresh one would restart its timer. */}
+                {isLoading && <SmallLoadingSpinner className="h-6 w-6" />}
                 {!isLoading &&
                   notifications!.map((n) => (
                     <ToggleItem

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -2190,11 +2190,9 @@ const AddModal = (props: AddModal) => {
                 )}
                 {yamlImporterModal && (
                   <LazyModalBoundary
-                    title={yaml ? t`Export Rules YAML` : t`Import Rules YAML`}
                     onCancel={() => {
                       setYamlImporterModal(false)
                     }}
-                    size="5xl"
                   >
                     <YamlImporterModal
                       yaml={yaml}
@@ -2211,7 +2209,6 @@ const AddModal = (props: AddModal) => {
 
                 {configureNotificationModal && (
                   <LazyModalBoundary
-                    title={t`Configure Notifications`}
                     onCancel={() => {
                       setConfigureNotificationModal(false)
                     }}

--- a/apps/ui/src/components/Settings/MediaServerSelector/index.spec.tsx
+++ b/apps/ui/src/components/Settings/MediaServerSelector/index.spec.tsx
@@ -1,5 +1,5 @@
 import { MediaServerType } from '@maintainerr/contracts'
-import { render, screen } from '../../../test-utils/render'
+import { fireEvent, render, screen, within } from '../../../test-utils/render'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import MediaServerSelector from './index'
 
@@ -8,6 +8,7 @@ const invalidateQueries = vi.fn()
 const refetchQueries = vi.fn()
 const previewSwitch = vi.fn()
 const switchServer = vi.fn()
+let switchPending = false
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => navigate,
@@ -34,7 +35,7 @@ vi.mock('../../../api/settings', () => ({
   }),
   useSwitchMediaServer: () => ({
     mutateAsync: switchServer,
-    isPending: false,
+    isPending: switchPending,
   }),
 }))
 
@@ -49,6 +50,47 @@ describe('MediaServerSelector', () => {
     refetchQueries.mockReset()
     previewSwitch.mockReset()
     switchServer.mockReset()
+    switchPending = false
+  })
+
+  // Closing mid-switch cannot stop the request, and skipped the finish step
+  // that reloads settings, so the dialog offers no close until it is done.
+  it('cannot be closed while the switch is running', async () => {
+    previewSwitch.mockResolvedValue({
+      currentServerType: MediaServerType.JELLYFIN,
+      targetServerType: MediaServerType.PLEX,
+      dataToBeCleared: {
+        collections: 0,
+        collectionMedia: 0,
+        exclusions: 0,
+        collectionLogs: 0,
+      },
+      dataToBeKept: {
+        generalSettings: true,
+        radarrSettings: 0,
+        sonarrSettings: 0,
+        sportarrSettings: 0,
+        seerrSettings: false,
+        tautulliSettings: false,
+        notificationSettings: false,
+      },
+    })
+    const { rerender } = render(
+      <MediaServerSelector currentType={MediaServerType.JELLYFIN} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Plex/ }))
+    await screen.findByRole('dialog')
+
+    switchPending = true
+    rerender(<MediaServerSelector currentType={MediaServerType.JELLYFIN} />)
+    const dialog = screen.getByRole('dialog')
+
+    expect(within(dialog).queryByRole('button', { name: 'Cancel' })).toBeNull()
+    expect(
+      within(dialog).getByRole('button', { name: /Switching/ }),
+    ).toHaveProperty('disabled', true)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.getByRole('dialog')).toBeTruthy()
   })
 
   it('uses the shared icon placement classes for all media server options', () => {

--- a/apps/ui/src/components/Settings/MediaServerSelector/index.tsx
+++ b/apps/ui/src/components/Settings/MediaServerSelector/index.tsx
@@ -18,7 +18,7 @@ import {
   useSwitchMediaServer,
 } from '../../../api/settings'
 import { logClientError } from '../../../utils/ClientLogger'
-import Button from '../../Common/Button'
+import PendingButton from '../../Common/PendingButton'
 import Modal from '../../Common/Modal'
 
 interface MediaServerSelectorProps {
@@ -280,20 +280,29 @@ const MediaServerSelector = ({
       {/* Confirmation Modal */}
       {showConfirmModal && (
         <Modal
-          onCancel={isSwitchComplete ? handleFinish : handleCancelSwitch}
+          // No close while the switch runs: the request cannot be cancelled,
+          // and closing here left the finish step, which reloads settings,
+          // unreachable.
+          onCancel={
+            isSwitchPending
+              ? undefined
+              : isSwitchComplete
+                ? handleFinish
+                : handleCancelSwitch
+          }
           cancelText={isSwitchComplete ? t`Done` : t`Cancel`}
           cancelButtonType={isSwitchComplete ? 'primary' : 'default'}
-          loading={isSwitchPending}
           footerActions={
             isSwitchComplete ? undefined : (
-              <Button
+              <PendingButton
                 buttonType="danger"
                 className="ml-3"
-                onClick={() => void handleConfirmSwitch()}
+                isPending={isSwitchPending}
+                idleLabel={t`Switch`}
+                pendingLabel={t`Switching...`}
                 disabled={isSwitchPending}
-              >
-                {isSwitchPending ? t`Switching...` : t`Switch`}
-              </Button>
+                onClick={() => void handleConfirmSwitch()}
+              />
             )
           }
         >

--- a/apps/ui/src/locales/cs.po
+++ b/apps/ui/src/locales/cs.po
@@ -856,10 +856,6 @@ msgstr ""
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr ""
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr ""
@@ -1546,10 +1542,6 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr ""
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr ""
@@ -1969,10 +1961,6 @@ msgstr ""
 
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
-msgstr ""
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
 msgstr ""
 
 #: src/components/Settings/MediaServerSelector/index.tsx

--- a/apps/ui/src/locales/da.po
+++ b/apps/ui/src/locales/da.po
@@ -856,10 +856,6 @@ msgstr ""
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr ""
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr ""
@@ -1546,10 +1542,6 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr ""
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr ""
@@ -1969,10 +1961,6 @@ msgstr ""
 
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
-msgstr ""
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
 msgstr ""
 
 #: src/components/Settings/MediaServerSelector/index.tsx

--- a/apps/ui/src/locales/de.po
+++ b/apps/ui/src/locales/de.po
@@ -856,10 +856,6 @@ msgstr ""
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr ""
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr ""
@@ -1546,10 +1542,6 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr ""
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr ""
@@ -1969,10 +1961,6 @@ msgstr ""
 
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
-msgstr ""
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
 msgstr ""
 
 #: src/components/Settings/MediaServerSelector/index.tsx

--- a/apps/ui/src/locales/en.po
+++ b/apps/ui/src/locales/en.po
@@ -856,10 +856,6 @@ msgstr "Configure global settings"
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr "Configure Notifications"
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr "Configure to refresh"
@@ -1546,10 +1542,6 @@ msgstr "Exists"
 msgid "Export"
 msgstr "Export"
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr "Export Rules YAML"
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr "Export your rules to a YAML document"
@@ -1970,10 +1962,6 @@ msgstr "Import rules from a YAML document. This will override your current rules
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
 msgstr "Import rules made by the community. This will override your current rules."
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
-msgstr "Import Rules YAML"
 
 #: src/components/Settings/MediaServerSelector/index.tsx
 msgid "Important:"

--- a/apps/ui/src/locales/es.po
+++ b/apps/ui/src/locales/es.po
@@ -856,10 +856,6 @@ msgstr "Configurar ajustes globales"
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr "Configura los proveedores de metadatos y establece la fuente principal para pósters, fondos y enriquecimiento de metadatos. Añadir una clave API de desarrollador de TVDB da a Maintainerr una fuente alternativa para referencias cruzadas de proveedores, lo que ayuda a recuperar IDs faltantes cuando el proveedor principal no puede resolver una coincidencia y puede aportar una segunda opinión para algunos elementos mediante referencias cruzadas de IDs externos existentes."
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr "Configurar notificaciones"
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr "Configurar para actualizar"
@@ -1546,10 +1542,6 @@ msgstr "Existe"
 msgid "Export"
 msgstr "Exportar"
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr "Exportar reglas YAML"
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr "Exporta tus reglas a un documento YAML"
@@ -1970,10 +1962,6 @@ msgstr "Importar reglas desde un documento YAML. Esto anulará tus reglas actual
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
 msgstr "Reglas de importación hechas por la comunidad. Esto anulará sus reglas actuales."
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
-msgstr "Importar reglas YAML"
 
 #: src/components/Settings/MediaServerSelector/index.tsx
 msgid "Important:"

--- a/apps/ui/src/locales/fi.po
+++ b/apps/ui/src/locales/fi.po
@@ -856,10 +856,6 @@ msgstr ""
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr ""
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr ""
@@ -1546,10 +1542,6 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr ""
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr ""
@@ -1969,10 +1961,6 @@ msgstr ""
 
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
-msgstr ""
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
 msgstr ""
 
 #: src/components/Settings/MediaServerSelector/index.tsx

--- a/apps/ui/src/locales/fr.po
+++ b/apps/ui/src/locales/fr.po
@@ -856,10 +856,6 @@ msgstr ""
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr ""
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr ""
@@ -1546,10 +1542,6 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr ""
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr ""
@@ -1969,10 +1961,6 @@ msgstr ""
 
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
-msgstr ""
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
 msgstr ""
 
 #: src/components/Settings/MediaServerSelector/index.tsx

--- a/apps/ui/src/locales/it.po
+++ b/apps/ui/src/locales/it.po
@@ -856,10 +856,6 @@ msgstr ""
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr ""
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr ""
@@ -1546,10 +1542,6 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr ""
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr ""
@@ -1969,10 +1961,6 @@ msgstr ""
 
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
-msgstr ""
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
 msgstr ""
 
 #: src/components/Settings/MediaServerSelector/index.tsx

--- a/apps/ui/src/locales/nb.po
+++ b/apps/ui/src/locales/nb.po
@@ -856,10 +856,6 @@ msgstr ""
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr ""
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr ""
@@ -1546,10 +1542,6 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr ""
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr ""
@@ -1969,10 +1961,6 @@ msgstr ""
 
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
-msgstr ""
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
 msgstr ""
 
 #: src/components/Settings/MediaServerSelector/index.tsx

--- a/apps/ui/src/locales/nl.po
+++ b/apps/ui/src/locales/nl.po
@@ -856,10 +856,6 @@ msgstr ""
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr ""
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr ""
@@ -1546,10 +1542,6 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr ""
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr ""
@@ -1969,10 +1961,6 @@ msgstr ""
 
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
-msgstr ""
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
 msgstr ""
 
 #: src/components/Settings/MediaServerSelector/index.tsx

--- a/apps/ui/src/locales/pl.po
+++ b/apps/ui/src/locales/pl.po
@@ -856,10 +856,6 @@ msgstr ""
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr ""
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr ""
@@ -1546,10 +1542,6 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr ""
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr ""
@@ -1969,10 +1961,6 @@ msgstr ""
 
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
-msgstr ""
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
 msgstr ""
 
 #: src/components/Settings/MediaServerSelector/index.tsx

--- a/apps/ui/src/locales/pt.po
+++ b/apps/ui/src/locales/pt.po
@@ -856,10 +856,6 @@ msgstr ""
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr ""
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr ""
@@ -1546,10 +1542,6 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr ""
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr ""
@@ -1969,10 +1961,6 @@ msgstr ""
 
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
-msgstr ""
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
 msgstr ""
 
 #: src/components/Settings/MediaServerSelector/index.tsx

--- a/apps/ui/src/locales/sv.po
+++ b/apps/ui/src/locales/sv.po
@@ -856,10 +856,6 @@ msgstr "Konfigurera globala inställningar"
 msgid "Configure metadata providers and set the primary source for posters, backdrops, and metadata enrichment. Adding a TVDB developer API key gives Maintainerr a fallback source for provider cross-references, which helps recover missing IDs when the primary provider cannot resolve a match and can provide a second opinion for some items through existing external ID cross-references."
 msgstr "Konfigurera metadataleverantörer och ange den primära källan för affischer, bakgrunder och metadataberikning. En TVDB-utvecklarnyckel ger Maintainerr en reservkälla för korsreferenser mellan leverantörer, vilket hjälper till att återskapa saknade ID:n när den primära leverantören inte hittar en matchning och kan ge en andra bedömning för vissa objekt via befintliga externa ID-korsreferenser."
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Configure Notifications"
-msgstr "Konfigurera aviseringar"
-
 #: src/components/Settings/Metadata/index.tsx
 msgid "Configure to refresh"
 msgstr "Konfigurera för att uppdatera"
@@ -1546,10 +1542,6 @@ msgstr "Finns"
 msgid "Export"
 msgstr "Exportera"
 
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Export Rules YAML"
-msgstr "Exportera regler som YAML"
-
 #: src/components/Common/YamlImporterModal/index.tsx
 msgid "Export your rules to a YAML document"
 msgstr "Exportera dina regler till ett YAML-dokument"
@@ -1970,10 +1962,6 @@ msgstr "Importera regler från ett YAML-dokument. Detta ersätter dina nuvarande
 #: src/components/Common/CommunityRuleModal/index.tsx
 msgid "Import rules made by the community. This will override your current rules."
 msgstr "Importera regler skapade av communityn. Detta ersätter dina nuvarande regler."
-
-#: src/components/Rules/RuleGroup/AddModal/index.tsx
-msgid "Import Rules YAML"
-msgstr "Importera regler från YAML"
 
 #: src/components/Settings/MediaServerSelector/index.tsx
 msgid "Important:"

--- a/apps/ui/src/pages/CollectionDetailPage.tsx
+++ b/apps/ui/src/pages/CollectionDetailPage.tsx
@@ -146,11 +146,9 @@ const CollectionDetailPage = () => {
 
         {mediaTestModalOpen && collection?.id ? (
           <LazyModalBoundary
-            title={t`Test Media`}
             onCancel={() => {
               setMediaTestModalOpen(false)
             }}
-            size="5xl"
           >
             <TestMediaItem
               collectionId={+collection.id}

--- a/apps/ui/styles/globals.css
+++ b/apps/ui/styles/globals.css
@@ -643,6 +643,10 @@
     @apply mr-1.5 ml-1.5 h-4 w-4 first:ml-0 last:mr-0;
   }
 
+  .modal-backdrop {
+    @apply fixed top-0 right-0 bottom-0 left-0 z-50 flex h-full w-full items-center justify-center bg-zinc-800/70;
+  }
+
   .modal-icon {
     @apply mx-auto flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-zinc-800 text-white ring-1 ring-zinc-500 sm:mx-0 sm:h-10 sm:w-10;
   }


### PR DESCRIPTION
Follow-ups to #3596, one commit each.

| Commit | Change | Was |
| --- | --- | --- |
| Footer rule | Border removed above the buttons on the shared `Modal` and the media card dialog | A line under the body on every dialog, dividing nothing on the ones that fit the screen |
| Lazy dialog placeholder | `LazyModalBoundary` falls back to the backdrop, scroll lock and delayed spinner, no panel, as `Modal` drew before #3596. Escape still closes it. Backdrop class moves to `globals.css` beside `.modal-icon` | A `Modal loading` shell with its own Cancel and height showed for the chunk load, then was swapped for the real dialog |
| Media server switch | No close while the switch runs; the Switch button carries the pending state | #3596 left Cancel reachable mid-switch, which skipped the finish step that reloads settings, so the server switched while the page still showed the old one |
| Media card dim | Uses `modal-backdrop` | `bg-black/70` where every other dialog dims with zinc |
| Notification agents wait | Immediate small spinner in place, OK disabled meanwhile | A second delayed spinner after the chunk's, which restarted its timer and blanked the body for 600ms on a slow load |
| Media card sheet in landscape | Header capped at half the viewport height | The `sm` header height is keyed on width, so a phone in landscape got the 288px tablet backdrop inside a 337px sheet and the footer, with its Close, was clipped below the edge |

Frame-sampled on Test Media: the page dims at 15ms with no panel, the dialog appears once at 421ms. The media card sheet checked with six screens of injected text at 320x568, 375x667, 667x375 and 768x1024: Close on screen and hittable at scroll-top, Escape, backdrop tap and Close all close it. The other changed dialogs re-checked at 320x568.