### PR TITLE
feat(sportarr): read the native sportarr id the media server agents stamp

### DIFF
--- a/apps/server/src/modules/actions/sportarr-action-handler.spec.ts
+++ b/apps/server/src/modules/actions/sportarr-action-handler.spec.ts
@@ -104,6 +104,29 @@ describe('SportarrActionHandler', () => {
     expect(mockClient.deleteLeague).not.toHaveBeenCalled();
   });
 
+  it('resolves a show from the native sportarr id its agent stamps', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      type: 'show' as MediaItemType,
+      sportarrSettingsId: 1,
+    });
+    const media = createCollectionMediaWithMetadata(collection, {
+      tvdbId: undefined,
+    });
+    mockMediaServer.getMetadata.mockResolvedValue(
+      createMediaItem({
+        type: 'show',
+        providerIds: { sportarr: [F1_EXTERNAL_ID] },
+      }),
+    );
+
+    await expect(handler.handleAction(collection, media)).resolves.toBe(true);
+    expect(mockClient.getLeagueByExternalId).toHaveBeenCalledWith(
+      F1_EXTERNAL_ID,
+    );
+    expect(mockClient.deleteLeague).toHaveBeenCalledWith(3, true);
+  });
+
   it('resolves a show from its own provider ids without walking to its parent', async () => {
     // On Jellyfin/Emby a show's parentId is the id-less library folder, so
     // walking up from a show resolves nothing (the #3065 trap). A show must

--- a/apps/server/src/modules/actions/sportarr-action-handler.ts
+++ b/apps/server/src/modules/actions/sportarr-action-handler.ts
@@ -54,11 +54,11 @@ export class SportarrActionHandler {
       mediaData = await mediaServer.getMetadata(media.mediaServerId);
     }
 
-    // Resolve the league from the tvdb alias Sportarr stamps on the Plex item's
-    // guid (present on season/episode members too, via the show). Prefer the id
-    // Maintainerr already stored on the collection member; fall back to the
-    // item's live metadata when it wasn't captured. No fuzzy matching - it is
-    // an exact id lookup.
+    // Resolve the league from the ids Sportarr stamps on the show (its own
+    // sportarr namespace, or the older tvdb alias). Prefer the alias Maintainerr
+    // already stored on the collection member; fall back to the item's live
+    // metadata when it wasn't captured. No fuzzy matching - it is an exact id
+    // lookup.
     let externalId = sportarrLeagueExternalIdFromTvdbAlias(media.tvdbId);
     if (!externalId) {
       // The alias lives on the show's guid, so follow a season/episode member
@@ -74,7 +74,7 @@ export class SportarrActionHandler {
         }
       }
       externalId = sportarrLeagueExternalIdFromProviderIds(
-        showItem?.providerIds?.tvdb,
+        showItem?.providerIds,
       );
     }
     if (!externalId) {

--- a/apps/server/src/modules/api/media-server/emby/emby.mapper.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby.mapper.spec.ts
@@ -60,6 +60,7 @@ describe('EmbyMapper', () => {
         imdb: ['tt1234567'],
         tmdb: [],
         tvdb: [],
+        sportarr: [],
       });
     });
 
@@ -68,6 +69,7 @@ describe('EmbyMapper', () => {
         imdb: [],
         tmdb: ['12345'],
         tvdb: [],
+        sportarr: [],
       });
     });
 
@@ -76,6 +78,16 @@ describe('EmbyMapper', () => {
         imdb: [],
         tmdb: [],
         tvdb: ['67890'],
+        sportarr: [],
+      });
+    });
+
+    it('extracts the Sportarr id its agent stamps', () => {
+      expect(EmbyMapper.extractProviderIds({ Sportarr: 'lg-000278' })).toEqual({
+        imdb: [],
+        tmdb: [],
+        tvdb: [],
+        sportarr: ['lg-000278'],
       });
     });
 
@@ -84,6 +96,7 @@ describe('EmbyMapper', () => {
         imdb: [],
         tmdb: [],
         tvdb: [],
+        sportarr: [],
       });
     });
 
@@ -92,6 +105,7 @@ describe('EmbyMapper', () => {
         imdb: [],
         tmdb: [],
         tvdb: [],
+        sportarr: [],
       });
     });
 
@@ -100,6 +114,7 @@ describe('EmbyMapper', () => {
         imdb: [],
         tmdb: [],
         tvdb: [],
+        sportarr: [],
       });
     });
   });
@@ -331,7 +346,12 @@ describe('EmbyMapper', () => {
       expect(result.id).toBe('minimal-1');
       expect(result.title).toBe('Minimal');
       expect(result.parentId).toBeUndefined();
-      expect(result.providerIds).toEqual({ imdb: [], tmdb: [], tvdb: [] });
+      expect(result.providerIds).toEqual({
+        imdb: [],
+        tmdb: [],
+        tvdb: [],
+        sportarr: [],
+      });
       expect(result.mediaSources).toEqual([]);
       expect(result.genres).toEqual([]);
       expect(result.actors).toEqual([]);

--- a/apps/server/src/modules/api/media-server/emby/emby.mapper.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby.mapper.spec.ts
@@ -82,15 +82,6 @@ describe('EmbyMapper', () => {
       });
     });
 
-    it('extracts the Sportarr id its agent stamps', () => {
-      expect(EmbyMapper.extractProviderIds({ Sportarr: 'lg-000278' })).toEqual({
-        imdb: [],
-        tmdb: [],
-        tvdb: [],
-        sportarr: ['lg-000278'],
-      });
-    });
-
     it('handles null', () => {
       expect(EmbyMapper.extractProviderIds(null)).toEqual({
         imdb: [],

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin.mapper.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin.mapper.spec.ts
@@ -70,13 +70,6 @@ describe('JellyfinMapper', () => {
       expect(result.tvdb).toEqual(['67890']);
     });
 
-    it('should extract the Sportarr id its agent stamps', () => {
-      const result = JellyfinMapper.extractProviderIds({
-        Sportarr: 'lg-000278',
-      });
-      expect(result.sportarr).toEqual(['lg-000278']);
-    });
-
     it('should extract multiple provider ids', () => {
       const providerIds = {
         Imdb: 'tt1234567',

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin.mapper.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin.mapper.spec.ts
@@ -70,6 +70,13 @@ describe('JellyfinMapper', () => {
       expect(result.tvdb).toEqual(['67890']);
     });
 
+    it('should extract the Sportarr id its agent stamps', () => {
+      const result = JellyfinMapper.extractProviderIds({
+        Sportarr: 'lg-000278',
+      });
+      expect(result.sportarr).toEqual(['lg-000278']);
+    });
+
     it('should extract multiple provider ids', () => {
       const providerIds = {
         Imdb: 'tt1234567',
@@ -84,17 +91,17 @@ describe('JellyfinMapper', () => {
 
     it('should handle undefined provider ids', () => {
       const result = JellyfinMapper.extractProviderIds(undefined);
-      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: [] });
+      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: [], sportarr: [] });
     });
 
     it('should handle null provider ids', () => {
       const result = JellyfinMapper.extractProviderIds(null);
-      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: [] });
+      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: [], sportarr: [] });
     });
 
     it('should handle empty provider ids', () => {
       const result = JellyfinMapper.extractProviderIds({});
-      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: [] });
+      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: [], sportarr: [] });
     });
   });
 
@@ -364,7 +371,12 @@ describe('JellyfinMapper', () => {
         expect(result.id).toBe('minimal123');
         expect(result.title).toBe('Minimal Item');
         expect(result.parentId).toBeUndefined();
-        expect(result.providerIds).toEqual({ imdb: [], tmdb: [], tvdb: [] });
+        expect(result.providerIds).toEqual({
+          imdb: [],
+          tmdb: [],
+          tvdb: [],
+          sportarr: [],
+        });
         expect(result.mediaSources).toEqual([]);
         expect(result.genres).toEqual([]);
       });

--- a/apps/server/src/modules/api/media-server/media-provider-ids.utils.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-provider-ids.utils.spec.ts
@@ -2,7 +2,12 @@ import { addProviderId, emptyProviderIds } from './media-provider-ids.utils';
 
 describe('media provider ids', () => {
   it('starts every provider off with an empty list', () => {
-    expect(emptyProviderIds()).toEqual({ imdb: [], tmdb: [], tvdb: [] });
+    expect(emptyProviderIds()).toEqual({
+      imdb: [],
+      tmdb: [],
+      tvdb: [],
+      sportarr: [],
+    });
   });
 
   it.each([
@@ -14,6 +19,8 @@ describe('media provider ids', () => {
     ['tvdb', 'tvdb'],
     ['Tvdb', 'tvdb'],
     ['thetvdb', 'tvdb'],
+    ['sportarr', 'sportarr'],
+    ['Sportarr', 'sportarr'],
   ])('files %s under %s', (name, provider) => {
     const providerIds = emptyProviderIds();
     addProviderId(providerIds, name, 'id-1');
@@ -39,6 +46,6 @@ describe('media provider ids', () => {
   ])('ignores %s', (scenario, name, id) => {
     const providerIds = emptyProviderIds();
     addProviderId(providerIds, name, id);
-    expect(providerIds).toEqual({ imdb: [], tmdb: [], tvdb: [] });
+    expect(providerIds).toEqual({ imdb: [], tmdb: [], tvdb: [], sportarr: [] });
   });
 });

--- a/apps/server/src/modules/api/media-server/media-provider-ids.utils.ts
+++ b/apps/server/src/modules/api/media-server/media-provider-ids.utils.ts
@@ -1,8 +1,9 @@
 import { MediaProviderIds } from '@maintainerr/contracts';
 
 // Every name a media server may use for the providers Maintainerr tracks:
-// the bare ones, the capitalised keys Jellyfin and Emby send, and the
-// spelled-out ones a legacy Plex agent carries. Matched lowercased.
+// the bare ones, the capitalised keys Jellyfin and Emby send, the
+// spelled-out ones a legacy Plex agent carries, and the Sportarr namespace
+// its own agents stamp. Matched lowercased.
 //
 // A Map, not an object literal: the name comes from the server's own metadata,
 // and `constructor` / `__proto__` resolve on an object literal's prototype
@@ -13,12 +14,14 @@ const PROVIDER_BY_NAME = new Map<string, keyof MediaProviderIds>([
   ['themoviedb', 'tmdb'],
   ['tvdb', 'tvdb'],
   ['thetvdb', 'tvdb'],
+  ['sportarr', 'sportarr'],
 ]);
 
 export const emptyProviderIds = (): MediaProviderIds => ({
   imdb: [],
   tmdb: [],
   tvdb: [],
+  sportarr: [],
 });
 
 /**

--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.spec.ts
@@ -148,12 +148,27 @@ describe('PlexMapper', () => {
       expect(result.imdb).toEqual(['tt1234567']);
     });
 
+    it('should extract the Sportarr id its metadata provider stamps beside the tvdb alias', () => {
+      const guids = [
+        { id: 'sportarr://lg-000278' },
+        { id: 'tvdb://900000278' },
+      ];
+      const result = PlexMapper.extractProviderIds(guids);
+      expect(result.sportarr).toEqual(['lg-000278']);
+      expect(result.tvdb).toEqual(['900000278']);
+    });
+
     it('should ignore a fallback guid the agent owns rather than a provider', () => {
       const result = PlexMapper.extractProviderIds(
         [{ id: 'tvdb://900000278' }],
         'tv.plex.agents.nfo.series://show/tvdb_900000278',
       );
-      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: ['900000278'] });
+      expect(result).toEqual({
+        imdb: [],
+        tmdb: [],
+        tvdb: ['900000278'],
+        sportarr: [],
+      });
     });
 
     it('should ignore plex:// guids', () => {
@@ -166,18 +181,18 @@ describe('PlexMapper', () => {
 
     it('should handle undefined guids', () => {
       const result = PlexMapper.extractProviderIds(undefined);
-      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: [] });
+      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: [], sportarr: [] });
     });
 
     it('should handle empty array', () => {
       const result = PlexMapper.extractProviderIds([]);
-      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: [] });
+      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: [], sportarr: [] });
     });
 
     it('should handle malformed guids', () => {
       const guids = [{ id: 'malformed-id' }, { id: '' }];
       const result = PlexMapper.extractProviderIds(guids);
-      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: [] });
+      expect(result).toEqual({ imdb: [], tmdb: [], tvdb: [], sportarr: [] });
     });
   });
 

--- a/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex.mapper.ts
@@ -43,7 +43,7 @@ const PLEX_AGENT_GUID_PREFIX = `plex${GUID_SCHEME_SEPARATOR}`;
  * - type → type (with enum mapping)
  * - addedAt (unix timestamp) → addedAt (Date)
  * - duration (ms) → durationMs
- * - Guid[] → providerIds { imdb, tmdb, tvdb }
+ * - Guid[] → providerIds { imdb, tmdb, tvdb, sportarr }
  * - Media[] → mediaSources
  */
 export class PlexMapper {
@@ -115,12 +115,13 @@ export class PlexMapper {
   }
 
   /**
-   * Extract provider IDs (IMDB, TMDB, TVDB) from Plex GUID format.
+   * Extract provider IDs (IMDB, TMDB, TVDB, Sportarr) from Plex GUID format.
    *
    * Plex GUIDs look like:
    * - "imdb://tt1234567"
    * - "tmdb://12345"
    * - "tvdb://12345"
+   * - "sportarr://lg-000278"
    * - "plex://movie/5d776830880197001ec7f3eb"
    * - "com.plexapp.agents.thetvdb://73141/1/1?lang=en" (legacy agent)
    *

--- a/apps/server/src/modules/api/servarr-api/helpers/sportarr-external-id.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sportarr-external-id.spec.ts
@@ -1,40 +1,8 @@
 import { SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET } from '@maintainerr/contracts';
 import {
-  sportarrLeagueExternalIdFromNativeId,
-  sportarrLeagueExternalIdFromNumber,
   sportarrLeagueExternalIdFromProviderIds,
   sportarrLeagueExternalIdFromTvdbAlias,
-  sportarrLeagueNumberFromExternalId,
-  sportarrLeagueNumberFromTvdbAlias,
 } from './sportarr-external-id';
-
-describe('sportarrLeagueExternalIdFromNativeId', () => {
-  it('accepts the league id the Sportarr agents stamp', () => {
-    expect(sportarrLeagueExternalIdFromNativeId('lg-000278')).toBe('lg-000278');
-    expect(sportarrLeagueExternalIdFromNativeId('lg-1234567')).toBe(
-      'lg-1234567',
-    );
-  });
-
-  it('normalises case and surrounding whitespace', () => {
-    expect(sportarrLeagueExternalIdFromNativeId(' LG-000278 ')).toBe(
-      'lg-000278',
-    );
-  });
-
-  it.each([
-    undefined,
-    null,
-    '',
-    'ev-848683', // an event, stamped on episodes, never a league
-    '900000278', // the tvdb alias digits, not a native id
-    'lg-', // no digits
-    'lg-12ab',
-    'league-278',
-  ])('returns null for %s', (value) => {
-    expect(sportarrLeagueExternalIdFromNativeId(value)).toBeNull();
-  });
-});
 
 describe('sportarrLeagueExternalIdFromTvdbAlias', () => {
   it('reverses the frozen offset back to a zero-padded league id', () => {
@@ -92,16 +60,29 @@ describe('sportarrLeagueExternalIdFromProviderIds', () => {
     ).toBe('lg-000278');
   });
 
+  it('canonicalises the stamped id, which is matched against Sportarr by string', () => {
+    expect(
+      sportarrLeagueExternalIdFromProviderIds({ sportarr: [' LG-278 '] }),
+    ).toBe('lg-000278');
+  });
+
   it('falls back to the tvdb alias for a show refreshed before the native id existed', () => {
     expect(
       sportarrLeagueExternalIdFromProviderIds({ tvdb: ['900000278'] }),
     ).toBe('lg-000278');
   });
 
-  it('skips an event id in the sportarr namespace and still reads the alias', () => {
+  it.each([
+    'ev-848683', // an event, stamped on episodes, never a league
+    '900000278', // the tvdb alias digits, not a native id
+    'lg-', // no digits
+    'lg-000000', // league 0 does not exist
+    'lg-12ab',
+    'league-278',
+  ])('ignores %s in the sportarr namespace and reads the alias', (value) => {
     expect(
       sportarrLeagueExternalIdFromProviderIds({
-        sportarr: ['ev-848683'],
+        sportarr: [value],
         tvdb: ['900000278'],
       }),
     ).toBe('lg-000278');
@@ -119,30 +100,11 @@ describe('sportarrLeagueExternalIdFromProviderIds', () => {
   it('returns null when nothing identifies a league', () => {
     expect(
       sportarrLeagueExternalIdFromProviderIds({
+        sportarr: ['ev-848683'],
         tvdb: ['342040', 'not-a-number'],
       }),
     ).toBeNull();
     expect(sportarrLeagueExternalIdFromProviderIds({})).toBeNull();
     expect(sportarrLeagueExternalIdFromProviderIds(undefined)).toBeNull();
-  });
-});
-
-describe('league numbers', () => {
-  it('round-trips a league id and its number', () => {
-    expect(sportarrLeagueNumberFromExternalId('lg-000278')).toBe(278);
-    expect(sportarrLeagueExternalIdFromNumber(278)).toBe('lg-000278');
-    expect(sportarrLeagueExternalIdFromNumber(1234567)).toBe('lg-1234567');
-  });
-
-  it('rejects ids that are not a league', () => {
-    expect(sportarrLeagueNumberFromExternalId('ev-848683')).toBeUndefined();
-    expect(sportarrLeagueNumberFromExternalId('lg-000000')).toBeUndefined();
-    expect(sportarrLeagueNumberFromExternalId(undefined)).toBeUndefined();
-  });
-
-  it('reads the league number out of a tvdb alias', () => {
-    expect(sportarrLeagueNumberFromTvdbAlias(900000278)).toBe(278);
-    expect(sportarrLeagueNumberFromTvdbAlias(342040)).toBeUndefined();
-    expect(sportarrLeagueNumberFromTvdbAlias(1000000000)).toBeUndefined();
   });
 });

--- a/apps/server/src/modules/api/servarr-api/helpers/sportarr-external-id.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sportarr-external-id.spec.ts
@@ -1,8 +1,40 @@
 import { SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET } from '@maintainerr/contracts';
 import {
+  sportarrLeagueExternalIdFromNativeId,
+  sportarrLeagueExternalIdFromNumber,
   sportarrLeagueExternalIdFromProviderIds,
   sportarrLeagueExternalIdFromTvdbAlias,
+  sportarrLeagueNumberFromExternalId,
+  sportarrLeagueNumberFromTvdbAlias,
 } from './sportarr-external-id';
+
+describe('sportarrLeagueExternalIdFromNativeId', () => {
+  it('accepts the league id the Sportarr agents stamp', () => {
+    expect(sportarrLeagueExternalIdFromNativeId('lg-000278')).toBe('lg-000278');
+    expect(sportarrLeagueExternalIdFromNativeId('lg-1234567')).toBe(
+      'lg-1234567',
+    );
+  });
+
+  it('normalises case and surrounding whitespace', () => {
+    expect(sportarrLeagueExternalIdFromNativeId(' LG-000278 ')).toBe(
+      'lg-000278',
+    );
+  });
+
+  it.each([
+    undefined,
+    null,
+    '',
+    'ev-848683', // an event, stamped on episodes, never a league
+    '900000278', // the tvdb alias digits, not a native id
+    'lg-', // no digits
+    'lg-12ab',
+    'league-278',
+  ])('returns null for %s', (value) => {
+    expect(sportarrLeagueExternalIdFromNativeId(value)).toBeNull();
+  });
+});
 
 describe('sportarrLeagueExternalIdFromTvdbAlias', () => {
   it('reverses the frozen offset back to a zero-padded league id', () => {
@@ -51,18 +83,66 @@ describe('sportarrLeagueExternalIdFromTvdbAlias', () => {
 });
 
 describe('sportarrLeagueExternalIdFromProviderIds', () => {
-  it('scans past non-alias entries to find the alias', () => {
-    // An agent-matched item can carry a real TVDB guid ahead of the alias.
+  it('prefers the native sportarr id over the tvdb alias', () => {
     expect(
-      sportarrLeagueExternalIdFromProviderIds(['342040', '900000278']),
+      sportarrLeagueExternalIdFromProviderIds({
+        sportarr: ['lg-000278'],
+        tvdb: ['900000999'],
+      }),
     ).toBe('lg-000278');
   });
 
-  it('returns null when no entry is inside the alias range', () => {
+  it('falls back to the tvdb alias for a show refreshed before the native id existed', () => {
     expect(
-      sportarrLeagueExternalIdFromProviderIds(['342040', 'not-a-number']),
+      sportarrLeagueExternalIdFromProviderIds({ tvdb: ['900000278'] }),
+    ).toBe('lg-000278');
+  });
+
+  it('skips an event id in the sportarr namespace and still reads the alias', () => {
+    expect(
+      sportarrLeagueExternalIdFromProviderIds({
+        sportarr: ['ev-848683'],
+        tvdb: ['900000278'],
+      }),
+    ).toBe('lg-000278');
+  });
+
+  it('scans past non-alias tvdb entries to find the alias', () => {
+    // An agent-matched item can carry a real TVDB guid ahead of the alias.
+    expect(
+      sportarrLeagueExternalIdFromProviderIds({
+        tvdb: ['342040', '900000278'],
+      }),
+    ).toBe('lg-000278');
+  });
+
+  it('returns null when nothing identifies a league', () => {
+    expect(
+      sportarrLeagueExternalIdFromProviderIds({
+        tvdb: ['342040', 'not-a-number'],
+      }),
     ).toBeNull();
-    expect(sportarrLeagueExternalIdFromProviderIds([])).toBeNull();
+    expect(sportarrLeagueExternalIdFromProviderIds({})).toBeNull();
     expect(sportarrLeagueExternalIdFromProviderIds(undefined)).toBeNull();
+  });
+});
+
+describe('league numbers', () => {
+  it('round-trips a league id and its number', () => {
+    expect(sportarrLeagueNumberFromExternalId('lg-000278')).toBe(278);
+    expect(sportarrLeagueExternalIdFromNumber(278)).toBe('lg-000278');
+    expect(sportarrLeagueExternalIdFromNumber(1234567)).toBe('lg-1234567');
+  });
+
+  it('rejects ids that are not a league', () => {
+    expect(sportarrLeagueNumberFromExternalId('ev-848683')).toBeUndefined();
+    expect(sportarrLeagueNumberFromExternalId('lg-000000')).toBeUndefined();
+    expect(sportarrLeagueNumberFromExternalId(undefined)).toBeUndefined();
+  });
+
+  it('reads the league number out of a tvdb alias', () => {
+    expect(sportarrLeagueNumberFromTvdbAlias(900000278)).toBe(278);
+    expect(sportarrLeagueNumberFromTvdbAlias(342040)).toBeUndefined();
+    expect(sportarrLeagueNumberFromTvdbAlias(1000000000)).toBeUndefined();
   });
 });

--- a/apps/server/src/modules/api/servarr-api/helpers/sportarr-external-id.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sportarr-external-id.ts
@@ -1,85 +1,68 @@
 import {
+  isSportarrTvdbAlias,
   MediaProviderIds,
   SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET,
-  SPORTARR_TVDB_ALIAS_RANGE,
 } from '@maintainerr/contracts';
 
 const LEAGUE_ID_PREFIX = 'lg-';
 const LEAGUE_ID_PAD = 6;
 
-// A Sportarr league id as its agents stamp it: `lg-` and at least one digit.
-// Event ids (`ev-...`) live on episodes and never identify a league.
-function isLeagueId(value: string): boolean {
-  if (
-    !value.startsWith(LEAGUE_ID_PREFIX) ||
-    value.length === LEAGUE_ID_PREFIX.length
-  ) {
-    return false;
+// The league number inside a Sportarr short id (lg-000278 -> 278). Event ids
+// (ev-...) live on episodes and never identify a league, so only the `lg-`
+// prefix parses.
+function leagueNumberFromExternalId(
+  value: string | undefined | null,
+): number | undefined {
+  const id = value?.trim().toLowerCase();
+  if (!id?.startsWith(LEAGUE_ID_PREFIX)) {
+    return undefined;
   }
-  for (let i = LEAGUE_ID_PREFIX.length; i < value.length; i++) {
-    const code = value.charCodeAt(i);
+
+  const digits = id.slice(LEAGUE_ID_PREFIX.length);
+  if (!digits.length) {
+    return undefined;
+  }
+  for (let i = 0; i < digits.length; i++) {
+    const code = digits.charCodeAt(i);
     if (code < 48 || code > 57) {
-      return false;
+      return undefined;
     }
   }
-  return true;
+
+  const n = Number(digits);
+  return Number.isSafeInteger(n) && n > 0 ? n : undefined;
+}
+
+// The league id for its number (278 -> lg-000278). Ids grow past the pad width
+// unpadded.
+function leagueExternalIdFromNumber(n: number): string {
+  return `${LEAGUE_ID_PREFIX}${String(n).padStart(LEAGUE_ID_PAD, '0')}`;
 }
 
 // The canonical league id from the `sportarr` namespace the Sportarr media
 // server agents stamp on a show (Plex `sportarr://lg-000278`, Jellyfin and
-// Emby `ProviderIds.Sportarr`). Anything else in that namespace is not a
-// league.
-export function sportarrLeagueExternalIdFromNativeId(
+// Emby `ProviderIds.Sportarr`). Re-padded, because the connection matches it
+// against Sportarr's own externalId by exact string.
+function leagueExternalIdFromNativeId(
   value: string | undefined | null,
 ): string | null {
-  const id = value?.trim().toLowerCase();
-  return id && isLeagueId(id) ? id : null;
+  const n = leagueNumberFromExternalId(value);
+  return n === undefined ? null : leagueExternalIdFromNumber(n);
 }
 
-// The number inside a league id (lg-000278 -> 278), which is how the
-// metadata layer keys a provider id.
-export function sportarrLeagueNumberFromExternalId(
-  externalId: string | undefined | null,
-): number | undefined {
-  const leagueId = sportarrLeagueExternalIdFromNativeId(externalId);
-  if (!leagueId) {
-    return undefined;
-  }
-  const n = Number(leagueId.slice(LEAGUE_ID_PREFIX.length));
-  return n > 0 ? n : undefined;
-}
-
-// The league id for its number (278 -> lg-000278). Ids grow past the pad
-// width unpadded.
-export function sportarrLeagueExternalIdFromNumber(n: number): string {
-  return `${LEAGUE_ID_PREFIX}${String(n).padStart(LEAGUE_ID_PAD, '0')}`;
-}
-
-// Before the agents stamped the native id they only carried a numeric alias
-// in the tvdb namespace (e.g. tvdb://900000278). Libraries that were never
-// refreshed since still resolve through it. Values outside the reserved
-// league alias range (900,000,000-999,999,999) are not Sportarr league ids.
-export function sportarrLeagueNumberFromTvdbAlias(
-  tvdbAlias: number | undefined | null,
-): number | undefined {
-  if (
-    tvdbAlias === undefined ||
-    tvdbAlias === null ||
-    !Number.isInteger(tvdbAlias)
-  ) {
-    return undefined;
-  }
-  const n = tvdbAlias - SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET;
-  return n > 0 && n < SPORTARR_TVDB_ALIAS_RANGE ? n : undefined;
-}
-
-// Reverse the tvdb alias back to the canonical league external id
-// (900000278 -> lg-000278).
+// Before the agents stamped the native id they only carried a numeric alias in
+// the tvdb namespace (e.g. tvdb://900000278). Libraries that were never
+// refreshed since still resolve through it.
 export function sportarrLeagueExternalIdFromTvdbAlias(
   tvdbAlias: number | undefined | null,
 ): string | null {
-  const n = sportarrLeagueNumberFromTvdbAlias(tvdbAlias);
-  return n === undefined ? null : sportarrLeagueExternalIdFromNumber(n);
+  if (!isSportarrTvdbAlias(tvdbAlias)) {
+    return null;
+  }
+
+  // The offset itself is the bottom of the window, not league 0.
+  const n = tvdbAlias - SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET;
+  return n > 0 ? leagueExternalIdFromNumber(n) : null;
 }
 
 // Resolve the league from everything a media-server item carries. The native
@@ -92,7 +75,7 @@ export function sportarrLeagueExternalIdFromProviderIds(
   providerIds: MediaProviderIds | undefined | null,
 ): string | null {
   for (const candidate of providerIds?.sportarr ?? []) {
-    const externalId = sportarrLeagueExternalIdFromNativeId(candidate);
+    const externalId = leagueExternalIdFromNativeId(candidate);
     if (externalId) {
       return externalId;
     }

--- a/apps/server/src/modules/api/servarr-api/helpers/sportarr-external-id.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sportarr-external-id.ts
@@ -1,42 +1,103 @@
 import {
+  MediaProviderIds,
   SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET,
   SPORTARR_TVDB_ALIAS_RANGE,
 } from '@maintainerr/contracts';
 
-// Sportarr stamps a numeric alias in the tvdb namespace onto its Plex items
-// (e.g. tvdb://900000278), alongside the native sportarr:// guid. Maintainerr's
-// Plex mapper already extracts the tvdb guid into providerIds.tvdb, so the
-// connection reverses that alias back to the canonical league external id
-// (lg-000278) instead of touching the shared guid-parsing layer.
-export function sportarrLeagueExternalIdFromTvdbAlias(
-  tvdbAlias: number | undefined | null,
+const LEAGUE_ID_PREFIX = 'lg-';
+const LEAGUE_ID_PAD = 6;
+
+// A Sportarr league id as its agents stamp it: `lg-` and at least one digit.
+// Event ids (`ev-...`) live on episodes and never identify a league.
+function isLeagueId(value: string): boolean {
+  if (
+    !value.startsWith(LEAGUE_ID_PREFIX) ||
+    value.length === LEAGUE_ID_PREFIX.length
+  ) {
+    return false;
+  }
+  for (let i = LEAGUE_ID_PREFIX.length; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 48 || code > 57) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// The canonical league id from the `sportarr` namespace the Sportarr media
+// server agents stamp on a show (Plex `sportarr://lg-000278`, Jellyfin and
+// Emby `ProviderIds.Sportarr`). Anything else in that namespace is not a
+// league.
+export function sportarrLeagueExternalIdFromNativeId(
+  value: string | undefined | null,
 ): string | null {
+  const id = value?.trim().toLowerCase();
+  return id && isLeagueId(id) ? id : null;
+}
+
+// The number inside a league id (lg-000278 -> 278), which is how the
+// metadata layer keys a provider id.
+export function sportarrLeagueNumberFromExternalId(
+  externalId: string | undefined | null,
+): number | undefined {
+  const leagueId = sportarrLeagueExternalIdFromNativeId(externalId);
+  if (!leagueId) {
+    return undefined;
+  }
+  const n = Number(leagueId.slice(LEAGUE_ID_PREFIX.length));
+  return n > 0 ? n : undefined;
+}
+
+// The league id for its number (278 -> lg-000278). Ids grow past the pad
+// width unpadded.
+export function sportarrLeagueExternalIdFromNumber(n: number): string {
+  return `${LEAGUE_ID_PREFIX}${String(n).padStart(LEAGUE_ID_PAD, '0')}`;
+}
+
+// Before the agents stamped the native id they only carried a numeric alias
+// in the tvdb namespace (e.g. tvdb://900000278). Libraries that were never
+// refreshed since still resolve through it. Values outside the reserved
+// league alias range (900,000,000-999,999,999) are not Sportarr league ids.
+export function sportarrLeagueNumberFromTvdbAlias(
+  tvdbAlias: number | undefined | null,
+): number | undefined {
   if (
     tvdbAlias === undefined ||
     tvdbAlias === null ||
     !Number.isInteger(tvdbAlias)
   ) {
-    return null;
+    return undefined;
   }
-
   const n = tvdbAlias - SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET;
-  // Values outside the reserved league alias range (900,000,000-999,999,999)
-  // are not Sportarr league ids.
-  if (n <= 0 || n >= SPORTARR_TVDB_ALIAS_RANGE) {
-    return null;
-  }
-
-  return `lg-${n.toString().padStart(6, '0')}`;
+  return n > 0 && n < SPORTARR_TVDB_ALIAS_RANGE ? n : undefined;
 }
 
-// A media-server item can carry several tvdb guids (e.g. a real TVDB id from
-// an agent match alongside the Sportarr alias), in no guaranteed order. Scan
-// them all for the one inside the reserved alias range instead of trusting
-// the first entry.
-export function sportarrLeagueExternalIdFromProviderIds(
-  tvdbIds: readonly string[] | undefined | null,
+// Reverse the tvdb alias back to the canonical league external id
+// (900000278 -> lg-000278).
+export function sportarrLeagueExternalIdFromTvdbAlias(
+  tvdbAlias: number | undefined | null,
 ): string | null {
-  for (const candidate of tvdbIds ?? []) {
+  const n = sportarrLeagueNumberFromTvdbAlias(tvdbAlias);
+  return n === undefined ? null : sportarrLeagueExternalIdFromNumber(n);
+}
+
+// Resolve the league from everything a media-server item carries. The native
+// `sportarr` id wins; the tvdb alias is the fallback for a show that predates
+// it. A media-server item can carry several tvdb guids (e.g. a real TVDB id
+// from an agent match alongside the alias), in no guaranteed order, so scan
+// them all for the one inside the reserved range instead of trusting the
+// first entry.
+export function sportarrLeagueExternalIdFromProviderIds(
+  providerIds: MediaProviderIds | undefined | null,
+): string | null {
+  for (const candidate of providerIds?.sportarr ?? []) {
+    const externalId = sportarrLeagueExternalIdFromNativeId(candidate);
+    if (externalId) {
+      return externalId;
+    }
+  }
+  for (const candidate of providerIds?.tvdb ?? []) {
     const externalId = sportarrLeagueExternalIdFromTvdbAlias(Number(candidate));
     if (externalId) {
       return externalId;

--- a/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.spec.ts
+++ b/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.spec.ts
@@ -276,4 +276,11 @@ describe('TmdbMetadataProvider', () => {
     expect(details?.firstAirDate).toBeUndefined();
     expect(details?.seasonCount).toBeUndefined();
   });
+
+  it('does not ask TMDB about an external namespace its find endpoint cannot resolve', async () => {
+    const result = await provider.findByExternalId('lg-000278', 'sportarr');
+
+    expect(result).toBeUndefined();
+    expect(tmdbApi.getByExternalId).not.toHaveBeenCalled();
+  });
 });

--- a/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.ts
+++ b/apps/server/src/modules/metadata/providers/tmdb-metadata.provider.ts
@@ -266,7 +266,9 @@ export class TmdbMetadataProvider implements IMetadataProvider {
     externalId: string | number,
     type: string,
   ): Promise<ExternalIdSearchResult[] | undefined> {
-    if (type === 'tmdb') {
+    // TMDB's find endpoint only knows imdb and tvdb. Any other namespace on
+    // the item (the Sportarr agents stamp their own) has no TMDB answer.
+    if (type !== 'imdb' && type !== 'tvdb') {
       return undefined;
     }
 

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.spec.ts
@@ -113,7 +113,19 @@ describe('SportarrGetterService', () => {
     expect(mockClient.getLeagueByExternalId).not.toHaveBeenCalled();
   });
 
-  it('finds the alias when it is not the first tvdb provider id', async () => {
+  it.each([
+    // A show refreshed since the agents stamp their own namespace carries the
+    // native id, and it wins over a conflicting alias.
+    {
+      name: 'the native sportarr id',
+      providerIds: { sportarr: [F1_EXTERNAL_ID], tvdb: ['900000999'] },
+    },
+    // An agent-matched item can carry a real TVDB id ahead of the alias.
+    {
+      name: 'the alias behind a real tvdb id',
+      providerIds: { tvdb: ['342040', F1_ALIAS] },
+    },
+  ])('resolves the league from $name', async ({ providerIds }) => {
     mockClient.getLeagueByExternalId.mockResolvedValue({
       id: 3,
       externalId: F1_EXTERNAL_ID,
@@ -122,36 +134,18 @@ describe('SportarrGetterService', () => {
       added: '2025-12-04T02:29:15.000Z',
     });
 
-    // A show refreshed since the agents stamp their own namespace carries the
-    // native id; it wins over the alias.
-    const nativeResult = await service.get(
-      1,
-      showItem({
-        providerIds: { sportarr: [F1_EXTERNAL_ID], tvdb: ['900000999'] },
-      }),
-      'show',
-      ruleGroup(),
-    );
-
-    expect(nativeResult).toBe(true);
-    expect(mockClient.getLeagueByExternalId).toHaveBeenCalledWith(
-      F1_EXTERNAL_ID,
-      expect.any(Array),
-    );
-
-    // An agent-matched item can carry a real TVDB id ahead of the alias.
     const result = await service.get(
       1,
-      showItem({ providerIds: { tvdb: ['342040', F1_ALIAS] } }),
+      showItem({ providerIds }),
       'show',
       ruleGroup(),
     );
 
+    expect(result).toBe(true);
     expect(mockClient.getLeagueByExternalId).toHaveBeenCalledWith(
       F1_EXTERNAL_ID,
       expect.any(Array),
     );
-    expect(result).toBe(true);
   });
 
   it('resolves the league by the reversed alias and returns addDate', async () => {

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.spec.ts
@@ -122,6 +122,23 @@ describe('SportarrGetterService', () => {
       added: '2025-12-04T02:29:15.000Z',
     });
 
+    // A show refreshed since the agents stamp their own namespace carries the
+    // native id; it wins over the alias.
+    const nativeResult = await service.get(
+      1,
+      showItem({
+        providerIds: { sportarr: [F1_EXTERNAL_ID], tvdb: ['900000999'] },
+      }),
+      'show',
+      ruleGroup(),
+    );
+
+    expect(nativeResult).toBe(true);
+    expect(mockClient.getLeagueByExternalId).toHaveBeenCalledWith(
+      F1_EXTERNAL_ID,
+      expect.any(Array),
+    );
+
     // An agent-matched item can carry a real TVDB id ahead of the alias.
     const result = await service.get(
       1,

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
@@ -18,8 +18,8 @@ import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 // Getter for the native Sportarr application. Resolution keys off the league
 // id the Sportarr agents stamp on a show (its sportarr namespace, or the older
 // tvdb alias reversed back to a league external id), then reads league/event
-// fields from Sportarr's own /api/. Nothing here
-// is shared with the Sonarr/Radarr getters.
+// fields from Sportarr's own /api/. Nothing here is shared with the
+// Sonarr/Radarr getters.
 @Injectable()
 export class SportarrGetterService {
   plexProperties: Property[];

--- a/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sportarr-getter.service.ts
@@ -15,9 +15,10 @@ import { RuleDto } from '../dtos/rule.dto';
 import { RuleGroupDto } from '../dtos/ruleGroup.dto';
 import { ArrLookupCache } from '../helpers/arr-lookup-cache';
 
-// Getter for the native Sportarr application. Resolution keys off the tvdb
-// alias Sportarr stamps on its Plex items (reversed back to a league external
-// id), then reads league/event fields from Sportarr's own /api/. Nothing here
+// Getter for the native Sportarr application. Resolution keys off the league
+// id the Sportarr agents stamp on a show (its sportarr namespace, or the older
+// tvdb alias reversed back to a league external id), then reads league/event
+// fields from Sportarr's own /api/. Nothing here
 // is shared with the Sonarr/Radarr getters.
 @Injectable()
 export class SportarrGetterService {
@@ -81,7 +82,7 @@ export class SportarrGetterService {
       const client = await this.servarrService.getSportarrApiClient(settingsId);
 
       let externalId = sportarrLeagueExternalIdFromProviderIds(
-        showItem?.providerIds?.tvdb,
+        showItem?.providerIds,
       );
       let showMetadataRead = showItem !== undefined;
       if (!externalId) {
@@ -103,7 +104,7 @@ export class SportarrGetterService {
           : fetchShow());
         showMetadataRead = fullShow !== undefined;
         externalId = sportarrLeagueExternalIdFromProviderIds(
-          fullShow?.providerIds?.tvdb,
+          fullShow?.providerIds,
         );
       }
       if (!externalId) {

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.spec.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.spec.tsx
@@ -210,6 +210,55 @@ describe('MediaModal', () => {
     expect(await screen.findByText('tvdb://202')).toBeTruthy()
   })
 
+  it('links a sportarr id to its league on sportarr.net', async () => {
+    getApiHandlerMock.mockImplementation((path: string) => {
+      if (path === '/media-server') {
+        return Promise.resolve({})
+      }
+
+      if (path === '/settings') {
+        return Promise.resolve({})
+      }
+
+      if (path === '/media-server/meta/3') {
+        return Promise.resolve({
+          providerIds: {
+            sportarr: ['lg-000278'],
+            tvdb: ['900000278'],
+          },
+        } as MediaItem)
+      }
+
+      if (path.startsWith('/metadata/backdrop/show?')) {
+        return Promise.resolve(undefined)
+      }
+
+      if (path === '/streamystats/info') {
+        return Promise.reject(new Error('404 Streamystats not configured'))
+      }
+
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    render(
+      <MediaModal
+        onClose={() => {}}
+        id={3}
+        mediaType="show"
+        title="Show"
+        summary="Show summary"
+        providerIds={{ sportarr: ['lg-000278'] }}
+      />,
+    )
+
+    const badge = await screen.findByText('sportarr://lg-000278')
+
+    expect(badge.closest('a')?.getAttribute('href')).toBe(
+      'https://sportarr.net/browse/leagues/lg-000278',
+    )
+    expect(screen.queryByText('tvdb://900000278')).toBeNull()
+  })
+
   it('shows maintainerr status for manually added items', async () => {
     getApiHandlerMock.mockImplementation((path: string) => {
       if (path === '/media-server') {

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
@@ -1,4 +1,5 @@
 import {
+  isSportarrTvdbAlias,
   MediaItem,
   ServarrAction,
   type MaintainerrMediaStatusDetails,
@@ -17,7 +18,6 @@ import { logClientError } from '../../../../utils/ClientLogger'
 import {
   buildMetadataPath,
   buildProviderUrl,
-  isSportarrTvdbAlias,
   mediaTypeLabel,
 } from '../../../../utils/mediaTypeUtils'
 import Button from '../../Button'
@@ -573,7 +573,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
       ['tmdb', 'imdb', 'tvdb', 'sportarr'] as const
     ).flatMap((provider) =>
       (providerIds?.[provider] ?? [])
-        .filter((id) => provider !== 'tvdb' || !isSportarrTvdbAlias(id))
+        .filter((id) => provider !== 'tvdb' || !isSportarrTvdbAlias(Number(id)))
         .map((id) => ({ provider, id })),
     )
 
@@ -888,7 +888,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
               the sheet scrolled sideways to reach the last one. */}
           <div className="flex shrink-0 flex-row flex-wrap items-center justify-between gap-4 p-4">
             {['movie', 'show'].includes(mediaType) &&
-              providerBadges.length > 0 && (
+              (providerBadges.length > 0 || showBackdropProviderBadge) && (
                 <div className="flex flex-wrap items-center gap-1 text-xs text-zinc-400">
                   {providerBadges.map(({ provider, id }) => (
                     <ProviderIdBadge

--- a/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/MediaModal/index.tsx
@@ -17,6 +17,7 @@ import { logClientError } from '../../../../utils/ClientLogger'
 import {
   buildMetadataPath,
   buildProviderUrl,
+  isSportarrTvdbAlias,
   mediaTypeLabel,
 } from '../../../../utils/mediaTypeUtils'
 import Button from '../../Button'
@@ -566,6 +567,15 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
       !providerIds?.[backdropProviderKey]?.includes(
         String(backdropResult.providerId),
       )
+    // The Sportarr alias in the tvdb namespace only exists for tools that
+    // cannot read the sportarr id. A person gets the real one.
+    const providerBadges = (
+      ['tmdb', 'imdb', 'tvdb', 'sportarr'] as const
+    ).flatMap((provider) =>
+      (providerIds?.[provider] ?? [])
+        .filter((id) => provider !== 'tvdb' || !isSportarrTvdbAlias(id))
+        .map((id) => ({ provider, id })),
+    )
 
     return (
       <div className="modal-backdrop px-3" onClick={onClose}>
@@ -877,22 +887,17 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
           {/* Wraps: side by side these actions are wider than a phone, and
               the sheet scrolled sideways to reach the last one. */}
           <div className="flex shrink-0 flex-row flex-wrap items-center justify-between gap-4 p-4">
-            {providerIds &&
-              ['movie', 'show'].includes(mediaType) &&
-              (providerIds.tmdb?.length ||
-                providerIds.imdb?.length ||
-                providerIds.tvdb?.length) && (
+            {['movie', 'show'].includes(mediaType) &&
+              providerBadges.length > 0 && (
                 <div className="flex flex-wrap items-center gap-1 text-xs text-zinc-400">
-                  {(['tmdb', 'imdb', 'tvdb'] as const).flatMap((provider) =>
-                    (providerIds[provider] ?? []).map((id) => (
-                      <ProviderIdBadge
-                        key={`${provider}-${id}`}
-                        provider={provider}
-                        providerId={id}
-                        mediaType={mediaType}
-                      />
-                    )),
-                  )}
+                  {providerBadges.map(({ provider, id }) => (
+                    <ProviderIdBadge
+                      key={`${provider}-${id}`}
+                      provider={provider}
+                      providerId={id}
+                      mediaType={mediaType}
+                    />
+                  ))}
                   {showBackdropProviderBadge && backdropProviderKey && (
                     <ProviderIdBadge
                       key={`${backdropProviderKey}-${backdropResult.providerId}`}

--- a/apps/ui/src/utils/mediaTypeUtils.ts
+++ b/apps/ui/src/utils/mediaTypeUtils.ts
@@ -1,7 +1,6 @@
 import { t } from '@lingui/core/macro'
 import {
-  SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET,
-  SPORTARR_TVDB_ALIAS_RANGE,
+  isSportarrTvdbAlias,
   type MediaItemType,
   type MediaProviderIds,
 } from '@maintainerr/contracts'
@@ -96,16 +95,6 @@ export function buildMetadataPath(
   return `/metadata/${kind}/${toImageEndpointType(mediaType)}?${params.toString()}`
 }
 
-// Sportarr stamps a numeric alias into the tvdb namespace so tools that only
-// read imdb/tmdb/tvdb can still resolve a league. It is not a TVDB id.
-export function isSportarrTvdbAlias(providerId: string): boolean {
-  const numericId = Number(providerId)
-  return (
-    numericId >= SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET &&
-    numericId < SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET + SPORTARR_TVDB_ALIAS_RANGE
-  )
-}
-
 /**
  * TMDB and TheTVDB split movies from series; TheTVDB goes through its
  * dereferrer, which resolves a numeric id to the right slug. Sportarr stamps
@@ -127,7 +116,7 @@ export function buildProviderUrl(
     case 'imdb':
       return `https://www.imdb.com/title/${id}/`
     case 'tvdb': {
-      if (isSportarrTvdbAlias(providerId)) {
+      if (isSportarrTvdbAlias(Number(providerId))) {
         return undefined
       }
       return `https://thetvdb.com/dereferrer/${isMovie ? 'movie' : 'series'}/${id}`

--- a/apps/ui/src/utils/mediaTypeUtils.ts
+++ b/apps/ui/src/utils/mediaTypeUtils.ts
@@ -96,11 +96,22 @@ export function buildMetadataPath(
   return `/metadata/${kind}/${toImageEndpointType(mediaType)}?${params.toString()}`
 }
 
+// Sportarr stamps a numeric alias into the tvdb namespace so tools that only
+// read imdb/tmdb/tvdb can still resolve a league. It is not a TVDB id.
+export function isSportarrTvdbAlias(providerId: string): boolean {
+  const numericId = Number(providerId)
+  return (
+    numericId >= SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET &&
+    numericId < SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET + SPORTARR_TVDB_ALIAS_RANGE
+  )
+}
+
 /**
  * TMDB and TheTVDB split movies from series; TheTVDB goes through its
  * dereferrer, which resolves a numeric id to the right slug. Sportarr stamps
  * numeric aliases into the tvdb namespace that have no page at all, so those
- * resolve to nothing rather than a dead link.
+ * resolve to nothing rather than a dead link; its own sportarr namespace
+ * links to the league on sportarr.net.
  */
 export function buildProviderUrl(
   provider: keyof MediaProviderIds,
@@ -116,16 +127,13 @@ export function buildProviderUrl(
     case 'imdb':
       return `https://www.imdb.com/title/${id}/`
     case 'tvdb': {
-      const numericId = Number(providerId)
-      if (
-        numericId >= SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET &&
-        numericId <
-          SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET + SPORTARR_TVDB_ALIAS_RANGE
-      ) {
+      if (isSportarrTvdbAlias(providerId)) {
         return undefined
       }
       return `https://thetvdb.com/dereferrer/${isMovie ? 'movie' : 'series'}/${id}`
     }
+    case 'sportarr':
+      return `https://sportarr.net/browse/leagues/${id}`
     default:
       return undefined
   }

--- a/packages/contracts/src/media-server/types.ts
+++ b/packages/contracts/src/media-server/types.ts
@@ -2,12 +2,14 @@ import { MediaItemType } from './enums'
 import { MediaLibrarySortField, MediaSortOrder } from './sorting'
 
 /**
- * Provider IDs for external databases (IMDB, TMDB, TVDB)
+ * Provider IDs for external databases (IMDB, TMDB, TVDB) and for Sportarr,
+ * whose media server agents stamp their own `sportarr` namespace (lg-000278).
  */
 export interface MediaProviderIds {
   imdb?: string[]
   tmdb?: string[]
   tvdb?: string[]
+  sportarr?: string[]
 }
 
 /**

--- a/packages/contracts/src/sportarr/sportarr.constants.ts
+++ b/packages/contracts/src/sportarr/sportarr.constants.ts
@@ -1,4 +1,5 @@
-// Sportarr-specific constants, shared by the server connection and the UI.
+// Sportarr-specific constants and the id predicate they define, shared by the
+// server connection and the UI.
 
 // Sportarr stamps numeric aliases in the tvdb provider-id namespace on its
 // media-server items (tvdb://900000278 for league lg-000278). The offset is a
@@ -8,6 +9,23 @@ export const SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET = 900_000_000
 
 // Width of the reserved league alias window.
 export const SPORTARR_TVDB_ALIAS_RANGE = 100_000_000
+
+/**
+ * True when a tvdb-namespace value falls inside Sportarr's reserved window.
+ * Nothing in the window is a TVDB id, so the UI never links one out and the
+ * connection reverses it to a league id instead. Single source of truth for
+ * the window, so the two cannot drift apart.
+ */
+export function isSportarrTvdbAlias(
+  tvdbId: number | undefined | null,
+): tvdbId is number {
+  return (
+    tvdbId != null &&
+    Number.isInteger(tvdbId) &&
+    tvdbId >= SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET &&
+    tvdbId < SPORTARR_TVDB_ALIAS_LEAGUE_OFFSET + SPORTARR_TVDB_ALIAS_RANGE
+  )
+}
 
 // The Sportarr release that ships the id-alias emission and the
 // download-history surface the native connection calls; the connection test


### PR DESCRIPTION
### Description & Design

Sportarr's Plex, Jellyfin and Emby agents stamp a `sportarr` namespace on every show (`sportarr://lg-000278` on Plex, `ProviderIds.Sportarr` on Jellyfin and Emby) next to the numeric tvdb alias the Sportarr connection resolves through today. This reads that namespace as a provider id and resolves the league from it first. The alias stays as the fallback for a library that has not been refreshed since the agents started stamping the native id, so nothing that works today changes.

- `MediaProviderIds` gains `sportarr`, filed by the shared mapper table on all three servers
- the getter and the action handler resolve from the whole provider id set, native id first
- the TMDB provider no longer asks TMDB about a namespace its find endpoint cannot resolve (it only knows imdb and tvdb, and a `sportarr` key in the id bag would have produced a `/find/NaN` request)
- the media card shows the sportarr id linked to its league on sportarr.net, and no longer shows the tvdb alias, which is not a TVDB id and linked nowhere

A second PR adds a metadata provider for the new namespace so Sportarr shows get artwork; it is built on this one and follows once this lands.

### Related issue

None. Follow-up to #3306.

### AI-Assisted Development

I used an AI coding assistant to draft the mapper, helper and test changes, modelled on the existing imdb/tmdb/tvdb handling and the Sportarr connection from #3306. I reviewed every line, traced the id flow from the Plex guid through the getter, the action handler and the metadata controller, and ran format, lint, type checking, the full jest and vitest suites and the e2e matrix locally. The design and the fallback behaviour are mine.

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I understand the code I am submitting and can explain how it works
- [x] I have performed a self-review of my code
- [x] I have linted and formatted my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

### How to test

1. Point a Plex library at the Sportarr metadata provider (https://sportarr.net/plex) and refresh a show, or use a Jellyfin/Emby library with the Sportarr plugin.
2. Open the show in Maintainerr. The media card shows a `sportarr://lg-...` badge that links to sportarr.net, and no tvdb alias badge.
3. Run a Sportarr rule on that library. The getter resolves the league from the native id; a show that only carries the tvdb alias still resolves as before.
