### PR TITLE
chore(tools): add a mock Sportarr and seed its connection

### DIFF
--- a/tools/dev/fake-emby.mjs
+++ b/tools/dev/fake-emby.mjs
@@ -42,7 +42,7 @@ const USERS = [
 ];
 
 // --- Items -----------------------------------------------------------------------
-function show(id, name) {
+function show(id, name, providerIds = {}) {
   return {
     Id: id,
     Name: name,
@@ -50,10 +50,24 @@ function show(id, name) {
     ParentId: 'emby-shows',
     ProductionYear: 2020,
     DateCreated: ISO('2026-01-01'),
-    ProviderIds: {},
+    ProviderIds: providerIds,
   };
 }
-const SHOWS = [show('emby-show-1', 'Mock Show Alpha')];
+const SHOWS = [
+  show('emby-show-1', 'Mock Show Alpha'),
+  // Sportarr fixtures, matching fake-sportarr's leagues. One carries the native
+  // id its agents stamp, one only the older tvdb alias, so both resolution paths
+  // are covered. emby-show-1 carries neither, which the getter answers with the
+  // transient signal at debug level - deliberately, so an ordinary show in a
+  // sports library cannot match a NOT_EXISTS rule (#3406).
+  show('emby-show-sportarr-native', 'Mock League Alpha', {
+    Sportarr: 'lg-000001',
+    Tvdb: '900000001',
+  }),
+  show('emby-show-sportarr-alias', 'Mock League Bravo', {
+    Tvdb: '900000042',
+  }),
+];
 
 // The shared manual ("custom name") BoxSet. Server-global, but reported only under
 // libraries whose content it holds - and it holds movies only.

--- a/tools/dev/fake-jellyfin.mjs
+++ b/tools/dev/fake-jellyfin.mjs
@@ -117,13 +117,27 @@ function series(id, name, addDate, providerIds = {}) {
 }
 
 const SHOWS = [
+  // Synthetic ids, deliberately below 900,000,000: that window is reserved by
+  // Sportarr for its league aliases, so ids inside it resolve as leagues.
   series('mock-show-1', 'Mock Show Alpha', '2026-01-01', {
-    Tvdb: '900000001',
-    Tmdb: '900000001',
+    Tvdb: '800000001',
+    Tmdb: '800000001',
   }),
   series('mock-show-2', 'Mock Show Bravo', '2026-02-01', {
-    Tvdb: '900000002',
-    Tmdb: '900000002',
+    Tvdb: '800000002',
+    Tmdb: '800000002',
+  }),
+  // Sportarr fixtures, matching fake-sportarr's leagues. One carries the native
+  // id its agents stamp, one only the older tvdb alias, so both resolution paths
+  // are covered. mock-show-1/2 carry neither, which the getter answers with the
+  // transient signal at debug level - deliberately, so an ordinary show in a
+  // sports library cannot match a NOT_EXISTS rule (#3406).
+  series('mock-show-sportarr-native', 'Mock League Alpha', '2026-01-05', {
+    Sportarr: 'lg-000001',
+    Tvdb: '900000001',
+  }),
+  series('mock-show-sportarr-alias', 'Mock League Bravo', '2026-01-06', {
+    Tvdb: '900000042',
   }),
 ];
 

--- a/tools/dev/fake-plex.mjs
+++ b/tools/dev/fake-plex.mjs
@@ -197,7 +197,23 @@ const EPISODES = [
   }),
 ];
 
-const ALL_ITEMS = [...MOVIES, SHOW, ...SEASONS, ...EPISODES];
+// Sportarr fixtures, matching fake-sportarr's leagues. One carries the native guid
+// its agents stamp beside the tvdb alias, one only the older alias, so both
+// resolution paths are covered. SHOW carries neither, which the getter answers with
+// the transient signal at debug level - deliberately, so an ordinary show in a
+// sports library cannot match a NOT_EXISTS rule (#3406).
+const SPORTARR_SHOWS = [
+  baseItem('sp1', 'show', 'Mock League Alpha', {
+    addedAt: daysAgo(180),
+    Guid: [{ id: 'sportarr://lg-000001' }, { id: 'tvdb://900000001' }],
+  }),
+  baseItem('sp2', 'show', 'Mock League Bravo', {
+    addedAt: daysAgo(150),
+    Guid: [{ id: 'tvdb://900000042' }],
+  }),
+];
+
+const ALL_ITEMS = [...MOVIES, SHOW, ...SPORTARR_SHOWS, ...SEASONS, ...EPISODES];
 const ITEMS_BY_ID = new Map(ALL_ITEMS.map((m) => [m.ratingKey, m]));
 
 // --- Optional large library for Seerr whole-library scale tests (#3152) ------
@@ -357,7 +373,7 @@ const server = http.createServer((req, res) => {
           ? SEASONS
           : type === '4'
             ? EPISODES
-            : [SHOW, ...SCALE_SHOWS];
+            : [SHOW, ...SPORTARR_SHOWS, ...SCALE_SHOWS];
     }
     return sendPaged(res, req, items);
   }

--- a/tools/dev/fake-sportarr.mjs
+++ b/tools/dev/fake-sportarr.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Dev-only mock Sportarr (native /api) HTTP server for Maintainerr.
+ *
+ * Maintainerr's Sportarr client (apps/server/.../servarr-api/helpers/sportarr.helper.ts)
+ * talks to Sportarr's own API, not the Sonarr-v3 compatibility shim, so none of the
+ * other mocks cover it. Without this the seeded Sportarr connection is dead, so every
+ * Sportarr rule answers the transient signal and its items sit pinned as
+ * evaluation-failed. This stub answers the endpoints the getter and action handler call.
+ *
+ * Leagues carry the canonical `lg-` external id the media server agents stamp, so the
+ * seeded shows in fake-jellyfin / fake-emby / fake-plex resolve two ways:
+ *   - the native `sportarr` provider id (Plex `sportarr://lg-000001`, Jellyfin/Emby
+ *     `ProviderIds.Sportarr`)
+ *   - the numeric alias in the tvdb namespace (`tvdb://900000001`), which is what a
+ *     library refreshed before the agents stamped the native id still carries
+ * A show with neither carries no league at all: the getter answers the transient
+ * signal and logs it at debug, deliberately, so an ordinary show sitting in a sports
+ * library cannot match a NOT_EXISTS rule (#3406).
+ *
+ * Writes (delete league, delete event files, monitor toggles, quality profile) are
+ * accepted and logged but change nothing, like fake-radarr: the action handler's
+ * request shape is what matters, not the state.
+ *
+ * Everything below is invented - no real leagues, teams or events (repo rule).
+ *
+ * Usage
+ * -----
+ *   node tools/dev/fake-sportarr.mjs                 # listens on :1867 (matches dev seed)
+ *   FAKE_SPORTARR_PORT=1867 node tools/dev/fake-sportarr.mjs
+ *   FAKE_SPORTARR_LOG=0 node tools/dev/fake-sportarr.mjs   # silence the per-request log
+ *
+ * The dev seed (tools/dev/seed-db.mjs) points sportarr_settings.url at
+ * http://localhost:1867, so no settings change is needed - start this before (or
+ * alongside) `yarn dev`, then trigger a run with `POST /api/rules/:id/execute` or a
+ * single-item check with `POST /api/rules/test`.
+ */
+import http from "node:http";
+
+const PORT = Number(process.env.FAKE_SPORTARR_PORT ?? 1867);
+const LOG = process.env.FAKE_SPORTARR_LOG !== "0";
+
+const DAY = 86_400_000;
+// Captured once so a process' answers stay stable across its lifetime.
+const NOW = Date.now();
+const iso = (msFromNow) => new Date(NOW + msFromNow).toISOString();
+
+// Must be >= MINIMUM_SPORTARR_VERSION in packages/contracts; the connection test
+// refuses anything older.
+const VERSION = "4.1.5.1115";
+
+const QUALITY_PROFILES = [
+  { id: 1, name: "WEB-1080p (mock)", isDefault: true },
+  { id: 2, name: "WEB-2160p (mock)", isDefault: false },
+];
+
+// Two leagues. The external id's digits plus the frozen 900,000,000 offset are the
+// tvdb alias the media-server mocks stamp, so lg-000001 <-> tvdb://900000001.
+const LEAGUES = [
+  {
+    id: 1,
+    externalId: "lg-000001",
+    name: "Mock League Alpha",
+    sport: "Mock Sport",
+    country: "XX",
+    monitored: true,
+    added: iso(-400 * DAY),
+    qualityProfileId: 1,
+  },
+  {
+    id: 42,
+    externalId: "lg-000042",
+    name: "Mock League Bravo",
+    sport: "Other Mock Sport",
+    country: "XX",
+    monitored: false,
+    added: iso(-120 * DAY),
+    qualityProfileId: 2,
+  },
+];
+
+// Seasons are calendar years, which is how Sportarr models them. One season aired and
+// one still to come, so "has upcoming events" is true and the downloaded-event count
+// is a fraction of the total rather than all or nothing.
+const SEASONS = [2025, 2026];
+const eventsFor = (league) =>
+  SEASONS.flatMap((seasonNumber, seasonIndex) =>
+    [1, 2, 3].map((episodeNumber) => {
+      const index = seasonIndex * 3 + episodeNumber;
+      const aired = seasonNumber === SEASONS[0];
+      return {
+        id: league.id * 1000 + index,
+        externalId: `ev-${String(league.id * 1000 + index).padStart(6, "0")}`,
+        title: `${league.name} round ${episodeNumber}`,
+        sport: league.sport,
+        leagueId: league.id,
+        leagueName: league.name,
+        season: String(seasonNumber),
+        seasonNumber,
+        episodeNumber,
+        round: String(episodeNumber),
+        eventDate: iso((aired ? -200 : 200) * DAY),
+        broadcastDate: iso((aired ? -200 : 200) * DAY),
+        venue: `Mock Venue ${episodeNumber}`,
+        monitored: episodeNumber !== 3,
+        hasFile: aired,
+        filePath: aired
+          ? `/sports/${league.name}/Season ${seasonNumber}/round-${episodeNumber}.mkv`
+          : null,
+        fileSize: aired ? 2 * 1024 ** 3 : null,
+        quality: aired ? "WEBDL-1080p" : null,
+        qualityProfileId: league.qualityProfileId,
+      };
+    }),
+  );
+
+// The list omits monitored counts; the detail carries them (same split as Sportarr).
+const leagueDetail = (league) => {
+  const events = eventsFor(league);
+  return {
+    ...league,
+    eventCount: events.length,
+    fileCount: events.filter((e) => e.hasFile).length,
+  };
+};
+
+const send = (res, status, body) => {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(body === undefined ? "" : JSON.stringify(body));
+  return status;
+};
+
+const leagueById = (id) => LEAGUES.find((l) => l.id === Number(id));
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, "http://localhost");
+  // The client's base URL ends in /api/, so strip that prefix and match the rest.
+  const API_PREFIX = "/api";
+  const path = url.pathname.startsWith(API_PREFIX)
+    ? url.pathname.slice(API_PREFIX.length)
+    : url.pathname;
+  const method = req.method ?? "GET";
+  let status;
+
+  if (method === "GET" && path === "/system/status") {
+    status = send(res, 200, {
+      appName: "Sportarr",
+      version: VERSION,
+      isDocker: true,
+      isProduction: true,
+    });
+  } else if (method === "GET" && path === "/leagues") {
+    status = send(res, 200, LEAGUES);
+  } else if (method === "GET" && path === "/qualityprofile") {
+    status = send(res, 200, QUALITY_PROFILES);
+  } else if (method === "GET" && path.startsWith("/leagues/")) {
+    const [, , idPart, tail] = path.split("/");
+    const league = leagueById(idPart);
+    if (!league) {
+      status = send(res, 404, { message: "league not found" });
+    } else if (!tail) {
+      status = send(res, 200, leagueDetail(league));
+    } else if (tail === "events") {
+      status = send(res, 200, eventsFor(league));
+    } else if (tail === "download-history") {
+      // One grab per event that has a file, so the download-client cleanup after
+      // a delete has something to walk.
+      status = send(
+        res,
+        200,
+        eventsFor(league)
+          .filter((e) => e.hasFile)
+          .map((e) => ({
+            eventId: e.id,
+            seasonNumber: e.seasonNumber,
+            downloadId: `mockhash${e.id}`,
+            torrentInfoHash: `mockhash${e.id}`,
+            protocol: "torrent",
+          })),
+      );
+    } else {
+      status = send(res, 404, { message: "not found" });
+    }
+  } else if (
+    (method === "DELETE" && path.startsWith("/leagues/")) ||
+    (method === "DELETE" && path.startsWith("/events/")) ||
+    (method === "PUT" && path.startsWith("/leagues/")) ||
+    (method === "PUT" && path.startsWith("/events/"))
+  ) {
+    // Accepted, not applied. The action handler only checks that the call succeeds.
+    status = send(res, 200, {});
+  } else {
+    status = send(res, 404, { message: "not found" });
+  }
+
+  if (LOG) {
+    console.log(`${method} ${url.pathname}${url.search} -> ${status}`);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`fake-sportarr listening on http://localhost:${PORT}`);
+  console.log(
+    `  leagues: ${LEAGUES.map((l) => `${l.externalId} (${l.name})`).join(", ")}`,
+  );
+});

--- a/tools/dev/seed-db.mjs
+++ b/tools/dev/seed-db.mjs
@@ -14,6 +14,7 @@
  *   - tools/dev/fake-emby.mjs      (mock Emby, :8097)     - pairs with MEDIA_SERVER=emby
  *   - tools/dev/fake-plex.mjs      (mock Plex, :32400)    - pairs with MEDIA_SERVER=plex
  *   - tools/dev/fake-seerr.mjs     (mock Seerr, :5055)    - evaluates the Seerr rule groups
+ *   - tools/dev/fake-sportarr.mjs  (mock Sportarr, :1867) - evaluates the Sportarr rule group
  *
  * Notes
  * -----
@@ -171,6 +172,7 @@ const run = db.transaction(() => {
     "collection",
     "radarr_settings",
     "sonarr_settings",
+    "sportarr_settings",
   ]) {
     db.prepare(`DELETE FROM ${t}`).run();
   }
@@ -272,6 +274,17 @@ const run = db.transaction(() => {
       "Sonarr (dev seed)",
       "http://localhost:8989",
       "devseed00sonarr00000000000000000000",
+    ).lastInsertRowid;
+  // Sportarr is its own native connection, not the Sonarr-v3 shim, so it needs
+  // its own mock (tools/dev/fake-sportarr.mjs) to answer anything.
+  const sportarrId = db
+    .prepare(
+      `INSERT INTO sportarr_settings (serverName, url, apiKey) VALUES (?, ?, ?)`,
+    )
+    .run(
+      "Sportarr (dev seed)",
+      "http://localhost:1867",
+      "devseed0sportarr0000000000000000000",
     ).lastInsertRowid;
 
   // 4) Collections + media + linked rule groups.
@@ -447,6 +460,64 @@ const run = db.transaction(() => {
       }),
     );
   }
+
+  // 4b2) Sportarr rule group. Sportarr is its own application (id 5), so none of
+  //      the media-server or Sonarr coverage above touches its getter. Every
+  //      show-scope property, each rule EXISTS so it resolves without a
+  //      comparison operand - the same shape the Seerr groups below use.
+  //      Resolution needs the mock's leagues (tools/dev/fake-sportarr.mjs) plus a
+  //      show carrying either the native `sportarr` id or the tvdb alias, both of
+  //      which the media-server mocks now stamp. The plain mock shows carry
+  //      neither, and answer the transient signal ("could not be read") rather
+  //      than an empty value, so they cannot match NOT_EXISTS (#3406) - worth
+  //      checking in the same run.
+  //      Season and episode scope are left out: no media-server mock serves
+  //      seasons or episodes for these shows, so those groups could only ever
+  //      resolve nothing.
+  const SPORTARR = 5; // Application.SPORTARR
+  const SPORTARR_SHOW_PROPS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 14];
+  const sportarrColId = insCollection.run({
+    libraryId: LIB.show,
+    title: "Sportarr Leagues",
+    description: "Every Sportarr show-scope property, EXISTS.",
+    type: "show",
+    mediaServerType: TARGET,
+    deleteAfterDays: 30,
+    visibleOnHome: 0,
+    arrAction: 4, // DO_NOTHING
+    listExclusions: 0,
+    radarrSettingsId: null,
+    sonarrSettingsId: null,
+    handledMediaAmount: 0,
+    handledMediaSizeBytes: 0,
+    totalSizeBytes: 0,
+    lastDuration: 0,
+    addDate: daysAgo(30),
+  }).lastInsertRowid;
+  db.prepare(`UPDATE collection SET sportarrSettingsId = ? WHERE id = ?`).run(
+    sportarrId,
+    sportarrColId,
+  );
+  const sportarrGroupId = insRuleGroup.run(
+    "Sportarr Leagues",
+    "Every Sportarr show-scope property, EXISTS.",
+    LIB.show,
+    sportarrColId,
+    "show",
+  ).lastInsertRowid;
+  SPORTARR_SHOW_PROPS.forEach((propId, i) =>
+    insRule.run(
+      sportarrGroupId,
+      JSON.stringify({
+        // EXISTS ignores the operand, so ruleTypeId is irrelevant here.
+        customVal: { ruleTypeId: 0, value: "" },
+        operator: i === 0 ? null : 0, // 0 = AND
+        firstVal: [SPORTARR, propId],
+        action: 18, // EXISTS
+        section: 0,
+      }),
+    ),
+  );
 
   // 4c) #3152 repro: Seerr-seeded rule groups. The Seerr getter now reads ONE
   //     bulk /request sweep per run (tools/dev/fake-seerr.mjs) instead of a
@@ -663,13 +734,16 @@ console.log(
   `Seeded ${results.length} collections, ${totalItems} media items, ${totalRules} rules into ${dbPath}`,
 );
 console.log(
-  `Media server set to ${TARGET === "plex" ? "Plex" : TARGET === "emby" ? "Emby" : "Jellyfin"} (dev seed); Radarr + Sonarr configured.`,
+  `Media server set to ${TARGET === "plex" ? "Plex" : TARGET === "emby" ? "Emby" : "Jellyfin"} (dev seed); Radarr + Sonarr + Sportarr configured.`,
 );
 console.log(
-  "Also seeded: Seerr rule groups (#3152), notifications, cron schedules, collection logs, exclusions, overlays.",
+  "Also seeded: Seerr rule groups (#3152), a Sportarr rule group, notifications, cron schedules, collection logs, exclusions, overlays.",
 );
 console.log(
   "Seerr points at tools/dev/fake-seerr.mjs (http://localhost:5055) - start it to evaluate the Seerr rule groups.",
+);
+console.log(
+  "Sportarr points at tools/dev/fake-sportarr.mjs (http://localhost:1867) - start it to evaluate the Sportarr rule group.",
 );
 console.log("Restart `yarn dev` and open http://localhost:3000/collections");
 db.close();


### PR DESCRIPTION
Sportarr was the one connection the dev seed did not cover. It talks to Sportarr's own `/api`, not the Sonarr-v3 shim, so none of the existing mocks answer for it: a seeded Sportarr rule group had nothing to resolve against and its items sat pinned as evaluation-failed.

Dev tooling only. No runtime code is touched.

| File | Change |
| --- | --- |
| `tools/dev/fake-sportarr.mjs` | New. Mock native Sportarr API on `:1867`, modelled on `fake-sonarr.mjs` |
| `tools/dev/seed-db.mjs` | Seeds `sportarr_settings` against the mock, plus a rule group over every show-scope Sportarr property |
| `tools/dev/fake-jellyfin.mjs` | Two Sportarr fixture shows; generic mock shows moved off the reserved tvdb window |
| `tools/dev/fake-emby.mjs` | Two Sportarr fixture shows |
| `tools/dev/fake-plex.mjs` | Two Sportarr fixture shows |

### The mock

Answers what the getter and the action handler call: `/api/system/status`, `/leagues`, `/leagues/:id`, `/leagues/:id/events`, `/leagues/:id/download-history`, `/qualityprofile`, plus the delete and monitor writes as accepted no-ops (same approach as `fake-radarr`). Two invented leagues, `lg-000001` and `lg-000042`, six events each across one aired and one upcoming season so the event counts and "has upcoming events" are not uniformly true.

### The fixtures

Each media-server mock gains two shows, so both id paths from #3604 are exercised:

| Fixture | Carries | Resolves through |
| --- | --- | --- |
| `*-sportarr-native` | `sportarr://lg-000001` / `ProviderIds.Sportarr` plus `tvdb://900000001` | the native id |
| `*-sportarr-alias` | `tvdb://900000042` only | the tvdb alias fallback |
| existing generic shows | neither | nothing; the getter answers the transient signal at debug level, so they cannot match NOT_EXISTS (#3406) |

### One thing worth a look

`fake-jellyfin` was giving its two generic mock shows `Tvdb: 900000001` and `900000002`, which sit **inside** the 900,000,000 window reserved for Sportarr league aliases. Those shows therefore resolved as leagues, which was never the intent. Moved to `800000001` / `800000002`. Nothing else in the repo referenced the old values.

### Verified

Seeded a throwaway DB against the mocks on the current `development`:

```
mock-show-sportarr-native  -> lg-000001            -> league 1,  10/10 properties resolve
mock-show-sportarr-alias   -> tvdb 900000042       -> lg-000042, 10/10 properties resolve
mock-show-1 (no league)    -> "Sportarr Date added could not be read for this item"
```

Plex and Emby fixtures confirmed serving the same id pairs.

### Not included

Season and episode scope. No media-server mock serves seasons or episodes for these shows, so such a group could only ever resolve nothing, which is why the existing `#3153` season group is Plex-only. That leaves `seasonNumber`, `episodeNumber`, `eventDate`, `hasFile` and `filePath` without dev coverage; closing that needs season and episode fixtures in the mocks.
