### PR TITLE
fix(settings): await the settings reads so their catch can see a locked database

### DIFF
--- a/apps/server/src/modules/settings/settings-data.service.spec.ts
+++ b/apps/server/src/modules/settings/settings-data.service.spec.ts
@@ -6,6 +6,7 @@ import { SettingsDataService } from './settings-data.service';
 describe('SettingsDataService', () => {
   let service: SettingsDataService;
   let settingsRepo: Mocked<Repository<Settings>>;
+  let repos: Record<string, Mocked<Repository<unknown>>>;
 
   beforeEach(async () => {
     const { unit, unitRef } =
@@ -13,6 +14,12 @@ describe('SettingsDataService', () => {
 
     service = unit;
     settingsRepo = unitRef.get('SettingsRepository');
+    repos = {
+      SettingsRepository: settingsRepo as Mocked<Repository<unknown>>,
+      RadarrSettingsRepository: unitRef.get('RadarrSettingsRepository'),
+      SonarrSettingsRepository: unitRef.get('SonarrSettingsRepository'),
+      SportarrSettingsRepository: unitRef.get('SportarrSettingsRepository'),
+    };
   });
 
   // Null is reserved for rows the telemetry migration carried over, which are
@@ -46,5 +53,44 @@ describe('SettingsDataService', () => {
 
     expect(settingsRepo.insert).not.toHaveBeenCalled();
     expect(service.telemetryEnabled).toBeNull();
+  });
+
+  // A locked database rejects rather than throwing synchronously, so these
+  // getters have to await inside their try for the catch to see it at all.
+  it('answers a status object when the database is locked', async () => {
+    const locked = () => Promise.reject(new Error('SQLITE_BUSY'));
+    const getters: [string, 'find' | 'findOne', () => Promise<unknown>][] = [
+      ['SettingsRepository', 'findOne', () => service.getSettings()],
+      ['RadarrSettingsRepository', 'find', () => service.getRadarrSettings()],
+      [
+        'RadarrSettingsRepository',
+        'findOne',
+        () => service.getRadarrSetting(1),
+      ],
+      ['SonarrSettingsRepository', 'find', () => service.getSonarrSettings()],
+      [
+        'SonarrSettingsRepository',
+        'findOne',
+        () => service.getSonarrSetting(1),
+      ],
+      [
+        'SportarrSettingsRepository',
+        'find',
+        () => service.getSportarrSettings(),
+      ],
+      [
+        'SportarrSettingsRepository',
+        'findOne',
+        () => service.getSportarrSetting(1),
+      ],
+    ];
+
+    for (const [repo, method, call] of getters) {
+      repos[repo][method].mockImplementation(locked);
+
+      await expect(call()).resolves.toEqual(
+        expect.objectContaining({ status: 'NOK', code: 0 }),
+      );
+    }
   });
 });

--- a/apps/server/src/modules/settings/settings-data.service.ts
+++ b/apps/server/src/modules/settings/settings-data.service.ts
@@ -283,7 +283,7 @@ export class SettingsDataService implements SettingDto {
 
   public async getSettings() {
     try {
-      return this.settingsRepo.findOne({ where: {} });
+      return await this.settingsRepo.findOne({ where: {} });
     } catch (error) {
       this.logger.error(
         'Something went wrong while getting settings. Is the database file locked?',
@@ -324,7 +324,7 @@ export class SettingsDataService implements SettingDto {
 
   public async getRadarrSettings() {
     try {
-      return this.radarrSettingsRepo.find();
+      return await this.radarrSettingsRepo.find();
     } catch (error) {
       this.logger.error(
         'Something went wrong while getting radarr settings. Is the database file locked?',
@@ -340,7 +340,7 @@ export class SettingsDataService implements SettingDto {
 
   public async getRadarrSetting(id: number) {
     try {
-      return this.radarrSettingsRepo.findOne({ where: { id: id } });
+      return await this.radarrSettingsRepo.findOne({ where: { id: id } });
     } catch (error) {
       this.logger.error(
         `Something went wrong while getting radarr setting ${id}. Is the database file locked?`,
@@ -356,7 +356,7 @@ export class SettingsDataService implements SettingDto {
 
   public async getSonarrSettings() {
     try {
-      return this.sonarrSettingsRepo.find();
+      return await this.sonarrSettingsRepo.find();
     } catch (error) {
       this.logger.error(
         'Something went wrong while getting sonarr settings. Is the database file locked?',
@@ -372,7 +372,7 @@ export class SettingsDataService implements SettingDto {
 
   public async getSonarrSetting(id: number) {
     try {
-      return this.sonarrSettingsRepo.findOne({ where: { id: id } });
+      return await this.sonarrSettingsRepo.findOne({ where: { id: id } });
     } catch (error) {
       this.logger.error(
         `Something went wrong while getting sonarr setting ${id}. Is the database file locked?`,
@@ -461,7 +461,7 @@ export class SettingsDataService implements SettingDto {
 
   public async getSportarrSettings() {
     try {
-      return this.sportarrSettingsRepo.find();
+      return await this.sportarrSettingsRepo.find();
     } catch (error) {
       this.logger.error(
         'Something went wrong while getting sportarr settings. Is the database file locked?',
@@ -477,7 +477,7 @@ export class SettingsDataService implements SettingDto {
 
   public async getSportarrSetting(id: number) {
     try {
-      return this.sportarrSettingsRepo.findOne({ where: { id: id } });
+      return await this.sportarrSettingsRepo.findOne({ where: { id: id } });
     } catch (error) {
       this.logger.error(
         `Something went wrong while getting sportarr setting ${id}. Is the database file locked?`,


### PR DESCRIPTION
Seven getters in `settings-data.service.ts` return the repository promise from inside their `try` instead of awaiting it, so the `catch` beside them never runs.

```ts
public async getSportarrSettings() {
  try {
    return this.sportarrSettingsRepo.find();   // not awaited
  } catch (error) {
    this.logger.error('... Is the database file locked?');
    return { status: 'NOK', code: 0, ... } as BasicResponseDto;
  }
}
```

Every one of those catch blocks exists for exactly the failure it cannot see. A locked database rejects; it does not throw synchronously.

## Before and after

The added test fails on the current code and passes with the fix:

```
● SettingsDataService › answers a status object when the database is locked
  Received promise rejected instead of resolved
  Rejected to value: [Error: SQLITE_BUSY]
```

Callers are told a status object comes back on failure. What actually came back was a rejected promise, so a `SQLITE_BUSY` surfaced as an unhandled rejection or an uncaught error at whichever caller happened to be first, instead of the handled `NOK`.

## Scope

| | |
|---|---|
| Fixed | `getSettings`, `getRadarrSettings`, `getRadarrSetting`, `getSonarrSettings`, `getSonarrSetting`, `getSportarrSettings`, `getSportarrSetting` |
| Test | One case covering the family, rather than seven near-identical ones |

I scanned the whole tree for the same shape (an un-awaited `return` inside a `try` that has a `catch`). 69 candidate sites, of which these 7 are the only real ones. The rest either return a synchronous value, return a promise that cannot reject because the callee has its own catch (`plex-api.service.ts` `updateCollection`), or sit in a nested async function whose result is awaited inside the try (`sportarr-getter.service.ts`). Those are left alone.

## Verification

Full suite: 2901 server tests across 3 shards, 403 UI across 2, lint and `tsc` clean. All four list endpoints (`/api/settings`, `/radarr`, `/sonarr`, `/sportarr`) answer 200 with unchanged payloads against the dev stack, and the settings pages render unchanged.