### PR TITLE
fix(metadata): read past a provider id that is not a number

### DIFF
--- a/apps/server/src/modules/metadata/metadata.service.spec.ts
+++ b/apps/server/src/modules/metadata/metadata.service.spec.ts
@@ -670,6 +670,30 @@ describe('MetadataService', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
+  // Plex files a legacy agent guid beside a modern one and both land under
+  // tvdb, so a namespace can hold more than one id.
+  it('reads past a first provider id that is not a number', async () => {
+    const libraryItem = createMediaItem({
+      id: 'show-1',
+      type: 'show',
+      year: 2014,
+      title: 'Fixture Chronicle',
+      providerIds: { tvdb: ['not-an-id', '202'] },
+    });
+    const { service } = createService({
+      tvdbDetails: {
+        title: 'Fixture Chronicle',
+        year: 2014,
+        type: 'tv',
+        externalIds: { tvdb: 202, type: 'tv' },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toMatchObject({ tvdb: 202, type: 'tv' });
+  });
+
   it('rejects direct provider ids when no configured provider confirms the release year', async () => {
     const libraryItem = createMediaItem({
       id: 'show-1',

--- a/apps/server/src/modules/metadata/metadata.service.ts
+++ b/apps/server/src/modules/metadata/metadata.service.ts
@@ -940,18 +940,24 @@ export class MetadataService {
       }
 
       if (providerKeys.has(key)) {
-        const numericId = Number(values[0]);
         const provider = this.providers.find(
           (itemProvider) => itemProvider.idKey === key,
         );
-        if (Number.isFinite(numericId) && provider) {
+        // A namespace can hold more than one id: Plex files a legacy agent
+        // guid beside a modern one and both land under tvdb. Take the first
+        // that reads as an id rather than only the first present.
+        const numericId = values
+          .map((value) => Number(value))
+          .find((candidate) => Number.isFinite(candidate));
+        if (numericId !== undefined && provider) {
           provider.assignId(ids, numericId);
         }
         continue;
       }
 
-      if (values[0]) {
-        ids[key] = values[0];
+      const value = values.find(Boolean);
+      if (value) {
+        ids[key] = value;
       }
     }
 


### PR DESCRIPTION
`extractDirectIds` took `values[0]` and dropped the rest, so a namespace holding more than one id resolved on whichever the server happened to list first, even when that one was unusable.

## A namespace really can hold two ids

Not hypothetical, and not Sportarr-specific:

- `PROVIDER_BY_NAME` maps **both** `tvdb` and `thetvdb` to the same array, and `tmdb`/`themoviedb` likewise.
- `addProviderId` does `providerIds[provider].push(id)` — it appends.
- `PlexMapper.extractProviderIds` calls `collect(fallbackGuid)` **in addition** to iterating `Guid[]`.

So a Plex library carrying a legacy `com.plexapp.agents.thetvdb://` guid beside a modern `tvdb://` one lands two ids under `tvdb` today.

## Before and after

The added test fails on the current code, and the failure is not a wrong id, it is the whole resolution collapsing:

```
● reads past a first provider id that is not a number
  Matcher error: received value must be a non-null object
  Received has value: undefined
```

The only usable id sat at index 1, so nothing resolved at all. After the fix it returns `{ tvdb: 202, type: 'tv' }`.

## What this deliberately does not change

Which id wins when several are usable. Measured on the fixed code:

```
providerIds { tvdb: ['202', '900000278'] }  ->  { type: 'tv', tvdb: 202 }
```

`ResolvedMediaIds` holds one id per namespace, so choosing between two valid ones is a policy question rather than a bug fix, and I could not find anything in the tree or in the upstream agents that produces that pair. Worth a separate look if a real case turns up.

## Provenance

Surfaced while reviewing #3606, but it is not that branch's code: the line is unchanged there apart from swapping `Number()` for `provider.parseId()`. Expect a small conflict when #3606 merges — this PR restructures the same block, so take both changes.

## Verification

Full suite: 2902 server tests across 3 shards, 403 UI across 2, `yarn check-types` and lint clean across all three workspaces.