### PR TITLE
fix(ci): read the paginated shape of Fider users endpoint

### DIFF
--- a/tools/fider-invite-codeowners.mjs
+++ b/tools/fider-invite-codeowners.mjs
@@ -32,6 +32,31 @@ const requireEnv = () => {
 
 const fider = createFider({ host: FIDER_HOST, apiKey: FIDER_API_KEY });
 
+// Fider's /api/v1/users response shape depends on the server version. Until
+// getfider/fider 28e73610 (2025-09-22) it returned a bare array of every user;
+// since then it returns a paginated object ({ users, totalCount, ... }) whose
+// page size defaults to 10. The published docs at docs.fider.io/api/users
+// still describe the old array shape, so neither can be assumed: an array is
+// the complete list, an object gets paged through to the end.
+const USERS_PAGE_SIZE = 500;
+// Sanity ceiling so a server that never advances the page can't loop forever.
+const MAX_USER_PAGES = 50;
+
+const fetchAllUsers = async () => {
+  const all = [];
+  for (let page = 1; page <= MAX_USER_PAGES; page += 1) {
+    const body = await fider(`/api/v1/users?page=${page}&limit=${USERS_PAGE_SIZE}`);
+    // Pre-pagination Fider ignores both params and returns everyone at once.
+    if (Array.isArray(body)) return body;
+    const users = Array.isArray(body?.users) ? body.users : [];
+    if (users.length === 0) break;
+    all.push(...users);
+    const totalCount = Number(body?.totalCount);
+    if (Number.isFinite(totalCount) && all.length >= totalCount) break;
+  }
+  return all;
+};
+
 const ghApi = async (path) => {
   const res = await fetch(`https://api.github.com${path}`, {
     headers: {
@@ -104,16 +129,14 @@ const main = async () => {
   // (case-insensitive); a false negative is just a re-sent invite.
   let onboardedNames = new Set();
   try {
-    const users = await fider('/api/v1/users');
-    if (Array.isArray(users)) {
-      onboardedNames = new Set(
-        users
-          .filter((u) => u && (u.role === 1 || u.role === 2 || u.role === 'administrator' || u.role === 'collaborator'))
-          .map((u) => (u.name || '').toLowerCase())
-          .filter(Boolean),
-      );
-    }
-    log(`Fider has ${onboardedNames.size} Collaborator/Administrator(s)`);
+    const users = await fetchAllUsers();
+    onboardedNames = new Set(
+      users
+        .filter((u) => u && (u.role === 1 || u.role === 2 || u.role === 'administrator' || u.role === 'collaborator'))
+        .map((u) => (u.name || '').toLowerCase())
+        .filter(Boolean),
+    );
+    log(`Fider has ${onboardedNames.size} Collaborator/Administrator(s) among ${users.length} user(s)`);
   } catch (err) {
     log(`could not fetch Fider users (${err.message}); will invite without de-dupe`);
   }


### PR DESCRIPTION
`Fider - Invite CODEOWNERS` has failed every Sunday since 2026-08-23 ([run 32623502533](https://github.com/Maintainerr/Maintainerr/actions/runs/32623502533)). The three runs before it logged `Fider has 5 Collaborator/Administrator(s)` and exited clean; 08-23 logged `0`, tried to re-invite every CODEOWNER, and died on Fider 400 "All these addresses have already been registered on this site".

- features.maintainerr.info was upgraded between 08-16 and 08-23. It now reports `dev-67c52826`, which is 435 commits ahead of getfider/fider `28e73610`. That commit changed `GET /api/v1/users` from a bare array to a paginated object (`{ users, totalCount, ... }`) and dropped the default page size from `"all"` to `10`.
- `fider-invite-codeowners.mjs` gated the de-dupe on `Array.isArray(users)`, which is now false, so the onboarded set stayed empty and every CODEOWNER looked un-invited.
- This PR pages through the object shape and keeps accepting the array shape. [docs.fider.io/api/users](https://docs.fider.io/api/users) still documents the array, so an older instance would still serve it. The explicit page size replaces the new 10-user default.
- The API key is fine and no secret needs rotating: the call returned 200, and the failure was 400 field validation, not 401.
- No other `fider-*` script calls `/api/v1/users`. Posts, tags and comments still return arrays, which is why triage and the stale sweep kept working through the upgrade.
