### PR TITLE
fix(rules): stop the stale-link resync marking a manual collection's members as manual

### DIFF
--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -3019,6 +3019,17 @@ export class CollectionsService {
     };
   }
 
+  /**
+   * Add media to a collection, creating or relinking its media server
+   * collection first if that is missing.
+   *
+   * An EMPTY `media` list is meaningful and load-bearing, not a no-op: the
+   * find-or-create still runs, and the existing members are read from the
+   * database and pushed to the collection it creates. That is how the rule
+   * executor rebuilds a link that went missing, without running every current
+   * member back through the membership update - which would re-mark provenance
+   * and write an "Added" log record per item, per run.
+   */
   async addToCollection(
     collectionDbId: number,
     media: CollectionMediaChange[],

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -1294,11 +1294,9 @@ describe('RuleExecutorService', () => {
     expect(
       collectionService.addToCollectionWithResolvedLink,
     ).not.toHaveBeenCalled();
-    expect(collectionService.addToCollection).toHaveBeenCalledWith(
-      1,
-      [{ mediaServerId: 'm1' }],
-      false,
-    );
+    // No member list and no membership flag: addToCollection re-reads the
+    // collection's members itself, and the resync must not re-mark them.
+    expect(collectionService.addToCollection).toHaveBeenCalledWith(1, []);
     expect(
       collectionService.removeFromCollectionWithResolvedLink,
     ).toHaveBeenCalledWith(
@@ -1316,6 +1314,54 @@ describe('RuleExecutorService', () => {
         },
       ],
       'rule',
+    );
+  });
+
+  // `manualCollection` says the rule group points at a collection the user made,
+  // not that any one membership was added by hand. Passing it as the membership
+  // flag stamped every rule-owned row as manual, which rules can never remove
+  // while the worker still ages it into deleteAfterDays.
+  it("does not mark a manual collection's members as manual when resyncing a stale link", async () => {
+    const { service, collectionService } = createService(
+      MediaServerType.JELLYFIN,
+    );
+
+    const staleCollection = {
+      id: 1,
+      title: 'Test Collection',
+      mediaServerId: 'stale-coll',
+      manualCollection: true,
+      manualCollectionName: 'User Made Collection',
+      deleteAfterDays: 0,
+    };
+
+    collectionService.getCollection.mockResolvedValue(staleCollection as any);
+    collectionService.getCollectionMedia.mockResolvedValue([
+      { mediaServerId: 'm1', includedByRule: true },
+    ] as any);
+    collectionService.checkAutomaticMediaServerLink.mockResolvedValueOnce({
+      ...staleCollection,
+      mediaServerId: null,
+    } as any);
+    collectionService.addToCollection.mockResolvedValueOnce({
+      ...staleCollection,
+      mediaServerId: 'new-coll',
+    } as any);
+    collectionService.saveCollection.mockImplementation(
+      async (collection) => collection as any,
+    );
+
+    (service as any).startTime = new Date();
+    (service as any).resultData = [];
+    (service as any).statisticsData = [];
+
+    await (service as any).handleCollection({ id: 10, collectionId: 1 });
+
+    expect(collectionService.addToCollection).toHaveBeenCalledWith(1, []);
+    expect(collectionService.addToCollection).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      true,
     );
   });
 

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -914,15 +914,21 @@ export class RuleExecutorService {
               );
           }
           // if collection doesn't exist in media server but should.. resync current data.
-          // Kept in Maintainerr only never should, and the resync is not free: it
-          // re-marks every member and writes an "Added" log record per item, per run.
+          // Kept in Maintainerr only never should.
+          //
+          // The member list is deliberately empty: addToCollection reads the
+          // collection's current members from the database and syncs those to the
+          // freshly created server collection itself. Passing them in only ran every
+          // existing row back through the membership update, re-marking each one and
+          // writing an "Added" log record per item per run - and it passed
+          // `collection.manualCollection`, a property of the COLLECTION, as the
+          // per-MEMBERSHIP "added by hand" flag. On a manual collection that stamped
+          // every rule-owned row as a manual member, which no rule can then remove
+          // while it still ages into deleteAfterDays.
           if (!collection.mediaServerId && !collection.keepInMaintainerrOnly) {
             collection = await this.collectionService.addToCollection(
               collection.id,
-              collMediaData.map((m) => ({
-                mediaServerId: m.mediaServerId,
-              })),
-              collection.manualCollection,
+              [],
             );
             if (collection) {
               collection =


### PR DESCRIPTION
Found while auditing the collection-membership code behind #3636. Independent of it; branches off `development`.

## Cause

`collection.manualCollection` is a property of the **collection** - the rule group points at a collection the user made, rather than Maintainerr creating one. It says nothing about how any individual item became a member.

The stale-link resync passed it as the per-**membership** "added by hand" flag:

```ts
collection = await this.collectionService.addToCollection(
  collection.id,
  collMediaData.map((m) => ({ mediaServerId: m.mediaServerId })),
  collection.manualCollection,   // <- membership-level parameter
);
```

Everything the executor passes is already a `collection_media` row, so it can only reach `updateExistingCollectionMediaForAdd`, which writes `manualMembershipSource` on every existing row when `manual` is true. On a manual collection whose link went missing, **every rule-owned row is rewritten as a manual member**. A manual member is force-kept by every later rule run yet still ages into `deleteAfterDays`, so the item can never leave the collection and is eventually deleted from disk.

There is a **mirror case on the same line**: for an *automatic* collection the resync passes `manual = false`, which forces `includedByRule: true` onto a user's manual-only member, silently promoting it to rule-owned. Both are fixed by the change below, because it stops that update running at all.

Both arguments are `boolean`, so the compiler could not catch it. Introduced in `65f551d4` (2023-09-18) and copied verbatim through every later rewrite of the membership model - `174a5cb2` only renamed `plexId` to `mediaServerId`. The only spec covering that branch pinned `manualCollection: false`.

## Reachable when

A manual collection sitting at `mediaServerId = null` with members still in `collection_media`. `checkAutomaticMediaServerLink` cannot repair it - its whole body is gated on `!collection.manualCollection` - and two ordinary UI paths write that state, neither guarded by `manualCollection`:

- opening the collection in the UI: a failed `getCollectionChildren` plus a confirming probe nulls the link
- saving the rule group or collection settings: `updateCollection` clears the link when the probe reports the server collection missing

So: point a rule group at an existing collection, let it fill, delete or rename that collection on the media server, then touch the collection in the UI. Every rule run from then on re-stamps every member, and writes an "Added" log record per item per run.

Once stamped there is no self-heal: force-keep puts the item back in `desiredMediaServerIds` every run so it is never in `mediaToRemove`, and the manual-child import only ever adopts.

## Change

Pass an empty member list and no flag.

`addToCollectionInternal` re-reads the collection's members from the database and syncs *those* to the freshly created server collection, so the list passed in was redundant. Its only effect was to run every existing row back through the membership update - which re-marked them, and wrote the per-item log record, a cost the comment above the call already noted.

| | before | after |
|---|---|---|
| rule-owned row on a manual collection | rewritten as manual, force-kept, deleted at `deleteAfterDays` | untouched |
| manual-only row on an automatic collection | promoted to rule-owned | untouched |
| "Added" log record per member per run | written | not written |
| server collection recreated and repopulated | yes | yes |

A follow-up commit documents at the signature that an empty list is load-bearing rather than a no-op, so a later cleanup does not remove it and restore the bug.

Regression test added; verified it fails against the unfixed code and passes with it.