### PR TITLE
fix(collections): report adds that had no media server collection to add to

### DIFF
--- a/apps/server/src/modules/collections/collections.controller.ts
+++ b/apps/server/src/modules/collections/collections.controller.ts
@@ -436,6 +436,14 @@ export class CollectionsController {
       );
     }
 
+    // Nothing was written locally or remotely, so answering 201 would close the
+    // modal on a no-op. Not a media server refusal: it was never asked.
+    if (result.unlinkedIds?.length) {
+      throw new BadRequestException(
+        'This collection has no media server collection to add to. Check that its collection still exists on the media server.',
+      );
+    }
+
     if (result.serverRejectedIds.length > 0) {
       throw new BadGatewayException(
         `The media server refused ${result.serverRejectedIds.length} of ${result.resolvedCount} item(s)`,

--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -1867,6 +1867,37 @@ describe('CollectionsService', () => {
     expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
   });
 
+  it('reports ids it could not add because the collection has no media server link', async () => {
+    // The find-or-create above could not produce a link (an unresolvable manual
+    // collection name, or a library search that threw). Nothing is written
+    // locally or remotely, so an empty rejection list would report a no-op as a
+    // success and close the modal on nothing.
+    const collection = createCollection({
+      id: 30,
+      mediaServerId: null,
+      manualCollection: true,
+      manualCollectionName: 'Gone From The Server',
+      title: 'Unlinked Collection',
+    });
+
+    collectionRepo.findOne.mockResolvedValue(collection);
+    collectionMediaRepo.find.mockResolvedValue([]);
+    collectionRepo.save.mockImplementation(async (c) => c as Collection);
+    mediaServer.getCollections.mockResolvedValue([]);
+    jest
+      .spyOn(service as any, 'checkAutomaticMediaServerLink')
+      .mockResolvedValue(collection);
+
+    const result = await (service as any).addToCollectionInternal(
+      collection.id,
+      [{ mediaServerId: 'item-1' }],
+    );
+
+    expect(result.unlinkedIds).toEqual(['item-1']);
+    expect(collectionMediaRepo.save).not.toHaveBeenCalled();
+    expect(mediaServer.addBatchToCollection).not.toHaveBeenCalled();
+  });
+
   it('heals an empty automatic collection when the media server rejects every add', async () => {
     const collection = createCollection({
       id: 21,

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -147,6 +147,10 @@ export interface CollectionAddResult {
   /** Ids the server accepted but whose membership row failed to persist; the
    * server add was rolled back, so nothing of the add survived. */
   unpersistedIds?: string[];
+  /** Ids that had no media server collection to be added to. The server was
+   * never asked and no membership row was written, so this is neither a refusal
+   * nor a persistence failure - but it is not a success either. */
+  unlinkedIds?: string[];
 }
 
 export interface ContextActionResult extends CollectionAddResult {
@@ -2852,9 +2856,15 @@ export class CollectionsService {
             const rejected = new Set(result.serverRejectedIds);
             const unconfirmed = new Set(result.serverUnconfirmedIds ?? []);
             const unpersisted = new Set(result.unpersistedIds ?? []);
+            const unlinked = new Set(result.unlinkedIds ?? []);
             for (const [mediaId, ids] of resolvedByMediaId) {
               if (ids.some((id) => rejected.has(id))) {
                 fail(mediaId, 'Failed - refused by the media server');
+              } else if (ids.some((id) => unlinked.has(id))) {
+                fail(
+                  mediaId,
+                  'Failed - this collection has no media server collection to add to',
+                );
               } else if (ids.some((id) => unconfirmed.has(id))) {
                 fail(
                   mediaId,
@@ -2995,9 +3005,11 @@ export class CollectionsService {
           ...result.serverRejectedIds,
           ...(result.unpersistedIds ?? []),
         ],
-        // Kept apart: the server never answered, so this is not a refusal, and
-        // reporting it as success is the false-success #3383 removed.
+        // Both kept apart from the refusals: the server never answered for one
+        // and was never asked for the other, so neither is a refusal, and
+        // reporting either as success is the false-success #3383 removed.
         serverUnconfirmedIds: result.serverUnconfirmedIds,
+        unlinkedIds: result.unlinkedIds,
         resolvedCount: handleMedia.length,
       };
     }
@@ -3119,6 +3131,7 @@ export class CollectionsService {
       let rejectedByServer: string[] = [];
       let unconfirmedByServer: string[] = [];
       let unpersistedIds: string[] = [];
+      let unlinkedIds: string[] = [];
 
       if (collection) {
         if (!skipAutomaticLinkCheck) {
@@ -3377,6 +3390,18 @@ export class CollectionsService {
               collection = await this.saveCollection(collection);
             }
           }
+        } else if (newMedia.length > 0) {
+          // No media server collection to add to, and not a collection kept in
+          // Maintainerr only. Nothing was written locally or remotely, so
+          // answering with an empty rejection list would report a silent no-op
+          // as a success. A failed find-or-create above (an unresolvable manual
+          // collection name, or a library search that threw) lands here.
+          unlinkedIds = newMedia.map(
+            (collectionMediaItem) => collectionMediaItem.mediaServerId,
+          );
+          this.logger.warn(
+            `Could not add ${unlinkedIds.length} item(s) to '${collection.title}': it has no media server collection to add them to.`,
+          );
         }
 
         // Push collection sort to the media server when membership changed
@@ -3404,6 +3429,7 @@ export class CollectionsService {
           serverRejectedIds: rejectedByServer,
           serverUnconfirmedIds: unconfirmedByServer,
           unpersistedIds,
+          unlinkedIds,
         };
       } else {
         this.logger.warn("Collection doesn't exist.");


### PR DESCRIPTION
Found while auditing the collection-membership code behind #3636. Independent of it; branches off `development`.

## Cause

`addToCollectionInternal` gates the whole membership block on a link existing:

```ts
if (newMedia.length > 0 && (collection.mediaServerId || keepInMaintainerrOnly)) {
```

When a collection has no `mediaServerId` and is not kept in Maintainerr only, execution falls straight past it. Nothing is written to the media server, and **no `collection_media` row is written either** - but `rejectedByServer` and `unpersistedIds` keep their empty initialisers, which is exactly the shape of a total success.

Both interactive callers then report success for an add that did nothing:

| Caller | Reports |
|---|---|
| `POST /collections/media/add` | 201 with the collection, so the modal closes as though it worked |
| `POST /collections/media/bulk` | every id defaults to `{ mediaId, code: 1 }` |

## Reachable when

The find-or-create above could not produce a link:

- a manual collection whose `manualCollectionName` no longer resolves on the media server (the code warns and moves on)
- a library search that threw, which deliberately skips the create for that run

## Change

Report it as its own outcome rather than folding it into the refusals - the server was never asked, so it is neither a refusal nor a local persistence failure, and #3636 keeps `serverUnconfirmedIds` separate for the same reason.

- `CollectionAddResult` gains `unlinkedIds`
- the skipped branch records those ids and warns, naming the collection
- `POST /media/add` answers **400** naming the cause, rather than 201
- the bulk endpoint fails those ids with "this collection has no media server collection to add to" instead of silently succeeding

No media-server interface change, no `supportsFeature` branching, no migration.

Regression test added; verified it fails against the unfixed code (`Expected: ["item-1"] Received: undefined`) and passes with it.