### PR TITLE
fix(collections): treat an unset deletion window as never, and stop clearing it

### DIFF
--- a/apps/server/src/modules/collections/collection-worker.server.spec.ts
+++ b/apps/server/src/modules/collections/collection-worker.server.spec.ts
@@ -122,6 +122,66 @@ describe('CollectionWorkerService', () => {
     expect(collectionHandler.handleMedia).not.toHaveBeenCalled();
   });
 
+  it('should not handle media for a collection with no deletion window set', async () => {
+    // A null window is "never" to the contracts helper, the collection card and
+    // the overlay processor. The due query read it as 0, which made every member
+    // due at once and handed the whole collection to a DELETE action.
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      deleteAfterDays: null,
+    });
+    const collectionMedia = createCollectionMedia(collection);
+
+    collectionRepository.find.mockResolvedValue([collection]);
+    collectionMediaRepository.find.mockResolvedValue([collectionMedia]);
+
+    await collectionWorkerService.execute();
+
+    expect(collectionHandler.handleMedia).not.toHaveBeenCalled();
+  });
+
+  it('should still handle a quality profile collection that has no window', async () => {
+    // The rule form hides the timer for CHANGE_QUALITY_PROFILE and saves no
+    // window, so skipping every null-window collection would strand every such
+    // rule forever and no profile change would ever reach the *arr.
+    const collection = createCollection({
+      arrAction: ServarrAction.CHANGE_QUALITY_PROFILE,
+      deleteAfterDays: null,
+    });
+    const collectionMedia = createCollectionMedia(collection);
+
+    collectionRepository.find.mockResolvedValue([collection]);
+    collectionMediaRepository.find.mockResolvedValue([collectionMedia]);
+    collectionHandler.handleMedia.mockResolvedValue('handled');
+
+    await collectionWorkerService.execute();
+
+    expect(collectionHandler.handleMedia).toHaveBeenCalled();
+  });
+
+  it("should not let a converted rule's leftover window delay a profile change", async () => {
+    // Converting a rule keeps the previous action's window, and the form shows
+    // no timer for CHANGE_QUALITY_PROFILE, so honouring it would silently hold
+    // the profile change back for that many days.
+    const collection = createCollection({
+      arrAction: ServarrAction.CHANGE_QUALITY_PROFILE,
+      deleteAfterDays: 30,
+    });
+    const collectionMedia = createCollectionMedia(collection);
+
+    collectionRepository.find.mockResolvedValue([collection]);
+    collectionMediaRepository.find.mockResolvedValue([collectionMedia]);
+    collectionHandler.handleMedia.mockResolvedValue('handled');
+
+    await collectionWorkerService.execute();
+
+    // A 30-day window would put the cutoff 30 days back; due-now is today.
+    const [{ where }] = collectionMediaRepository.find.mock.calls.at(-1)!;
+    const cutoff = (where as { addDate: { value: Date } }).addDate.value;
+    expect(Date.now() - cutoff.getTime()).toBeLessThan(60_000);
+    expect(collectionHandler.handleMedia).toHaveBeenCalled();
+  });
+
   it('should handle media for collection and trigger availability syncs', async () => {
     settings.seerrConfigured.mockReturnValue(true);
 
@@ -512,7 +572,7 @@ describe('CollectionWorkerService', () => {
       "Skipping collection 'Radarr + Seerr' because no media is due for handling",
     );
     expect(logger.log).toHaveBeenCalledWith(
-      'Collection handler summary: 2 total (isActive), 0 skipped (Do Nothing), 2 skipped (no due media), 0 queued for handling',
+      'Collection handler summary: 2 total (isActive), 0 skipped (Do Nothing), 0 skipped (no window set), 2 skipped (no due media), 0 queued for handling',
     );
   });
 });

--- a/apps/server/src/modules/collections/collection-worker.service.ts
+++ b/apps/server/src/modules/collections/collection-worker.service.ts
@@ -44,6 +44,20 @@ import {
 } from './entities/collection_media.entities';
 import { ServarrAction } from './interfaces/collection.interface';
 
+/**
+ * The window the worker should act on, in days: `null` for "never", 0 for
+ * "now".
+ *
+ * The rule form hides the timer for CHANGE_QUALITY_PROFILE and saves no window,
+ * so a profile change is always due now. Any window still stored on such a
+ * collection is vestigial - left behind by the action it was converted from -
+ * and must neither strand the collection nor delay it.
+ */
+const effectiveDeletionWindow = (collection: Collection): number | null =>
+  collection.arrAction === ServarrAction.CHANGE_QUALITY_PROFILE
+    ? 0
+    : (collection.deleteAfterDays ?? null);
+
 @Injectable()
 export class CollectionWorkerService extends TaskBase {
   protected name = 'Collection Handler';
@@ -190,6 +204,7 @@ export class CollectionWorkerService extends TaskBase {
       let removedMissingMedia = 0;
       let collectionHandlingFailed = false;
       let doNothingCollectionCount = 0;
+      let noWindowCollectionCount = 0;
       let noDueMediaCollectionCount = 0;
 
       // loop over all active collections
@@ -202,6 +217,19 @@ export class CollectionWorkerService extends TaskBase {
           doNothingCollectionCount++;
           this.logger.log(
             `Skipping collection '${collection.title}' as its action is 'Do Nothing'`,
+          );
+          return false;
+        }
+
+        // No window means no deadline, which is what every other consumer of
+        // deleteAfterDays already reads it as: the contracts helper answers no
+        // delete date, the collection card shows "Never", and the overlay
+        // processor draws no countdown. Only the due query read it as 0, which
+        // made the danger date now and every member due at once.
+        if (effectiveDeletionWindow(collection) == null) {
+          noWindowCollectionCount++;
+          this.logger.log(
+            `Skipping collection '${collection.title}' as it has no 'take action after days' set`,
           );
           return false;
         }
@@ -219,7 +247,9 @@ export class CollectionWorkerService extends TaskBase {
       const exclusionsFor = await this.readExclusionsPerCollection();
 
       for (const collection of collectionsToHandle) {
-        const dangerDate = getCollectionDangerDate(collection.deleteAfterDays);
+        const dangerDate = getCollectionDangerDate(
+          effectiveDeletionWindow(collection),
+        );
 
         const dueMedia = (
           await this.collectionMediaRepo.find({
@@ -271,7 +301,7 @@ export class CollectionWorkerService extends TaskBase {
       }
 
       this.logger.log(
-        `Collection handler summary: ${collections.length} total (isActive), ${doNothingCollectionCount} skipped (Do Nothing), ${noDueMediaCollectionCount} skipped (no due media), ${collectionHandleMediaGroup.length} queued for handling`,
+        `Collection handler summary: ${collections.length} total (isActive), ${doNothingCollectionCount} skipped (Do Nothing), ${noWindowCollectionCount} skipped (no window set), ${noDueMediaCollectionCount} skipped (no due media), ${collectionHandleMediaGroup.length} queued for handling`,
       );
 
       const totalMediaToHandle = collectionHandleMediaGroup.reduce(

--- a/apps/server/src/modules/rules/rules.service.ts
+++ b/apps/server/src/modules/rules/rules.service.ts
@@ -745,7 +745,14 @@ export class RulesService {
             dbCollection?.visibleOnRecommended,
           visibleOnHome:
             params.collection?.visibleOnHome ?? dbCollection?.visibleOnHome,
-          deleteAfterDays: params.collection?.deleteAfterDays ?? null,
+          // Same rule as the two fields above: an update that omits the
+          // collection block keeps the saved value. This is the field that
+          // decides whether files are deleted, so silently clearing it is the
+          // worst one of the three to get wrong.
+          deleteAfterDays:
+            params.collection?.deleteAfterDays ??
+            dbCollection?.deleteAfterDays ??
+            null,
           manualCollection:
             params.collection?.manualCollection ??
             dbCollection?.manualCollection,

--- a/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
+++ b/apps/server/src/modules/rules/rules.service.updateRules.spec.ts
@@ -427,6 +427,7 @@ describe('RulesService.updateRules', () => {
       manualCollectionName: 'Shared Collection',
       visibleOnHome: true,
       visibleOnRecommended: true,
+      deleteAfterDays: 30,
     };
 
     const collectionMediaRepository = { delete: jest.fn() };
@@ -482,6 +483,9 @@ describe('RulesService.updateRules', () => {
         manualCollectionName: 'Shared Collection',
         visibleOnHome: true,
         visibleOnRecommended: true,
+        // The field that decides whether files get deleted: clearing it made
+        // the whole collection due at once.
+        deleteAfterDays: 30,
       }),
     );
     expect(result).toEqual({


### PR DESCRIPTION
Found while auditing the deletion paths behind #3636. Independent of it; branches off `development`.

## Cause

`getCollectionDangerDate` coerces a null `deleteAfterDays` to `0`:

```ts
new Date(Date.now() - +(deleteAfterDays ?? 0) * 86400000)
```

so the danger date is *now*, and the worker's due query (`addDate <= dangerDate`) matches **every member of the collection at once**. The configured action then runs against all of it, and the default action is DELETE.

Every other consumer reads the same null as "never":

| Consumer | Reads null as |
|---|---|
| `getCollectionDeleteDate` (contracts) | no delete date |
| collection card | "Never" |
| overlay processor | no countdown drawn |
| **collection worker** | **0 - everything due now** |

The worker is the outlier, and the only one that deletes files.

## Reachable when

**Not** through the rule form - a `superRefine` requires the field unless the action is Do Nothing or Change Quality Profile, and submit only omits it for those two. (An earlier draft of this report said otherwise; that was wrong.)

It is reachable through the API. `POST /api/rules` is unvalidated (`@Body() body: RuleGroupDto`, no Zod pipe), and `updateRules` reset a saved window to null whenever an update omitted the `collection` block:

```ts
visibleOnRecommended: params.collection?.visibleOnRecommended ?? dbCollection?.visibleOnRecommended,
visibleOnHome:        params.collection?.visibleOnHome        ?? dbCollection?.visibleOnHome,
deleteAfterDays:      params.collection?.deleteAfterDays      ?? null,   // <-
```

The two fields above it fall back to the saved value, under a comment saying an omitted block must keep them. The one field that decides whether files are deleted did not.

## Change

Both sides:

- the worker skips a collection with no window, alongside the existing Do Nothing skip, and says so in the handler summary
- `updateRules` preserves the saved `deleteAfterDays` like its neighbours (the create path still defaults to null, which is correct)

Two regression tests, both verified failing against the unfixed code. The second one's failure output shows the exact hazard: `deleteAfterDays: null` alongside `arrAction: 0`.