### PR TITLE
fix(plex): drop the cached collection children after a collection mutation

### DIFF
--- a/apps/server/src/modules/api/lib/plexApi.ts
+++ b/apps/server/src/modules/api/lib/plexApi.ts
@@ -222,6 +222,22 @@ class PlexApi {
     }
   }
 
+  /**
+   * Drop every cached response whose request uri contains `fragment`.
+   *
+   * queryAll caches one entry per page, and the cache key is the serialized
+   * request options, so a paginated read leaves several keys that all carry the
+   * uri. Matching on the uri is the only way to clear them together.
+   */
+  invalidateCachedUri(fragment: string): void {
+    const stale = this.cache.data
+      .keys()
+      .filter((key) => key.includes(fragment));
+    if (stale.length > 0) {
+      this.cache.data.del(stale);
+    }
+  }
+
   private serializeCacheKey(params: Record<string, unknown>) {
     try {
       return `${JSON.stringify(params)}`;

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -142,6 +142,63 @@ describe('PlexApiService.getMetadata', () => {
     );
   });
 
+  // A membership decision made from a stale child list has already produced
+  // phantom manual members once (#1446), and nothing invalidated this cache.
+  it('drops the cached child pages after a collection add, and after one that failed', async () => {
+    const invalidateCachedUri = jest.fn();
+    (service as any).plexClient = {
+      putQuery: jest
+        .fn()
+        .mockResolvedValue({ MediaContainer: { Metadata: [{}] } }),
+      invalidateCachedUri,
+    };
+    (service as any).machineId = 'machine-1';
+
+    await service.addChildrenToCollection('col-1', ['item-1']);
+
+    expect(invalidateCachedUri).toHaveBeenCalledWith(
+      '/library/collections/col-1/children',
+    );
+
+    // The batch path is the one collection sync uses: Plex commits a write it
+    // has begun and can answer past the client timeout, so the cached list is
+    // no more trustworthy than on the success path.
+    invalidateCachedUri.mockClear();
+    (service as any).plexClient.putQuery = jest
+      .fn()
+      .mockRejectedValue(new Error('timeout of 30000ms exceeded'));
+
+    await service.addChildrenToCollection('col-1', ['item-1']);
+    expect(invalidateCachedUri).toHaveBeenCalledWith(
+      '/library/collections/col-1/children',
+    );
+  });
+
+  it('drops the cached child pages after a removal, and after one that failed', async () => {
+    const invalidateCachedUri = jest.fn();
+    (service as any).plexClient = {
+      deleteQuery: jest.fn().mockResolvedValue({}),
+      invalidateCachedUri,
+    };
+
+    await service.deleteChildFromCollection('col-1', 'item-1');
+    expect(invalidateCachedUri).toHaveBeenCalledWith(
+      '/library/collections/col-1/children',
+    );
+
+    // A write that failed may still have been applied, so the cached list is no
+    // more trustworthy than on the success path.
+    invalidateCachedUri.mockClear();
+    (service as any).plexClient.deleteQuery = jest
+      .fn()
+      .mockRejectedValue(new Error('timeout of 30000ms exceeded'));
+
+    await service.deleteChildFromCollection('col-1', 'item-1');
+    expect(invalidateCachedUri).toHaveBeenCalledWith(
+      '/library/collections/col-1/children',
+    );
+  });
+
   // #3449: a collection still listing deleted media logged one
   // "is the application running?" ERROR per item against a healthy Plex.
   it('reports a 404 as a missing item, not as a communication failure', async () => {
@@ -331,7 +388,7 @@ describe('PlexApiService.getMetadata', () => {
     });
 
     (service as any).machineId = 'machine123';
-    (service as any).plexClient = { putQuery };
+    (service as any).plexClient = { putQuery, invalidateCachedUri: jest.fn() };
 
     await service.addChildrenToCollection('55', ['1', '2']);
 
@@ -351,7 +408,7 @@ describe('PlexApiService.getMetadata', () => {
     });
 
     (service as any).machineId = 'machine123';
-    (service as any).plexClient = { putQuery };
+    (service as any).plexClient = { putQuery, invalidateCachedUri: jest.fn() };
 
     const result = await service.addChildrenToCollection('55', ['1', '2']);
 
@@ -387,7 +444,7 @@ describe('PlexApiService.getMetadata', () => {
     );
 
     (service as any).machineId = 'machine123';
-    (service as any).plexClient = { putQuery };
+    (service as any).plexClient = { putQuery, invalidateCachedUri: jest.fn() };
 
     const result = await service.addChildrenToCollection('55', ['1', '2']);
 
@@ -403,7 +460,7 @@ describe('PlexApiService.getMetadata', () => {
 
   it('switches a collection into custom sort mode via prefs', async () => {
     const putQuery = jest.fn().mockResolvedValue(undefined);
-    (service as any).plexClient = { putQuery };
+    (service as any).plexClient = { putQuery, invalidateCachedUri: jest.fn() };
 
     await service.setCollectionCustomSort('55');
 
@@ -414,7 +471,7 @@ describe('PlexApiService.getMetadata', () => {
 
   it('omits the after parameter when moving an item to the front', async () => {
     const putQuery = jest.fn().mockResolvedValue(undefined);
-    (service as any).plexClient = { putQuery };
+    (service as any).plexClient = { putQuery, invalidateCachedUri: jest.fn() };
 
     await service.moveCollectionItem('55', '99');
 
@@ -425,7 +482,7 @@ describe('PlexApiService.getMetadata', () => {
 
   it('places an item after the given sibling when moving', async () => {
     const putQuery = jest.fn().mockResolvedValue(undefined);
-    (service as any).plexClient = { putQuery };
+    (service as any).plexClient = { putQuery, invalidateCachedUri: jest.fn() };
 
     await service.moveCollectionItem('55', '99', '42');
 
@@ -437,7 +494,10 @@ describe('PlexApiService.getMetadata', () => {
   it('uses the canonical Plex items path when deleting a collection child', async () => {
     const deleteQuery = jest.fn().mockResolvedValue(undefined);
 
-    (service as any).plexClient = { deleteQuery };
+    (service as any).plexClient = {
+      deleteQuery,
+      invalidateCachedUri: jest.fn(),
+    };
 
     await expect(
       service.deleteChildFromCollection('55', '99'),
@@ -459,7 +519,7 @@ describe('PlexApiService.getMetadata', () => {
       .mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:32400'));
 
     (service as any).machineId = 'machine123';
-    (service as any).plexClient = { putQuery };
+    (service as any).plexClient = { putQuery, invalidateCachedUri: jest.fn() };
 
     const result = await service.addChildrenToCollection('55', ['1']);
 

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -1478,6 +1478,21 @@ export class PlexApiService {
     }
   }
 
+  /**
+   * Drop the cached child pages for one collection.
+   *
+   * getCollectionChildren reads through the 5-minute `plexguid` cache, so
+   * without this a mutation is followed by a stale child list - and a membership
+   * decision made from one has already produced phantom manual members once
+   * (#1446). Jellyfin invalidates the same way after every collection mutation;
+   * Emby does not cache the read at all.
+   */
+  private invalidateCollectionChildrenCache(collectionId: string): void {
+    this.plexClient?.invalidateCachedUri(
+      `/library/collections/${collectionId}/children`,
+    );
+  }
+
   public async addChildToCollection(
     collectionId: string,
     childId: string,
@@ -1487,8 +1502,12 @@ export class PlexApiService {
       const response: PlexLibraryResponse = await this.plexClient.putQuery({
         uri: `/library/collections/${collectionId}/items?uri=${this.buildCollectionItemsUri([childId])}`,
       });
+      this.invalidateCollectionChildrenCache(collectionId);
       return response.MediaContainer.Metadata[0] as PlexCollection;
     } catch (error) {
+      // A write that failed may still have been applied, so the cached child
+      // list is no more trustworthy here than on the success path.
+      this.invalidateCollectionChildrenCache(collectionId);
       const failure = this.buildCollectionMutationFailure(error);
 
       if (failure.logLevel === 'warn') {
@@ -1522,6 +1541,7 @@ export class PlexApiService {
       const response: PlexLibraryResponse = await this.plexClient.putQuery({
         uri: `/library/collections/${collectionId}/items?uri=${this.buildCollectionItemsUri(childIds)}`,
       });
+      this.invalidateCollectionChildrenCache(collectionId);
 
       return (
         (response.MediaContainer.Metadata?.[0] as PlexCollection | undefined) ??
@@ -1532,6 +1552,9 @@ export class PlexApiService {
         } as BasicResponseDto)
       );
     } catch (error) {
+      // A write that failed may still have been applied, so the cached child
+      // list is no more trustworthy here than on the success path.
+      this.invalidateCollectionChildrenCache(collectionId);
       const failure = this.buildCollectionMutationFailure(error);
 
       if (failure.logLevel === 'error') {
@@ -1646,12 +1669,17 @@ export class PlexApiService {
       await this.plexClient.deleteQuery({
         uri: `/library/collections/${collectionId}/items/${childId}`,
       });
+      this.invalidateCollectionChildrenCache(collectionId);
       return {
         status: 'OK',
         code: 1,
         message: `successfully deleted child with id ${childId}`,
       } as BasicResponseDto;
     } catch (error) {
+      // A write that failed may still have been applied, so the cached child
+      // list is no more trustworthy here than on the success path.
+      this.invalidateCollectionChildrenCache(collectionId);
+
       // Same classification the add path uses: `code` carries the status Plex
       // answered with, or 0 when nothing answered. Callers need that difference
       // to tell a refusal from a write that may well have applied.


### PR DESCRIPTION
Found while auditing the collection-membership code behind #3636. Independent of it; branches off `development`.

## Cause

`plexApi.getCollectionChildren(collectionId, useCache = true)` reads through the 5-minute `plexguid` cache. The adapter never passes `false`, and `collections.service.ts` never imports `cacheManager` at all - so the only thing that ever cleared it was the `cacheManager.flushAll()` at the top of each rule group's run.

Plex is alone in this:

| Server | Caches the children read | Invalidated by a mutation |
|---|---|---|
| Plex | yes, 5 min | **no** |
| Jellyfin | yes | yes, after every collection mutation |
| Emby | no | n/a |

The rule executor's membership sync compares that child list against a **freshly read** database snapshot, so a stale list is taken as the server's current truth. This is not hypothetical: a cached children read already produced phantom manual members once, in #1446 ("When syncing manual added/removed, we were not bypassing the cache when getting the items in the Plex collection. If cached items were returned then that could cause incorrect add & removes").

## Change

- `PlexApi.invalidateCachedUri(fragment)` drops every cached entry whose request uri contains the fragment. `queryAll` caches one entry per page and the key is the serialized request options, so a paginated read leaves several keys that all carry the uri; matching on the uri clears them together.
- `PlexApiService` calls it after `addChildToCollection`, `addChildrenToCollection` and `deleteChildFromCollection` - mirroring where the Jellyfin adapter does it, so every caller benefits.

Two details worth noting:

- Including the trailing `/children` in the fragment keeps collection `24` from matching collection `241`.
- Invalidated on the **failure** path too. A write that timed out may still have been applied - the premise of #3636 - so the cached list is no more trustworthy after a failure than after a success.

Regression tests added, verified failing against the unfixed code (`Number of calls: 0`). One existing test stubbed `plexClient` without the new method; the stub was incomplete rather than the code being wrong, so the stub is completed.