### PR TITLE
fix(collections): count a custom collection as a sibling when guarding adoption

### DIFF
--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -615,6 +615,84 @@ describe('CollectionsService', () => {
     expect(Array.from(result)).toEqual(['rule-owned']);
   });
 
+  // Now that a custom collection's members are no longer adopted, an automatic
+  // collection can genuinely drain to zero while a custom one still points at
+  // the same media server collection - and that one is the user's own.
+  it('does not delete a media server collection a custom collection still points at', async () => {
+    const collection = createCollection({
+      id: 12,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+    });
+
+    collectionRepo.findOne.mockResolvedValue(collection);
+    collectionMediaRepo.find
+      .mockResolvedValueOnce([
+        createCollectionMedia(collection, { mediaServerId: 'item-1' }),
+      ])
+      .mockResolvedValue([]);
+    collectionRepo.save.mockImplementation(
+      async (value) => value as Collection,
+    );
+    // The only other collection on this media server collection is a custom
+    // one, so the same-kind question answers "not shared".
+    collectionRepo.count.mockResolvedValue(1);
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(false);
+    jest
+      .spyOn(service as any, 'checkAutomaticMediaServerLink')
+      .mockResolvedValue(collection);
+    jest
+      .spyOn(service as any, 'removeChildrenFromCollection')
+      .mockResolvedValue(['item-1']);
+
+    await service.removeFromCollection(collection.id, [
+      { mediaServerId: 'item-1' },
+    ]);
+
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+  });
+
+  it('keeps the link when the sibling lookup fails', async () => {
+    const collection = createCollection({
+      id: 13,
+      mediaServerId: 'remote-collection',
+      manualCollection: false,
+    });
+
+    collectionRepo.findOne.mockResolvedValue(collection);
+    collectionMediaRepo.find
+      .mockResolvedValueOnce([
+        createCollectionMedia(collection, { mediaServerId: 'item-1' }),
+      ])
+      .mockResolvedValue([]);
+    collectionRepo.save.mockImplementation(
+      async (value) => value as Collection,
+    );
+    collectionRepo.count.mockRejectedValue(new Error('database is locked'));
+    jest
+      .spyOn(service, 'isMediaServerCollectionShared')
+      .mockResolvedValue(false);
+    jest
+      .spyOn(service as any, 'checkAutomaticMediaServerLink')
+      .mockResolvedValue(collection);
+    jest
+      .spyOn(service as any, 'removeChildrenFromCollection')
+      .mockResolvedValue(['item-1']);
+
+    await service.removeFromCollection(collection.id, [
+      { mediaServerId: 'item-1' },
+    ]);
+
+    // Unlinking on a failed lookup orphans the server collection and revokes
+    // the guard for every later run.
+    expect(mediaServer.deleteCollection).not.toHaveBeenCalled();
+    expect(collectionRepo.save).not.toHaveBeenCalledWith(
+      expect.objectContaining({ mediaServerId: null }),
+    );
+  });
+
   it('does not delete a shared media server collection when one rule empties locally', async () => {
     const collection = createCollection({
       id: 11,
@@ -639,7 +717,7 @@ describe('CollectionsService', () => {
       .spyOn(service as any, 'removeChildrenFromCollection')
       .mockResolvedValue(['item-1']);
     jest
-      .spyOn(service, 'isMediaServerCollectionShared')
+      .spyOn(service, 'isMediaServerCollectionLinkedElsewhere')
       .mockResolvedValue(true);
 
     await service.removeFromCollection(collection.id, [
@@ -1147,21 +1225,38 @@ describe('CollectionsService', () => {
     expect(result.mediaServerId).toBe('remote-collection');
   });
 
-  it('getSiblingRuleOwnedMediaServerIds excludes manual sibling collections', async () => {
+  // #2766 scoped the sibling lookup to automatic collections because that was
+  // the report it fixed (two same-titled rule groups). A custom collection
+  // sharing the same media server collection is just as foreign to this rule,
+  // and adopting its members subjects them to this rule's deleteAfterDays.
+  it('getSiblingRuleOwnedMediaServerIds counts a manual sibling collection too', async () => {
     const collection = createCollection({
       id: 20,
       mediaServerId: 'remote-collection',
       manualCollection: false,
     });
-    collectionRepo.find.mockResolvedValue([]);
+    const manualSibling = createCollection({
+      id: 21,
+      mediaServerId: 'remote-collection',
+      manualCollection: true,
+    });
+    collectionRepo.find.mockResolvedValue([manualSibling]);
+    collectionMediaRepo.find.mockResolvedValue([
+      createCollectionMedia(manualSibling, {
+        mediaServerId: 'owned-by-the-custom-collection',
+        includedByRule: true,
+        manualMembershipSource: null,
+      }),
+    ]);
 
     const result = await service.getSiblingRuleOwnedMediaServerIds(collection);
 
-    expect(Array.from(result)).toEqual([]);
+    expect(Array.from(result)).toEqual(['owned-by-the-custom-collection']);
+    // The query must no longer filter siblings by kind.
     expect(collectionRepo.find).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          manualCollection: false,
+        where: expect.not.objectContaining({
+          manualCollection: expect.anything(),
         }),
       }),
     );

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -385,6 +385,48 @@ export class CollectionsService {
     });
   }
 
+  /**
+   * Whether any OTHER Maintainerr collection points at the same media server
+   * collection, of either kind.
+   *
+   * Distinct from isMediaServerCollectionShared, which compares kinds on
+   * purpose for the contamination guards. Destroying a media server collection
+   * is not a same-kind question: a custom collection's rule group is pointing at
+   * one the user made, and deleting it because an automatic collection happened
+   * to empty first destroys the user's own collection.
+   *
+   * `undefined` means the lookup itself failed, which is not an answer either
+   * way - see the catch below.
+   */
+  public async isMediaServerCollectionLinkedElsewhere(
+    collection: Pick<Collection, 'id' | 'mediaServerId'>,
+  ): Promise<boolean | undefined> {
+    if (!collection.mediaServerId) {
+      return false;
+    }
+
+    try {
+      return (
+        (await this.collectionRepo.count({
+          where: {
+            mediaServerId: collection.mediaServerId,
+            ...(collection.id !== undefined ? { id: Not(collection.id) } : {}),
+          },
+        })) > 0
+      );
+    } catch (error) {
+      // Neither answer is safe to assume. "Linked" avoids the delete but still
+      // unlinks, orphaning the server collection and revoking this very guard;
+      // "not linked" authorises destroying one the user may own. Report the
+      // uncertainty and let the caller leave the collection alone.
+      this.logger.warn(
+        'Failed to determine whether a media server collection is linked elsewhere',
+      );
+      this.logger.debug(error);
+      return undefined;
+    }
+  }
+
   public async isMediaServerCollectionShared(
     collection: Pick<Collection, 'id' | 'mediaServerId' | 'manualCollection'>,
   ): Promise<boolean> {
@@ -417,7 +459,7 @@ export class CollectionsService {
 
   /**
    * Returns the set of media server IDs that are rule-owned by another
-   * automatic collection sharing this collection's media server collection.
+   * collection sharing this collection's media server collection.
    *
    * Throws on repository failure. Callers must treat a thrown error as
    * "ownership unknown" - silently defaulting to an empty set would
@@ -461,10 +503,16 @@ export class CollectionsService {
       return [];
     }
 
+    // Kind is irrelevant: a custom collection's member is as foreign to this
+    // rule as an automatic sibling's, and adopting it subjects it to this
+    // rule's deleteAfterDays and action. #2766 scoped this to automatic
+    // siblings because that was the report it fixed, which left an automatic
+    // collection that title-links onto a user's custom collection unguarded.
+    // Not the same question as isMediaServerCollectionShared, which compares
+    // kinds on purpose to decide delete-versus-leave on teardown.
     const siblings = await this.collectionRepo.find({
       where: {
         mediaServerId: collection.mediaServerId,
-        manualCollection: false,
         ...(collection.id !== undefined ? { id: Not(collection.id) } : {}),
       },
     });
@@ -3686,17 +3734,25 @@ export class CollectionsService {
           // runs later in the same rule execution.
           !collection.keepInMaintainerrOnly
         ) {
-          // Another rule group with the same title may share this media
-          // server collection. Deleting it would also wipe the sibling rule's
-          // items, so just unlink locally and let the sibling keep ownership.
-          const isShared = await this.isMediaServerCollectionShared(collection);
+          // Another Maintainerr collection may point at this media server
+          // collection. Deleting it would also wipe that one's items, so just
+          // unlink locally and let it keep ownership. Asked of either kind:
+          // now that a custom collection's members are no longer adopted here,
+          // an automatic collection can genuinely reach zero members while a
+          // custom one still points at the same collection - and that one is
+          // the user's own.
+          const linkedElsewhere =
+            await this.isMediaServerCollectionLinkedElsewhere(collection);
 
-          if (isShared) {
+          // A failed lookup answers neither branch: unlinking on a guess
+          // strands the server collection, deleting on a guess can destroy one
+          // the user owns. Leave it linked and let the next run decide.
+          if (linkedElsewhere === true) {
             collection = await this.collectionRepo.save({
               ...collection,
               mediaServerId: null,
             });
-          } else {
+          } else if (linkedElsewhere === false) {
             try {
               await mediaServer.deleteCollection(collection.mediaServerId);
               collection = await this.collectionRepo.save({


### PR DESCRIPTION
Found while auditing the collection-membership code behind #3636. Independent of it; branches off `development`.

## Cause

`getSiblingMedia` hardcoded `manualCollection: false`, so "sibling" meant "sibling **automatic** collection" regardless of the subject's kind. Both adoption guards built on it returned nothing for a custom collection sharing the same media-server collection:

- `getSiblingRuleOwnedMediaServerIds`
- `getSiblingMemberMediaServerIds`

An automatic collection that title-links onto a user's custom collection therefore adopts that collection's members as its own **manual** members, which the worker ages into *this* rule's `deleteAfterDays` and hands to *this* rule's action. `skipManualChildImport` does not prevent it - it only suppresses the run that establishes the link, as its own comment says. The same blind spot lets the rule-removal self-heal pull an item out of the shared collection that the custom rule group still holds.

## Why this is a gap and not a decision

The filter came from `98b96e8f` (#2766). Its report, #2765, was explicitly two same-titled **automatic** rule groups - "When two different rules target the same (non-manual) collection" - and the PR body says it applied the approach "to the automatic-collection same-title case it didn't cover". It scoped the fix to the case it was fixing; it did not decide that custom siblings should be ignored.

Kind is irrelevant to this question: a custom collection's member is as foreign to this rule as an automatic sibling's is.

**Not** the same question as `isMediaServerCollectionShared`, which compares kinds on purpose (with a comment saying so) to decide delete-versus-leave on teardown. That one is left alone.

## Change

One line: drop the `manualCollection: false` predicate, plus the doc comment that described siblings as automatic-only, and a note on the query saying why kind is irrelevant here and pointing at the function that legitimately does compare kinds.

The existing spec asserted the old scope (`excludes manual sibling collections`); it now asserts the corrected contract, and I verified it fails against the unfixed code.