### PR TITLE
refactor(rules): ask a capability, not the server type, about empty child lists

### DIFF
--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -279,6 +279,40 @@ describe('RuleExecutorService', () => {
     );
   });
 
+  // The decision follows the capability, not the configured server. Branching on
+  // the type in the shared layer is what the architecture guardrails forbid, and
+  // it would silently hand a fourth media server Plex's answer.
+  it('trusts an empty child list only when the server declares the capability', async () => {
+    const { service, mediaServer, collectionService } = createService(
+      MediaServerType.PLEX,
+    );
+    mediaServer.getCollectionChildren.mockResolvedValue([]);
+    collectionService.getCollectionMedia.mockResolvedValue([]);
+    mediaServer.supportsFeature.mockImplementation(
+      (feature: MediaServerFeature) =>
+        feature !== MediaServerFeature.TRUSTWORTHY_EMPTY_COLLECTION,
+    );
+
+    await (
+      service as unknown as {
+        syncManualMediaServerToCollectionDB: (
+          ruleGroup: { id: number; collectionId: number },
+          collectionSyncChanges: {
+            addedMediaServerIds: Set<string>;
+            removedMediaServerIds: Set<string>;
+          },
+        ) => Promise<void>;
+      }
+    ).syncManualMediaServerToCollectionDB(
+      { id: 10, collectionId: 1 },
+      { addedMediaServerIds: new Set(), removedMediaServerIds: new Set() },
+    );
+
+    expect(collectionService.reconcileRuleRemovedOrphans.mock.calls[0][3]).toBe(
+      false,
+    );
+  });
+
   it('does not emit a failed rule notification when a rule group finishes successfully', async () => {
     const { service, rulesService, eventEmitter } = createService(
       MediaServerType.JELLYFIN,

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -5,7 +5,6 @@ import {
   MediaItem,
   MediaItemType,
   MediaServerFeature,
-  MediaServerType,
   RuleHandlerFinishedEventDto,
   RuleHandlerStartedEventDto,
 } from '@maintainerr/contracts';
@@ -487,12 +486,14 @@ export class RuleExecutorService {
           return;
         }
 
-        // An empty child list is a trustworthy "empty" snapshot for Plex, but
-        // Jellyfin/Emby can transiently return [] during sync delays, so their
-        // empty result is treated as ambiguous (see the removal sweep below).
-        const isJellyfin =
-          this.settings.media_server_type === MediaServerType.JELLYFIN;
-        const isEmby = this.settings.media_server_type === MediaServerType.EMBY;
+        // Whether an empty child list means "this collection is empty" or only
+        // "the server answered with nothing this time". Asked as a capability
+        // rather than by server type: the shared layer must not branch on which
+        // server is configured, and a fourth one would otherwise silently
+        // inherit Plex's answer.
+        const emptyChildListIsTrustworthy = (
+          await this.getMediaServer()
+        ).supportsFeature(MediaServerFeature.TRUSTWORTHY_EMPTY_COLLECTION);
 
         // Handle manually added
         if (syncContext.skipManualChildImport) {
@@ -681,7 +682,7 @@ export class RuleExecutorService {
               collection,
               children ?? [],
               new Set(),
-              !(isJellyfin || isEmby),
+              emptyChildListIsTrustworthy,
             );
           } catch (error) {
             this.logger.warn(
@@ -691,15 +692,13 @@ export class RuleExecutorService {
           }
         }
 
-        // Handle manually removed items from collections
-        // Jellyfin/Emby workaround: Skip removal check when children array is empty.
-        // Unlike Plex, the .NET BoxSet collection API can return empty children
-        // during brief sync delays after collection modifications, causing false
-        // positives where valid items would be incorrectly flagged as "manually
-        // removed". This workaround can be removed if the upstream improves
-        // collection sync consistency.
+        // Handle manually removed items from collections.
+        // An empty child list only means "no members left" on a server whose
+        // empty answer is trustworthy. Where it is not, acting on it would flag
+        // every member as removed by hand during a brief post-modification sync
+        // delay, so the sweep waits for a non-empty read.
         const shouldCheckRemovals =
-          isJellyfin || isEmby ? children && children.length > 0 : true;
+          emptyChildListIsTrustworthy || (children && children.length > 0);
 
         if (
           collectionMedia &&

--- a/packages/contracts/src/media-server/enums.ts
+++ b/packages/contracts/src/media-server/enums.ts
@@ -66,4 +66,13 @@ export enum MediaServerFeature {
    * bound to one library. Gates the cross-library lookup for manual collections.
    */
   CROSS_LIBRARY_COLLECTIONS = 'cross_library_collections',
+  /**
+   * An empty collection-children read is a trustworthy "this collection is
+   * empty" answer rather than a possible sync-delay artefact. Plex answers
+   * definitively; the .NET BoxSet API can return no children for a brief window
+   * after a collection is modified, so treating that as empty would flag every
+   * member as removed by hand. Gates the membership reconciliation that runs
+   * off an empty child list.
+   */
+  TRUSTWORTHY_EMPTY_COLLECTION = 'trustworthy_empty_collection',
 }

--- a/packages/contracts/src/media-server/features.ts
+++ b/packages/contracts/src/media-server/features.ts
@@ -19,6 +19,7 @@ export const MEDIA_SERVER_FEATURES: Record<
     // Verified against a live PMS 1.43.3: listings carry studio and sort=studio
     // genuinely sorts, though /library/sections/{id}/sorts never advertises it.
     MediaServerFeature.LIBRARY_STUDIO_SORT,
+    MediaServerFeature.TRUSTWORTHY_EMPTY_COLLECTION,
   ]),
   [MediaServerType.JELLYFIN]: new Set([
     MediaServerFeature.LABELS, // Tags in Jellyfin
@@ -32,6 +33,8 @@ export const MEDIA_SERVER_FEATURES: Record<
     // Note: COLLECTION_VISIBILITY not supported
     // Note: WATCHLIST not supported (no API)
     // Note: COLLECTION_SORT not supported - no boxset reorder API; ForcedSortName has global side-effects.
+    // Note: TRUSTWORTHY_EMPTY_COLLECTION not supported - the BoxSet API can
+    // answer with no children during a brief sync delay after a modification.
   ]),
   [MediaServerType.EMBY]: new Set([
     MediaServerFeature.LABELS,
@@ -50,6 +53,7 @@ export const MEDIA_SERVER_FEATURES: Record<
     // - COLLECTION_SORT: Emby exposes DisplayOrder = PremiereDate | SortName
     //   on a BoxSet but no item-move/reorder endpoint, so Maintainerr's
     //   "push an explicit ordered list of item IDs" contract isn't satisfiable.
+    // - TRUSTWORTHY_EMPTY_COLLECTION: same .NET BoxSet sync delay as Jellyfin.
   ]),
 }
 


### PR DESCRIPTION
Found while auditing the collection-membership code behind #3636. Independent of it; branches off `development`.

## Cause

The membership sync branched on the configured server to decide two things:

```ts
const isJellyfin = this.settings.media_server_type === MediaServerType.JELLYFIN;
const isEmby     = this.settings.media_server_type === MediaServerType.EMBY;
...
reconcileRuleRemovedOrphans(collection, children ?? [], new Set(), !(isJellyfin || isEmby));
const shouldCheckRemovals = isJellyfin || isEmby ? children && children.length > 0 : true;
```

Both are asking one question: **is an empty child list a trustworthy "this collection is empty", or possibly a sync-delay artefact?** That is a property of the media server, and the guardrails in `ARCHITECTURE.md` and implementation rule 6 say the shared layer must use `supportsFeature()` rather than branch on server type.

It also fails open in the dangerous direction: the ternary's default arm is the Plex one, so a fourth media server would silently inherit "act on an empty list" - the branch that flags every member as removed by hand.

## Change

Add `MediaServerFeature.TRUSTWORTHY_EMPTY_COLLECTION`, held by Plex only. The .NET BoxSet API can answer with no children for a brief window after a collection is modified, which is the entire reason the workaround exists - so it belongs in the capability matrix beside the other server properties, documented where the other Jellyfin/Emby exclusions are documented.

The sweep condition is also stated the way it actually reads now:

```ts
const shouldCheckRemovals =
  emptyChildListIsTrustworthy || (children && children.length > 0);
```

**Behaviour is unchanged for all three supported servers.** The existing Jellyfin and Plex tests pass untouched, because the spec's `supportsFeature` mock already delegates to the real matrix - so they now exercise the flag.

One test added, asserting the decision follows the capability rather than the configured type (a Plex service with the flag forced off must not trust an empty read). Verified failing against the unfixed code.