### PR TITLE
fix(ui): say why a bulk action failed instead of one catch-all

### DIFF
--- a/apps/ui/src/api/bulkMediaAction.spec.ts
+++ b/apps/ui/src/api/bulkMediaAction.spec.ts
@@ -59,11 +59,61 @@ describe('postBulkExclusions', () => {
     ).toBe(true)
     expect(
       response.results
-        .slice(25)
+        .slice(25, 50)
         .every(
           (result) => result.code === 0 && result.message === 'request error',
         ),
     ).toBe(true)
+    // The last chunk was never sent, so it did not fail for that reason.
+    expect(
+      response.results
+        .slice(50)
+        .every(
+          (result) => result.code === 0 && result.message === 'not attempted',
+        ),
+    ).toBe(true)
+  })
+
+  it('reports the reason the server gave instead of a single catch-all', async () => {
+    // A lock conflict and a dropped connection both used to read "request
+    // error". The server's own message is the honest answer for the one that
+    // has it.
+    postMock.mockRejectedValueOnce(
+      Object.assign(new Error('Request failed with status code 409'), {
+        isAxiosError: true,
+        toJSON: () => ({}),
+        response: {
+          status: 409,
+          data: {
+            message:
+              'A collection or rule run held the execution lock too long',
+          },
+        },
+      }),
+    )
+
+    const response = await postBulkExclusions({ mediaIds: ids(25), action: 0 })
+
+    expect(response.results).toHaveLength(25)
+    expect(response.results[0].code).toBe(0)
+    expect(response.results[0].message).toBe(
+      'A collection or rule run held the execution lock too long',
+    )
+  })
+
+  it('does not invent a timeout budget the request never had', async () => {
+    // The connection-test vocabulary says "timed out after 5 seconds"; this
+    // path sets no axios timeout, so that number would be untrue.
+    postMock.mockRejectedValueOnce(
+      Object.assign(new Error('timeout of 30000ms exceeded'), {
+        isAxiosError: true,
+        toJSON: () => ({}),
+      }),
+    )
+
+    const response = await postBulkExclusions({ mediaIds: ids(25), action: 0 })
+
+    expect(response.results[0].message).not.toContain('5 seconds')
   })
 
   it('carries the collection through every chunk so the scope never changes mid-run', async () => {

--- a/apps/ui/src/api/bulkMediaAction.ts
+++ b/apps/ui/src/api/bulkMediaAction.ts
@@ -5,6 +5,7 @@ import type {
   BulkMediaItemResult,
   BulkMediaResponse,
 } from '@maintainerr/contracts'
+import axios from 'axios'
 import { chunk } from 'lodash-es'
 import { PostApiHandler } from '../utils/ApiHandler'
 
@@ -14,6 +15,38 @@ import { PostApiHandler } from '../utils/ApiHandler'
 // comfortably inside reverse-proxy timeouts and let a selection larger than one
 // request cap still succeed as a whole.
 const BULK_REQUEST_CHUNK = 25
+
+/**
+ * What to tell the user about a failed chunk request.
+ *
+ * Deliberately not getApiErrorMessage: that ends in
+ * normalizeConnectionErrorMessage, whose vocabulary is written for the
+ * media-server and *arr connection tests. It rewrites anything timeout-shaped
+ * into "Connection timed out after 5 seconds", and this path has no such budget
+ * - the UI sets no axios timeout at all - so a reverse-proxy 504 would be
+ * reported with a number that is simply untrue. The failing hop here is the
+ * browser to Maintainerr, and the server's own message is the honest answer.
+ */
+const failureReason = (error: unknown): string => {
+  if (axios.isAxiosError(error)) {
+    const body = error.response?.data as
+      { message?: string | string[] } | undefined
+    const message = Array.isArray(body?.message)
+      ? body.message.join('; ')
+      : body?.message
+
+    if (message && message.trim().length > 0) {
+      return message
+    }
+
+    const status = error.response?.status
+    if (status) {
+      return t`server responded ${status}`
+    }
+  }
+
+  return t`request error`
+}
 
 /**
  * Runs a bulk request one chunk at a time. Earlier chunks are already persisted
@@ -31,17 +64,25 @@ const postInChunks = async (
     try {
       const response = await postChunk(batch)
       results.push(...response.results)
-    } catch {
-      for (const remaining of batches.slice(index)) {
+    } catch (error) {
+      // The transport error is the only evidence of what went wrong. Discarding
+      // it reported a read timeout, a 409 lock conflict and a dropped
+      // connection identically; failureReason gives each its own sentence.
+      //
+      // No "Failed - " prefix on either message: that prefix is the server's,
+      // and the toast strips it by matching the English text. A translated
+      // prefix would survive the strip and read twice.
+      const reason = failureReason(error)
+      for (const mediaId of batch) {
+        results.push({ mediaId, code: 0, message: reason })
+      }
+
+      // Everything after this batch was never sent, so it did not fail for that
+      // reason - or for any reason yet. Reported separately so a retry is not
+      // chasing a fault those items never hit.
+      for (const remaining of batches.slice(index + 1)) {
         for (const mediaId of remaining) {
-          results.push({
-            mediaId,
-            code: 0,
-            // No "Failed - " prefix: that prefix is the server's, and the
-            // toast strips it by matching the English text. A translated
-            // prefix would survive the strip and read twice.
-            message: t`request error`,
-          })
+          results.push({ mediaId, code: 0, message: t`not attempted` })
         }
       }
       break

--- a/apps/ui/src/locales/cs.po
+++ b/apps/ui/src/locales/cs.po
@@ -2688,6 +2688,10 @@ msgstr ""
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr ""
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr ""
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr ""
@@ -3528,6 +3532,10 @@ msgstr ""
 
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
+msgstr ""
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
 msgstr ""
 
 #: src/components/Settings/About/index.tsx

--- a/apps/ui/src/locales/da.po
+++ b/apps/ui/src/locales/da.po
@@ -2688,6 +2688,10 @@ msgstr ""
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr ""
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr ""
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr ""
@@ -3528,6 +3532,10 @@ msgstr ""
 
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
+msgstr ""
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
 msgstr ""
 
 #: src/components/Settings/About/index.tsx

--- a/apps/ui/src/locales/de.po
+++ b/apps/ui/src/locales/de.po
@@ -2688,6 +2688,10 @@ msgstr ""
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr ""
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr ""
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr ""
@@ -3528,6 +3532,10 @@ msgstr ""
 
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
+msgstr ""
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
 msgstr ""
 
 #: src/components/Settings/About/index.tsx

--- a/apps/ui/src/locales/en.po
+++ b/apps/ui/src/locales/en.po
@@ -2688,6 +2688,10 @@ msgstr "Not all fields contain values"
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr "Not all required (*) fields contain values and at least 1 valid rule is required"
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr "not attempted"
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr "Not Contains (All items)"
@@ -3529,6 +3533,10 @@ msgstr "Server in-use"
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
 msgstr "Server Name"
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
+msgstr "server responded {status}"
 
 #: src/components/Settings/About/index.tsx
 msgid "Services Status"

--- a/apps/ui/src/locales/es.po
+++ b/apps/ui/src/locales/es.po
@@ -2688,6 +2688,10 @@ msgstr "No todos los campos contienen valores"
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr "No todos los campos obligatorios (*) contienen valores y se requiere al menos 1 regla válida"
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr ""
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr "No contiene (todos los elementos)"
@@ -3529,6 +3533,10 @@ msgstr "Servidor en uso"
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
 msgstr "Nombre del servidor"
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
+msgstr ""
 
 #: src/components/Settings/About/index.tsx
 msgid "Services Status"

--- a/apps/ui/src/locales/fi.po
+++ b/apps/ui/src/locales/fi.po
@@ -2688,6 +2688,10 @@ msgstr ""
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr ""
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr ""
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr ""
@@ -3528,6 +3532,10 @@ msgstr ""
 
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
+msgstr ""
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
 msgstr ""
 
 #: src/components/Settings/About/index.tsx

--- a/apps/ui/src/locales/fr.po
+++ b/apps/ui/src/locales/fr.po
@@ -2688,6 +2688,10 @@ msgstr "Certains champs ne sont pas remplis"
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr "Certains champs requis (*) ne sont pas remplis et au moins 1 règle valide est requise"
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr ""
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr "Ne contient pas (tous les éléments)"
@@ -3529,6 +3533,10 @@ msgstr "Serveur en cours d'utilisation"
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
 msgstr "Nom du serveur"
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
+msgstr ""
 
 #: src/components/Settings/About/index.tsx
 msgid "Services Status"

--- a/apps/ui/src/locales/it.po
+++ b/apps/ui/src/locales/it.po
@@ -2688,6 +2688,10 @@ msgstr ""
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr ""
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr ""
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr ""
@@ -3528,6 +3532,10 @@ msgstr ""
 
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
+msgstr ""
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
 msgstr ""
 
 #: src/components/Settings/About/index.tsx

--- a/apps/ui/src/locales/nb.po
+++ b/apps/ui/src/locales/nb.po
@@ -2688,6 +2688,10 @@ msgstr ""
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr ""
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr ""
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr ""
@@ -3528,6 +3532,10 @@ msgstr ""
 
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
+msgstr ""
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
 msgstr ""
 
 #: src/components/Settings/About/index.tsx

--- a/apps/ui/src/locales/nl.po
+++ b/apps/ui/src/locales/nl.po
@@ -2688,6 +2688,10 @@ msgstr ""
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr ""
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr ""
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr ""
@@ -3528,6 +3532,10 @@ msgstr ""
 
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
+msgstr ""
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
 msgstr ""
 
 #: src/components/Settings/About/index.tsx

--- a/apps/ui/src/locales/pl.po
+++ b/apps/ui/src/locales/pl.po
@@ -2688,6 +2688,10 @@ msgstr ""
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr ""
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr ""
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr ""
@@ -3528,6 +3532,10 @@ msgstr ""
 
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
+msgstr ""
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
 msgstr ""
 
 #: src/components/Settings/About/index.tsx

--- a/apps/ui/src/locales/pt.po
+++ b/apps/ui/src/locales/pt.po
@@ -2688,6 +2688,10 @@ msgstr ""
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr ""
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr ""
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr ""
@@ -3528,6 +3532,10 @@ msgstr ""
 
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
+msgstr ""
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
 msgstr ""
 
 #: src/components/Settings/About/index.tsx

--- a/apps/ui/src/locales/sv.po
+++ b/apps/ui/src/locales/sv.po
@@ -2688,6 +2688,10 @@ msgstr "Alla fält innehåller inte värden"
 msgid "Not all required (*) fields contain values and at least 1 valid rule is required"
 msgstr "Alla obligatoriska fält (*) innehåller inte värden och minst 1 giltig regel krävs"
 
+#: src/api/bulkMediaAction.ts
+msgid "not attempted"
+msgstr ""
+
 #: src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
 msgid "Not Contains (All items)"
 msgstr "Innehåller inte (alla objekt)"
@@ -3529,6 +3533,10 @@ msgstr "Servern används"
 #: src/components/Settings/Servarr/ServarrSettingsModal.tsx
 msgid "Server Name"
 msgstr "Servernamn"
+
+#: src/api/bulkMediaAction.ts
+msgid "server responded {status}"
+msgstr ""
 
 #: src/components/Settings/About/index.tsx
 msgid "Services Status"


### PR DESCRIPTION
Found while auditing the collection-membership code behind #3636. Independent of it; branches off `development`.

## Cause

`postInChunks` caught the transport error and never looked at it:

```ts
} catch {
  for (const remaining of batches.slice(index)) {
    for (const mediaId of remaining) {
      results.push({ mediaId, code: 0, message: t`request error` })
    }
  }
  break
}
```

So a read timeout, a 409 lock conflict (the rules controller documents one: "A collection or rule run held the execution lock for too long"), a 500 and a dropped connection all reach the toast identically.

The shared `getApiErrorMessage` helper is not correct for this path. It ends in `normalizeConnectionErrorMessage`, whose vocabulary is written for media-server and *arr connection tests, and rewrites timeout-shaped failures to "Connection timed out after 5 seconds." This browser-to-Maintainerr request sets no Axios timeout, so that would invent a duration. The local classifier instead preserves the backend message, then the HTTP status, and falls back to `request error` when the response supplies neither.

The old code also stamped `batches.slice(index)` - the failed batch **and every batch after it** - with the same message, though the later ones were never sent.

## Change

- classify the failed chunk locally: use the backend's message when present, otherwise report its HTTP status, and keep `request error` as the fallback when no response detail exists
- report the batches that were never sent as `not attempted`, so a retry is not chasing a fault those items never hit

None of the local messages carries a `Failed - ` prefix: that prefix is the server's and the toast strips it by matching the English text, so a translated one would survive the strip and read twice (the existing comment, still honoured).

i18n: the file already uses the non-reactive `t` from `@lingui/core/macro`, which is correct inside an async callback per `i18n.instructions.md`. Catalogs re-extracted for the two new strings; `yarn i18n:check` passes.

Two new tests plus expanded chunk-failure coverage, all verified against the unfixed code. Full UI suite green (74 files, 407 tests).

Not in this PR: `handleBulkOutcome` is duplicated across `CollectionMediaPage`, `Exclusions` and `Overview` with byte-identical heads and tails, and has already diverged three ways. That is a refactor rather than this bug, so it is worth its own change.
