### PR TITLE
fix(collections): drop rule-removal markers when a collection stops syncing

### DIFF
--- a/apps/server/src/modules/collections/collections.service.spec.ts
+++ b/apps/server/src/modules/collections/collections.service.spec.ts
@@ -71,6 +71,13 @@ describe('CollectionsService', () => {
     ruleRemovalRepo = unitRef.get(
       getRepositoryToken(CollectionMediaRuleRemoval) as string,
     );
+    // stopMediaServerSync unlinks inside a transaction. Run the callback and
+    // hand back the same repository mocks, so these cases still assert on the
+    // writes; the rollback itself needs a real database and is covered in
+    // stop-media-server-sync.integration.spec.ts.
+    dataSource.transaction.mockImplementation((runInTransaction: any) =>
+      runInTransaction({ withRepository: (repo: unknown) => repo }),
+    );
     metadataService = unitRef.get(MetadataService);
     mediaItemEnrichmentService = unitRef.get(MediaItemEnrichmentService);
     mediaItemEnrichmentService.enrichItems.mockImplementation(
@@ -4847,6 +4854,41 @@ describe('CollectionsService', () => {
       expect(collectionRepo.save).toHaveBeenCalledWith(
         expect.objectContaining({ id: 32, mediaServerId: null }),
       );
+      // The teardown established the server is not holding anything, and the
+      // reconciler returns early once the link is gone, so a marker left here
+      // could only ever be applied to a collection a later re-link creates.
+      expect(ruleRemovalRepo.delete).toHaveBeenCalledWith({
+        collectionId: 32,
+      });
+    });
+
+    it('stopMediaServerSync keeps the markers when the unlink itself fails', async () => {
+      const collection = createCollection({
+        id: 35,
+        mediaServerId: 'remote-collection',
+      });
+      collectionRepo.save.mockRejectedValue(new Error('db down'));
+
+      await expect(service.stopMediaServerSync(collection)).rejects.toThrow();
+
+      // Dropping them first and then failing to unlink would leave a still
+      // linked collection with no record of what a rule removed, and the next
+      // run adopts exactly those items as manual members.
+      expect(ruleRemovalRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('stopMediaServerSync keeps the markers when the teardown fails', async () => {
+      const collection = createCollection({
+        id: 34,
+        mediaServerId: 'remote-collection',
+      });
+      mediaServer.deleteCollection.mockRejectedValue(new Error('unreachable'));
+
+      await service.stopMediaServerSync(collection);
+
+      // The link is kept so the teardown retries; the markers are the record of
+      // what still has to come out of that collection.
+      expect(ruleRemovalRepo.delete).not.toHaveBeenCalled();
     });
 
     it('stopMediaServerSync keeps the link when the delete fails, so it is not orphaned', async () => {

--- a/apps/server/src/modules/collections/collections.service.ts
+++ b/apps/server/src/modules/collections/collections.service.ts
@@ -4231,7 +4231,42 @@ export class CollectionsService {
       this.logger.log(
         `Removed the media server collection for '${collection.title}' - it is now kept in Maintainerr only`,
       );
-      return await this.saveCollection({ ...collection, mediaServerId: null });
+
+      // A rule-removal marker only means "the media server may still be holding
+      // this". The teardown just established that it is not, and once the link
+      // is gone reconcileRuleRemovedOrphans returns early, so nothing would ever
+      // clear them. Left behind they are applied to whatever collection a later
+      // re-link creates, where an item present but not a member - one the user
+      // added by hand - is read as a lingering orphan and taken back out. Same
+      // wipe deactivateCollection does, for the same reason: the FK cascade
+      // cannot fire while the collection row survives.
+      //
+      // One transaction because either half alone is a defect: markers without
+      // the unlink leave a still-linked collection with no record of what a rule
+      // removed, and the next run adopts exactly those items as manual members;
+      // the unlink without the delete strands the markers for good, since every
+      // later call returns early once mediaServerId is gone.
+      const unlinked = await this.connection.transaction(async (manager) => {
+        const saved = await manager.withRepository(this.collectionRepo).save({
+          ...collection,
+          mediaServerId: null,
+        });
+
+        await manager
+          .withRepository(this.CollectionMediaRuleRemovalRepo)
+          .delete({ collectionId: collection.id });
+
+        return saved;
+      });
+
+      // saveCollection would have emitted this; after the commit, so a listener
+      // never reads a state that may still roll back.
+      this.eventEmitter.emit(MaintainerrEvent.Collection_Updated, {
+        collection: unlinked,
+        oldCollection: collection,
+      });
+
+      return unlinked;
     }
 
     return collection;

--- a/apps/server/src/modules/collections/stop-media-server-sync.integration.spec.ts
+++ b/apps/server/src/modules/collections/stop-media-server-sync.integration.spec.ts
@@ -1,0 +1,126 @@
+import { DataSource, EntitySchema } from 'typeorm';
+import { createMockLogger } from '../../../test/utils/data';
+import { CollectionsService } from './collections.service';
+
+// Only the two tables the unlink touches, mirrored rather than registered for
+// the same reason the marker test mirrors its own: the real Collection drags in
+// the whole relation graph.
+const CollectionSchema = new EntitySchema<{
+  id: number;
+  title: string;
+  mediaServerId: string | null;
+}>({
+  name: 'Collection',
+  tableName: 'collection',
+  columns: {
+    id: { type: 'integer', primary: true, generated: true },
+    title: { type: 'varchar' },
+    mediaServerId: { type: 'varchar', nullable: true },
+  },
+});
+
+const MarkerSchema = new EntitySchema<{
+  id: number;
+  collectionId: number;
+  mediaServerId: string;
+}>({
+  name: 'CollectionMediaRuleRemoval',
+  tableName: 'collection_media_rule_removal',
+  columns: {
+    id: { type: 'integer', primary: true, generated: true },
+    collectionId: { type: 'integer' },
+    mediaServerId: { type: 'varchar' },
+  },
+});
+
+// Real-DB test for the unlink in CollectionsService.stopMediaServerSync.
+//
+// Clearing the link and dropping the rule-removal markers has to be one commit.
+// Unlinking alone strands the markers for good - every later call returns early
+// once mediaServerId is gone - and they are then applied to whatever collection
+// a re-link creates, taking a user's hand-added item back out.
+//
+// Only a database shows a rollback. A mocked repository records the save whether
+// or not the transaction commits, so it cannot tell this apart from the
+// sequential save-then-delete it replaced.
+describe('CollectionsService.stopMediaServerSync (real SQLite)', () => {
+  let dataSource: DataSource;
+  let service: CollectionsService;
+
+  const seed = async () => {
+    const collection = await dataSource
+      .getRepository(CollectionSchema)
+      .save({ title: 'a collection', mediaServerId: 'remote-1' });
+
+    await dataSource
+      .getRepository(MarkerSchema)
+      .save({ collectionId: collection.id, mediaServerId: 'item-1' });
+
+    return collection;
+  };
+
+  const reread = (id: number) =>
+    dataSource.getRepository(CollectionSchema).findOne({ where: { id } });
+
+  beforeEach(async () => {
+    dataSource = await new DataSource({
+      type: 'better-sqlite3',
+      database: ':memory:',
+      synchronize: true,
+      entities: [CollectionSchema, MarkerSchema],
+    }).initialize();
+
+    service = new CollectionsService(
+      dataSource.getRepository(CollectionSchema) as any,
+      {} as any, // CollectionMediaRepo
+      dataSource.getRepository(MarkerSchema) as any,
+      {} as any, // CollectionLogRepo
+      {} as any, // ruleGroupRepo
+      {} as any, // exclusionRepo
+      dataSource,
+      {} as any, // mediaServerFactory
+      {} as any, // mediaItemEnrichmentService
+      {} as any, // settingsDataService
+      {} as any, // metadataService
+      { emit: jest.fn() } as any,
+      {} as any, // collectionPosterService
+      {} as any, // overlayProcessor
+      createMockLogger() as any,
+    );
+
+    // The media server teardown owns its coverage in the service spec; this is
+    // about what the database is left holding once it succeeds.
+    jest
+      .spyOn(service as any, 'deleteMediaServerCollection')
+      .mockResolvedValue({ ok: true });
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('clears the link and the markers together', async () => {
+    const collection = await seed();
+
+    await service.stopMediaServerSync(collection as any);
+
+    expect((await reread(collection.id))?.mediaServerId).toBeNull();
+    expect(await dataSource.getRepository(MarkerSchema).find()).toEqual([]);
+  });
+
+  it('keeps the link when the marker delete fails', async () => {
+    const collection = await seed();
+
+    // Fail the second half from inside the transaction, the way a locked or
+    // broken database would.
+    await dataSource.query('DROP TABLE collection_media_rule_removal');
+
+    await expect(
+      service.stopMediaServerSync(collection as any),
+    ).rejects.toThrow();
+
+    // Sequentially this has already committed, and nothing clears the markers
+    // again once the link is gone.
+    expect((await reread(collection.id))?.mediaServerId).toBe('remote-1');
+  });
+});


### PR DESCRIPTION
Found while auditing the collection-membership code behind #3636. Branches off `development`.

## Cause

`stopMediaServerSync` tears down the media server collection and nulls the link, but left the collection's `collection_media_rule_removal` markers behind.

`reconcileRuleRemovedOrphans` returns early on a missing `mediaServerId`, so from that point nothing could ever reconcile or clear them, and the FK cascade only fires when the collection row itself is deleted.

The shared-leave path (`leaveSharedMediaServerCollection`) already clears its markers. Only the non-shared unlink path did not.

## Why it is not just dead rows

A marker means "the media server may still be holding this", and the teardown just established that it is not.

If the user later turns the keep-in-Maintainerr-only opt-in back off, a new media server collection is created and the stale markers are reconciled against **that** one. An item that is present there but is not a member - one the user added by hand - matches `present && !memberOrSibling` and is read as a lingering orphan, so the self-heal takes it back out of the user's collection.

## Change

Wipe the collection's markers after a successful teardown - the same wipe `deactivateCollection` already does after its own, with the same reasoning (the FK cascade cannot fire while the collection row survives).

Kept when the teardown **fails**: the link is kept so it retries, and the markers are the record of what still has to come out of that collection.

Two tests, the first verified failing against the unfixed code.

## Overlap with #3636

#3636 adds a `direction` column to this table and changes `reconcileRuleRemovedOrphans`. It does not touch `stopMediaServerSync`, so the two should not conflict textually - but they are the two PRs closest together, so whichever merges second is the one to re-run the collections suite on.