### PR TITLE
refactor(ui): report a bulk outcome from the outcome itself

### DIFF
--- a/apps/ui/src/components/Collection/CollectionDetail/Exclusions/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/Exclusions/index.tsx
@@ -121,13 +121,8 @@ const CollectionExcludions = (props: ICollectionExclusions) => {
     })
   }
 
-  const handleBulkOutcome = ({
-    action,
-    collectionId,
-    succeededIds,
-    failedIds,
-    failureReasons,
-  }: MediaActionOutcome) => {
+  const handleBulkOutcome = (outcome: MediaActionOutcome) => {
+    const { action, collectionId, succeededIds, failedIds } = outcome
     applyBulkOutcome(new Set(failedIds))
 
     for (const mediaServerId of succeededIds) {
@@ -147,13 +142,7 @@ const CollectionExcludions = (props: ICollectionExclusions) => {
       )
     }
 
-    reportBulkOutcome({
-      action,
-      collectionId,
-      succeeded: succeededIds.length,
-      failed: failedIds.length,
-      failureReasons,
-    })
+    reportBulkOutcome(outcome)
   }
 
   const showRefreshing = isLoading && data.length > 0

--- a/apps/ui/src/components/Overview/index.tsx
+++ b/apps/ui/src/components/Overview/index.tsx
@@ -409,16 +409,10 @@ const Overview = () => {
     )
   }
 
-  const handleBulkOutcome = ({
-    action,
-    collectionId,
-    collectionTitle,
-    succeededIds: succeeded,
-    failedIds: failed,
-    failureReasons,
-  }: MediaActionOutcome) => {
-    const succeededIds = new Set(succeeded)
-    applyBulkOutcome(new Set(failed))
+  const handleBulkOutcome = (outcome: MediaActionOutcome) => {
+    const { action, collectionId, collectionTitle } = outcome
+    const succeededIds = new Set(outcome.succeededIds)
+    applyBulkOutcome(new Set(outcome.failedIds))
 
     if (succeededIds.size > 0) {
       // The server cascades an excluded show to its seasons and episodes, so
@@ -493,13 +487,7 @@ const Overview = () => {
       setStatusChangedIds((current) => new Set([...current, ...invalidated]))
     }
 
-    reportBulkOutcome({
-      action,
-      collectionId,
-      succeeded: succeededIds.size,
-      failed: failed.length,
-      failureReasons,
-    })
+    reportBulkOutcome(outcome)
   }
 
   useEffect(() => {

--- a/apps/ui/src/pages/CollectionMediaPage.tsx
+++ b/apps/ui/src/pages/CollectionMediaPage.tsx
@@ -151,13 +151,8 @@ const CollectionMediaPage = () => {
     )
   }
 
-  const handleBulkOutcome = ({
-    action,
-    collectionId,
-    succeededIds,
-    failedIds,
-    failureReasons,
-  }: MediaActionOutcome) => {
+  const handleBulkOutcome = (outcome: MediaActionOutcome) => {
+    const { action, collectionId, succeededIds, failedIds } = outcome
     applyBulkOutcome(new Set(failedIds))
 
     for (const mediaServerId of succeededIds) {
@@ -177,13 +172,7 @@ const CollectionMediaPage = () => {
       }
     }
 
-    reportBulkOutcome({
-      action,
-      collectionId,
-      succeeded: succeededIds.length,
-      failed: failedIds.length,
-      failureReasons,
-    })
+    reportBulkOutcome(outcome)
   }
 
   const showRefreshing = isLoading && data.length > 0

--- a/apps/ui/src/utils/bulkOutcome.ts
+++ b/apps/ui/src/utils/bulkOutcome.ts
@@ -105,30 +105,24 @@ const failureMessage = (
   }
 }
 
+/** Takes the modal's outcome as-is, so no caller restates its counts. */
 export const reportBulkOutcome = ({
   action,
   collectionId,
-  succeeded,
-  failed,
+  succeededIds,
+  failedIds,
   failureReasons = [],
-}: {
-  action: BulkAction
-  /** undefined means every collection. */
-  collectionId?: number
-  succeeded: number
-  failed: number
-  failureReasons?: string[]
-}): void => {
+}: MediaActionOutcome): void => {
   const everyCollection = collectionId === undefined
-  const success = successMessage(action, everyCollection, succeeded)
+  const success = successMessage(action, everyCollection, succeededIds.length)
 
-  if (failed > 0) {
+  if (failedIds.length > 0) {
     const why = failureReasons.length
       ? ` (${failureReasons.map(withoutFailedPrefix).join('; ')})`
       : ''
 
     toast.error(
-      `${success} ${failureMessage(action, everyCollection, failed, why)}`,
+      `${success} ${failureMessage(action, everyCollection, failedIds.length, why)}`,
     )
     return
   }


### PR DESCRIPTION
`reportBulkOutcome` took counts, so every call site restated fields off the `MediaActionOutcome` it already held. It now takes the outcome.

| | Before | After |
|---|---|---|
| Signature | `{ action, collectionId, succeeded: number, failed: number, failureReasons }` | `MediaActionOutcome` |
| Call sites | 7 lines each, 3 sites | `reportBulkOutcome(outcome)` |
| Net | | -40 lines |

Overview passed a de-duplicated `succeededIds.size` where the other two passed `succeededIds.length`. Not reachable today (one server result per selected id, and the input is a `Set`), so this is not a bug fix, but it is the drift that restating invites.

No behaviour change. Toast wording, the `Failed - ` prefix strip, and the failed-items-stay-selected contract are untouched.

## Verification

| Check | Result |
|---|---|
| `CollectionMediaPage` / `Overview` / `Exclusions` specs | 29/29, unchanged before and after |
| Full UI suite, both shards, `--force` | 74 files, 407 tests, 0 cached |
| `check-types`, `lint`, `format:check` | pass |
| `i18n:check` | catalog current |

Real stack, live Plex 1.43.3 through the UI:

| Path | Toast |
|---|---|
| Add 2 items, real write | `2 items added.` (success variant, selection closed) |
| 3 items forced to fail with a reason | `0 items added. 3 items could not be added (Collection is locked); the failed items stay selected.` (error variant, selection kept open) |

The success case was confirmed server-side: collection membership and the Plex collection both went 3 to 4, and the added item was removed again afterwards.