### PR TITLE
fix: let deletes wait for the server instead of timing out (#3673)

### DIFF
--- a/apps/server/src/modules/api/download-client-api/download-client-api.service.ts
+++ b/apps/server/src/modules/api/download-client-api/download-client-api.service.ts
@@ -3,10 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { AxiosError } from 'axios';
 import { SettingsDataService } from '../../../modules/settings/settings-data.service';
 import {
-  CONNECTION_TEST_TIMEOUT_MS,
   formatConnectionFailureMessage,
   logConnectionTestError,
 } from '../../../utils/connection-error';
+import { CONNECTION_TEST_TIMEOUT_MS } from '../lib/httpTimeouts';
 
 // qBittorrent rejects an authenticated request with 403 when its Web UI security
 // blocks the caller. Bad credentials are NOT this case (they are rejected at

--- a/apps/server/src/modules/api/emby-api/emby-api.helper.ts
+++ b/apps/server/src/modules/api/emby-api/emby-api.helper.ts
@@ -1,6 +1,7 @@
 import { stripTrailingSlashes } from '@maintainerr/contracts';
 import axios, { type AxiosInstance } from 'axios';
 import { applyHttpRetry } from '../lib/httpRetry';
+import { MEDIA_SERVER_REQUEST_TIMEOUT_MS } from '../lib/httpTimeouts';
 
 interface EmbyApiOptions {
   url: string;
@@ -43,7 +44,7 @@ export class EmbyApi {
 
     this.axios = axios.create({
       baseURL,
-      timeout: options.timeout ?? 30000,
+      timeout: options.timeout ?? MEDIA_SERVER_REQUEST_TIMEOUT_MS,
       headers,
     });
 

--- a/apps/server/src/modules/api/external-api/external-api.service.ts
+++ b/apps/server/src/modules/api/external-api/external-api.service.ts
@@ -2,6 +2,7 @@ import axios, { AxiosError, AxiosInstance, RawAxiosRequestConfig } from 'axios';
 import NodeCache from 'node-cache';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { applyHttpRetry } from '../lib/httpRetry';
+import { DEFAULT_REQUEST_TIMEOUT_MS } from '../lib/httpTimeouts';
 import { describeRequestTarget } from '../lib/requestLogging';
 
 // 20 minute default TTL (in seconds)
@@ -29,7 +30,7 @@ export class ExternalApiService {
     this.axios = axios.create({
       baseURL: baseUrl,
       params,
-      timeout: 10000, // timeout after 10s
+      timeout: DEFAULT_REQUEST_TIMEOUT_MS,
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',

--- a/apps/server/src/modules/api/lib/httpTimeouts.ts
+++ b/apps/server/src/modules/api/lib/httpTimeouts.ts
@@ -1,3 +1,26 @@
+// One home for the outbound HTTP timeouts, as httpRetry.ts is for retries.
+// axios's timeout is an inactivity timer on the socket, so it fires while a
+// server that is still working has simply not answered yet.
+
+/** ExternalApiService's default for every request that sets nothing else. */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+/** Connection tests and settings probes. */
+export const CONNECTION_TEST_TIMEOUT_MS = 5_000;
+
+/**
+ * Uncached arr reads whose failure would change action or rule behaviour.
+ * Slow or underpowered instances take more than the default even for simple
+ * reads (#3181).
+ */
+export const SLOW_INSTANCE_TIMEOUT_MS = 20_000;
+
+/**
+ * The Plex and Emby runtime clients: bounds a wedged socket so it cannot stall
+ * the rule executor indefinitely. The Jellyfin SDK client sets none.
+ */
+export const MEDIA_SERVER_REQUEST_TIMEOUT_MS = 30_000;
+
 /**
  * axios reads 0 as "no timeout". Every delete waits like this: Radarr, Sonarr,
  * Sportarr and Jellyfin remove the file before they answer, so the wait is the

--- a/apps/server/src/modules/api/lib/httpTimeouts.ts
+++ b/apps/server/src/modules/api/lib/httpTimeouts.ts
@@ -1,0 +1,9 @@
+/**
+ * axios reads 0 as "no timeout". Every delete waits like this: Radarr, Sonarr,
+ * Sportarr and Jellyfin remove the file before they answer, so the wait is the
+ * disk's (#3673 measured 4m23s for one 31.6 GB file), and a client that gives
+ * up records as failed a delete the server then finishes. A peer that has died
+ * still fails the request: Node's agent arms TCP keepalive on every socket, so
+ * the kernel reports it within seconds.
+ */
+export const NO_TIMEOUT = 0;

--- a/apps/server/src/modules/api/lib/plexApi.spec.ts
+++ b/apps/server/src/modules/api/lib/plexApi.spec.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import axiosRetry from 'axios-retry';
+import { NO_TIMEOUT } from './httpTimeouts';
 import PlexApi from './plexApi';
 
 jest.mock('axios', () => ({
@@ -57,6 +58,22 @@ describe('PlexApi', () => {
 
     expect(axios.create).toHaveBeenCalledWith(
       expect.objectContaining({ timeout: 30000 }),
+    );
+  });
+
+  it('lets one request wait past the instance timeout', async () => {
+    const request = jest.fn().mockResolvedValue({ data: {} });
+    (axios.create as jest.Mock).mockReturnValue({ request });
+
+    await new PlexApi({
+      hostname: 'plex.local',
+      port: 32400,
+      token: 'token',
+      timeout: 30000,
+    }).deleteQuery({ uri: '/library/metadata/4', timeout: NO_TIMEOUT });
+
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'DELETE', timeout: NO_TIMEOUT }),
     );
   });
 

--- a/apps/server/src/modules/api/lib/plexApi.ts
+++ b/apps/server/src/modules/api/lib/plexApi.ts
@@ -17,6 +17,7 @@ type RequestOptions = {
   uri: string;
   extraHeaders?: Record<string, string>;
   signal?: AbortSignal;
+  timeout?: number;
 };
 
 class PlexApi {
@@ -172,6 +173,7 @@ class PlexApi {
       method,
       headers: options.extraHeaders,
       signal: options.signal,
+      timeout: options.timeout,
     };
 
     try {

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.spec.ts
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios';
+import { NO_TIMEOUT } from '../../lib/httpTimeouts';
 import { batchIdsByRequestCost } from '../metadata-batch.util';
 import { EMBY_METADATA_FIELDS } from './emby-adapter.service';
 import { EMBY_CACHE_TTL } from './emby.constants';
@@ -147,7 +148,9 @@ describe('EmbyAdapterService', () => {
 
       await service.deleteFromDisk('42');
 
-      expect(http.delete).toHaveBeenCalledWith('/Items/42');
+      expect(http.delete).toHaveBeenCalledWith('/Items/42', {
+        timeout: NO_TIMEOUT,
+      });
     });
   });
 

--- a/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/emby/emby-adapter.service.ts
@@ -23,6 +23,7 @@ import { MaintainerrLogger } from '../../../logging/logs.service';
 import { SettingsDataService } from '../../../settings/settings-data.service';
 import { EmbyApi } from '../../emby-api/emby-api.helper';
 import cacheManager, { type Cache } from '../../lib/cache';
+import { NO_TIMEOUT } from '../../lib/httpTimeouts';
 import { resolveContextActionIds } from '../context-action.util';
 import { onlyRequestedItemKinds } from '../item-kinds.util';
 import { supportsFeature } from '../media-server.constants';
@@ -1727,7 +1728,7 @@ export class EmbyAdapterService implements IMediaServerService {
     }
 
     try {
-      await this.http.delete(`/Items/${itemId}`);
+      await this.http.delete(`/Items/${itemId}`, { timeout: NO_TIMEOUT });
     } catch (error) {
       const message = formatConnectionFailureMessage(
         error,

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -14,6 +14,7 @@ import {
   jellyfinWatchSnapshotCacheKey,
 } from './jellyfin.constants';
 import { batchIdsByRequestCost } from '../metadata-batch.util';
+import { NO_TIMEOUT } from '../../lib/httpTimeouts';
 import { JellyfinAdapterService } from './jellyfin-adapter.service';
 import { JELLYFIN_BATCH_SIZE, JELLYFIN_CACHE_TTL } from './jellyfin.constants';
 
@@ -2426,6 +2427,27 @@ describe('JellyfinAdapterService', () => {
       service.resetMetadataCache();
 
       expect(jellyfinCacheMocks.data.flushAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deleteFromDisk', () => {
+    beforeEach(async () => {
+      settingsDataService.getSettings.mockResolvedValue(
+        mockSettings as unknown as Awaited<
+          ReturnType<SettingsDataService['getSettings']>
+        >,
+      );
+      await service.initialize();
+    });
+
+    // Jellyfin removes the file before it answers, so the request waits for it.
+    it('waits for the answer instead of applying a request timeout', async () => {
+      await service.deleteFromDisk('item-1');
+
+      expect(jellyfinApiMocks.deleteItem).toHaveBeenCalledWith(
+        { itemId: 'item-1' },
+        { timeout: NO_TIMEOUT },
+      );
     });
   });
 

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -59,6 +59,7 @@ import { SettingsDataService } from '../../../settings/settings-data.service';
 import { createPrefetchProgressReporter } from '../../../../utils/prefetch-progress';
 import cacheManager, { type Cache } from '../../lib/cache';
 import { applyHttpRetry } from '../../lib/httpRetry';
+import { NO_TIMEOUT } from '../../lib/httpTimeouts';
 import {
   isBlankMediaServerId,
   isForeignServerId,
@@ -2687,7 +2688,10 @@ export class JellyfinAdapterService implements IMediaServerService {
     }
 
     try {
-      await getLibraryApi(this.api).deleteItem({ itemId });
+      await getLibraryApi(this.api).deleteItem(
+        { itemId },
+        { timeout: NO_TIMEOUT },
+      );
       this.logger.log(`Successfully deleted Jellyfin item ${itemId} from disk`);
     } catch (error) {
       this.logger.error(`Failed to delete item ${itemId} from disk`);

--- a/apps/server/src/modules/api/plex-api/plex-api.constants.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.constants.ts
@@ -12,11 +12,6 @@ export const PLEX_PAGE_SIZE = {
   MAX_PAGE_SIZE: 500,
 } as const;
 
-// Bounds runtime Plex socket reads so a wedged request can't stall the rule
-// executor indefinitely. Connection probes use the shorter
-// CONNECTION_TEST_TIMEOUT_MS; this applies to the long-lived runtime client.
-export const PLEX_REQUEST_TIMEOUT_MS = 30_000;
-
 // plex.tv answers with HTTP 200 and a `User not found:` GraphQL error when it
 // refuses to resolve the requested user at all: the account keeps its watchlist
 // private ("User privacy prevents viewing"), or the uuid is unknown to plex.tv.

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -12,6 +12,7 @@ import {
   watchHistoryCacheKey,
 } from './plex-api.constants';
 import { PlexConnection } from './interfaces/server.interface';
+import { NO_TIMEOUT } from '../lib/httpTimeouts';
 import { PlexApiService } from './plex-api.service';
 
 const createDeferred = () => {
@@ -716,6 +717,29 @@ describe('PlexApiService.getMetadata', () => {
 // The diagnostic still distinguishes a missing section from an auth failure;
 // #3344 only changed the outcome - every failure now propagates instead of
 // reading downstream as "this library has no collections".
+describe('PlexApiService.deleteMediaFromDisk', () => {
+  let service: PlexApiService;
+
+  beforeEach(async () => {
+    const { unit } = await TestBed.solitary(PlexApiService).compile();
+    service = unit;
+  });
+
+  // Plex removes the file before it answers, so the request waits for it. The
+  // failure has to reach the caller: swallowed here, the adapter logged a
+  // success and the handler retired an item whose file was still on disk.
+  it('waits for the answer and surfaces a refused delete', async () => {
+    const deleteQuery = jest.fn().mockRejectedValue(new Error('denied'));
+    (service as any).plexClient = { deleteQuery };
+
+    await expect(service.deleteMediaFromDisk('4')).rejects.toThrow('denied');
+    expect(deleteQuery).toHaveBeenCalledWith({
+      uri: '/library/metadata/4',
+      timeout: NO_TIMEOUT,
+    });
+  });
+});
+
 describe('PlexApiService.getCollections (invalid section vs auth)', () => {
   let service: PlexApiService;
   let settingsDataService: PlexApiSettingsStub;

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -9,6 +9,7 @@ import {
 import { createPrefetchProgressReporter } from '../../../utils/prefetch-progress';
 import cacheManager from '../../api/lib/cache';
 import { retryingHttp } from '../../api/lib/httpRetry';
+import { NO_TIMEOUT } from '../../api/lib/httpTimeouts';
 import PlexCommunityApi, {
   PlexCommunityErrorResponse,
   PlexCommunityWatchList,
@@ -1270,19 +1271,13 @@ export class PlexApiService {
   }
 
   public async deleteMediaFromDisk(plexId: number | string): Promise<void> {
-    try {
-      await this.plexClient.deleteQuery({
-        uri: `/library/metadata/${plexId}`,
-      });
-      this.logger.log(
-        `[Plex] Removed media with ID ${plexId} from Plex library.`,
-      );
-    } catch (error) {
-      this.logger.error(
-        `Something went wrong while removing media ${plexId} from Plex.`,
-      );
-      this.logger.debug(error);
-    }
+    await this.plexClient.deleteQuery({
+      uri: `/library/metadata/${plexId}`,
+      timeout: NO_TIMEOUT,
+    });
+    this.logger.log(
+      `[Plex] Removed media with ID ${plexId} from Plex library.`,
+    );
   }
 
   public async refreshMediaMetadata(ratingKey: string): Promise<void> {

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -2,14 +2,15 @@ import { BasicResponseDto, PlexSetting } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import axios from 'axios';
 import { isIP } from 'net';
-import {
-  CONNECTION_TEST_TIMEOUT_MS,
-  getErrorMessage,
-} from '../../../utils/connection-error';
+import { getErrorMessage } from '../../../utils/connection-error';
 import { createPrefetchProgressReporter } from '../../../utils/prefetch-progress';
 import cacheManager from '../../api/lib/cache';
 import { retryingHttp } from '../../api/lib/httpRetry';
-import { NO_TIMEOUT } from '../../api/lib/httpTimeouts';
+import {
+  CONNECTION_TEST_TIMEOUT_MS,
+  MEDIA_SERVER_REQUEST_TIMEOUT_MS,
+  NO_TIMEOUT,
+} from '../../api/lib/httpTimeouts';
 import PlexCommunityApi, {
   PlexCommunityErrorResponse,
   PlexCommunityWatchList,
@@ -55,7 +56,6 @@ import {
 import {
   PLEX_COMMUNITY_UNRESOLVED_USER_ERROR,
   PLEX_PAGE_SIZE,
-  PLEX_REQUEST_TIMEOUT_MS,
   WATCH_HISTORY_EXCLUDE_FIELDS,
   WATCH_HISTORY_MAX_ENTRIES,
   watchHistoryCacheKey,
@@ -265,7 +265,7 @@ export class PlexApiService {
         port: settingsPlex.port,
         https: settingsPlex.useSsl,
         token: plexToken,
-        timeout: PLEX_REQUEST_TIMEOUT_MS,
+        timeout: MEDIA_SERVER_REQUEST_TIMEOUT_MS,
       });
 
       const machineId = await this.setMachineId();
@@ -353,7 +353,7 @@ export class PlexApiService {
           port: conn.port,
           https: conn.protocol === 'https',
           token: plexToken,
-          timeout: PLEX_REQUEST_TIMEOUT_MS,
+          timeout: MEDIA_SERVER_REQUEST_TIMEOUT_MS,
         });
 
         await this.settings.updatePlexConnectionDetails({

--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
@@ -3,10 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { cloneDeep } from 'lodash';
 import { SettingsDataService } from '../../../modules/settings/settings-data.service';
 import {
-  CONNECTION_TEST_TIMEOUT_MS,
   formatConnectionFailureMessage,
   logConnectionTestError,
 } from '../../../utils/connection-error';
+import { CONNECTION_TEST_TIMEOUT_MS } from '../lib/httpTimeouts';
 import {
   MaintainerrLogger,
   MaintainerrLoggerFactory,

--- a/apps/server/src/modules/api/servarr-api/common/servarr-api.service.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/common/servarr-api.service.spec.ts
@@ -1,5 +1,6 @@
 import type { ArrDiskspaceResource } from '@maintainerr/contracts';
 import type { MaintainerrLogger } from '../../../logging/logs.service';
+import { NO_TIMEOUT } from '../../lib/httpTimeouts';
 import { ServarrApi } from './servarr-api.service';
 
 class TestServarrApi extends ServarrApi<Record<string, never>> {}
@@ -123,6 +124,15 @@ describe('ServarrApi', () => {
 
       await expect(api.ensureTag('dnd')).resolves.toBeUndefined();
     });
+  });
+
+  // The arr answers a file delete after the disk is done with it. Applying the
+  // read timeout recorded as failed a delete the arr then finished (#3673).
+  it('waits for a delete to be answered instead of applying the read timeout', async () => {
+    const del = jest.spyOn(api, 'delete').mockResolvedValue({});
+
+    await expect((api as any).runDelete('moviefile/1')).resolves.toBe(true);
+    expect(del).toHaveBeenCalledWith('/moviefile/1', { timeout: NO_TIMEOUT });
   });
 
   describe('getRootFolders caching', () => {

--- a/apps/server/src/modules/api/servarr-api/common/servarr-api.service.ts
+++ b/apps/server/src/modules/api/servarr-api/common/servarr-api.service.ts
@@ -3,7 +3,7 @@ import { ExternalApiService } from '../../../../modules/api/external-api/externa
 import { DVRSettings } from '../../../../modules/settings/interfaces/dvr-settings.interface';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import cacheManager from '../../lib/cache';
-import { NO_TIMEOUT } from '../../lib/httpTimeouts';
+import { NO_TIMEOUT, SLOW_INSTANCE_TIMEOUT_MS } from '../../lib/httpTimeouts';
 import {
   DiskSpaceResource,
   HistoryRecord,
@@ -13,12 +13,6 @@ import {
   SystemStatus,
   Tag,
 } from '../interfaces/servarr.interface';
-
-// Slow/underpowered *arr instances can take >10s to answer even simple reads;
-// allow more headroom than the shared 10s axios default before aborting
-// (#3181). Used for uncached reads whose failure would change action or rule
-// behavior.
-export const SLOW_INSTANCE_TIMEOUT_MS = 20000;
 
 export abstract class ServarrApi<QueueItemAppendT> extends ExternalApiService {
   static buildUrl(settings: DVRSettings, path?: string): string {

--- a/apps/server/src/modules/api/servarr-api/common/servarr-api.service.ts
+++ b/apps/server/src/modules/api/servarr-api/common/servarr-api.service.ts
@@ -3,6 +3,7 @@ import { ExternalApiService } from '../../../../modules/api/external-api/externa
 import { DVRSettings } from '../../../../modules/settings/interfaces/dvr-settings.interface';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import cacheManager from '../../lib/cache';
+import { NO_TIMEOUT } from '../../lib/httpTimeouts';
 import {
   DiskSpaceResource,
   HistoryRecord,
@@ -331,7 +332,9 @@ export abstract class ServarrApi<QueueItemAppendT> extends ExternalApiService {
 
   protected async runDelete(command: string): Promise<boolean> {
     try {
-      const result = await this.delete(`/${command}`);
+      const result = await this.delete(`/${command}`, {
+        timeout: NO_TIMEOUT,
+      });
 
       if (result === undefined) {
         this.logger.warn(`Failed to run DELETE: /${command}`);

--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.ts
@@ -1,10 +1,10 @@
 import { isAxiosError } from 'axios';
-import { CONNECTION_TEST_TIMEOUT_MS } from '../../../../utils/connection-error';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import {
-  ServarrApi,
+  CONNECTION_TEST_TIMEOUT_MS,
   SLOW_INSTANCE_TIMEOUT_MS,
-} from '../common/servarr-api.service';
+} from '../../lib/httpTimeouts';
+import { ServarrApi } from '../common/servarr-api.service';
 import {
   RadarrImportListExclusion,
   RadarrInfo,

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
@@ -1,9 +1,9 @@
-import { CONNECTION_TEST_TIMEOUT_MS } from '../../../../utils/connection-error';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import {
-  ServarrApi,
+  CONNECTION_TEST_TIMEOUT_MS,
   SLOW_INSTANCE_TIMEOUT_MS,
-} from '../common/servarr-api.service';
+} from '../../lib/httpTimeouts';
+import { ServarrApi } from '../common/servarr-api.service';
 import {
   DownloadHistoryItem,
   SonarrEpisode,

--- a/apps/server/src/modules/api/servarr-api/helpers/sportarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sportarr.helper.spec.ts
@@ -1,4 +1,5 @@
 import { MaintainerrLogger } from '../../../logging/logs.service';
+import { NO_TIMEOUT } from '../../lib/httpTimeouts';
 import { SportarrApi } from './sportarr.helper';
 
 describe('SportarrApi', () => {
@@ -109,10 +110,10 @@ describe('SportarrApi', () => {
         .mockResolvedValue({ data: {} });
 
       await expect(sportarrApi.deleteLeague(3, true)).resolves.toBe(true);
-      expect(del).toHaveBeenCalledWith(
-        '/leagues/3',
-        expect.objectContaining({ params: { deleteFiles: true } }),
-      );
+      expect(del).toHaveBeenCalledWith('/leagues/3', {
+        params: { deleteFiles: true },
+        timeout: NO_TIMEOUT,
+      });
     });
 
     it('deleteLeague returns false when the request throws', async () => {
@@ -159,7 +160,9 @@ describe('SportarrApi', () => {
         .mockResolvedValue({ data: {} });
 
       await expect(sportarrApi.deleteEventFiles(999)).resolves.toBe(true);
-      expect(del).toHaveBeenCalledWith('/events/999/files', expect.anything());
+      expect(del).toHaveBeenCalledWith('/events/999/files', {
+        timeout: NO_TIMEOUT,
+      });
     });
   });
 

--- a/apps/server/src/modules/api/servarr-api/helpers/sportarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sportarr.helper.ts
@@ -1,5 +1,6 @@
 import { CONNECTION_TEST_TIMEOUT_MS } from '../../../../utils/connection-error';
 import { MaintainerrLogger } from '../../../logging/logs.service';
+import { NO_TIMEOUT } from '../../lib/httpTimeouts';
 import {
   ServarrApi,
   SLOW_INSTANCE_TIMEOUT_MS,
@@ -170,7 +171,7 @@ export class SportarrApi extends ServarrApi<{
     try {
       await this.axios.delete(`/leagues/${leagueId}`, {
         params: { deleteFiles },
-        timeout: SLOW_INSTANCE_TIMEOUT_MS,
+        timeout: NO_TIMEOUT,
       });
       return true;
     } catch (error) {
@@ -185,7 +186,7 @@ export class SportarrApi extends ServarrApi<{
   public async deleteEventFiles(eventId: number): Promise<boolean> {
     try {
       await this.axios.delete(`/events/${eventId}/files`, {
-        timeout: SLOW_INSTANCE_TIMEOUT_MS,
+        timeout: NO_TIMEOUT,
       });
       return true;
     } catch (error) {

--- a/apps/server/src/modules/api/servarr-api/helpers/sportarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sportarr.helper.ts
@@ -1,10 +1,10 @@
-import { CONNECTION_TEST_TIMEOUT_MS } from '../../../../utils/connection-error';
 import { MaintainerrLogger } from '../../../logging/logs.service';
-import { NO_TIMEOUT } from '../../lib/httpTimeouts';
 import {
-  ServarrApi,
+  CONNECTION_TEST_TIMEOUT_MS,
+  NO_TIMEOUT,
   SLOW_INSTANCE_TIMEOUT_MS,
-} from '../common/servarr-api.service';
+} from '../../lib/httpTimeouts';
+import { ServarrApi } from '../common/servarr-api.service';
 import {
   SportarrDownloadHistoryItem,
   SportarrEvent,

--- a/apps/server/src/modules/api/streamystats-api/streamystats-api.service.ts
+++ b/apps/server/src/modules/api/streamystats-api/streamystats-api.service.ts
@@ -8,10 +8,10 @@ import {
 import { Injectable } from '@nestjs/common';
 import { SettingsDataService } from '../../../modules/settings/settings-data.service';
 import {
-  CONNECTION_TEST_TIMEOUT_MS,
   formatConnectionFailureMessage,
   logConnectionTestError,
 } from '../../../utils/connection-error';
+import { CONNECTION_TEST_TIMEOUT_MS } from '../lib/httpTimeouts';
 import {
   MaintainerrLogger,
   MaintainerrLoggerFactory,

--- a/apps/server/src/modules/api/tautulli-api/tautulli-api.service.ts
+++ b/apps/server/src/modules/api/tautulli-api/tautulli-api.service.ts
@@ -4,10 +4,10 @@ import { AxiosError } from 'axios';
 import { unionBy } from 'lodash';
 import { SettingsDataService } from '../../..//modules/settings/settings-data.service';
 import {
-  CONNECTION_TEST_TIMEOUT_MS,
   formatConnectionFailureMessage,
   logConnectionTestError,
 } from '../../../utils/connection-error';
+import { CONNECTION_TEST_TIMEOUT_MS } from '../lib/httpTimeouts';
 import {
   MaintainerrLogger,
   MaintainerrLoggerFactory,

--- a/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
+++ b/apps/server/src/modules/api/tracearr-api/tracearr-api.service.ts
@@ -15,10 +15,10 @@ import { SettingsDataService } from '../../settings/settings-data.service';
 import { resolveDescendants } from '../media-server/context-action.util';
 import { MediaServerFactory } from '../media-server/media-server.factory';
 import {
-  CONNECTION_TEST_TIMEOUT_MS,
   formatConnectionFailureMessage,
   logConnectionTestError,
 } from '../../../utils/connection-error';
+import { CONNECTION_TEST_TIMEOUT_MS } from '../lib/httpTimeouts';
 import {
   MaintainerrLogger,
   MaintainerrLoggerFactory,

--- a/apps/server/src/utils/connection-error.ts
+++ b/apps/server/src/utils/connection-error.ts
@@ -2,9 +2,8 @@
 // SDKs (e.g. @jellyfin/sdk) come from a second axios module instance, so an
 // instanceof check against this CommonJS build never matches them.
 import { isAxiosError } from 'axios';
+import { CONNECTION_TEST_TIMEOUT_MS } from '../modules/api/lib/httpTimeouts';
 import type { MaintainerrLogger } from '../modules/logging/logs.service';
-
-export const CONNECTION_TEST_TIMEOUT_MS = 5000;
 
 const normalizeMessageText = (message?: string): string | undefined => {
   if (!message) {


### PR DESCRIPTION
Fixes #3673.

`runDelete()` inherited the 10s axios default, so a large arr file delete timed out client-side while the arr finished it: the app logged `Failed to run DELETE`, left the item in the collection with a media-server id that soon 404s, and never counted it as handled. Radarr, Sonarr, Sportarr and Jellyfin all delete the file before they answer, so the wait is the disk's and no client-side number can be right. Every delete now waits for the server's answer (`timeout: 0`, one shared `NO_TIMEOUT`). A dead peer still fails the request: Node's agent arms TCP keepalive on every socket.

| Delete path | Before | After |
|---|---|---|
| Radarr / Sonarr `runDelete` (movie, moviefile, series, episodefile) | 10s | waits |
| Sportarr `deleteLeague`, `deleteEventFiles` | 20s | waits |
| Plex `deleteFromDisk` | 30s; a refused or timed-out delete was swallowed, logged as `Successfully deleted` and counted as handled | waits; the failure surfaces and the item stays for retry |
| Jellyfin `deleteFromDisk` | no timeout (SDK uses the global axios) | explicit, unchanged behaviour |
| Emby `deleteFromDisk` | 30s | waits |

Verified on the dev stack against the real services with a proxy that forwards the DELETE at once and holds the answer past the old timeout:

| Service | Server answered at | Before | After |
|---|---|---|---|
| Radarr, through the collection handler | +15ms | `Failed to run DELETE` at +10.0s, HTTP 409, item kept, handled 0 | waits 15s, item removed, handled 1 |
| Sonarr `deleteShow` | +23ms | false at +10.1s, series already gone | true at +15.1s |
| Sportarr `deleteEventFiles` | +33ms | false at +20.0s | true at +25.0s |
| Emby `deleteFromDisk` | +1ms | timeout error at +30.0s | resolves at +35.0s |
| Plex, refused delete (media deletion off) | immediate 403 | `Successfully deleted`, HTTP 201, handled 1 | `Failed to delete item`, item kept |

The second commit gives the outbound HTTP timeouts one home, `modules/api/lib/httpTimeouts.ts`, the way `httpRetry.ts` holds the retry policy: the `ExternalApiService` 10s default, `CONNECTION_TEST_TIMEOUT_MS` (from `utils/connection-error.ts`), `SLOW_INSTANCE_TIMEOUT_MS` (from the servarr base), the 30s Plex and Emby client timeout (`PLEX_REQUEST_TIMEOUT_MS` plus the Emby literal, now `MEDIA_SERVER_REQUEST_TIMEOUT_MS`) and `NO_TIMEOUT`. No value changed.
