### PR TITLE
fix(sonarr): read the episode list fresh before unmonitoring or deleting files

### DIFF
--- a/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/radarr.helper.spec.ts
@@ -266,6 +266,31 @@ describe('RadarrApi', () => {
       expect(getWithoutCacheSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('deletes current file ids without using the rule evaluation cache', async () => {
+      const cached = jest
+        .spyOn(api, 'get')
+        .mockResolvedValue([createRadarrMovieFile({ id: 800 })]);
+      const fresh = jest
+        .spyOn(api, 'getWithoutCache')
+        .mockResolvedValueOnce(movie)
+        .mockResolvedValueOnce([createRadarrMovieFile({ id: 900 })]);
+      jest.spyOn(api as any, 'runPut').mockResolvedValue(true);
+      const runDeleteSpy = jest
+        .spyOn(api as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      await expect(
+        api.updateMovie(5, { monitored: false, deleteFiles: true }),
+      ).resolves.toEqual({ ok: true, deletedFileCount: 1 });
+
+      expect(cached).not.toHaveBeenCalled();
+      expect(fresh).toHaveBeenCalledWith('moviefile?movieId=5', {
+        timeout: 20000,
+      });
+      expect(runDeleteSpy).toHaveBeenCalledTimes(1);
+      expect(runDeleteSpy).toHaveBeenCalledWith('moviefile/900');
+    });
+
     it('fails closed when the movie file listing fails instead of reporting success', async () => {
       jest
         .spyOn(api, 'getWithoutCache')

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.spec.ts
@@ -23,6 +23,29 @@ describe('SonarrApi', () => {
     );
   });
 
+  it.each(['all', 'existing', 3] as const)(
+    'does not mutate seasons when the fresh episode read fails (%s)',
+    async (scope) => {
+      jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue(undefined);
+      jest.spyOn((sonarrApi as any).axios, 'get').mockResolvedValue({
+        data: createSonarrSeries({
+          seasons: [{ seasonNumber: 3, monitored: true }],
+        }),
+      });
+      const runPutSpy = jest.spyOn(sonarrApi as any, 'runPut');
+      const runDeleteSpy = jest.spyOn(sonarrApi as any, 'runDelete');
+
+      await expect(
+        sonarrApi.unmonitorSeasons(1, scope),
+      ).resolves.toBeUndefined();
+
+      expect(runPutSpy).not.toHaveBeenCalled();
+      expect(runDeleteSpy).not.toHaveBeenCalled();
+    },
+  );
+
   it('should match episodes by air date when episode numbers are empty', async () => {
     const matchingEpisode = createSonarrEpisode({
       id: 101,
@@ -40,7 +63,7 @@ describe('SonarrApi', () => {
     });
 
     jest
-      .spyOn(sonarrApi as any, 'get')
+      .spyOn(sonarrApi, 'getEpisodes')
       .mockResolvedValue([matchingEpisode, otherEpisode]);
     const runPutSpy = jest
       .spyOn(sonarrApi as any, 'runPut')
@@ -88,7 +111,7 @@ describe('SonarrApi', () => {
     });
 
     jest
-      .spyOn(sonarrApi as any, 'get')
+      .spyOn(sonarrApi, 'getEpisodes')
       .mockResolvedValue([firstMatchingEpisode, secondMatchingEpisode]);
     const runPutSpy = jest
       .spyOn(sonarrApi as any, 'runPut')
@@ -149,7 +172,7 @@ describe('SonarrApi', () => {
     );
   });
 
-  it('should use episode numbers and episode file ids for existing-season cleanup', async () => {
+  it('should unmonitor each existing episode from the one episode read, then delete its file', async () => {
     const episode = createSonarrEpisode({
       id: 99,
       seasonNumber: 3,
@@ -161,13 +184,14 @@ describe('SonarrApi', () => {
       seasons: [{ seasonNumber: 3, monitored: true }],
     });
 
-    jest.spyOn(sonarrApi, 'getEpisodes').mockResolvedValue([episode]);
-    jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(true);
+    const getEpisodesSpy = jest
+      .spyOn(sonarrApi, 'getEpisodes')
+      .mockResolvedValue([episode]);
+    const runPutSpy = jest
+      .spyOn(sonarrApi as any, 'runPut')
+      .mockResolvedValue(true);
     const runDeleteSpy = jest
       .spyOn(sonarrApi as any, 'runDelete')
-      .mockResolvedValue(true);
-    const unmonitorDeleteEpisodesSpy = jest
-      .spyOn(sonarrApi, 'UnmonitorDeleteEpisodes')
       .mockResolvedValue(true);
     jest.spyOn((sonarrApi as any).axios, 'get').mockResolvedValue({
       data: series,
@@ -177,7 +201,11 @@ describe('SonarrApi', () => {
       expect.objectContaining({ id: 1 }),
     );
 
-    expect(unmonitorDeleteEpisodesSpy).toHaveBeenCalledWith(1, 3, [7], false);
+    expect(getEpisodesSpy).toHaveBeenCalledTimes(1);
+    expect(runPutSpy).toHaveBeenCalledWith(
+      'episode/99',
+      JSON.stringify({ ...episode, monitored: false }),
+    );
     expect(runDeleteSpy).toHaveBeenCalledWith('episodefile/700');
   });
 
@@ -210,12 +238,7 @@ describe('SonarrApi', () => {
   it('should refuse an episode action without a season number (#3415)', async () => {
     // An unfiltered episode read returns every season, so episode 1 would match
     // - and be deleted - in each of them.
-    const getSpy = jest
-      .spyOn(sonarrApi as any, 'get')
-      .mockResolvedValue([
-        createSonarrEpisode({ seasonNumber: 1, episodeNumber: 1 }),
-        createSonarrEpisode({ seasonNumber: 2, episodeNumber: 1 }),
-      ]);
+    const getSpy = jest.spyOn(sonarrApi, 'getEpisodes');
     const runPutSpy = jest.spyOn(sonarrApi as any, 'runPut');
     const runDeleteSpy = jest.spyOn(sonarrApi as any, 'runDelete');
 
@@ -543,7 +566,7 @@ describe('SonarrApi', () => {
         episodeFileId: 501,
         monitored: true,
       });
-      jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
+      jest.spyOn(sonarrApi, 'getEpisodes').mockResolvedValue([episode]);
       jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(false);
       const getWithoutCacheSpy = jest
         .spyOn(sonarrApi as any, 'getWithoutCache')
@@ -582,7 +605,7 @@ describe('SonarrApi', () => {
         episodeFileId: 501,
         monitored: true,
       });
-      jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
+      jest.spyOn(sonarrApi, 'getEpisodes').mockResolvedValue([episode]);
       jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(true);
       const getWithoutCacheSpy = jest
         .spyOn(sonarrApi as any, 'getWithoutCache')
@@ -610,7 +633,7 @@ describe('SonarrApi', () => {
         episodeFileId: 501,
         monitored: true,
       });
-      jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
+      jest.spyOn(sonarrApi, 'getEpisodes').mockResolvedValue([episode]);
       jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(false);
       jest
         .spyOn(sonarrApi as any, 'getWithoutCache')
@@ -640,7 +663,7 @@ describe('SonarrApi', () => {
         episodeFileId: 501,
         monitored: true,
       });
-      jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
+      jest.spyOn(sonarrApi, 'getEpisodes').mockResolvedValue([episode]);
       jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(false);
       jest
         .spyOn(sonarrApi as any, 'getWithoutCache')
@@ -673,7 +696,7 @@ describe('SonarrApi', () => {
         episodeFileId: 501,
         monitored: true,
       });
-      jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
+      jest.spyOn(sonarrApi, 'getEpisodes').mockResolvedValue([episode]);
       jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(false);
       jest
         .spyOn(sonarrApi as any, 'getWithoutCache')
@@ -706,7 +729,7 @@ describe('SonarrApi', () => {
         episodeFileId: 501,
         monitored: true,
       });
-      jest.spyOn(sonarrApi as any, 'get').mockResolvedValue([episode]);
+      jest.spyOn(sonarrApi, 'getEpisodes').mockResolvedValue([episode]);
       jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(false);
       jest
         .spyOn(sonarrApi as any, 'getWithoutCache')
@@ -746,7 +769,7 @@ describe('SonarrApi', () => {
       });
 
       jest
-        .spyOn(sonarrApi as any, 'get')
+        .spyOn(sonarrApi, 'getEpisodes')
         .mockResolvedValue([firstEpisode, secondEpisode]);
       jest
         .spyOn(sonarrApi as any, 'runPut')
@@ -791,7 +814,7 @@ describe('SonarrApi', () => {
       });
 
       jest
-        .spyOn(sonarrApi as any, 'get')
+        .spyOn(sonarrApi, 'getEpisodes')
         .mockResolvedValue([firstEpisode, secondEpisode]);
       jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(true);
       const runDeleteSpy = jest
@@ -856,6 +879,85 @@ describe('SonarrApi', () => {
         .mockResolvedValue(undefined);
 
       await expect(sonarrApi.getEpisodeFiles(42)).resolves.toBeUndefined();
+    });
+
+    it('reads the episode list uncached before a season delete', async () => {
+      const cached = jest.spyOn(sonarrApi as any, 'get');
+      const uncached = jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue([
+          createSonarrEpisode({ seasonNumber: 3, episodeFileId: 700 }),
+        ]);
+      jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(true);
+      const runDeleteSpy = jest
+        .spyOn(sonarrApi as any, 'runDelete')
+        .mockResolvedValue(true);
+      jest.spyOn((sonarrApi as any).axios, 'get').mockResolvedValue({
+        data: createSonarrSeries({
+          id: 1,
+          seasons: [{ seasonNumber: 3, monitored: true }],
+        }),
+      });
+
+      await sonarrApi.unmonitorSeasons(1, 3);
+
+      expect(uncached).toHaveBeenCalledWith('/episode?seriesId=1', {
+        timeout: 20000,
+      });
+      expect(cached).not.toHaveBeenCalled();
+      expect(runDeleteSpy).toHaveBeenCalledWith('episodefile/700');
+      expect(logger.log).toHaveBeenCalledWith(
+        'Unmonitored season 3 from Sonarr show with ID 1 and removed 1 episode file(s)',
+      );
+    });
+
+    it('says so when a season delete found no files to remove', async () => {
+      jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue([
+          createSonarrEpisode({ seasonNumber: 3, episodeFileId: 0 }),
+        ]);
+      jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(true);
+      const runDeleteSpy = jest.spyOn(sonarrApi as any, 'runDelete');
+      jest.spyOn((sonarrApi as any).axios, 'get').mockResolvedValue({
+        data: createSonarrSeries({
+          id: 1,
+          seasons: [{ seasonNumber: 3, monitored: true }],
+        }),
+      });
+
+      await sonarrApi.unmonitorSeasons(1, 3);
+
+      expect(runDeleteSpy).not.toHaveBeenCalled();
+      expect(logger.log).toHaveBeenCalledWith(
+        'Unmonitored season 3 from Sonarr show with ID 1; it had no episode files to remove',
+      );
+    });
+
+    it('reads the season episodes uncached before an episode delete', async () => {
+      const cached = jest.spyOn(sonarrApi as any, 'get');
+      const uncached = jest
+        .spyOn(sonarrApi as any, 'getWithoutCache')
+        .mockResolvedValue([
+          createSonarrEpisode({
+            seasonNumber: 3,
+            episodeNumber: 7,
+            episodeFileId: 700,
+          }),
+        ]);
+      jest.spyOn(sonarrApi as any, 'runPut').mockResolvedValue(true);
+      const runDeleteSpy = jest
+        .spyOn(sonarrApi as any, 'runDelete')
+        .mockResolvedValue(true);
+
+      await sonarrApi.UnmonitorDeleteEpisodes(1, 3, [7]);
+
+      expect(uncached).toHaveBeenCalledWith(
+        '/episode?seriesId=1&seasonNumber=3',
+        { timeout: 20000 },
+      );
+      expect(cached).not.toHaveBeenCalled();
+      expect(runDeleteSpy).toHaveBeenCalledWith('episodefile/700');
     });
   });
 });

--- a/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
+++ b/apps/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
@@ -50,13 +50,22 @@ export class SonarrApi extends ServarrApi<{
     }
   }
 
+  /**
+   * Use fresh reads for actions so file ids cannot come from rule evaluation's
+   * cached episode list.
+   */
   public async getEpisodes(
     seriesID: number,
     seasonNumber?: number,
     episodeNumbers?: number[],
+    options?: { fresh?: boolean },
   ): Promise<SonarrEpisode[]> {
     try {
-      const response = await this.fetchEpisodes(seriesID, seasonNumber);
+      const response = await this.fetchEpisodes(
+        seriesID,
+        seasonNumber,
+        options?.fresh,
+      );
 
       if (episodeNumbers !== undefined) {
         const validEpisodeNumbers =
@@ -295,7 +304,14 @@ export class SonarrApi extends ServarrApi<{
     }
 
     try {
-      const episodes = await this.getEpisodes(seriesId, seasonNumber);
+      const episodes = await this.getEpisodes(
+        seriesId,
+        seasonNumber,
+        undefined,
+        {
+          fresh: true,
+        },
+      );
 
       const matchedEpisodes = this.findEpisodesForAction(
         episodes,
@@ -356,7 +372,15 @@ export class SonarrApi extends ServarrApi<{
       const data: SonarrSeries = (await this.axios.get(`series/${seriesId}`))
         .data;
 
-      const episodes = await this.getEpisodes(+seriesId);
+      const episodes = await this.getEpisodes(+seriesId, undefined, undefined, {
+        fresh: true,
+      });
+      if (!Array.isArray(episodes)) {
+        this.logger.warn(
+          `Could not list series ${seriesId}'s episodes; no action was taken.`,
+        );
+        return undefined;
+      }
       let success = true;
 
       data.seasons = await Promise.all(
@@ -370,12 +394,7 @@ export class SonarrApi extends ServarrApi<{
             for (const e of episodes) {
               if (e.seasonNumber === s.seasonNumber && e.episodeFileId) {
                 success =
-                  (await this.UnmonitorDeleteEpisodes(
-                    +seriesId,
-                    e.seasonNumber,
-                    [e.episodeNumber],
-                    false,
-                  )) && success;
+                  (await this.unmonitorAndDeleteEpisode(e, false)) && success;
               }
             }
           } else if (typeof type === 'number') {
@@ -391,18 +410,19 @@ export class SonarrApi extends ServarrApi<{
       // Skip the file deletes when an unmonitor failed: the content may still
       // be monitored and Sonarr would re-download it (#3228). The action
       // reports failure and is retried next run.
+      let deletedFileCount = 0;
       if (deleteFiles && success) {
         for (const e of episodes) {
-          if (typeof type === 'number') {
-            if (e.seasonNumber === type && e.episodeFileId) {
-              success =
-                (await this.runDelete(`episodefile/${e.episodeFileId}`)) &&
-                success;
-            }
-          } else if (e.episodeFileId) {
-            success =
-              (await this.runDelete(`episodefile/${e.episodeFileId}`)) &&
-              success;
+          if (!e.episodeFileId) {
+            continue;
+          }
+          if (typeof type === 'number' && e.seasonNumber !== type) {
+            continue;
+          }
+          if (await this.runDelete(`episodefile/${e.episodeFileId}`)) {
+            deletedFileCount++;
+          } else {
+            success = false;
           }
         }
       }
@@ -414,7 +434,13 @@ export class SonarrApi extends ServarrApi<{
       this.logger.log(
         `Unmonitored ${
           typeof type === 'number' ? `season ${type}` : 'seasons'
-        } from Sonarr show with ID ${seriesId}`,
+        } from Sonarr show with ID ${seriesId}${
+          !deleteFiles
+            ? ''
+            : deletedFileCount > 0
+              ? ` and removed ${deletedFileCount} episode file(s)`
+              : '; it had no episode files to remove'
+        }`,
       );
 
       return data;
@@ -513,12 +539,17 @@ export class SonarrApi extends ServarrApi<{
   private async fetchEpisodes(
     seriesID: number,
     seasonNumber?: number,
+    fresh = false,
   ): Promise<SonarrEpisode[]> {
-    return this.get<SonarrEpisode[]>(
-      `/episode?seriesId=${seriesID}${
-        seasonNumber !== undefined ? `&seasonNumber=${seasonNumber}` : ''
-      }`,
-    );
+    const path = `/episode?seriesId=${seriesID}${
+      seasonNumber !== undefined ? `&seasonNumber=${seasonNumber}` : ''
+    }`;
+
+    return fresh
+      ? this.getWithoutCache<SonarrEpisode[]>(path, {
+          timeout: SLOW_INSTANCE_TIMEOUT_MS,
+        })
+      : this.get<SonarrEpisode[]>(path);
   }
 
   private findEpisodesForAction(


### PR DESCRIPTION
Reported on Discord: "Unmonitor and delete season" left the Sonarr season unmonitored while its episodes stayed monitored. That part does not reproduce. Sonarr's `SeriesService.UpdateSeries` propagates a changed season flag to that season's episodes on the series PUT in v2, v3 and v4, and both a raw replay and the real collection handler against dev Sonarr 4.0.19 unmonitored the season and all of its episodes. What did reproduce, in the same function, is a stale read in front of the file deletes.

## Cause

`unmonitorSeasons` and `UnmonitorDeleteEpisodes` took the episode list from the cached `get`, the entry rule evaluation fills and keeps for 20 minutes. The delete loop keys off that list's `episodeFileId`s.

| List state at action time | Before |
|---|---|
| file added since the cached read | skipped; `Removed season N` logged; item left the collection |
| file replaced since the cached read | old id deleted, 404, action fails until the entry expires |
| listing failed | season PUT already sent, then the delete loop threw |

## Change

| Path | Change |
|---|---|
| `getEpisodes` | `{ fresh: true }` option: `getWithoutCache` with the slow-instance timeout, the shape of `getRootFolders({ fresh })`; the rule getters keep the cached read |
| `unmonitorSeasons`, `UnmonitorDeleteEpisodes` | read fresh; a failed listing returns before any PUT or delete |
| `existing` scope | unmonitors each episode from that one read instead of a per-episode `UnmonitorDeleteEpisodes` round trip |
| season success log | carries the deleted file count, or says there were none, as the Radarr log does |
| Radarr | already read `moviefile` uncached before deleting; a regression test pins it |

Sportarr reads uncached before every delete, the Plex, Jellyfin and Emby deletes take the item id, and Seerr and the download client read live, so nothing changes there.

## Verified

Dev Sonarr 4.0.19 through the real handler (`POST /api/collections/media/handle`, Plex season to Sonarr series), files hardlink-imported so the fixtures survive:

| Sequence | Before | After |
|---|---|---|
| season action with no files, import 2 files, re-run within the TTL | 0 deletes, Sonarr log silent, `Removed season 1` logged, item removed | 2 deletes, both in Sonarr's `MediaFileDeletionService` log |
| season and episode monitored state after the action | season and all 13 episodes unmonitored | same |
