### PR TITLE
fix(seerr): honour the forced request removal for delete-show-if-empty

### DIFF
--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.spec.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.spec.ts
@@ -247,6 +247,19 @@ describe('SeerrApiService', () => {
     results,
   });
 
+  it('reads the show uncached when fresh', async () => {
+    const getWithoutCache = jest.fn().mockResolvedValue({ id: 1 });
+    const get = jest.fn();
+    service.api = { get, getWithoutCache } as never;
+
+    await expect(service.getShow(1, { fresh: true })).resolves.toEqual({
+      id: 1,
+    });
+
+    expect(getWithoutCache).toHaveBeenCalledWith('/tv/1');
+    expect(get).not.toHaveBeenCalled();
+  });
+
   describe('removeSeasonRequest', () => {
     const tvRequest = (id: number, seasonNumbers: number[]) =>
       ({
@@ -297,6 +310,7 @@ describe('SeerrApiService', () => {
 
       await expect(service.removeSeasonRequest(100, 1)).resolves.toBe(true);
 
+      expect(service.getShow).toHaveBeenCalledWith(100, { fresh: true });
       expect(del).toHaveBeenCalledTimes(1);
       expect(del).toHaveBeenCalledWith('/request/10', undefined, {
         rethrow: true,

--- a/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
+++ b/apps/server/src/modules/api/seerr-api/seerr-api.service.ts
@@ -241,9 +241,18 @@ export class SeerrApiService {
     return this.settings.seerrConfigured();
   }
 
-  public async getMovie(id: string | number): Promise<SeerrMovieResponse> {
+  /**
+   * `fresh` bypasses the read cache. The delete paths never invalidate it, so
+   * a read that precedes a write or a decision must not come from it.
+   */
+  public async getMovie(
+    id: string | number,
+    options?: { fresh?: boolean },
+  ): Promise<SeerrMovieResponse> {
     try {
-      const response: SeerrMovieResponse = await this.api.get(`/movie/${id}`);
+      const response: SeerrMovieResponse = options?.fresh
+        ? await this.api.getWithoutCache(`/movie/${id}`)
+        : await this.api.get(`/movie/${id}`);
       return response;
     } catch (error) {
       this.logger.warn(
@@ -257,10 +266,15 @@ export class SeerrApiService {
     }
   }
 
-  public async getShow(showId: string | number): Promise<SeerrTVResponse> {
+  public async getShow(
+    showId: string | number,
+    options?: { fresh?: boolean },
+  ): Promise<SeerrTVResponse> {
     try {
       if (showId) {
-        const response: SeerrTVResponse = await this.api.get(`/tv/${showId}`);
+        const response: SeerrTVResponse = options?.fresh
+          ? await this.api.getWithoutCache(`/tv/${showId}`)
+          : await this.api.get(`/tv/${showId}`);
         return response;
       }
       return undefined;
@@ -558,7 +572,7 @@ export class SeerrApiService {
     season: number,
   ): Promise<boolean | undefined> {
     try {
-      const media = await this.getShow(tmdbid);
+      const media = await this.getShow(tmdbid, { fresh: true });
 
       // getShow returns undefined only on communication failure or falsy id;
       // the show being untracked still yields a response with mediaInfo == null.
@@ -616,7 +630,7 @@ export class SeerrApiService {
     }
 
     try {
-      const media = await this.getShow(tmdbid);
+      const media = await this.getShow(tmdbid, { fresh: true });
 
       // getShow returns undefined only on communication failure or falsy id;
       // the show being untracked still yields a response with mediaInfo == null.
@@ -678,7 +692,9 @@ export class SeerrApiService {
   ): Promise<boolean | undefined> {
     try {
       const media: SeerrMovieResponse | SeerrTVResponse =
-        type === 'movie' ? await this.getMovie(id) : await this.getShow(id);
+        type === 'movie'
+          ? await this.getMovie(id, { fresh: true })
+          : await this.getShow(id, { fresh: true });
 
       // Reading through an undefined media used to throw, which the catch
       // below then reported as a communication failure. Answer it directly.

--- a/apps/server/src/modules/collections/collection-handler.spec.ts
+++ b/apps/server/src/modules/collections/collection-handler.spec.ts
@@ -499,7 +499,7 @@ describe('CollectionHandler', () => {
     expect(seerrApi.removeMediaByTmdbId).not.toHaveBeenCalled();
   });
 
-  it('should not mutate Seerr requests for DELETE_SHOW_IF_EMPTY season actions', async () => {
+  it('removes the season request for DELETE_SHOW_IF_EMPTY when forced', async () => {
     const collection = createCollection({
       arrAction: ServarrAction.DELETE_SHOW_IF_EMPTY,
       forceSeerr: true,
@@ -517,13 +517,40 @@ describe('CollectionHandler', () => {
       }),
     );
     mockMediaServerMetadata(collectionMedia.mediaData);
+    sonarrActionHandler.handleAction.mockResolvedValue(true);
 
-    await collectionHandler.handleMedia(collection, collectionMedia);
+    await expect(
+      collectionHandler.handleMedia(collection, collectionMedia),
+    ).resolves.toBe('handled');
 
-    expect(sonarrActionHandler.handleAction).toHaveBeenCalledWith(
-      collection,
-      collectionMedia,
+    expect(seerrApi.removeSeasonRequest).toHaveBeenCalledWith(
+      collectionMedia.tmdbId,
+      collectionMedia.mediaData.index,
     );
+  });
+
+  it('does not touch Seerr for UNMONITOR_SHOW_IF_EMPTY (no files are removed)', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR_SHOW_IF_EMPTY,
+      forceSeerr: true,
+      sonarrSettingsId: 1,
+      type: 'season',
+    });
+    const collectionMedia = createCollectionMediaWithMetadata(collection);
+
+    settings.seerrConfigured.mockReturnValue(true);
+    mediaServer.getLibraries.mockResolvedValue(
+      createMediaLibraries({
+        id: collection.libraryId.toString(),
+        type: 'show',
+      }),
+    );
+    sonarrActionHandler.handleAction.mockResolvedValue(true);
+
+    await expect(
+      collectionHandler.handleMedia(collection, collectionMedia),
+    ).resolves.toBe('handled');
+
     expect(seerrApi.removeSeasonRequest).not.toHaveBeenCalled();
     expect(seerrApi.removeMediaByTmdbId).not.toHaveBeenCalled();
   });

--- a/apps/server/src/modules/collections/collection-handler.ts
+++ b/apps/server/src/modules/collections/collection-handler.ts
@@ -104,11 +104,7 @@ export class CollectionHandler {
       !collection.sonarrSettingsId &&
       !collection.sportarrSettingsId
     ) {
-      if (
-        collection.arrAction !== ServarrAction.UNMONITOR &&
-        collection.arrAction !== ServarrAction.UNMONITOR_SHOW_IF_EMPTY &&
-        collection.arrAction !== ServarrAction.CHANGE_QUALITY_PROFILE
-      ) {
+      if (freesDisk) {
         this.logger.log(
           `Couldn't utilize *arr to find and remove the media with id ${media.mediaServerId}. Attempting to remove from the filesystem via media server. No unmonitor action was taken.`,
         );
@@ -156,14 +152,9 @@ export class CollectionHandler {
       return 'removed-missing';
     }
 
-    // Only remove requests & file if needed
-    if (
-      collection.arrAction !== ServarrAction.UNMONITOR &&
-      collection.arrAction !== ServarrAction.UNMONITOR_SHOW_IF_EMPTY &&
-      collection.arrAction !== ServarrAction.DELETE_SHOW_IF_EMPTY &&
-      collection.arrAction !== ServarrAction.CHANGE_QUALITY_PROFILE
-    ) {
-      // Seerr, if forced. Otherwise rely on media sync
+    // The request goes with the files. Seerr, if forced; otherwise rely on
+    // its availability sync.
+    if (freesDisk) {
       if (this.settings.seerrConfigured() && collection.forceSeerr) {
         const ids = await this.metadataService.resolveIdsForService(
           media.mediaServerId,


### PR DESCRIPTION
Related to #3677.

"Force delete Seerr request" was silently ignored for `Unmonitor and delete season + delete show if empty`: the Seerr block in `CollectionHandler.handleMedia` sat behind an inline action list that excluded `DELETE_SHOW_IF_EMPTY`, while the UI offers the toggle for that action and the docs promise the removal. The exclusion came from #2618, which made the action inspect Seerr (`hasRemainingSeasonRequests`) instead of requiring request mutation. That inspection is unchanged and still runs first; with the toggle off nothing changes.

- Both gates in `handleMedia` now read the existing `freesDisk` predicate: the request goes with the files.
- With the removal running after the Sonarr action, the next season of the same show read the just-deleted request back out of the 20-minute Seerr cache, which the delete paths never invalidate: the emptied show stayed in Sonarr and a duplicate `DELETE /request` 404'd into two false warnings. `removeSeasonRequest`, `hasRemainingSeasonRequests` and `removeMediaByTmdbId` now read Seerr uncached (`getShow`/`getMovie` take `{ fresh }`, the servarr readers' shape). Rule getters keep the cached read.

Verified on the real dev stack (Sonarr, Seerr 3.4.1, toggle on), one Sonarr series per run with hardlinked files:

| case | server | before | after |
|---|---|---|---|
| delete season + delete show if empty | Plex, Jellyfin, Emby | season and show deleted, request left in Seerr, no Seerr log line | request removed |
| two seasons of one show, one request covering both | Jellyfin | season 2 leaves the emptied show in Sonarr, two false warnings | show deleted, no warnings |

Regression set, all unchanged from `development`:

| case | outcome |
|---|---|
| delete show if empty while another season is still actively requested | show kept, only the handled season's request removed |
| unmonitor season + unmonitor show if empty, toggle on | Seerr untouched |
| delete season, delete show, movie removal | request or record removed as before |
| rule group saved through the UI with the action and the toggle | persisted |
