### PR TITLE
fix(download-client): qBittorrent seed-time units, and a 23-hour floor for unlimited downloads

### DIFF
--- a/apps/server/src/modules/api/download-client-api/download-client-api.service.spec.ts
+++ b/apps/server/src/modules/api/download-client-api/download-client-api.service.spec.ts
@@ -24,7 +24,8 @@ const torrent = (
   name: 'Sample Download',
   content_path: '/downloads/sample',
   ratio: 1,
-  // null = the client enforces no limit, so the fallback ratio applies.
+  seedingTime: 48 * 3600,
+  // null = the client enforces no limit, so the fallbacks apply.
   reachedSeedingGoal: null,
   ...overrides,
 });
@@ -182,7 +183,7 @@ describe('DownloadClientApiService', () => {
       expect(apiMock.deleteTorrents).not.toHaveBeenCalled();
     });
 
-    it('applies the fallback ratio only when the client enforces no limit', async () => {
+    it('applies the fallback ratio and hours only when the client enforces no limit', async () => {
       apiMock.getTorrentByHash.mockResolvedValue(
         torrent({ reachedSeedingGoal: null, ratio: 0.7 }),
       );
@@ -190,6 +191,16 @@ describe('DownloadClientApiService', () => {
       await service.removeDownloads(['abc']);
 
       expect(apiMock.deleteTorrents).toHaveBeenCalledWith(['abc'], true);
+    });
+
+    it('keeps seeding when there is no client limit and the fallback hours are not seeded yet', async () => {
+      apiMock.getTorrentByHash.mockResolvedValue(
+        torrent({ reachedSeedingGoal: null, ratio: 9, seedingTime: 22 * 3600 }),
+      );
+
+      await service.removeDownloads(['abc']);
+
+      expect(apiMock.deleteTorrents).not.toHaveBeenCalled();
     });
 
     it('keeps seeding when there is no client limit and ratio is below the fallback', async () => {

--- a/apps/server/src/modules/api/download-client-api/download-client-api.service.ts
+++ b/apps/server/src/modules/api/download-client-api/download-client-api.service.ts
@@ -35,6 +35,13 @@ import {
 } from './download-client.interface';
 
 /**
+ * Seed-time floor for a download the client does not limit. The fallback ratio
+ * alone lets a tracker's seed-time rule be broken the moment the ratio is met,
+ * so both must hold before such a download is removed.
+ */
+const FALLBACK_SEEDING_HOURS = 23;
+
+/**
  * Talks to the configured download client to clean up completed downloads for
  * media Radarr/Sonarr removes. qBittorrent is currently the only supported
  * backend; the qBittorrent specifics live in the helper so additional backends
@@ -127,8 +134,8 @@ export class DownloadClientApiService {
    * is a side effect.
    *
    * Whether a download has finished seeding is decided by the download client's
-   * own ratio / seed-time limits. Only when the client enforces no limit does
-   * Maintainerr's fallback ratio apply.
+   * own ratio / seed-time limits. Only when the client enforces no limit do
+   * Maintainerr's fallbacks apply, and then both must be met.
    *
    * Cross-seed protection (inspired by qbit_manage): when deleting data, a
    * download whose content path is shared by another download is removed
@@ -167,7 +174,7 @@ export class DownloadClientApiService {
           this.logger.log(
             torrent.reachedSeedingGoal === false
               ? `Keeping download '${torrent.name}' seeding: its download-client seeding goal isn't met yet`
-              : `Keeping download '${torrent.name}' seeding: the download client enforces no limit and ratio ${torrent.ratio} is below the fallback minimum of ${fallbackRatio}`,
+              : `Keeping download '${torrent.name}' seeding: the download client enforces no limit and it is at ratio ${torrent.ratio} after ${(torrent.seedingTime / 3600).toFixed(1)}h against fallback minimums of ${fallbackRatio} and ${FALLBACK_SEEDING_HOURS}h`,
           );
           continue;
         }
@@ -227,9 +234,9 @@ export class DownloadClientApiService {
 
   /**
    * Defer to the download client's own seeding goal; only when it enforces no
-   * limit (`reachedSeedingGoal === null`) apply Maintainerr's fallback ratio.
-   * The client normalizes an unbounded ratio to Infinity, so a plain `>=`
-   * covers that case too.
+   * limit (`reachedSeedingGoal === null`) apply Maintainerr's fallbacks, both
+   * of which must be met. The client normalizes an unbounded ratio to
+   * Infinity, so a plain `>=` covers that case too.
    */
   private shouldRemove(
     torrent: DownloadClientTorrent,
@@ -238,6 +245,9 @@ export class DownloadClientApiService {
     if (torrent.reachedSeedingGoal !== null) {
       return torrent.reachedSeedingGoal;
     }
-    return torrent.ratio >= fallbackRatio;
+    return (
+      torrent.ratio >= fallbackRatio &&
+      torrent.seedingTime >= FALLBACK_SEEDING_HOURS * 3600
+    );
   }
 }

--- a/apps/server/src/modules/api/download-client-api/download-client.interface.ts
+++ b/apps/server/src/modules/api/download-client-api/download-client.interface.ts
@@ -18,6 +18,8 @@ export interface DownloadClientTorrent {
    * fallback when the client enforces no seeding goal of its own.
    */
   ratio: number;
+  /** Seconds spent seeding since the download completed. Same use as `ratio`. */
+  seedingTime: number;
   /**
    * Whether the client's OWN seeding goal (its ratio / seed-time limit) is met,
    * decided entirely by the client:

--- a/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.spec.ts
+++ b/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.spec.ts
@@ -165,16 +165,21 @@ describe('QbittorrentApi auth', () => {
     ).toBe(false);
   });
 
-  it('treats the seed-time limit as met independently of ratio', async () => {
-    const t = await getMappedTorrent(
+  it('compares seeding_time (seconds) against max_seeding_time (minutes)', async () => {
+    const seededFor = (seeding_time: number) =>
       rawTorrent({
         max_ratio: -1,
         ratio: 0.1,
-        max_seeding_time: 3600,
-        seeding_time: 7200,
-      }),
+        max_seeding_time: 60,
+        seeding_time,
+      });
+
+    expect((await getMappedTorrent(seededFor(3600)))?.reachedSeedingGoal).toBe(
+      true,
     );
-    expect(t?.reachedSeedingGoal).toBe(true);
+    expect((await getMappedTorrent(seededFor(3599)))?.reachedSeedingGoal).toBe(
+      false,
+    );
   });
 });
 

--- a/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.spec.ts
+++ b/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.spec.ts
@@ -134,12 +134,15 @@ describe('QbittorrentApi auth', () => {
   it('normalizes qBittorrent\'s -1 "unbounded" ratio to Infinity and lowercases the hash lookup', async () => {
     const { api, axiosMock } = buildApi();
     axiosMock.post.mockResolvedValue({ data: 'Ok.', headers: {} });
-    axiosMock.get.mockResolvedValue({ data: [rawTorrent({ ratio: -1 })] });
+    axiosMock.get.mockResolvedValue({
+      data: [rawTorrent({ ratio: -1, seeding_time: 7200 })],
+    });
 
     const single = await api.getTorrentByHash('ABC');
     const [fromList] = await api.getTorrents();
 
     expect(single?.ratio).toBe(Infinity);
+    expect(single?.seedingTime).toBe(7200);
     expect(fromList?.ratio).toBe(Infinity);
     expect(axiosMock.get).toHaveBeenCalledWith(
       '/torrents/info',

--- a/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.ts
+++ b/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.ts
@@ -54,6 +54,7 @@ const toDownloadClientTorrent = (
     name: raw.name,
     content_path: raw.content_path,
     ratio,
+    seedingTime: raw.seeding_time,
     reachedSeedingGoal,
   };
 };

--- a/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.ts
+++ b/apps/server/src/modules/api/download-client-api/helpers/qbittorrent.helper.ts
@@ -10,7 +10,9 @@ import {
  * The qBittorrent `torrents/info` fields we read. `max_ratio` /
  * `max_seeding_time` are the EFFECTIVE limits qBittorrent enforces ("…until
  * torrent is stopped from seeding"), already resolving any global default; `-1`
- * means "no limit". `seeding_time` and `max_seeding_time` are in seconds.
+ * means "no limit". `seeding_time` is in seconds; `max_seeding_time` is in
+ * MINUTES, like the preference it mirrors (qBittorrent itself compares
+ * `finishedTime() / 60` against it).
  */
 interface RawQbittorrentTorrent {
   hash: string;
@@ -44,7 +46,7 @@ const toDownloadClientTorrent = (
   } else {
     reachedSeedingGoal =
       (hasRatioLimit && ratio >= raw.max_ratio) ||
-      (hasTimeLimit && raw.seeding_time >= raw.max_seeding_time);
+      (hasTimeLimit && raw.seeding_time >= raw.max_seeding_time * 60);
   }
 
   return {


### PR DESCRIPTION
Fixes #3678.

Two commits, both in the qBittorrent download-client path.

**1. The seed-time limit was compared in the wrong unit.** `GET /api/v2/torrents/info` reports `seeding_time` in seconds and `max_seeding_time` in minutes, mirroring the `max_seeding_time` preference. Verified in qBittorrent's source at the 4.3.4 floor and at 5.1.2: `finishedTime()` is `total_seconds(finished_duration)`, `maxSeedingTime()` resolves to `globalMaxSeedingMinutes()`, and qBittorrent's own share-limit check compares `finishedTime() / 60` against it. The wiki's `torrents/info` table says seconds for `max_seeding_time`; the wiki is wrong there. The mapper compared the two raw, so a limit of N minutes read as reached after N seconds, and the fallback never got a turn because the verdict was not `null`. The comparison now multiplies the limit by 60; the spec pins one second either side of a 60-minute limit.

**2. A seed-time floor beside the fallback ratio.** For a download qBittorrent does not limit, the fallback was ratio only, so a tracker's seed-time rule could be broken the moment the ratio was met. The client-agnostic torrent shape now carries `seedingTime` (seconds), and such a download is removed only once it has seeded for 23 hours and reached the fallback ratio. Fixed in code, no setting and no migration. qBittorrent's own limits still decide first, unchanged. Installs with no qBittorrent limits will now keep a download they used to remove at ratio 0.5 within the first 23 hours; the keep log names both minimums.

Live on dev-qbittorrent 5.2.3, reading through the compiled code:

| case | limit | `seeding_time` | before | after |
|---|---|---|---|---|
| unit fix | 5 min | 10 s | reached | not reached |
| unit fix | 5 min | 49 s | | not reached |
| unit fix | 1 min | 124 s | | reached |
| floor, full chain | none | 51 s, ratio 0 | | kept, "against fallback minimums of 0.5 and 23h" |

The full-chain row ran the real path: the torrent registered as Sonarr's download client, the fixture files manual-imported against its download id so Sonarr's history carried it, then a show-level delete on Plex through Maintainerr, which removed the show in Sonarr, looked the hash up in qBittorrent and kept it. The ratio-met but time-short branch is unit-tested only; nothing downloads from the dev qBittorrent, so a live torrent never reaches ratio 0.5.

Not touched: `max_inactive_seeding_time` (also minutes) is not read anywhere. The docs' "Fallback seeding ratio" row still describes ratio only; a one-sentence docs update follows separately.
