### PR TITLE
fix(plex): scan library after file deletion

### DIFF
--- a/apps/server/src/modules/api/media-server/media-server.interface.ts
+++ b/apps/server/src/modules/api/media-server/media-server.interface.ts
@@ -449,6 +449,12 @@ export interface IMediaServerService {
   deleteFromDisk(itemId: string): Promise<void>;
 
   /**
+   * Ask the media server to scan a library for filesystem changes.
+   * Currently implemented by Plex only.
+   */
+  scanLibrary?(libraryId: string): Promise<void>;
+
+  /**
    * Get all media server IDs for a context action (add/remove from collection).
    * Handles show→season→episode traversal based on collection type.
    *

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.spec.ts
@@ -144,6 +144,24 @@ describe('PlexAdapterService', () => {
     });
   });
 
+  describe('scanLibrary', () => {
+    it('delegates a library scan to PlexApiService', async () => {
+      plexApi.scanLibrary.mockResolvedValue(undefined);
+
+      await service.scanLibrary('2');
+
+      expect(plexApi.scanLibrary).toHaveBeenCalledWith('2');
+    });
+
+    it('rejects blank library ids before calling PlexApiService', async () => {
+      await expect(service.scanLibrary('   ')).rejects.toThrow(
+        'scanLibrary called with empty libraryId - aborting library scan request',
+      );
+
+      expect(plexApi.scanLibrary).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getStatus', () => {
     it('should return undefined when PlexApiService returns undefined', async () => {
       plexApi.getStatus.mockResolvedValue(undefined);

--- a/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/plex/plex-adapter.service.ts
@@ -935,6 +935,16 @@ export class PlexAdapterService implements IMediaServerService {
     }
   }
 
+  async scanLibrary(libraryId: string): Promise<void> {
+    if (!libraryId || libraryId.trim() === '') {
+      throw new Error(
+        'scanLibrary called with empty libraryId - aborting library scan request',
+      );
+    }
+
+    await this.plexApi.scanLibrary(libraryId);
+  }
+
   async getAllIdsForContextAction(
     collectionType: MediaItemType | undefined,
     context: { type: MediaItemType; id: string },

--- a/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.spec.ts
@@ -740,6 +740,36 @@ describe('PlexApiService.deleteMediaFromDisk', () => {
   });
 });
 
+describe('PlexApiService.scanLibrary', () => {
+  let service: PlexApiService;
+
+  beforeEach(async () => {
+    const { unit } = await TestBed.solitary(PlexApiService).compile();
+    service = unit;
+  });
+
+  it('starts a scan for a library section', async () => {
+    const postQuery = jest.fn().mockResolvedValue(undefined);
+    (service as any).plexClient = { postQuery };
+
+    await service.scanLibrary('2');
+
+    expect(postQuery).toHaveBeenCalledWith({
+      uri: '/library/sections/2/refresh',
+    });
+  });
+
+  it('rejects an empty library id', async () => {
+    const postQuery = jest.fn();
+    (service as any).plexClient = { postQuery };
+
+    await expect(service.scanLibrary('  ')).rejects.toThrow(
+      'scanLibrary called with empty libraryId - aborting library scan request',
+    );
+    expect(postQuery).not.toHaveBeenCalled();
+  });
+});
+
 describe('PlexApiService.getCollections (invalid section vs auth)', () => {
   let service: PlexApiService;
   let settingsDataService: PlexApiSettingsStub;

--- a/apps/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/apps/server/src/modules/api/plex-api/plex-api.service.ts
@@ -1280,6 +1280,27 @@ export class PlexApiService {
     );
   }
 
+  public async scanLibrary(libraryId: string | number): Promise<void> {
+    if (`${libraryId}`.trim() === '') {
+      throw new Error(
+        'scanLibrary called with empty libraryId - aborting library scan request',
+      );
+    }
+
+    try {
+      await this.plexClient.postQuery({
+        uri: `/library/sections/${libraryId}/refresh`,
+      });
+      this.logger.log(`[Plex] Started library scan for section ${libraryId}`);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to start Plex library scan for section ${libraryId}`,
+      );
+      this.logger.debug(error);
+      throw error;
+    }
+  }
+
   public async refreshMediaMetadata(ratingKey: string): Promise<void> {
     try {
       await this.plexClient.putQuery({

--- a/apps/server/src/modules/collections/collection-handler.spec.ts
+++ b/apps/server/src/modules/collections/collection-handler.spec.ts
@@ -114,6 +114,32 @@ describe('CollectionHandler', () => {
     expect(mediaServer.deleteFromDisk).toHaveBeenCalled();
   });
 
+  it('scans the library after a file-removal action', async () => {
+    mediaServer.scanLibrary = jest.fn().mockResolvedValue(undefined);
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      type: 'show',
+    });
+
+    await collectionHandler.scanLibraryAfterDelete(collection);
+
+    expect(mediaServer.scanLibrary).toHaveBeenCalledWith(
+      collection.libraryId.toString(),
+    );
+  });
+
+  it('does not scan the library for an unmonitor-only action', async () => {
+    mediaServer.scanLibrary = jest.fn().mockResolvedValue(undefined);
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR,
+      type: 'show',
+    });
+
+    await collectionHandler.scanLibraryAfterDelete(collection);
+
+    expect(mediaServer.scanLibrary).not.toHaveBeenCalled();
+  });
+
   it('prunes the item from sibling collections after a file-removal action', async () => {
     const collection = createCollection({
       arrAction: ServarrAction.DELETE,

--- a/apps/server/src/modules/collections/collection-handler.ts
+++ b/apps/server/src/modules/collections/collection-handler.ts
@@ -23,6 +23,12 @@ import { RecentlyHandledMediaService } from './recently-handled-media.service';
  */
 export type HandleMediaResult = 'handled' | 'failed' | 'removed-missing';
 
+const actionDeletesFiles = (action: ServarrAction): boolean =>
+  action === ServarrAction.DELETE ||
+  action === ServarrAction.UNMONITOR_DELETE_ALL ||
+  action === ServarrAction.UNMONITOR_DELETE_EXISTING ||
+  action === ServarrAction.DELETE_SHOW_IF_EMPTY;
+
 @Injectable()
 export class CollectionHandler {
   constructor(
@@ -67,10 +73,7 @@ export class CollectionHandler {
     // is null and the post-action increment below would silently drop the
     // bytes. After a delete-style action the file is gone and the media
     // server's metadata loses the size, so this lookup has to happen first.
-    const freesDisk =
-      collection.arrAction !== ServarrAction.UNMONITOR &&
-      collection.arrAction !== ServarrAction.UNMONITOR_SHOW_IF_EMPTY &&
-      collection.arrAction !== ServarrAction.CHANGE_QUALITY_PROFILE;
+    const freesDisk = actionDeletesFiles(collection.arrAction);
     let resolvedSizeBytes: number | null =
       media.sizeBytes != null && Number(media.sizeBytes) > 0
         ? Number(media.sizeBytes)
@@ -306,6 +309,26 @@ export class CollectionHandler {
     await this.collectionService.saveCollection(collection);
 
     return 'handled';
+  }
+
+  /**
+   * Reconcile a Plex library after a successful file-deleting action.
+   * Scanning is best-effort and does not retry the deletion.
+   */
+  public async scanLibraryAfterDelete(collection: Collection): Promise<void> {
+    if (!actionDeletesFiles(collection.arrAction)) return;
+
+    const mediaServer = await this.getMediaServer();
+    if (!mediaServer.scanLibrary) return;
+
+    try {
+      await mediaServer.scanLibrary(collection.libraryId.toString());
+    } catch (error) {
+      this.logger.warn(
+        `Failed to scan library ${collection.libraryId} after handling collection '${collection.title}'`,
+      );
+      this.logger.debug(error);
+    }
   }
 
   /**

--- a/apps/server/src/modules/collections/collection-worker.service.ts
+++ b/apps/server/src/modules/collections/collection-worker.service.ts
@@ -413,6 +413,10 @@ export class CollectionWorkerService extends TaskBase {
           emitProgressedEvent();
         }
 
+        if (handledMediaForNotification.length > 0) {
+          await this.collectionHandler.scanLibraryAfterDelete(collection);
+        }
+
         // handle notification
         if (handledMediaForNotification.length > 0) {
           this.eventEmitter.emit(

--- a/apps/server/src/modules/collections/collections.controller.spec.ts
+++ b/apps/server/src/modules/collections/collections.controller.spec.ts
@@ -57,6 +57,7 @@ describe('CollectionsController', () => {
 
   const collectionHandler = {
     handleMedia: jest.fn(),
+    scanLibraryAfterDelete: jest.fn(),
   } as unknown as jest.Mocked<CollectionHandler>;
 
   const collectionPosterService = {
@@ -423,6 +424,9 @@ describe('CollectionsController', () => {
     expect(collectionHandler.handleMedia).toHaveBeenCalledWith(
       collection,
       media,
+    );
+    expect(collectionHandler.scanLibraryAfterDelete).toHaveBeenCalledWith(
+      collection,
     );
     expect(executionLock.tryAcquire).toHaveBeenCalledWith(
       RULES_COLLECTIONS_EXECUTION_LOCK_KEY,

--- a/apps/server/src/modules/collections/collections.controller.ts
+++ b/apps/server/src/modules/collections/collections.controller.ts
@@ -552,6 +552,10 @@ export class CollectionsController {
           'The collection action could not be executed for this item',
         );
       }
+
+      if (result === 'handled') {
+        await this.collectionHandler.scanLibraryAfterDelete(collection);
+      }
     } finally {
       release();
     }


### PR DESCRIPTION
## Description & Design

Maintainerr deletes media files through Sonarr, Radarr, or Plex, but Plex can retain the deleted item until its next library scan. This leaves orphaned shows visible in Plex clients.

The change adds a Plex library-scan operation and invokes it once after a successful batch of delete-style actions. Unmonitor-only and quality-profile actions do not scan. Scan failures are logged without retrying a completed deletion.

## Related request

https://features.maintainerr.info/posts/106/update-library-command-on-delete-similar-to-radarr

## AI-Assisted Development

AI assistance was used to inspect the codebase, trace the deletion flow, draft the implementation and tests, and review the diff. I reviewed the design and changes, kept the scan at the collection-handling boundary, and confirmed the Plex endpoint against a live server.

## Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I understand the code I am submitting and can explain how it works
- [x] I have performed a self-review of my code
- [x] I have linted and formatted my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## How to test

1. Configure a Plex server and a delete-style Maintainerr collection action.
2. Handle a disposable media item through the normal worker or manual collection endpoint.
3. Confirm Maintainerr starts a scan for the affected Plex library and the deleted item disappears after the scan.
4. Confirm unmonitor-only actions do not start a scan.